### PR TITLE
Configure public resources, ref #238

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ subprojects {
       mavenCentral()
     }
     dependencies {
-      classpath 'com.android.tools.build:gradle:1.2.3'
+      classpath 'com.android.tools.build:gradle:1.3.0'
     }
   }
 }

--- a/leakcanary-analyzer/build.gradle
+++ b/leakcanary-analyzer/build.gradle
@@ -38,7 +38,7 @@ task copyTestResources(type: Copy) {
 }
 
 afterEvaluate { project ->
-  testDebug.dependsOn copyTestResources
+  testDebugUnitTest.dependsOn copyTestResources
 }
 
 android {

--- a/leakcanary-android/src/main/res/values/leak_canary_public.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_public.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License.
   -->
 <resources>
-  <string name="app_name">LeakCanary Sample</string>
-  <string name="start_async_task">Start new AsyncTask</string>
-  <string name="helper_text">Start the async task, <b>rotate the screen</b> and wait for a bit. A
-    wild notification appears.
-  </string>
-  <string name="leak_canary_display_activity_label">Leaks Sample</string>
+
+  <public name="leak_canary_icon" type="drawable"/>
+  <public name="leak_canary_display_activity_label" type="string"/>
+  <public name="leak_canary_max_stored_leaks" type="integer"/>
+  <public name="leak_canary_heap_dump_toast" type="layout"/>
+
 </resources>


### PR DESCRIPTION
Public resources are:
 - activity icon
 - activity name
 - max stored leaks value
 - dump toast layout

Gradle 1.3.0 is required, seems to change the value of "testDebug" task to "testDebugUnitTest".
A public.xml file is now exported in the aar output.