### PR TITLE
Lower memory usage when parsing heap dumps on M

### DIFF
--- a/leakcanary-analyzer/build.gradle
+++ b/leakcanary-analyzer/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   compile 'com.squareup.haha:haha:2.0.2'
   compile project(':leakcanary-watcher')
   testCompile 'junit:junit:4.12'
+  testCompile 'org.assertj:assertj-core:1.7.0'
 }
 
 android.libraryVariants.all { variant ->

--- a/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/HeapAnalyzerTest.java
+++ b/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/HeapAnalyzerTest.java
@@ -1,0 +1,61 @@
+package com.squareup.leakcanary;
+
+import com.squareup.haha.perflib.RootObj;
+import com.squareup.haha.perflib.Snapshot;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static com.squareup.haha.perflib.RootType.NATIVE_STATIC;
+import static com.squareup.haha.perflib.RootType.SYSTEM_CLASS;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HeapAnalyzerTest {
+  private static final ExcludedRefs NO_EXCLUDED_REFS = null;
+  private static final List<RootObj> DUP_ROOTS =
+          asList(new RootObj(SYSTEM_CLASS, 6L),
+                  new RootObj(SYSTEM_CLASS, 5L),
+                  new RootObj(SYSTEM_CLASS, 3L),
+                  new RootObj(SYSTEM_CLASS, 5L),
+                  new RootObj(NATIVE_STATIC, 3L));
+
+  private HeapAnalyzer heapAnalyzer;
+
+  @Before
+  public void setUp() {
+    heapAnalyzer = new HeapAnalyzer(NO_EXCLUDED_REFS);
+  }
+
+  @Test
+  public void ensureUniqueRoots() {
+    Snapshot snapshot = createSnapshot(DUP_ROOTS);
+
+    heapAnalyzer.deduplicateGcRoots(snapshot);
+
+    Collection<RootObj> uniqueRoots = snapshot.getGCRoots();
+    assertThat(uniqueRoots).hasSize(4);
+
+    List<Long> rootIds = new ArrayList<>();
+    for (RootObj root : uniqueRoots) {
+      rootIds.add(root.getId());
+    }
+    Collections.sort(rootIds);
+
+    // 3 appears twice because even though two RootObjs have the same id, they're different types.
+    assertThat(rootIds).containsExactly(3L, 3L, 5L, 6L);
+  }
+
+  private Snapshot createSnapshot(List<RootObj> gcRoots) {
+    Snapshot snapshot = new Snapshot(null);
+    for (RootObj root : gcRoots) {
+      snapshot.addRoot(root);
+    }
+    return snapshot;
+  }
+}


### PR DESCRIPTION
Parsing an hprof file generated on M results in a Snapshot filled with duplicate GC root entries.  This extra memory usage leaves little room for LeakCanary to analyze and find the leak trace and often results in an OutOfMemoryError.  This commit removes the duplicate GC root entries to alleviate the memory pressure.

Fixes #223