### PR TITLE
Improve storage of leaks

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
@@ -1,0 +1,32 @@
+package com.squareup.leakcanary;
+
+import android.content.Context;
+import android.os.Environment;
+import java.io.File;
+
+import static android.os.Environment.DIRECTORY_DOWNLOADS;
+
+public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider {
+
+  private final Context context;
+
+  public DefaultLeakDirectoryProvider(Context context) {
+    this.context = context.getApplicationContext();
+  }
+
+  @Override public File leakDirectory() {
+    File downloadsDirectory = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS);
+    File directory = new File(downloadsDirectory, "leakcanary-" + context.getPackageName());
+    boolean success = directory.mkdirs();
+    if (!success && !directory.exists()) {
+      throw new UnsupportedOperationException(
+          "Could not create leak directory " + directory.getPath());
+    }
+    return directory;
+  }
+
+  @Override public boolean isLeakStorageWritable() {
+    String state = Environment.getExternalStorageState();
+    return Environment.MEDIA_MOUNTED.equals(state);
+  }
+}

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -19,6 +19,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.os.Build;
 import android.util.Log;
 import com.squareup.leakcanary.internal.DisplayLeakActivity;
@@ -61,13 +62,15 @@ public final class LeakCanary {
    */
   public static RefWatcher androidWatcher(Context context, HeapDump.Listener heapDumpListener,
       ExcludedRefs excludedRefs) {
+    LeakDirectoryProvider leakDirectoryProvider = new DefaultLeakDirectoryProvider(context);
     DebuggerControl debuggerControl = new AndroidDebuggerControl();
-    AndroidHeapDumper heapDumper = new AndroidHeapDumper(context);
+    AndroidHeapDumper heapDumper = new AndroidHeapDumper(context, leakDirectoryProvider);
     heapDumper.cleanup();
-    int watchDelayMillis =
-        context.getResources().getInteger(R.integer.leak_canary_watch_delay_millis);
-    return new RefWatcher(new AndroidWatchExecutor(watchDelayMillis), debuggerControl,
-        GcTrigger.DEFAULT, heapDumper, heapDumpListener, excludedRefs);
+    Resources resources = context.getResources();
+    int watchDelayMillis = resources.getInteger(R.integer.leak_canary_watch_delay_millis);
+    AndroidWatchExecutor executor = new AndroidWatchExecutor(watchDelayMillis);
+    return new RefWatcher(executor, debuggerControl, GcTrigger.DEFAULT, heapDumper,
+        heapDumpListener, excludedRefs);
   }
 
   public static void enableDisplayLeakActivity(Context context) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
@@ -1,0 +1,13 @@
+package com.squareup.leakcanary;
+
+import java.io.File;
+
+/** Provides the directory in which heap dumps and analysis results will be stored. */
+public interface LeakDirectoryProvider {
+
+  /** Returns a path to an existing directory were leaks can be stored. */
+  File leakDirectory();
+
+  /** True if we can currently write to the leak directory. */
+  boolean isLeakStorageWritable();
+}

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -22,9 +22,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
-import android.os.Environment;
 import com.squareup.leakcanary.CanaryLog;
-import java.io.File;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -32,7 +30,6 @@ import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
 import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
 import static android.content.pm.PackageManager.DONT_KILL_APP;
 import static android.content.pm.PackageManager.GET_SERVICES;
-import static android.os.Environment.DIRECTORY_DOWNLOADS;
 
 public final class LeakCanaryInternals {
 
@@ -47,40 +44,6 @@ public final class LeakCanaryInternals {
 
   public static void executeOnFileIoThread(Runnable runnable) {
     fileIoExecutor.execute(runnable);
-  }
-
-  public static File storageDirectory() {
-    File downloadsDirectory = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS);
-    File leakCanaryDirectory = new File(downloadsDirectory, "leakcanary");
-    leakCanaryDirectory.mkdirs();
-    return leakCanaryDirectory;
-  }
-
-  public static File detectedLeakDirectory() {
-    File directory = new File(storageDirectory(), "detected_leaks");
-    directory.mkdirs();
-    return directory;
-  }
-
-  public static File leakResultFile(File heapdumpFile) {
-    return new File(heapdumpFile.getParentFile(), heapdumpFile.getName() + ".result");
-  }
-
-  public static boolean isExternalStorageWritable() {
-    String state = Environment.getExternalStorageState();
-    return Environment.MEDIA_MOUNTED.equals(state);
-  }
-
-  public static File findNextAvailableHprofFile(int maxFiles) {
-    File directory = detectedLeakDirectory();
-    for (int i = 0; i < maxFiles; i++) {
-      String heapDumpName = "heap_dump_" + i + ".hprof";
-      File file = new File(directory, heapDumpName);
-      if (!file.exists()) {
-        return file;
-      }
-    }
-    return null;
   }
 
   /** Extracts the class simple name out of a string containing a fully qualified class name. */

--- a/leakcanary-android/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_strings.xml
@@ -17,10 +17,9 @@
 <resources>
 
   <string name="leak_canary_class_has_leaked">%s has leaked</string>
-  <string name="leak_canary_class_leak_ignored">Ignored %s leak</string>
+  <string name="leak_canary_leak_excluded">%s has leaked (excluded leak)</string>
   <string name="leak_canary_analysis_failed">Leak analysis failed</string>
   <string name="leak_canary_leak_list_title">Leaks in %s</string>
-  <string name="leak_canary_notification_leak_ignored_message">Click to see previous leaks</string>
   <string name="leak_canary_notification_message">Click for more details</string>
   <string name="leak_canary_share_leak">Share info</string>
   <string name="leak_canary_share_heap_dump">Share heap dump</string>
@@ -30,5 +29,9 @@
   <string name="leak_canary_delete">Delete</string>
   <string name="leak_canary_failure_report">"Please report this failure to http://github.com/square/leakcanary\n"</string>
   <string name="leak_canary_delete_all">Delete all</string>
-
+  <string name="leak_canary_could_not_save_title">Could not save result.</string>
+  <string name="leak_canary_could_not_save_text">LeakCanary was unable to save the analysis result.</string>
+  <string name="leak_canary_no_leak_title">No leak found</string>
+  <string name="leak_canary_no_leak_text">The GC was being lazy.</string>
+  <string name="leak_canary_excluded_row">[Excluded] %s</string>
 </resources>

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDump.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDump.java
@@ -61,11 +61,4 @@ public final class HeapDump implements Serializable {
     this.gcDurationMs = gcDurationMs;
     this.heapDumpDurationMs = heapDumpDurationMs;
   }
-
-  /** Renames the heap dump file and creates a new {@link HeapDump} pointing to it. */
-  public HeapDump renameFile(File newFile) {
-    heapDumpFile.renameTo(newFile);
-    return new HeapDump(newFile, referenceKey, referenceName, excludedRefs, watchDurationMs,
-        gcDurationMs, heapDumpDurationMs);
-  }
 }


### PR DESCRIPTION
* One directory per package.
* Stored on the SDCard by default, but customizable
* One atomic file per package for "heap dump currently being processed". If the file exists, skip the leak.
* We keep a limited number of heap dumps, but an unlimited number of analysis results.
* When full and getting a new result, we always delete the oldest heap dump.
* We save result and heap dumps for all leaks, whether they contain excluded refs or not.
* We now always show a notification if we've done a heap dump, no matter what happened afterwards.

Still missing:

*  Handling M permissions