### PR TITLE
Store heap dumps in package specific directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added excluded leaks to text report [#119](https://github.com/square/leakcanary/issues/119).
 * Added LeakCanary SHA to text report [#120](https://github.com/square/leakcanary/issues/120).
 * Renamed all resources to begin with `leak_canary_` instead of `__leak_canary`[#161](https://github.com/square/leakcanary/pull/161)
+* Store heap dumps in package specific directories [#235](https://github.com/square/leakcanary/pull/235)
 
 ### Public API changes
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
@@ -69,7 +69,7 @@ public class DisplayLeakService extends AbstractAnalysisResultService {
     }
 
     int maxStoredLeaks = getResources().getInteger(R.integer.leak_canary_max_stored_leaks);
-    File renamedFile = findNextAvailableHprofFile(maxStoredLeaks);
+    File renamedFile = findNextAvailableHprofFile(this, maxStoredLeaks);
 
     if (renamedFile == null) {
       // No file available.

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -277,7 +277,7 @@ public final class DisplayLeakActivity extends Activity {
         actionButton.setText(R.string.leak_canary_delete_all);
         actionButton.setOnClickListener(new View.OnClickListener() {
           @Override public void onClick(View v) {
-            File[] files = detectedLeakDirectory().listFiles();
+            File[] files = detectedLeakDirectory(DisplayLeakActivity.this).listFiles();
             if (files != null) {
               for (File file : files) {
                 file.delete();
@@ -382,18 +382,19 @@ public final class DisplayLeakActivity extends Activity {
     }
 
     private DisplayLeakActivity activityOrNull;
-    private final File leakDirectory;
     private final Handler mainHandler;
 
     LoadLeaks(DisplayLeakActivity activity) {
       this.activityOrNull = activity;
-      leakDirectory = detectedLeakDirectory();
       mainHandler = new Handler(Looper.getMainLooper());
     }
 
     @Override public void run() {
+      if (activityOrNull == null) {
+        return;
+      }
       final List<Leak> leaks = new ArrayList<>();
-      File[] files = leakDirectory.listFiles(new FilenameFilter() {
+      File[] files = detectedLeakDirectory(activityOrNull).listFiles(new FilenameFilter() {
         @Override public boolean accept(File dir, String filename) {
           return filename.endsWith(".hprof");
         }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -56,8 +56,8 @@ public final class LeakCanaryInternals {
     return leakCanaryDirectory;
   }
 
-  public static File detectedLeakDirectory() {
-    File directory = new File(storageDirectory(), "detected_leaks");
+  public static File detectedLeakDirectory(Context context) {
+    File directory = new File(storageDirectory(), "detected_leaks/" + context.getPackageName());
     directory.mkdirs();
     return directory;
   }
@@ -71,8 +71,8 @@ public final class LeakCanaryInternals {
     return Environment.MEDIA_MOUNTED.equals(state);
   }
 
-  public static File findNextAvailableHprofFile(int maxFiles) {
-    File directory = detectedLeakDirectory();
+  public static File findNextAvailableHprofFile(Context context, int maxFiles) {
+    File directory = detectedLeakDirectory(context);
     for (int i = 0; i < maxFiles; i++) {
       String heapDumpName = "heap_dump_" + i + ".hprof";
       File file = new File(directory, heapDumpName);


### PR DESCRIPTION
Fixes #154

I am aware that #158 is another way of doing this. Personally, I don't think storing leaks on the external storage is a security risk, as developers should be smart enough to not ship a release with leak canary activated, and on many devices external storage will have more capacity available.

Also, #158 adds an extra burden of forcing the support library dependency, which I feel is best to avoid if possible. But the leak reports certainly need to be separated by package, I have 13 apps running leak canary and it makes it very difficult to track exactly where the leaks are coming from specifically when it occurs in a library class.