### PR TITLE
Exclude AudioManager instance field that leaks an Activity context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Switched to [HAHA 2.0.2](https://github.com/square/haha/blob/master/CHANGELOG.md#version-202-2015-07-20) with uses Perflib instead of MAT under the hood [#219](https://github.com/square/leakcanary/pull/219). This should fix most crashes and improve speed a lot. We can now parse Android M heap dumps, although there are still memory issues (see [#223](https://github.com/square/leakcanary/issues/223)).
 * A status bar notification is displayed when the trace analysis results in an excluded ref leak [#216](https://github.com/square/leakcanary/pull/216).
 * Added ProGuard configuration for debug library [#132](https://github.com/square/leakcanary/issues/132).
-* 2 new ignored Android SDK leaks: [#26](https://github.com/square/leakcanary/issues/26) [#62](https://github.com/square/leakcanary/issues/62). 1 Android SDK leak updated: [#133](https://github.com/square/leakcanary/issues/133).
+* 3 new ignored Android SDK leaks: [#26](https://github.com/square/leakcanary/issues/26) [#62](https://github.com/square/leakcanary/issues/62) [#205](https://github.com/square/leakcanary/issues/205). 1 Android SDK leak updated: [#133](https://github.com/square/leakcanary/issues/133).
 * Fixed crash for anonymous classes that extend Object: [#195](https://github.com/square/leakcanary/issues/195).
 * Added excluded leaks to text report [#119](https://github.com/square/leakcanary/issues/119).
 * Added LeakCanary SHA to text report [#120](https://github.com/square/leakcanary/issues/120).

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -350,6 +350,20 @@ public enum AndroidExcludedRefs {
     }
   },
 
+  AUDIO_MANAGER(SDK_INT <= LOLLIPOP_MR1) {
+    @Override void add(ExcludedRefs.Builder excluded) {
+      // Prior to Android M, VideoView required audio focus from AudioManager and
+      // never abandoned it, which leaks the Activity context through the AudioManager.
+      // The root of the problem is that AudioManager uses whichever
+      // context it receives, which in the case of the VideoView example is an Activity,
+      // even though it only needs the application's context. The issue is fixed in
+      // Android M, and the AudioManager now uses the application's context.
+      // Tracked here: https://code.google.com/p/android/issues/detail?id=152173
+      // Fix: https://gist.github.com/jankovd/891d96f476f7a9ce24e2
+      excluded.instanceField("android.media.AudioManager$1", "this$0");
+    }
+  },
+
   FINALIZER_WATCHDOG_DAEMON {
     @Override void add(ExcludedRefs.Builder excluded) {
       // If the FinalizerWatchdogDaemon thread is on the shortest path, then there was no other


### PR DESCRIPTION
Please take a look at the description of the newly excluded ref and whether it's informative enough.

Relevang leak trace information:
```
In app.package.debug:1.0-SNAPSHOT:1.
* app.package.VideoPlayerActivity has leaked:
* GC ROOT android.media.AudioManager$1.this$0 (anonymous class extends android.media.IAudioFocusDispatcher$Stub)
* references android.media.AudioManager.mContext
* references android.app.ContextImpl.mOuterContext
* leaks app.package.VideoPlayerActivity instance

* Reference Key: 035d9c60-b6f2-4cfe-ad2f-5c210203be6f
* Device: LGE google Nexus 5 hammerhead
* Android Version: 5.1.1 API: 22 LeakCanary: 1.3.1
* Durations: watch=5013ms, gc=148ms, heap dump=4765ms, analysis=21565ms

* Details:
* Instance of android.media.AudioManager$1
|   this$0 = android.media.AudioManager [id=0x12e0e600]
|   mDescriptor = java.lang.String [id=0x70044458]
|   mObject = -1603813928
|   mOwner = android.media.AudioManager$1 [id=0x12ecbc20]
```

Closes #205