### PR TITLE
Exclude TextLine.sCached leak in Lollipop MR1 too

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -94,7 +94,7 @@ public enum AndroidExcludedRefs {
     }
   },
 
-  TEXT_LINE__SCACHED(SDK_INT < LOLLIPOP_MR1) {
+  TEXT_LINE__SCACHED(SDK_INT <= LOLLIPOP_MR1) {
     @Override void add(ExcludedRefs.Builder excluded) {
       // TextLine.sCached is a pool of 3 TextLine instances. TextLine.recycle() has had at least two
       // bugs that created memory leaks by not correctly clearing the recycled TextLine instances.


### PR DESCRIPTION
We are still experiencing occasional reports of TextLine related leaks on Lollipop MR1.

The comment at https://github.com/square/leakcanary/blob/master/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java#L105-L107 says there were at least two memory leak related fixes, one of which still isn't released - 

```
// The second was fixed, not released yet:
// https://github.com/android/platform_frameworks_base/commit/b3a9bc038d3a218b1dbdf7b5668e3d6c12be5ee4
```

Given this, should we include Lollipop MR1 in the exclusion?