### PR TITLE
Add ability to ignore specific classes

### DIFF
--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
@@ -38,13 +38,15 @@ public final class ExcludedRefs implements Serializable {
   public final Map<String, Set<String>> excludeFieldMap;
   public final Map<String, Set<String>> excludeStaticFieldMap;
   public final Set<String> excludedThreads;
+  public final Set<String> excludedClasses;
 
   private ExcludedRefs(Map<String, Set<String>> excludeFieldMap,
-      Map<String, Set<String>> excludeStaticFieldMap, Set<String> excludedThreads) {
+      Map<String, Set<String>> excludeStaticFieldMap, Set<String> excludedThreads, Set<String> excludedClasses) {
     // Copy + unmodifiable.
     this.excludeFieldMap = unmodifiableMap(new LinkedHashMap<>(excludeFieldMap));
     this.excludeStaticFieldMap = unmodifiableMap(new LinkedHashMap<>(excludeStaticFieldMap));
     this.excludedThreads = unmodifiableSet(new LinkedHashSet<>(excludedThreads));
+    this.excludedClasses = unmodifiableSet(new LinkedHashSet<>(excludedClasses));
   }
 
   @Override public String toString() {
@@ -64,6 +66,9 @@ public final class ExcludedRefs implements Serializable {
     for (String thread : excludedThreads) {
       string += "| Thread:" + thread;
     }
+    for (String className : excludedClasses) {
+      string += "| Classes:" + className;
+    }
     return string;
   }
 
@@ -71,6 +76,7 @@ public final class ExcludedRefs implements Serializable {
     private final Map<String, Set<String>> excludeFieldMap = new LinkedHashMap<>();
     private final Map<String, Set<String>> excludeStaticFieldMap = new LinkedHashMap<>();
     private final Set<String> excludedThreads = new LinkedHashSet<>();
+    private final Set<String> excludedClasses = new LinkedHashSet<>();
 
     public Builder instanceField(String className, String fieldName) {
       checkNotNull(className, "className");
@@ -102,8 +108,14 @@ public final class ExcludedRefs implements Serializable {
       return this;
     }
 
+    public Builder ignoreClass(String className) {
+      checkNotNull(className, "className");
+      excludedClasses.add(className);
+      return this;
+    }
+
     public ExcludedRefs build() {
-      return new ExcludedRefs(excludeFieldMap, excludeStaticFieldMap, excludedThreads);
+      return new ExcludedRefs(excludeFieldMap, excludeStaticFieldMap, excludedThreads, excludedClasses);
     }
   }
 }

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/RefWatcher.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/RefWatcher.java
@@ -92,6 +92,10 @@ public final class RefWatcher {
     if (debuggerControl.isDebuggerAttached()) {
       return;
     }
+    if (excludedRefs.excludedClasses.contains(watchedReference.getClass().getName())) {
+      // Don't watch specifically excluded classes
+      return;
+    }
     final long watchStartNanoTime = System.nanoTime();
     String key = UUID.randomUUID().toString();
     retainedKeys.add(key);


### PR DESCRIPTION
I needed this for my personal project, as thanks to some third party libraries, I have to use a LeakableActivity class that is only ever instantiated once, to avoid leaking any actual activities. Unfortunately, if I add exclusions for the specific fields in those libraries, eventually Leak Canary ends up finding GC roots in core framework places which I do not wish to ignore for other activities, but am happy to dismiss for this particular empty singleton.

This PR just adds the ability to specify a complete class name to exclude from the activity lifecycle callbacks, for example:

    ExcludedRefs excludedRefs = AndroidExcludedRefs.createAppDefaults()
        .ignoreClass("com.lennox.utils.activities.LeakableActivity")
        .build();