### PR TITLE
Store heap dumps in internal cache and expose them using a ContentProvider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ android:
   components:
     - build-tools-21.1.2
     - android-21
+    - extra-android-m2repository
+    - extra-android-support
   licenses:
     - android-sdk-license-5be876d5
 

--- a/leakcanary-android/build.gradle
+++ b/leakcanary-android/build.gradle
@@ -15,6 +15,7 @@ repositories {
 
 dependencies {
   compile project(':leakcanary-analyzer')
+  compile "com.android.support:support-v4:22.1.1"
 }
 
 def gitSha() {

--- a/leakcanary-android/src/main/AndroidManifest.xml
+++ b/leakcanary-android/src/main/AndroidManifest.xml
@@ -46,5 +46,14 @@
       </intent-filter>
     </activity>
 
+  <provider
+      android:name="android.support.v4.content.FileProvider"
+      android:authorities="@string/__leak_canary_file_provider_authority"
+      android:exported="false"
+      android:grantUriPermissions="true">
+      <meta-data
+          android:name="android.support.FILE_PROVIDER_PATHS"
+          android:resource="@xml/file_paths" />
+  </provider>
   </application>
 </manifest>

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -29,7 +29,6 @@ import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.io.File;
 import java.io.IOException;
 
-import static com.squareup.leakcanary.internal.LeakCanaryInternals.isExternalStorageWritable;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.storageDirectory;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -46,9 +45,6 @@ public final class AndroidHeapDumper implements HeapDumper {
   }
 
   @Override public File dumpHeap() {
-    if (!isExternalStorageWritable()) {
-      Log.d(TAG, "Could not dump heap, external storage not mounted.");
-    }
     File heapDumpFile = getHeapDumpFile();
     if (heapDumpFile.exists()) {
       Log.d(TAG, "Could not dump heap, previous analysis still is in progress.");
@@ -84,9 +80,6 @@ public final class AndroidHeapDumper implements HeapDumper {
   public void cleanup() {
     LeakCanaryInternals.executeOnFileIoThread(new Runnable() {
       @Override public void run() {
-        if (isExternalStorageWritable()) {
-          Log.d(TAG, "Could not attempt cleanup, external storage not mounted.");
-        }
         File heapDumpFile = getHeapDumpFile();
         if (heapDumpFile.exists()) {
           Log.d(TAG, "Previous analysis did not complete correctly, cleaning: " + heapDumpFile);
@@ -97,7 +90,7 @@ public final class AndroidHeapDumper implements HeapDumper {
   }
 
   private File getHeapDumpFile() {
-    return new File(storageDirectory(), "suspected_leak_heapdump.hprof");
+    return new File(storageDirectory(context), "suspected_leak_heapdump.hprof");
   }
 
   private void showToast(final FutureResult<Toast> waitingForToast) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
@@ -62,7 +62,7 @@ public class DisplayLeakService extends AbstractAnalysisResultService {
     }
 
     int maxStoredLeaks = getResources().getInteger(R.integer.__leak_canary_max_stored_leaks);
-    File renamedFile = findNextAvailableHprofFile(maxStoredLeaks);
+    File renamedFile = findNextAvailableHprofFile(this, maxStoredLeaks);
 
     if (renamedFile == null) {
       // No file available.

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -22,8 +22,8 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
-import android.os.Environment;
 import android.util.Log;
+
 import java.io.File;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -32,7 +32,6 @@ import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
 import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
 import static android.content.pm.PackageManager.DONT_KILL_APP;
 import static android.content.pm.PackageManager.GET_SERVICES;
-import static android.os.Environment.DIRECTORY_DOWNLOADS;
 
 public final class LeakCanaryInternals {
 
@@ -49,15 +48,15 @@ public final class LeakCanaryInternals {
     fileIoExecutor.execute(runnable);
   }
 
-  public static File storageDirectory() {
-    File downloadsDirectory = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS);
-    File leakCanaryDirectory = new File(downloadsDirectory, "leakcanary");
+  public static File storageDirectory(Context context) {
+    File cacheDir = context.getCacheDir();
+    File leakCanaryDirectory = new File(cacheDir, "leakcanary");
     leakCanaryDirectory.mkdirs();
     return leakCanaryDirectory;
   }
 
-  public static File detectedLeakDirectory() {
-    File directory = new File(storageDirectory(), "detected_leaks");
+  public static File detectedLeakDirectory(Context context) {
+    File directory = new File(storageDirectory(context), "detected_leaks");
     directory.mkdirs();
     return directory;
   }
@@ -66,13 +65,8 @@ public final class LeakCanaryInternals {
     return new File(heapdumpFile.getParentFile(), heapdumpFile.getName() + ".result");
   }
 
-  public static boolean isExternalStorageWritable() {
-    String state = Environment.getExternalStorageState();
-    return Environment.MEDIA_MOUNTED.equals(state);
-  }
-
-  public static File findNextAvailableHprofFile(int maxFiles) {
-    File directory = detectedLeakDirectory();
+  public static File findNextAvailableHprofFile(Context context, int maxFiles) {
+    File directory = detectedLeakDirectory(context);
     for (int i = 0; i < maxFiles; i++) {
       String heapDumpName = "heap_dump_" + i + ".hprof";
       File file = new File(directory, heapDumpName);

--- a/leakcanary-android/src/main/res/values/__leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values/__leak_canary_strings.xml
@@ -28,5 +28,5 @@
   <string name="__leak_canary_delete">Delete</string>
   <string name="__leak_canary_failure_report">"Please report this failure to http://github.com/square/leakcanary\n"</string>
   <string name="__leak_canary_delete_all">Delete all</string>
-
+  <string name="__leak_canary_file_provider_authority">com.squareup.leakcanary.fileprovider</string>
 </resources>

--- a/leakcanary-android/src/main/res/xml/file_paths.xml
+++ b/leakcanary-android/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="leakcanary" path="leakcanary/" />
+</paths>


### PR DESCRIPTION
This should fix #154 without regressing #21. Heap dumps are stored in the internal cache directory and exposed when you choose to share them using a content provider and temporary permissions.

 