### PR TITLE
#268 Make AndroidWatchExecutor delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,17 @@ res/
 </resources>
 ```
 
+### Watcher delay
+
+With version 1.4-SNAPSHOT you now have the possibility to change the delay time until a reference is effectively considered a memory leak by providing `R.integer.leak_canary_watch_delay_millis` in your app:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <integer name="leak_canary_watch_delay_millis">1500</integer>
+</resources>
+```
+
 ### Uploading to a server
 
 You can change the default behavior to upload the leak trace and heap dump to a server of your choosing.

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
@@ -23,22 +23,22 @@ import java.util.concurrent.Executor;
 
 /**
  * {@link Executor} suitable for watching Android reference leaks. This executor waits for the main
- * thread to be idle then posts to a serial background thread with a delay of {@link
- * #DELAY_MILLIS} milliseconds.
+ * thread to be idle then posts to a serial background thread with a delay of
+ * {@link R.integer.leak_canary_watch_delay_millis} seconds.
  */
 public final class AndroidWatchExecutor implements Executor {
 
   static final String LEAK_CANARY_THREAD_NAME = "LeakCanary-Heap-Dump";
-  private static final int DELAY_MILLIS = 5000;
-
   private final Handler mainHandler;
   private final Handler backgroundHandler;
+  private final long delayMillis;
 
-  public AndroidWatchExecutor() {
+  public AndroidWatchExecutor(int delayMillis) {
     mainHandler = new Handler(Looper.getMainLooper());
     HandlerThread handlerThread = new HandlerThread(LEAK_CANARY_THREAD_NAME);
     handlerThread.start();
     backgroundHandler = new Handler(handlerThread.getLooper());
+    this.delayMillis = delayMillis;
   }
 
   @Override public void execute(final Runnable command) {
@@ -61,7 +61,7 @@ public final class AndroidWatchExecutor implements Executor {
     // This needs to be called from the main thread.
     Looper.myQueue().addIdleHandler(new MessageQueue.IdleHandler() {
       @Override public boolean queueIdle() {
-        backgroundHandler.postDelayed(runnable, DELAY_MILLIS);
+        backgroundHandler.postDelayed(runnable, delayMillis);
         return false;
       }
     });

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -64,8 +64,10 @@ public final class LeakCanary {
     DebuggerControl debuggerControl = new AndroidDebuggerControl();
     AndroidHeapDumper heapDumper = new AndroidHeapDumper(context);
     heapDumper.cleanup();
-    return new RefWatcher(new AndroidWatchExecutor(), debuggerControl, GcTrigger.DEFAULT,
-        heapDumper, heapDumpListener, excludedRefs);
+    int watchDelayMillis =
+        context.getResources().getInteger(R.integer.leak_canary_watch_delay_millis);
+    return new RefWatcher(new AndroidWatchExecutor(watchDelayMillis), debuggerControl,
+        GcTrigger.DEFAULT, heapDumper, heapDumpListener, excludedRefs);
   }
 
   public static void enableDisplayLeakActivity(Context context) {

--- a/leakcanary-android/src/main/res/values/leak_canary_int.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_int.xml
@@ -16,4 +16,5 @@
   -->
 <resources>
   <integer name="leak_canary_max_stored_leaks">7</integer>
+  <integer name="leak_canary_watch_delay_millis">5000</integer>
 </resources>


### PR DESCRIPTION
This PR allows library clients to configure the time until a reference is considered a memory leak just as @pyricau suggested in his latest message in #268.