### PR TITLE
Name the threads used in the leak canary project

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -54,7 +54,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
 import static android.text.format.DateUtils.FORMAT_SHOW_DATE;
@@ -62,6 +61,7 @@ import static android.text.format.DateUtils.FORMAT_SHOW_TIME;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static com.squareup.leakcanary.LeakCanary.leakInfo;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.newSingleThreadExecutor;
 
 @SuppressWarnings("ConstantConditions") @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public final class DisplayLeakActivity extends Activity {
@@ -380,8 +380,9 @@ public final class DisplayLeakActivity extends Activity {
             + leak.result.failure.getMessage();
       }
       titleView.setText(title);
-      String time = DateUtils.formatDateTime(DisplayLeakActivity.this, leak.resultFile.lastModified(),
-          FORMAT_SHOW_TIME | FORMAT_SHOW_DATE);
+      String time =
+          DateUtils.formatDateTime(DisplayLeakActivity.this, leak.resultFile.lastModified(),
+              FORMAT_SHOW_TIME | FORMAT_SHOW_DATE);
       timeView.setText(time);
       return convertView;
     }
@@ -403,7 +404,7 @@ public final class DisplayLeakActivity extends Activity {
 
     static final List<LoadLeaks> inFlight = new ArrayList<>();
 
-    static final Executor backgroundExecutor = Executors.newSingleThreadExecutor();
+    static final Executor backgroundExecutor = newSingleThreadExecutor("LoadLeaks");
 
     static void load(DisplayLeakActivity activity) {
       LoadLeaks loadLeaks = new LoadLeaks(activity);

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -40,7 +40,7 @@ public final class LeakCanaryInternals {
   public static final String LG = "LGE";
   public static final String NVIDIA = "NVIDIA";
 
-  private static final Executor fileIoExecutor = Executors.newSingleThreadExecutor();
+  private static final Executor fileIoExecutor = newSingleThreadExecutor("File-IO");
 
   public static void executeOnFileIoThread(Runnable runnable) {
     fileIoExecutor.execute(runnable);
@@ -112,6 +112,10 @@ public final class LeakCanaryInternals {
     }
 
     return myProcess.processName.equals(serviceInfo.processName);
+  }
+
+  public static Executor newSingleThreadExecutor(String threadName) {
+    return Executors.newSingleThreadExecutor(new LeakCanarySingleThreadFactory(threadName));
   }
 
   private LeakCanaryInternals() {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanarySingleThreadFactory.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanarySingleThreadFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.leakcanary.internal;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * This is intended to only be used with a single thread executor.
+ */
+final class LeakCanarySingleThreadFactory implements ThreadFactory {
+
+  private final String threadName;
+
+  LeakCanarySingleThreadFactory(String threadName) {
+    this.threadName = "LeakCanary-" + threadName;
+  }
+
+  @Override public Thread newThread(Runnable runnable) {
+    return new Thread(runnable, threadName);
+  }
+}


### PR DESCRIPTION
The LoadLeaks and File IO background executors now have appropriate thread names.

This fixes #347