### PR TITLE
Fix Strict mode violations

### DIFF
--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -17,6 +17,7 @@ package com.squareup.leakcanary;
 
 import android.os.Debug;
 import android.util.Log;
+import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.io.File;
 import java.io.IOException;
 
@@ -57,13 +58,17 @@ public final class AndroidHeapDumper implements HeapDumper {
    * the app process was killed.
    */
   public void cleanup() {
-    if (isExternalStorageWritable()) {
-      Log.d(TAG, "Could not attempt cleanup, external storage not mounted.");
-    }
-    File heapDumpFile = getHeapDumpFile();
-    if (heapDumpFile.exists()) {
-      Log.d(TAG, "Previous analysis did not complete correctly, cleaning: " + heapDumpFile);
-      heapDumpFile.delete();
-    }
+    LeakCanaryInternals.executeOnFileIoThread(new Runnable() {
+      @Override public void run() {
+        if (isExternalStorageWritable()) {
+          Log.d(TAG, "Could not attempt cleanup, external storage not mounted.");
+        }
+        File heapDumpFile = getHeapDumpFile();
+        if (heapDumpFile.exists()) {
+          Log.d(TAG, "Previous analysis did not complete correctly, cleaning: " + heapDumpFile);
+          heapDumpFile.delete();
+        }
+      }
+    });
   }
 }

--- a/library/leakcanary-sample/src/main/java/com/example/leakcanary/ExampleApplication.java
+++ b/library/leakcanary-sample/src/main/java/com/example/leakcanary/ExampleApplication.java
@@ -16,21 +16,22 @@
 package com.example.leakcanary;
 
 import android.app.Application;
-import android.content.Context;
+import android.os.StrictMode;
 import com.squareup.leakcanary.LeakCanary;
-import com.squareup.leakcanary.RefWatcher;
 
 public class ExampleApplication extends Application {
 
-  public static RefWatcher getRefWatcher(Context context) {
-    ExampleApplication application = (ExampleApplication) context.getApplicationContext();
-    return application.refWatcher;
-  }
-
-  private RefWatcher refWatcher;
-
   @Override public void onCreate() {
     super.onCreate();
-    refWatcher = LeakCanary.install(this);
+    enabledStrictMode();
+    LeakCanary.install(this);
+  }
+
+  private void enabledStrictMode() {
+    StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder() //
+        .detectAll() //
+        .penaltyLog() //
+        .penaltyDeath() //
+        .build());
   }
 }


### PR DESCRIPTION
* Enable Strict Mode thread policy in the sample app.
* Fixed violation when cleaning up files on startup.
* Fixed violation when enabling components, the other side of the binder does IO operations.

Fixes #15