### PR TITLE
Add proguard rule for android.app.Notification

### DIFF
--- a/leakcanary-android/consumer-proguard-rules.pro
+++ b/leakcanary-android/consumer-proguard-rules.pro
@@ -1,2 +1,5 @@
 -keep class org.eclipse.mat.** { *; }
 -keep class com.squareup.leakcanary.** { *; }
+
+# Marshmallow removed Notification.setLatestEventInfo()
+-dontwarn android.app.Notification


### PR DESCRIPTION
Marshmallow removed Notification.setLatestEventInfo(). LeakCanary uses it,
but only pre-Marshmallow. This rule should prevent proguard from complaining.

Sidenote: f you were using Google Play Services 7.8.0 (and previous), they automatically added this proguard rule. So if you update to 8.1.0 it can look like LeakCanary is suddenly having proguard issues.