### PR TITLE
Document in sample that Application.onCreate is called from multiple processes

### DIFF
--- a/leakcanary-sample/src/debug/AndroidManifest.xml
+++ b/leakcanary-sample/src/debug/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2016 Square, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest
+    package="com.example.leakcanary"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    >
+    <application
+        tools:replace="name"
+        android:name=".DebugExampleApplication"
+        />
+</manifest>

--- a/leakcanary-sample/src/debug/java/com/example/leakcanary/DebugExampleApplication.java
+++ b/leakcanary-sample/src/debug/java/com/example/leakcanary/DebugExampleApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.leakcanary;
+
+import com.squareup.leakcanary.LeakCanary;
+
+public class DebugExampleApplication extends ExampleApplication {
+
+  @Override public void onCreate() {
+    // Often times this method is overridden so app dependencies are initialized
+    // and set up. For single-process applications where some work is being done in this
+    // method, allowing it to continue as normal can lead to subtle bugs. One would expect
+    // that that work would be done only once in the lifecycle of the application - which
+    // is technically still true since the app is created in a different process, and might
+    // not realize that LeakCanary starts a new process which leads to this method being
+    // called while there is already an instance of the application in a different process.
+    // LeakCanary does not need any setup while it analyzes a heap dump in its analyzer process,
+    // no one benefits from any work that would be done in 'ExampleApplication.onCreate' since
+    // no app code would be executed after this method exits, so it is safe to not call super.
+    if (!LeakCanary.isInAnalyzerProcess(this)) {
+      super.onCreate();
+    }
+  }
+}


### PR DESCRIPTION
Often times `Application.onCreate` is overridden so app dependencies are initialized
and set up. For single-process applications where some work is being done in this
method, allowing it to continue as normal can lead to subtle bugs. One would expect
that that work would be done only once in the lifecycle of the application - which
is technically still true since the app is created in a different process, and might
not realise that LeakCanary starts a new process which leads to this method being
called while there is already an instance of the application in a different process.

I had an issue in an app that uses LeakCanary, where I restarted failed tasks from
`Application.onCreate` which performed IO that should've not happen in that process.
I had some other problems that I cannot recall atm. The tasks should've not been started
from `onCreate` or maybe I did not need to care about any of that extra work being done
only in the LeakCanary process for debug builds, but that's besides my point.
It took me a moment to realise that LeakCanary starts its own process and that that
is the root cause of my issues, and I'm somewhat familiar with LeakCanary internals.
Novice users might not have so much luck and might spend a lot more time tracking
similar issues.

In case you plan to merge this PR, I'd like for you to suggest other ways this can
be documented by either including a notice in readme, updating the sample, or maybe
something else entirely.