### PR TITLE
Increase heap size for leakcanary process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added LeakCanary SHA to text report [#120](https://github.com/square/leakcanary/issues/120).
 * Renamed all resources to begin with `leak_canary_` instead of `__leak_canary`[#161](https://github.com/square/leakcanary/pull/161)
 * No crash when heap dump fails [#226](https://github.com/square/leakcanary/issues/226).
+* Enabled `largeHeap` for the `leakcanary` process to avoid OOM when analyzing large heaps.
 
 ### Public API changes
 

--- a/leakcanary-android/src/main/AndroidManifest.xml
+++ b/leakcanary-android/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:name=".internal.HeapAnalyzerService"
         android:process=":leakcanary"
         android:enabled="false"
+        android:largeHeap="true"
         />
     <service
         android:name=".DisplayLeakService"


### PR DESCRIPTION
May help to resolve the scenario where the heap analyzer running in the leakcanary process runs out of memory. Resolves #348.