### PR TITLE
Provide a custom Application class

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,30 @@ In your `build.gradle`:
  }
 ```
 
-In your `Application` class:
+In your `AndroidManifest` class:
+
+```xml
+<manifest ...>
+    <application android:name="com.squareup.leakcanary.Application" ...>
+        ...
+```
+
+**You're good to go!** LeakCanary will automatically show a notification when an activity memory leak is detected in your debug build.
+
+### What if I'm using another Application class
+
+If you are using a custom Application class, you can extend com.squareup.leakcanary.Application instead of android.app.Application:
 
 ```java
-public class ExampleApplication extends Application {
+public class ExampleApplication extends com.squareup.leakcanary.Application {
+  ...
+}
+```
+
+If you are already extending another class, you'll need to initialize LeakCanary manually:
+
+```java
+public class ExampleApplication extends OtherApplication {
 
   @Override public void onCreate() {
     super.onCreate();
@@ -28,8 +48,6 @@ public class ExampleApplication extends Application {
   }
 }
 ```
-
-**You're good to go!** LeakCanary will automatically show a notification when an activity memory leak is detected in your debug build.
 
 ## Why should I use LeakCanary?
 
@@ -46,34 +64,14 @@ RefWatcher refWatcher = {...};
 refWatcher.watch(schrodingerCat);
 ```
 
-`LeakCanary.install()` returns a pre configured `RefWatcher`.
-It also installs an `ActivityRefWatcher` that automatically detects if an activity is leaking after `Activity.onDestroy()` has been called.
-
-```java
-public class ExampleApplication extends Application {
-
-  public static RefWatcher getRefWatcher(Context context) {
-    ExampleApplication application = (ExampleApplication) context.getApplicationContext();
-    return application.refWatcher;
-  }
-
-  private RefWatcher refWatcher;
-
-  @Override public void onCreate() {
-    super.onCreate();
-    refWatcher = LeakCanary.install(this);
-  }
-}
-```
-
-You could use the `RefWatcher` to watch for fragment leaks:
+You can use the Applicacion class to get a `RefWatcher`:
 
 ```java
 public abstract class BaseFragment extends Fragment {
 
   @Override public void onDestroy() {
     super.onDestroy();
-    RefWatcher refWatcher = ExampleApplication.getRefWatcher(getActivity());
+    RefWatcher refWatcher = com.squareup.leakcanary.Application.getRefWatcher(getActivity());
     refWatcher.watch(this);
   }
 }
@@ -140,7 +138,7 @@ Sometimes the leak trace isn't enough and you need to dig into the heap dump wit
 
 ### Customizing and using the no-op dependency
 
-The `leakcanary-android-no-op` dependency for release builds only contains the `LeakCanary` and `RefWatcher` class. If you start customizing LeakCanary, you need to make sure that the customization happens only in debug build, since it will likely reference classes that do not exist in the `leakcanary-android-no-op` dependency.
+The `leakcanary-android-no-op` dependency for release builds only contains the `Application`, `LeakCanary` and `RefWatcher` class. If you start customizing LeakCanary, you need to make sure that the customization happens only in debug build, since it will likely reference classes that do not exist in the `leakcanary-android-no-op` dependency.
 
 Let's say your release build declares an `ExampleApplication` class in `AndroidManifest.xml`, and your debug build declares a `DebugExampleApplication` that extends `ExampleApplication`.
 

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/Application.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/Application.java
@@ -1,0 +1,13 @@
+package com.squareup.leakcanary;
+
+import android.content.Context;
+
+/**
+ * A no-op version of {@link Application} that can be used in release builds.
+ */
+public class Application extends android.app.Application {
+
+  public static RefWatcher getRefWatcher(Context context) {
+    return RefWatcher.DISABLED;
+  }
+}

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/Application.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/Application.java
@@ -13,21 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.leakcanary;
+package com.squareup.leakcanary;
 
-import android.app.Application;
+import android.content.Context;
 import android.os.StrictMode;
-import com.squareup.leakcanary.LeakCanary;
 
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.GINGERBREAD;
 
-public class ExampleApplication extends Application {
+public class Application extends android.app.Application {
+  private RefWatcher refWatcher;
 
   @Override public void onCreate() {
     super.onCreate();
     enabledStrictMode();
-    LeakCanary.install(this);
+    refWatcher = LeakCanary.install(this);
+  }
+
+  public static RefWatcher getRefWatcher(Context context) {
+    Application application = (Application) context.getApplicationContext();
+    return application.refWatcher;
   }
 
   private void enabledStrictMode() {

--- a/leakcanary-sample/src/main/AndroidManifest.xml
+++ b/leakcanary-sample/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.leakcanary"
     >
-  <application android:name=".ExampleApplication" android:allowBackup="false"
+  <application android:name="com.squareup.leakcanary.Application" android:allowBackup="false"
       android:icon="@drawable/ic_launcher"
       >
     <activity


### PR DESCRIPTION
I don't know if this is a wanted feature (fill free to close the issue if it's no), but I find it useful, so any feedback is welcome.

I've simply created a custom Application class so that the user only needs to use this class instead of android.app.Application.
This not only simplifies the initial setup, but allows LeakCanary to add features to this Application class in the future and user's wont have to change anything. For example for enabling strict mode (although I'm not sure if you want to enable it by default).