### PR TITLE
change activity_choose_model excluded refs from staticField to instanceField

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -184,9 +184,9 @@ public enum AndroidExcludedRefs {
       // which can be an activity context.
       // Tracked here : https://code.google.com/p/android/issues/detail?id=172659
       // Hack : https://gist.github.com/andaag/b05ab66ed0f06167d6e0
-      excluded.staticField("android.support.v7.internal.widget.ActivityChooserModel",
-          "mActivityChoserModelPolicy");
-      excluded.staticField("android.widget.ActivityChooserModel", "mActivityChoserModelPolicy");
+      excluded.instanceField("android.support.v7.internal.widget.ActivityChooserModel",
+                             "mActivityChoserModelPolicy");
+      excluded.instanceField("android.widget.ActivityChooserModel", "mActivityChoserModelPolicy");
     }
   },
 


### PR DESCRIPTION
I was getting a leak for the ActivityChooserModel ([leak trace] (https://gist.github.com/LShuttneab/0745107963bb35e2bcba)) and found this code issue:
https://github.com/square/leakcanary/issues/47

The leak was added to the AndroidExcludedRefs in this [commit](https://github.com/square/leakcanary/commit/89700312cae03e7480870b79773a845b562797dc)

However, it didn't seem to be working. On further inspection I noticed the field was [not static](https://github.com/android/platform_frameworks_support/blob/master/v7/appcompat/src/android/support/v7/internal/widget/ActivityChooserModel.java#L307)

Switching from `staticField` to `instanceField` corrects the issue.