### PR TITLE
Detailed runtime info

### DIFF
--- a/library/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTrace.java
+++ b/library/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTrace.java
@@ -16,6 +16,7 @@
 package com.squareup.leakcanary;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.unmodifiableList;
@@ -29,7 +30,7 @@ public final class LeakTrace implements Serializable {
   public final List<LeakTraceElement> elements;
 
   LeakTrace(List<LeakTraceElement> elements) {
-    this.elements = unmodifiableList(elements);
+    this.elements = unmodifiableList(new ArrayList<>(elements));
   }
 
   @Override public String toString() {
@@ -47,5 +48,13 @@ public final class LeakTrace implements Serializable {
       sb.append(element).append("\n");
     }
     return sb.toString();
+  }
+
+  public String toDetailedString() {
+    String string = "";
+    for (LeakTraceElement element : elements) {
+      string += element.toDetailedString();
+    }
+    return string;
   }
 }

--- a/library/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTraceElement.java
+++ b/library/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTraceElement.java
@@ -16,10 +16,14 @@
 package com.squareup.leakcanary;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.squareup.leakcanary.LeakTraceElement.Holder.ARRAY;
+import static com.squareup.leakcanary.LeakTraceElement.Holder.CLASS;
 import static com.squareup.leakcanary.LeakTraceElement.Holder.THREAD;
 import static com.squareup.leakcanary.LeakTraceElement.Type.STATIC_FIELD;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Locale.US;
 
 /** Represents one reference in the chain of references that holds a leaking object in memory. */
@@ -44,12 +48,17 @@ public final class LeakTraceElement implements Serializable {
   /** Additional information, may be null. */
   public final String extra;
 
-  LeakTraceElement(String referenceName, Type type, Holder holder, String className, String extra) {
+  /** List of all fields (member and static) for that object. */
+  public final List<String> fields;
+
+  LeakTraceElement(String referenceName, Type type, Holder holder, String className, String extra,
+      List<String> fields) {
     this.referenceName = referenceName;
     this.type = type;
     this.holder = holder;
     this.className = className;
     this.extra = extra;
+    this.fields = unmodifiableList(new ArrayList<>(fields));
   }
 
   @Override public String toString() {
@@ -73,6 +82,22 @@ public final class LeakTraceElement implements Serializable {
 
     if (extra != null) {
       string += " " + extra;
+    }
+    return string;
+  }
+
+  public String toDetailedString() {
+    String string = "* ";
+    if (holder == ARRAY) {
+      string += "Array of";
+    } else if (holder == CLASS) {
+      string += "Class";
+    } else {
+      string += "Instance of";
+    }
+    string += " " + className + "\n";
+    for (String field : fields) {
+      string += "|   " + field + "\n";
     }
     return string;
   }

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
@@ -46,8 +46,15 @@ public class DisplayLeakService extends AbstractAnalysisResultService {
 
   @TargetApi(HONEYCOMB) @Override
   protected final void onHeapAnalyzed(HeapDump heapDump, AnalysisResult result) {
-    String leakInfo = leakInfo(this, heapDump, result);
-    Log.d("LeakCanary", leakInfo);
+    String leakInfo = leakInfo(this, heapDump, result, true);
+    if (leakInfo.length() < 4000) {
+      Log.d("LeakCanary", leakInfo);
+    } else {
+      String[] lines = leakInfo.split("\n");
+      for (String line : lines) {
+        Log.d("LeakCanary", line);
+      }
+    }
 
     if (!result.leakFound || result.excludedLeak) {
       afterDefaultHandling(heapDump, result, leakInfo);

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -73,7 +73,8 @@ public final class LeakCanary {
   }
 
   /** Returns a string representation of the result of a heap analysis. */
-  public static String leakInfo(Context context, HeapDump heapDump, AnalysisResult result) {
+  public static String leakInfo(Context context, HeapDump heapDump, AnalysisResult result,
+      boolean detailed) {
     PackageManager packageManager = context.getPackageManager();
     String packageName = context.getPackageName();
     PackageInfo packageInfo;
@@ -85,6 +86,7 @@ public final class LeakCanary {
     String versionName = packageInfo.versionName;
     int versionCode = packageInfo.versionCode;
     String info = "In " + packageName + ":" + versionName + ":" + versionCode + ".\n";
+    String detailedString = "";
     if (result.leakFound) {
       if (result.excludedLeak) {
         info += "* LEAK CAN BE IGNORED.\n";
@@ -94,6 +96,9 @@ public final class LeakCanary {
         info += " (" + heapDump.referenceName + ")";
       }
       info += " has leaked:\n" + result.leakTrace.toString() + "\n";
+      if (detailed) {
+        detailedString = "\n* Details:\n" + result.leakTrace.toDetailedString();
+      }
     } else if (result.failure != null) {
       info += "* FAILURE:\n" + Log.getStackTraceString(result.failure) + "\n";
     } else {
@@ -127,7 +132,8 @@ public final class LeakCanary {
         + "ms, analysis="
         + result.analysisDurationMs
         + "ms"
-        + "\n";
+        + "\n"
+        + detailedString;
 
     return info;
   }

--- a/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/library/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -166,7 +166,7 @@ public final class DisplayLeakActivity extends Activity {
 
   private void shareLeak() {
     Leak visibleLeak = getVisibleLeak();
-    String leakInfo = leakInfo(this, visibleLeak.heapDump, visibleLeak.result);
+    String leakInfo = leakInfo(this, visibleLeak.heapDump, visibleLeak.result, true);
     Intent intent = new Intent(Intent.ACTION_SEND);
     intent.setType("text/plain");
     intent.putExtra(Intent.EXTRA_TEXT, leakInfo);


### PR DESCRIPTION
* API Change: `LeakCanary.leakInfo()` takes a new `detailed` boolean param.
* Added description for each field of each element in `LeakTraceElement`
* Rename parent / child to held / holder to clarify the relationships in `HeapAnalyser`

Fixes #13

Sample logs:

```
* Details:
* Class com.example.leakcanary.MainActivity
|   static $staticOverhead = byte[] [id=0x12ca1001;length=8;size=24]
|   static lala = android.app.Activity[] [id=0x12cc3160;length=6]
* Array of android.app.Activity[]
|   [0] = null
|   [1] = null
|   [2] = com.example.leakcanary.MainActivity [id=0x12c293b0]
|   [3] = null
|   [4] = null
|   [5] = null
* Instance of com.example.leakcanary.MainActivity
|   static $staticOverhead = byte[] [id=0x12ca1001;length=8;size=24]
|   static lala = android.app.Activity[] [id=0x12cc3160;length=6]
|   mActionBar = com.android.internal.app.WindowDecorActionBar [id=0x12c4efa0]
|   mActivityInfo = android.content.pm.ActivityInfo [id=0x12c62080]
```