### PR TITLE
Detect Samsung mLastHoveredView leak on Lollipop.

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -289,7 +289,8 @@ public enum AndroidExcludedRefs {
     }
   },
 
-  TEXT_VIEW__MLAST_HOVERED_VIEW(SAMSUNG.equals(MANUFACTURER) && SDK_INT == KITKAT) {
+  TEXT_VIEW__MLAST_HOVERED_VIEW(
+      SAMSUNG.equals(MANUFACTURER) && (SDK_INT >= KITKAT && SDK_INT <= LOLLIPOP)) {
     @Override void add(ExcludedRefs.Builder excluded) {
       // mLastHoveredView is a static field in TextView that leaks the last hovered view.
       excluded.staticField("android.widget.TextView", "mLastHoveredView");


### PR DESCRIPTION
Samsung have an addition to TextView (mLastHoveredView) that leaks a
context on KitKat. We've detected the same leak on Lollipop (5.0.1) for
Samsung devices.

Fixes issue #220.