### PR TITLE
Remove old references to "__" prefixed resources initiated by #159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Snapshots are available in Sonatype's `snapshots` repository:
 * Added LeakCanary version name to `LeakCanary.leakInfo()`: [#49](https://github.com/square/leakcanary/issues/49).
 * `leakcanary-android-no-op` is lighter, it does not depend on `leakcanary-watcher` anymore, only 2 classes now: [#74](https://github.com/square/leakcanary/issues/74).
 * Adding field state details to the text leak trace.
-* A Toast is displayed while the heap dump is in progress to warn that the UI will freeze: [#20](https://github.com/square/leakcanary/issues/49). You can customize the toast by providing your own layout named `__leak_canary_heap_dump_toast.xml` (e.g. you could make it an empty layout).
+* A Toast is displayed while the heap dump is in progress to warn that the UI will freeze: [#20](https://github.com/square/leakcanary/issues/49). You can customize the toast by providing your own layout named `leak_canary_heap_dump_toast.xml` (e.g. you could make it an empty layout).
 * If the analysis fails, the result and heap dump are kept so that it can be reported to LeakCanary: [#102](https://github.com/square/leakcanary/issues/102).
 * Update to HAHA 1.3 to fix a 2 crashes [#3](https://github.com/square/leakcanary/issues/3) [46](https://github.com/square/leakcanary/issues/46)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Snapshots are available in Sonatype's `snapshots` repository:
 * Added LeakCanary version name to `LeakCanary.leakInfo()`: [#49](https://github.com/square/leakcanary/issues/49).
 * `leakcanary-android-no-op` is lighter, it does not depend on `leakcanary-watcher` anymore, only 2 classes now: [#74](https://github.com/square/leakcanary/issues/74).
 * Adding field state details to the text leak trace.
-* A Toast is displayed while the heap dump is in progress to warn that the UI will freeze: [#20](https://github.com/square/leakcanary/issues/49). You can customize the toast by providing your own layout named `leak_canary_heap_dump_toast.xml` (e.g. you could make it an empty layout).
+* A Toast is displayed while the heap dump is in progress to warn that the UI will freeze: [#20](https://github.com/square/leakcanary/issues/49). You can customize the toast by providing your own layout named `__leak_canary_heap_dump_toast.xml` (e.g. you could make it an empty layout).
 * If the analysis fails, the result and heap dump are kept so that it can be reported to LeakCanary: [#102](https://github.com/square/leakcanary/issues/102).
 * Update to HAHA 1.3 to fix a 2 crashes [#3](https://github.com/square/leakcanary/issues/3) [46](https://github.com/square/leakcanary/issues/46)
 

--- a/README.md
+++ b/README.md
@@ -181,37 +181,37 @@ That way, your release code will contain no reference to LeakCanary other than t
 
 ### Icon and label
 
-`DisplayLeakActivity` comes with a default icon and label, which you can change by providing `R.drawable.__leak_canary_icon` and `R.string.__leak_canary_display_activity_label` in your app:
+`DisplayLeakActivity` comes with a default icon and label, which you can change by providing `R.drawable.leak_canary_icon` and `R.string.leak_canary_display_activity_label` in your app:
 
 ```
 res/
   drawable-hdpi/
-    __leak_canary_icon.png
+    leak_canary_icon.png
   drawable-mdpi/
-    __leak_canary_icon.png
+    leak_canary_icon.png
   drawable-xhdpi/
-    __leak_canary_icon.png
+    leak_canary_icon.png
   drawable-xxhdpi/
-    __leak_canary_icon.png
+    leak_canary_icon.png
   drawable-xxxhdpi/
-    __leak_canary_icon.png
+    leak_canary_icon.png
 ```
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="__leak_canary_display_activity_label">MyLeaks</string>
+  <string name="leak_canary_display_activity_label">MyLeaks</string>
 </resources>
 ```
 
 ### Stored leak traces
 
-`DisplayLeakActivity` saves up to 7 heap dumps & leak traces in the app directory. You can change that number by providing `R.integer.__leak_canary_max_stored_leaks` in your app:
+`DisplayLeakActivity` saves up to 7 heap dumps & leak traces in the app directory. You can change that number by providing `R.integer.leak_canary_max_stored_leaks` in your app:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <integer name="__leak_canary_max_stored_leaks">20</integer>
+  <integer name="leak_canary_max_stored_leaks">20</integer>
 </resources>
 ```
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -105,9 +105,9 @@ public final class DisplayLeakActivity extends Activity {
 
     setContentView(R.layout.leak_canary_display_leak);
 
-    listView = (ListView) findViewById(R.id.__leak_canary_display_leak_list);
-    failureView = (TextView) findViewById(R.id.__leak_canary_display_leak_failure);
-    actionButton = (Button) findViewById(R.id.__leak_canary_action);
+    listView = (ListView) findViewById(R.id.leak_canary_display_leak_list);
+    failureView = (TextView) findViewById(R.id.leak_canary_display_leak_failure);
+    actionButton = (Button) findViewById(R.id.leak_canary_action);
 
     maxStoredLeaks = getResources().getInteger(R.integer.leak_canary_max_stored_leaks);
 
@@ -323,8 +323,8 @@ public final class DisplayLeakActivity extends Activity {
         convertView = LayoutInflater.from(DisplayLeakActivity.this)
             .inflate(R.layout.leak_canary_leak_row, parent, false);
       }
-      TextView titleView = (TextView) convertView.findViewById(R.id.__leak_canary_row_text);
-      TextView timeView = (TextView) convertView.findViewById(R.id.__leak_canary_row_time);
+      TextView titleView = (TextView) convertView.findViewById(R.id.leak_canary_row_text);
+      TextView timeView = (TextView) convertView.findViewById(R.id.leak_canary_row_time);
       Leak leak = getItem(position);
 
       String index;

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakAdapter.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakAdapter.java
@@ -51,14 +51,14 @@ final class DisplayLeakAdapter extends BaseAdapter {
         convertView =
             LayoutInflater.from(context).inflate(R.layout.leak_canary_ref_top_row, parent, false);
       }
-      TextView textView = findById(convertView, R.id.__leak_canary_row_text);
+      TextView textView = findById(convertView, R.id.leak_canary_row_text);
       textView.setText(context.getPackageName());
     } else {
       if (convertView == null) {
         convertView =
             LayoutInflater.from(context).inflate(R.layout.leak_canary_ref_row, parent, false);
       }
-      TextView textView = findById(convertView, R.id.__leak_canary_row_text);
+      TextView textView = findById(convertView, R.id.leak_canary_row_text);
 
       boolean isRoot = position == 1;
       boolean isLeakingInstance = position == getCount() - 1;
@@ -69,7 +69,7 @@ final class DisplayLeakAdapter extends BaseAdapter {
       }
       textView.setText(Html.fromHtml(htmlString));
 
-      DisplayLeakConnectorView connector = findById(convertView, R.id.__leak_canary_row_connector);
+      DisplayLeakConnectorView connector = findById(convertView, R.id.leak_canary_row_connector);
       if (isRoot) {
         connector.setType(DisplayLeakConnectorView.Type.START);
       } else {
@@ -79,7 +79,7 @@ final class DisplayLeakAdapter extends BaseAdapter {
           connector.setType(DisplayLeakConnectorView.Type.NODE);
         }
       }
-      MoreDetailsView moreDetailsView = findById(convertView, R.id.__leak_canary_row_more);
+      MoreDetailsView moreDetailsView = findById(convertView, R.id.leak_canary_row_more);
       moreDetailsView.setOpened(opened[position]);
     }
 

--- a/leakcanary-android/src/main/res/layout/leak_canary_display_leak.xml
+++ b/leakcanary-android/src/main/res/layout/leak_canary_display_leak.xml
@@ -21,7 +21,7 @@
     android:background="#3c3c3c"
     >
   <ListView
-      android:id="@+id/__leak_canary_display_leak_list"
+      android:id="@+id/leak_canary_display_leak_list"
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:layout_weight="1"
@@ -29,7 +29,7 @@
       android:divider="@null"
       />
   <TextView
-      android:id="@+id/__leak_canary_display_leak_failure"
+      android:id="@+id/leak_canary_display_leak_failure"
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:layout_weight="1"
@@ -37,7 +37,7 @@
       android:visibility="gone"
       />
   <Button
-      android:id="@+id/__leak_canary_action"
+      android:id="@+id/leak_canary_action"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:visibility="gone"

--- a/leakcanary-android/src/main/res/layout/leak_canary_leak_row.xml
+++ b/leakcanary-android/src/main/res/layout/leak_canary_leak_row.xml
@@ -23,7 +23,7 @@
     >
 
   <TextView
-      android:id="@+id/__leak_canary_row_text"
+      android:id="@+id/leak_canary_row_text"
       android:layout_width="0dp"
       android:layout_weight="1"
       android:layout_height="wrap_content"
@@ -32,7 +32,7 @@
       />
 
   <TextView
-      android:id="@+id/__leak_canary_row_time"
+      android:id="@+id/leak_canary_row_time"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="center_vertical"

--- a/leakcanary-android/src/main/res/layout/leak_canary_ref_row.xml
+++ b/leakcanary-android/src/main/res/layout/leak_canary_ref_row.xml
@@ -22,7 +22,7 @@
     >
 
   <com.squareup.leakcanary.internal.DisplayLeakConnectorView
-      android:id="@+id/__leak_canary_row_connector"
+      android:id="@+id/leak_canary_row_connector"
       android:layout_width="16dp"
       android:layout_height="match_parent"
       android:layout_marginStart="16dp"
@@ -30,7 +30,7 @@
       />
 
   <TextView
-      android:id="@+id/__leak_canary_row_text"
+      android:id="@+id/leak_canary_row_text"
       android:layout_width="0dp"
       android:layout_weight="1"
       android:layout_height="wrap_content"
@@ -38,7 +38,7 @@
       />
 
   <com.squareup.leakcanary.internal.MoreDetailsView
-      android:id="@+id/__leak_canary_row_more"
+      android:id="@+id/leak_canary_row_more"
       android:layout_width="12dp"
       android:layout_height="12dp"
       android:layout_gravity="center_vertical"

--- a/leakcanary-android/src/main/res/layout/leak_canary_ref_top_row.xml
+++ b/leakcanary-android/src/main/res/layout/leak_canary_ref_top_row.xml
@@ -16,7 +16,7 @@
   -->
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/__leak_canary_row_text"
+    android:id="@+id/leak_canary_row_text"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="16dp"

--- a/leakcanary-sample/src/main/res/values/strings.xml
+++ b/leakcanary-sample/src/main/res/values/strings.xml
@@ -20,5 +20,5 @@
   <string name="helper_text">Start the async task, <b>rotate the screen</b> and wait for a bit. A
     wild notification appears.
   </string>
-  <string name="__leak_canary_display_activity_label">Leaks Sample</string>
+  <string name="leak_canary_display_activity_label">Leaks Sample</string>
 </resources>


### PR DESCRIPTION
Updated README.md as well as CHANGELOG.md
Removed prefixes from internal layouts.
And finally, the leakcanary-sample module was still using this prefix to override the Activity label.