### PR TITLE
Add missing no-op static methods

### DIFF
--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AbstractAnalysisResultService.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AbstractAnalysisResultService.java
@@ -1,0 +1,23 @@
+package com.squareup.leakcanary;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Dummy class for no-op version.
+ */
+public abstract class AbstractAnalysisResultService extends IntentService {
+  public static void sendResultToListener(Context context, String listenerServiceClassName,
+      HeapDump heapDump, AnalysisResult result) {
+  }
+
+  public AbstractAnalysisResultService() {
+    super(AbstractAnalysisResultService.class.getName());
+  }
+
+  @Override protected final void onHandleIntent(Intent intent) {
+  }
+
+  protected abstract void onHeapAnalyzed(HeapDump heapDump, AnalysisResult result);
+}

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AnalysisResult.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AnalysisResult.java
@@ -1,0 +1,9 @@
+package com.squareup.leakcanary;
+
+import java.io.Serializable;
+
+/**
+ * Dummy class for no-op version.
+ */
+public final class AnalysisResult implements Serializable {
+}

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
@@ -1,0 +1,9 @@
+package com.squareup.leakcanary;
+
+import java.io.Serializable;
+
+/**
+ * Dummy class for no-op version.
+ */
+public class ExcludedRefs implements Serializable {
+}

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/HeapDump.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/HeapDump.java
@@ -1,0 +1,12 @@
+package com.squareup.leakcanary;
+
+import java.io.Serializable;
+
+/**
+ * Dummy class for no-op version.
+ */
+public class HeapDump implements Serializable {
+  public interface Listener {
+    void analyze(HeapDump heapDump);
+  }
+}

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -1,6 +1,7 @@
 package com.squareup.leakcanary;
 
 import android.app.Application;
+import android.content.Context;
 
 /**
  * A no-op version of {@link LeakCanary} that can be used in release builds.
@@ -9,6 +10,29 @@ public final class LeakCanary {
 
   public static RefWatcher install(Application application) {
     return RefWatcher.DISABLED;
+  }
+
+  public static RefWatcher install(Application application,
+      Class<? extends AbstractAnalysisResultService> listenerServiceClass,
+      ExcludedRefs excludedRefs) {
+    return RefWatcher.DISABLED;
+  }
+
+  public static RefWatcher androidWatcher(Context context, HeapDump.Listener heapDumpListener,
+      ExcludedRefs excludedRefs) {
+    return RefWatcher.DISABLED;
+  }
+
+  public static void enableDisplayLeakActivity(Context context) {
+  }
+
+  public static String leakInfo(Context context, HeapDump heapDump, AnalysisResult result,
+      boolean detailed) {
+    return "";
+  }
+
+  public static boolean isInAnalyzerProcess(Context context) {
+    return false;
   }
 
   private LeakCanary() {


### PR DESCRIPTION
Since clients can access all static methods of debug version LeakCanary, release build will fail when client uses missing methods in no-op LeakCanary.

I have added those missing methods in no-op LeakCanary so that no-op LeakCanary APIs should be consistent with normal LeakCanary APIs.