### PR TITLE
Add excluded refs to leak info

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -104,6 +104,10 @@ public final class LeakCanary {
     } else {
       info += "* NO LEAK FOUND.\n\n";
     }
+    if (detailed) {
+      detailedString += "* Excluded Refs:\n" + heapDump.excludedRefs;
+    }
+
     info += "* Reference Key: "
         + heapDump.referenceKey
         + "\n"

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
@@ -47,6 +47,26 @@ public final class ExcludedRefs implements Serializable {
     this.excludedThreads = unmodifiableSet(new LinkedHashSet<>(excludedThreads));
   }
 
+  @Override public String toString() {
+    String string = "";
+    for (Map.Entry<String, Set<String>> classes : excludeFieldMap.entrySet()) {
+      String clazz = classes.getKey();
+      for (String field : classes.getValue()) {
+        string += "| Field: " + clazz + "." + field + "\n";
+      }
+    }
+    for (Map.Entry<String, Set<String>> classes : excludeStaticFieldMap.entrySet()) {
+      String clazz = classes.getKey();
+      for (String field : classes.getValue()) {
+        string += "| Static field: " + clazz + "." + field + "\n";
+      }
+    }
+    for (String thread : excludedThreads) {
+      string += "| Thread:" + thread;
+    }
+    return string;
+  }
+
   public static final class Builder {
     private final Map<String, Set<String>> excludeFieldMap = new LinkedHashMap<>();
     private final Map<String, Set<String>> excludeStaticFieldMap = new LinkedHashMap<>();


### PR DESCRIPTION
Fixes #119

Result:

```
* Excluded Refs:
| Field: android.view.inputmethod.InputMethodManager.mNextServedView
| Field: android.view.inputmethod.InputMethodManager.mServedView
| Field: android.view.inputmethod.InputMethodManager.mServedInputConnection
| Field: android.view.inputmethod.InputMethodManager.mCurRootView
| Field: android.animation.LayoutTransition$1.val$parent
| Field: android.view.textservice.SpellCheckerSession$1.this$0
| Field: android.accounts.AccountManager$AmsTask$Response.this$1
| Field: android.media.MediaScannerConnection.mContext
| Field: android.os.UserManager.mContext
| Field: android.view.Choreographer.FrameDisplayEventReceiver.mMessageQueue
| Static field: android.support.v7.internal.widget.ActivityChooserModel.mActivityChoserModelPolicy
| Static field: android.widget.ActivityChooserModel.mActivityChoserModelPolicy
| Thread:FinalizerWatchdogDaemon| Thread:main| Thread:LeakCanary-Heap-Dump
```