### PR TITLE
Handle storage permission on M

### DIFF
--- a/leakcanary-android/src/main/AndroidManifest.xml
+++ b/leakcanary-android/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     >
 
   <!-- To store the heap dumps and leak analysis results. -->
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   <application>
@@ -45,6 +46,14 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+    <activity
+        android:theme="@style/leak_canary_Theme.Transparent"
+        android:name=".internal.RequestStoragePermissionActivity"
+        android:taskAffinity="com.squareup.leakcanary"
+        android:enabled="false"
+        android:icon="@drawable/leak_canary_icon"
+        android:label="@string/leak_canary_storage_permission_activity_label"
+        />
 
   </application>
 </manifest>

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -46,7 +46,9 @@ public final class AndroidHeapDumper implements HeapDumper {
 
   @Override public File dumpHeap() {
     if (!leakDirectoryProvider.isLeakStorageWritable()) {
-      CanaryLog.d("Could not dump heap, external storage not mounted.");
+      CanaryLog.d("Could not write to leak storage to dump heap.");
+      leakDirectoryProvider.requestWritePermission();
+      return NO_DUMP;
     }
     File heapDumpFile = getHeapDumpFile();
     // Atomic way to check for existence & create the file if it doesn't exist.
@@ -95,7 +97,8 @@ public final class AndroidHeapDumper implements HeapDumper {
     LeakCanaryInternals.executeOnFileIoThread(new Runnable() {
       @Override public void run() {
         if (!leakDirectoryProvider.isLeakStorageWritable()) {
-          CanaryLog.d("Could not attempt cleanup, leak storage not mounted.");
+          CanaryLog.d("Could not attempt cleanup, leak storage not writable.");
+          return;
         }
         File heapDumpFile = getHeapDumpFile();
         if (heapDumpFile.exists()) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
@@ -1,10 +1,33 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.leakcanary;
 
+import android.annotation.TargetApi;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.os.Environment;
+import com.squareup.leakcanary.internal.RequestStoragePermissionActivity;
 import java.io.File;
 
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.M;
 import static android.os.Environment.DIRECTORY_DOWNLOADS;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.showNotification;
 
 public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider {
 
@@ -25,8 +48,30 @@ public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider
     return directory;
   }
 
+  @Override public void requestWritePermission() {
+    if (hasStoragePermission()) {
+      return;
+    }
+    PendingIntent pendingIntent = RequestStoragePermissionActivity.createPendingIntent(context);
+    String contentTitle = context.getString(R.string.leak_canary_permission_notification_title);
+    CharSequence packageName = context.getPackageName();
+    String contentText =
+        context.getString(R.string.leak_canary_permission_notification_text, packageName);
+    showNotification(context, contentTitle, contentText, pendingIntent);
+  }
+
   @Override public boolean isLeakStorageWritable() {
+    if (!hasStoragePermission()) {
+      return false;
+    }
     String state = Environment.getExternalStorageState();
     return Environment.MEDIA_MOUNTED.equals(state);
+  }
+
+  @TargetApi(M) private boolean hasStoragePermission() {
+    if (SDK_INT < M) {
+      return true;
+    }
+    return context.checkSelfPermission(WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED;
   }
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -78,6 +78,11 @@ public final class LeakCanary {
     setEnabled(context, DisplayLeakActivity.class, true);
   }
 
+  public static void setDisplayLeakActivityDirectoryProvider(
+      LeakDirectoryProvider leakDirectoryProvider) {
+    DisplayLeakActivity.setLeakDirectoryProvider(leakDirectoryProvider);
+  }
+
   /** Returns a string representation of the result of a heap analysis. */
   public static String leakInfo(Context context, HeapDump heapDump, AnalysisResult result,
       boolean detailed) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
@@ -1,12 +1,33 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.leakcanary;
 
 import java.io.File;
 
-/** Provides the directory in which heap dumps and analysis results will be stored. */
+/**
+ * Provides the directory in which heap dumps and analysis results will be stored.
+ * When using your own implementation, you may also want to call {@link
+ * LeakCanary#setDisplayLeakActivityDirectoryProvider(LeakDirectoryProvider)}.
+ */
 public interface LeakDirectoryProvider {
 
   /** Returns a path to an existing directory were leaks can be stored. */
   File leakDirectory();
+
+  void requestWritePermission();
 
   /** True if we can currently write to the leak directory. */
   boolean isLeakStorageWritable();

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/RequestStoragePermissionActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/RequestStoragePermissionActivity.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.leakcanary.internal;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP;
+import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static android.os.Build.VERSION_CODES.M;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabledBlocking;
+
+@TargetApi(M) //
+public class RequestStoragePermissionActivity extends Activity {
+
+  public static PendingIntent createPendingIntent(Context context) {
+    setEnabledBlocking(context, RequestStoragePermissionActivity.class, true);
+    Intent intent = new Intent(context, RequestStoragePermissionActivity.class);
+    intent.setFlags(FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP);
+    return PendingIntent.getActivity(context, 1, intent, FLAG_UPDATE_CURRENT);
+  }
+
+  @Override protected void onResume() {
+    super.onResume();
+    // This won't work well if the user doesn't enable the permission.
+    // Seems ok for a dev tool, especially since you have to click a notification
+    // to get here.
+    if (checkSelfPermission(WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED) {
+      finish();
+    } else {
+      String[] permissions = {
+          WRITE_EXTERNAL_STORAGE
+      };
+      requestPermissions(permissions, 42);
+    }
+  }
+}

--- a/leakcanary-android/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_strings.xml
@@ -24,6 +24,7 @@
   <string name="leak_canary_share_heap_dump">Share heap dump</string>
   <string name="leak_canary_share_with">Share with…</string>
   <string name="leak_canary_display_activity_label">Leaks</string>
+  <string name="leak_canary_storage_permission_activity_label">Storage permission</string>
   <string name="leak_canary_toast_heap_dump">Dumping memory, app will freeze. Brrrr.</string>
   <string name="leak_canary_delete">Delete</string>
   <string name="leak_canary_failure_report">"Please report this failure to http://github.com/square/leakcanary\n"</string>
@@ -33,4 +34,6 @@
   <string name="leak_canary_no_leak_title">No leak found</string>
   <string name="leak_canary_no_leak_text">The GC was being lazy.</string>
   <string name="leak_canary_excluded_row">[Excluded] %s</string>
+  <string name="leak_canary_permission_notification_title">Leak detected, need permission</string>
+  <string name="leak_canary_permission_notification_text">Click to enable storage permission for %s.</string>
 </resources>

--- a/leakcanary-android/src/main/res/values/leak_canary_themes.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_themes.xml
@@ -17,4 +17,12 @@
 <resources>
   <style name="leak_canary_LeakCanary.Base" parent="android:Theme">
   </style>
+
+  <style name="leak_canary_Theme.Transparent" parent="android:Theme">
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowBackground">@android:color/transparent</item>
+    <item name="android:windowContentOverlay">@null</item>
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:backgroundDimEnabled">false</item>
+  </style>
 </resources>


### PR DESCRIPTION
When a potential leak is detected, if the storage permission is missing, we drop the leak and we show a notification. That notification will then show the permission dialog.

Fixes #285