### PR TITLE
Don't save index file

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,6 +2,9 @@ subprojects {
 
   repositories {
     mavenCentral()
+//    maven {
+//      url 'https://oss.sonatype.org/content/repositories/snapshots/'
+//    }
   }
 
   buildscript {

--- a/library/leakcanary-analyzer/build.gradle
+++ b/library/leakcanary-analyzer/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.squareup.haha:haha:1.2'
+  compile 'com.squareup.haha:haha:1.3'
   compile project(':leakcanary-watcher')
   testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
Updating to HAHA 1.3 which doesn't save its index file any more. Will hopefully resolve #3 (although there might be other issues down the road).