### PR TITLE
Heap dumps on SD card

### DIFF
--- a/library/leakcanary-android/src/main/AndroidManifest.xml
+++ b/library/leakcanary-android/src/main/AndroidManifest.xml
@@ -19,6 +19,9 @@
     package="com.squareup.leakcanary"
     >
 
+  <!-- To store the heap dumps and leak analysis results. -->
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
   <application>
     <service
         android:name=".internal.HeapAnalyzerService"

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -15,23 +15,17 @@
  */
 package com.squareup.leakcanary;
 
-import android.app.ActivityManager;
 import android.app.Application;
-import android.app.Service;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.util.Log;
 import com.squareup.leakcanary.internal.DisplayLeakActivity;
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
 
-import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
-import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
-import static android.content.pm.PackageManager.DONT_KILL_APP;
-import static android.content.pm.PackageManager.GET_SERVICES;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.isInServiceProcess;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabled;
 
 public final class LeakCanary {
 
@@ -55,7 +49,7 @@ public final class LeakCanary {
     enableDisplayLeakActivity(application);
     HeapDump.Listener heapDumpListener =
         new ServiceHeapDumpListener(application, listenerServiceClass);
-    RefWatcher refWatcher = androidWatcher(application, heapDumpListener);
+    RefWatcher refWatcher = androidWatcher(heapDumpListener);
     ActivityRefWatcher.installOnIcsPlus(application, refWatcher);
     return refWatcher;
   }
@@ -63,9 +57,9 @@ public final class LeakCanary {
   /**
    * Creates a {@link RefWatcher} with a default configuration suitable for Android.
    */
-  public static RefWatcher androidWatcher(Application app, HeapDump.Listener heapDumpListener) {
+  public static RefWatcher androidWatcher(HeapDump.Listener heapDumpListener) {
     DebuggerControl debuggerControl = new AndroidDebuggerControl();
-    AndroidHeapDumper heapDumper = new AndroidHeapDumper(app);
+    AndroidHeapDumper heapDumper = new AndroidHeapDumper();
     heapDumper.cleanup();
     return new RefWatcher(new AndroidWatchExecutor(), debuggerControl, GcTrigger.DEFAULT,
         heapDumper, heapDumpListener);
@@ -139,70 +133,6 @@ public final class LeakCanary {
    */
   public static boolean isInAnalyzerProcess(Context context) {
     return isInServiceProcess(context, HeapAnalyzerService.class);
-  }
-
-  private static boolean isInServiceProcess(Context context,
-      Class<? extends Service> serviceClass) {
-    PackageManager packageManager = context.getPackageManager();
-    PackageInfo packageInfo;
-    try {
-      packageInfo = packageManager.getPackageInfo(context.getPackageName(), GET_SERVICES);
-    } catch (Exception e) {
-      Log.e("AndroidUtils", "Could not get package info for " + context.getPackageName(), e);
-      return false;
-    }
-    String mainProcess = packageInfo.applicationInfo.processName;
-
-    ComponentName component = new ComponentName(context, serviceClass);
-    ServiceInfo serviceInfo;
-    try {
-      serviceInfo = packageManager.getServiceInfo(component, 0);
-    } catch (PackageManager.NameNotFoundException ignored) {
-      // Service is disabled.
-      return false;
-    }
-
-    if (serviceInfo.processName.equals(mainProcess)) {
-      Log.e("AndroidUtils",
-          "Did not expect service " + serviceClass + " to run in main process " + mainProcess);
-      // Technically we are in the service process, but we're not in the service dedicated process.
-      return false;
-    }
-
-    int myPid = android.os.Process.myPid();
-    ActivityManager activityManager =
-        (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-    ActivityManager.RunningAppProcessInfo myProcess = null;
-    for (ActivityManager.RunningAppProcessInfo process : activityManager.getRunningAppProcesses()) {
-      if (process.pid == myPid) {
-        myProcess = process;
-        break;
-      }
-    }
-    if (myProcess == null) {
-      Log.e("AndroidUtils", "Could not find running process for " + myPid);
-      return false;
-    }
-
-    return myProcess.processName.equals(serviceInfo.processName);
-  }
-
-  static void setEnabled(Context context, Class<?> componentClass, boolean enabled) {
-    ComponentName component = new ComponentName(context, componentClass);
-    PackageManager packageManager = context.getPackageManager();
-    int newState = enabled ? COMPONENT_ENABLED_STATE_ENABLED : COMPONENT_ENABLED_STATE_DISABLED;
-    // Blocks on IPC.
-    packageManager.setComponentEnabledSetting(component, newState, DONT_KILL_APP);
-  }
-
-  /** Extracts the class simple name out of a string containing a fully qualified class name. */
-  static String classSimpleName(String className) {
-    int separator = className.lastIndexOf('.');
-    if (separator == -1) {
-      return className;
-    } else {
-      return className.substring(separator + 1);
-    }
   }
 
   private LeakCanary() {

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
 
 import static com.squareup.leakcanary.Preconditions.checkNotNull;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabled;
 
 public final class ServiceHeapDumpListener implements HeapDump.Listener {
 
@@ -27,8 +28,8 @@ public final class ServiceHeapDumpListener implements HeapDump.Listener {
 
   public ServiceHeapDumpListener(Context context,
       Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
-    LeakCanary.setEnabled(context, listenerServiceClass, true);
-    LeakCanary.setEnabled(context, HeapAnalyzerService.class, true);
+    setEnabled(context, listenerServiceClass, true);
+    setEnabled(context, HeapAnalyzerService.class, true);
     this.listenerServiceClass = checkNotNull(listenerServiceClass, "listenerServiceClass");
     this.context = checkNotNull(context, "context").getApplicationContext();
   }

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.leakcanary.internal;
+
+import android.app.ActivityManager;
+import android.app.Service;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
+import android.os.Environment;
+import android.util.Log;
+import java.io.File;
+
+import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
+import static android.content.pm.PackageManager.DONT_KILL_APP;
+import static android.content.pm.PackageManager.GET_SERVICES;
+import static android.os.Environment.DIRECTORY_DOWNLOADS;
+
+public final class LeakCanaryInternals {
+
+  public static File storageDirectory() {
+    File downloadsDirectory = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS);
+    File leakCanaryDirectory = new File(downloadsDirectory, "leakcanary");
+    leakCanaryDirectory.mkdirs();
+    return leakCanaryDirectory;
+  }
+
+  public static File detectedLeakDirectory() {
+    File directory = new File(storageDirectory(), "detected_leaks");
+    directory.mkdirs();
+    return directory;
+  }
+
+  public static File leakResultFile(File heapdumpFile) {
+    return new File(heapdumpFile.getParentFile(), heapdumpFile.getName() + ".result");
+  }
+
+  public static boolean isExternalStorageWritable() {
+    String state = Environment.getExternalStorageState();
+    return Environment.MEDIA_MOUNTED.equals(state);
+  }
+
+  public static File findNextAvailableHprofFile(int maxFiles) {
+    File directory = detectedLeakDirectory();
+    for (int i = 0; i < maxFiles; i++) {
+      String heapDumpName = "heap_dump_" + i + ".hprof";
+      File file = new File(directory, heapDumpName);
+      if (!file.exists()) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  /** Extracts the class simple name out of a string containing a fully qualified class name. */
+  public static String classSimpleName(String className) {
+    int separator = className.lastIndexOf('.');
+    if (separator == -1) {
+      return className;
+    } else {
+      return className.substring(separator + 1);
+    }
+  }
+
+  public static void setEnabled(Context context, Class<?> componentClass, boolean enabled) {
+    ComponentName component = new ComponentName(context, componentClass);
+    PackageManager packageManager = context.getPackageManager();
+    int newState = enabled ? COMPONENT_ENABLED_STATE_ENABLED : COMPONENT_ENABLED_STATE_DISABLED;
+    // Blocks on IPC.
+    packageManager.setComponentEnabledSetting(component, newState, DONT_KILL_APP);
+  }
+
+  public static boolean isInServiceProcess(Context context, Class<? extends Service> serviceClass) {
+    PackageManager packageManager = context.getPackageManager();
+    PackageInfo packageInfo;
+    try {
+      packageInfo = packageManager.getPackageInfo(context.getPackageName(), GET_SERVICES);
+    } catch (Exception e) {
+      Log.e("AndroidUtils", "Could not get package info for " + context.getPackageName(), e);
+      return false;
+    }
+    String mainProcess = packageInfo.applicationInfo.processName;
+
+    ComponentName component = new ComponentName(context, serviceClass);
+    ServiceInfo serviceInfo;
+    try {
+      serviceInfo = packageManager.getServiceInfo(component, 0);
+    } catch (PackageManager.NameNotFoundException ignored) {
+      // Service is disabled.
+      return false;
+    }
+
+    if (serviceInfo.processName.equals(mainProcess)) {
+      Log.e("AndroidUtils",
+          "Did not expect service " + serviceClass + " to run in main process " + mainProcess);
+      // Technically we are in the service process, but we're not in the service dedicated process.
+      return false;
+    }
+
+    int myPid = android.os.Process.myPid();
+    ActivityManager activityManager =
+        (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    ActivityManager.RunningAppProcessInfo myProcess = null;
+    for (ActivityManager.RunningAppProcessInfo process : activityManager.getRunningAppProcesses()) {
+      if (process.pid == myPid) {
+        myProcess = process;
+        break;
+      }
+    }
+    if (myProcess == null) {
+      Log.e("AndroidUtils", "Could not find running process for " + myPid);
+      return false;
+    }
+
+    return myProcess.processName.equals(serviceInfo.processName);
+  }
+
+  private LeakCanaryInternals() {
+    throw new AssertionError();
+  }
+}


### PR DESCRIPTION
* Heap dumps and analysis results were previously saved in the app directory. They are now saved on the external storage (sd card).
* Centralized internal static helper methods to a dedicated class: `LeakCanaryInternals`.

BREAKING CHANGES

* When upgrading, previously saved heap dumps will be lost, but won't be removed from the app directory. You should probably uninstall your app.
* Added permission WRITE_EXTERNAL_STORAGE
* Public API change: Removed `Application` parameter in `LeakCanary.androidWatcher()`
* Public API change: Removed `Application` parameter in `AndroidHeapDumper()`

* Fixes #21 (can't share heap dump)
* This is a step towards fixing #15 (strict mode violations), although there's still more work.