### PR TITLE
A bit of View code cleanup

### DIFF
--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakConnectorView.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakConnectorView.java
@@ -33,11 +33,11 @@ public final class DisplayLeakConnectorView extends View {
   private static final Paint clearPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
   static {
-    iconPaint.setColor(Ui.LIGHT_GREY);
-    rootPaint.setColor(Ui.ROOT_COLOR);
-    leakPaint.setColor(Ui.LEAK_COLOR);
+    iconPaint.setColor(LeakCanaryUi.LIGHT_GREY);
+    rootPaint.setColor(LeakCanaryUi.ROOT_COLOR);
+    leakPaint.setColor(LeakCanaryUi.LEAK_COLOR);
     clearPaint.setColor(Color.TRANSPARENT);
-    clearPaint.setXfermode(Ui.CLEAR_XFER_MODE);
+    clearPaint.setXfermode(LeakCanaryUi.CLEAR_XFER_MODE);
   }
 
   public enum Type {
@@ -71,7 +71,7 @@ public final class DisplayLeakConnectorView extends View {
       float halfHeight = height / 2f;
       float thirdWidth = width / 3f;
 
-      float strokeSize = Ui.dpToPixel(4f, getResources());
+      float strokeSize = LeakCanaryUi.dpToPixel(4f, getResources());
 
       iconPaint.setStrokeWidth(strokeSize);
       rootPaint.setStrokeWidth(strokeSize);

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryUi.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryUi.java
@@ -21,7 +21,7 @@ import android.util.DisplayMetrics;
 
 import static android.graphics.PorterDuff.Mode.CLEAR;
 
-final class Ui {
+final class LeakCanaryUi {
   static final int LIGHT_GREY = 0xFFbababa;
   static final int ROOT_COLOR = 0xFF84a6c5;
   static final int LEAK_COLOR = 0xFFb1554e;
@@ -46,7 +46,7 @@ final class Ui {
     return metrics.density * dp;
   }
 
-  private Ui() {
+  private LeakCanaryUi() {
     throw new AssertionError();
   }
 }

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/MoreDetailsView.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/MoreDetailsView.java
@@ -16,27 +16,24 @@
 package com.squareup.leakcanary.internal;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.view.View;
-
-import static com.squareup.leakcanary.internal.DisplayLeakConnectorView.ROOT_COLOR;
 
 public final class MoreDetailsView extends View {
 
-  private final Paint iconPaint;
+  private static final Paint iconPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+  static {
+    iconPaint.setColor(Ui.ROOT_COLOR);
+  }
+
+  private final float strokeSize;
 
   public MoreDetailsView(Context context, AttributeSet attrs) {
     super(context, attrs);
-
-    float strokeSize = dpToPixel(2, getResources());
-    iconPaint = new Paint();
-    iconPaint.setColor(ROOT_COLOR);
-    iconPaint.setStrokeWidth(strokeSize);
-    iconPaint.setAntiAlias(true);
+    strokeSize = Ui.dpToPixel(2f, getResources());
   }
 
   private boolean opened;
@@ -46,6 +43,8 @@ public final class MoreDetailsView extends View {
     int height = getHeight();
     int halfHeight = height / 2;
     int halfWidth = width / 2;
+
+    iconPaint.setStrokeWidth(strokeSize);
 
     if (opened) {
       canvas.drawLine(0, halfHeight, width, halfHeight, iconPaint);
@@ -60,11 +59,5 @@ public final class MoreDetailsView extends View {
       this.opened = opened;
       invalidate();
     }
-  }
-
-  static float dpToPixel(float dp, Resources resources) {
-    DisplayMetrics metrics = resources.getDisplayMetrics();
-    float px = dp * (metrics.densityDpi / 160f);
-    return px;
   }
 }

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/MoreDetailsView.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/MoreDetailsView.java
@@ -26,14 +26,14 @@ public final class MoreDetailsView extends View {
   private static final Paint iconPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
   static {
-    iconPaint.setColor(Ui.ROOT_COLOR);
+    iconPaint.setColor(LeakCanaryUi.ROOT_COLOR);
   }
-
-  private final float strokeSize;
 
   public MoreDetailsView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    strokeSize = Ui.dpToPixel(2f, getResources());
+
+    float strokeSize = LeakCanaryUi.dpToPixel(2f, getResources());
+    iconPaint.setStrokeWidth(strokeSize);
   }
 
   private boolean opened;
@@ -43,8 +43,6 @@ public final class MoreDetailsView extends View {
     int height = getHeight();
     int halfHeight = height / 2;
     int halfWidth = width / 2;
-
-    iconPaint.setStrokeWidth(strokeSize);
 
     if (opened) {
       canvas.drawLine(0, halfHeight, width, halfHeight, iconPaint);

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/Ui.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/Ui.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.leakcanary.internal;
+
+import android.content.res.Resources;
+import android.graphics.PorterDuffXfermode;
+import android.util.DisplayMetrics;
+
+import static android.graphics.PorterDuff.Mode.CLEAR;
+
+final class Ui {
+  static final int LIGHT_GREY = 0xFFbababa;
+  static final int ROOT_COLOR = 0xFF84a6c5;
+  static final int LEAK_COLOR = 0xFFb1554e;
+
+  static final PorterDuffXfermode CLEAR_XFER_MODE = new PorterDuffXfermode(CLEAR);
+
+  /**
+   * Converts from device independent pixels (dp or dip) to
+   * device dependent pixels. This method returns the input
+   * multiplied by the display's density. The result is not
+   * rounded nor clamped.
+   *
+   * The value returned by this method is well suited for
+   * drawing with the Canvas API but should not be used to
+   * set layout dimensions.
+   *
+   * @param dp The value in dp to convert to pixels
+   * @param resources An instances of Resources
+   */
+  static float dpToPixel(float dp, Resources resources) {
+    DisplayMetrics metrics = resources.getDisplayMetrics();
+    return metrics.density * dp;
+  }
+
+  private Ui() {
+    throw new AssertionError();
+  }
+}


### PR DESCRIPTION
- Introduces a Ui class to hold methods and values useful to several
views (colors, xfermodes, etc.)
- Make Paints static where possible, this saves on memory and
allocations, it may also help draw batching
- Set Paints’ antialiasing flag at instantiation time
- Use a switch on connector type instead of an if. It is safer and
since Type is an enum, we get the static imports for free