### PR TITLE
Add ExcludedRefs for no-op build

### DIFF
--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -5,23 +5,22 @@ import java.util.EnumSet;
 /**
  * A no-op version of {@link AndroidExcludedRefs} that can be used in release builds.
  */
-@SuppressWarnings("unused")
-public enum AndroidExcludedRefs {
-	;
+@SuppressWarnings("unused") public enum AndroidExcludedRefs {
+  ;
 
-	public static ExcludedRefs.Builder createAndroidDefaults() {
-		return createBuilder();
-	}
+  public static ExcludedRefs.Builder createAndroidDefaults() {
+    return createBuilder();
+  }
 
-	public static ExcludedRefs.Builder createAppDefaults() {
-		return createBuilder();
-	}
+  public static ExcludedRefs.Builder createAppDefaults() {
+    return createBuilder();
+  }
 
-	public static ExcludedRefs.Builder createBuilder(EnumSet<AndroidExcludedRefs> refs) {
-		return createBuilder();
-	}
+  public static ExcludedRefs.Builder createBuilder(EnumSet<AndroidExcludedRefs> refs) {
+    return createBuilder();
+  }
 
-	private static ExcludedRefs.Builder createBuilder() {
-		return new ExcludedRefs.Builder();
-	}
+  private static ExcludedRefs.Builder createBuilder() {
+    return new ExcludedRefs.Builder();
+  }
 }

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -1,0 +1,27 @@
+package com.squareup.leakcanary;
+
+import java.util.EnumSet;
+
+/**
+ * A no-op version of {@link AndroidExcludedRefs} that can be used in release builds.
+ */
+@SuppressWarnings("unused")
+public enum AndroidExcludedRefs {
+	;
+
+	public static ExcludedRefs.Builder createAndroidDefaults() {
+		return createBuilder();
+	}
+
+	public static ExcludedRefs.Builder createAppDefaults() {
+		return createBuilder();
+	}
+
+	public static ExcludedRefs.Builder createBuilder(EnumSet<AndroidExcludedRefs> refs) {
+		return createBuilder();
+	}
+
+	private static ExcludedRefs.Builder createBuilder() {
+		return new ExcludedRefs.Builder();
+	}
+}

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
@@ -1,0 +1,54 @@
+package com.squareup.leakcanary;
+
+import java.io.Serializable;
+
+/**
+ * A no-op version of {@link ExcludedRefs} that can be used in release builds.
+ */
+public class ExcludedRefs implements Serializable {
+
+	@Override
+	public String toString() {
+		return "Empty class for no-op";
+	}
+
+	@SuppressWarnings("unused")
+	public static final class Builder {
+
+		public Builder instanceField(String className, String fieldName) {
+			return this;
+		}
+
+		public Builder instanceField(String className, String fieldName, boolean always) {
+			return this;
+		}
+
+		public Builder staticField(String className, String fieldName) {
+			return this;
+		}
+
+		public Builder staticField(String className, String fieldName, boolean always) {
+			return this;
+		}
+
+		public Builder thread(String threadName) {
+			return this;
+		}
+
+		public Builder thread(String threadName, boolean always) {
+			return this;
+		}
+
+		public Builder clazz(String className) {
+			return this;
+		}
+
+		public Builder clazz(String className, boolean always) {
+			return this;
+		}
+
+		public ExcludedRefs build() {
+			return new ExcludedRefs();
+		}
+	}
+}

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/ExcludedRefs.java
@@ -7,48 +7,46 @@ import java.io.Serializable;
  */
 public class ExcludedRefs implements Serializable {
 
-	@Override
-	public String toString() {
-		return "Empty class for no-op";
-	}
+  @Override public String toString() {
+    return "Empty class for no-op";
+  }
 
-	@SuppressWarnings("unused")
-	public static final class Builder {
+  @SuppressWarnings("unused") public static final class Builder {
 
-		public Builder instanceField(String className, String fieldName) {
-			return this;
-		}
+    public Builder instanceField(String className, String fieldName) {
+      return this;
+    }
 
-		public Builder instanceField(String className, String fieldName, boolean always) {
-			return this;
-		}
+    public Builder instanceField(String className, String fieldName, boolean always) {
+      return this;
+    }
 
-		public Builder staticField(String className, String fieldName) {
-			return this;
-		}
+    public Builder staticField(String className, String fieldName) {
+      return this;
+    }
 
-		public Builder staticField(String className, String fieldName, boolean always) {
-			return this;
-		}
+    public Builder staticField(String className, String fieldName, boolean always) {
+      return this;
+    }
 
-		public Builder thread(String threadName) {
-			return this;
-		}
+    public Builder thread(String threadName) {
+      return this;
+    }
 
-		public Builder thread(String threadName, boolean always) {
-			return this;
-		}
+    public Builder thread(String threadName, boolean always) {
+      return this;
+    }
 
-		public Builder clazz(String className) {
-			return this;
-		}
+    public Builder clazz(String className) {
+      return this;
+    }
 
-		public Builder clazz(String className, boolean always) {
-			return this;
-		}
+    public Builder clazz(String className, boolean always) {
+      return this;
+    }
 
-		public ExcludedRefs build() {
-			return new ExcludedRefs();
-		}
-	}
+    public ExcludedRefs build() {
+      return new ExcludedRefs();
+    }
+  }
 }


### PR DESCRIPTION
If you need to enable exclusions you need to setup leak canary per flavor/build class e.g. having a `LeakCanaryUtils#setup()`

This PR enables ExcludedRefs regardless the build.

Nothing really sophisticated.

Update: The build fails because of an empty enum (using SquareAndroid formatting).