### PR TITLE
Remove redundant android plugin defination from leakcanary-sample.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ subprojects {
 }
 
 ext {
-  androidPlugin = 'com.android.tools.build:gradle:1.2.0'
   minSdkVersion = 8
   compileSdkVersion = 21
   targetSdkVersion = compileSdkVersion

--- a/leakcanary-sample/build.gradle
+++ b/leakcanary-sample/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-  dependencies {
-    classpath rootProject.ext.androidPlugin
-  }
-}
-
 apply plugin: 'com.android.application'
 
 dependencies {


### PR DESCRIPTION
We don't need to set androidPlugin version explicitly in leakcanary-sample/build.gradle, because it is already set by root build.gradle.