### PR TITLE
Show notification when trace analysis results in an excluded ref leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 1.3.2-SNAPSHOT
 
+* A statusbar notification is displayed when the trace analysis results in an excluded ref leak.
 * Added ProGuard configuration for debug library [132](https://github.com/square/leakcanary/issues/132).
 * 2 new ignored Android SDK leaks: [#26](https://github.com/square/leakcanary/issues/26) [#62](https://github.com/square/leakcanary/issues/62).
 * Added excluded leaks to text report [#119](https://github.com/square/leakcanary/issues/119).

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -68,6 +68,10 @@ public final class DisplayLeakActivity extends Activity {
   private static final String TAG = "DisplayLeakActivity";
   private static final String SHOW_LEAK_EXTRA = "show_latest";
 
+  public static PendingIntent createPendingIntent(Context context) {
+    return createPendingIntent(context, null);
+  }
+
   public static PendingIntent createPendingIntent(Context context, String referenceKey) {
     Intent intent = new Intent(context, DisplayLeakActivity.class);
     intent.putExtra(SHOW_LEAK_EXTRA, referenceKey);

--- a/leakcanary-android/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_strings.xml
@@ -17,8 +17,10 @@
 <resources>
 
   <string name="leak_canary_class_has_leaked">%s has leaked</string>
+  <string name="leak_canary_class_leak_ignored">Ignored %s leak</string>
   <string name="leak_canary_analysis_failed">Leak analysis failed</string>
   <string name="leak_canary_leak_list_title">Leaks in %s</string>
+  <string name="leak_canary_notification_leak_ignored_message">Click to see previous leaks</string>
   <string name="leak_canary_notification_message">Click for more details</string>
   <string name="leak_canary_share_leak">Share info</string>
   <string name="leak_canary_share_heap_dump">Share heap dump</string>


### PR DESCRIPTION
Pretty useful feature, at least for me, since every time an ignored leak is found there is nothing shown on the device after the toast notifying about app freeze. This leaves the developer puzzling whether the leak analysis is still running or whether the analysis found a leak that is being ignored, resulting in the developer being forced to open the logcat and scroll through the messages to see what has happened.