### PR TITLE
INPUT_METHOD_MANAGER__SERVED_VIEW observed also on JELLY_BEAN

### DIFF
--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -133,7 +133,7 @@ public enum AndroidExcludedRefs {
     }
   },
 
-  INPUT_METHOD_MANAGER__SERVED_VIEW(SDK_INT >= KITKAT && SDK_INT <= LOLLIPOP_MR1) {
+  INPUT_METHOD_MANAGER__SERVED_VIEW(SDK_INT >= JELLY_BEAN && SDK_INT <= LOLLIPOP_MR1) {
     @Override void add(ExcludedRefs.Builder excluded) {
       // When we detach a view that receives keyboard input, the InputMethodManager leaks a
       // reference to it until a new view asks for keyboard input.


### PR DESCRIPTION
I've got a report of `INPUT_METHOD_MANAGER__SERVED_VIEW` also on a JELLY_BEAN HTC One device:

```
* GC ROOT static android.view.inputmethod.InputMethodManager.mInstance
* references android.view.inputmethod.InputMethodManager.mServedView
* references wtf.kong.widget.ChannelTextView.mContext
* references wtf.kong.MainActivity.mFragments
* references android.app.FragmentManagerImpl.mAdded
* references java.util.ArrayList.array
* references array java.lang.Object[].[2]
* leaks wtf.kong.fragments.FeedFragment instance

* Reference Key: 972e1673-4ea1-4183-ba3e-4a2211b21f90
* Device: HTC htc HTCONE m7wls
* Android Version: 4.1.2 API: 16
* Durations: watch=5015ms, gc=230ms, heap dump=757ms, analysis=33466ms
```