### PR TITLE
Add version info to stacktrace

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -26,6 +26,8 @@ import com.squareup.leakcanary.internal.DisplayLeakActivity;
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
 
 import static android.text.format.Formatter.formatShortFileSize;
+import static com.squareup.leakcanary.BuildConfig.GIT_SHA;
+import static com.squareup.leakcanary.BuildConfig.LIBRARY_VERSION;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.isInServiceProcess;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabled;
 
@@ -112,7 +114,10 @@ public final class LeakCanary {
         detailedString = "\n* Details:\n" + result.leakTrace.toDetailedString();
       }
     } else if (result.failure != null) {
-      info += "* FAILURE:\n" + Log.getStackTraceString(result.failure) + "\n";
+      // We duplicate the library version & Sha information because bug reports often only contain
+      // the stacktrace.
+      info += "* FAILURE in " + LIBRARY_VERSION + " " + GIT_SHA + ":" + Log.getStackTraceString(
+          result.failure) + "\n";
     } else {
       info += "* NO LEAK FOUND.\n\n";
     }
@@ -137,9 +142,9 @@ public final class LeakCanary {
         + " API: "
         + Build.VERSION.SDK_INT
         + " LeakCanary: "
-        + BuildConfig.LIBRARY_VERSION
+        + LIBRARY_VERSION
         + " "
-        + BuildConfig.GIT_SHA
+        + GIT_SHA
         + "\n"
         + "* Durations: watch="
         + heapDump.watchDurationMs

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -61,6 +61,8 @@ import static android.text.format.DateUtils.FORMAT_SHOW_TIME;
 import static android.text.format.Formatter.formatShortFileSize;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
+import static com.squareup.leakcanary.BuildConfig.GIT_SHA;
+import static com.squareup.leakcanary.BuildConfig.LIBRARY_VERSION;
 import static com.squareup.leakcanary.LeakCanary.leakInfo;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.newSingleThreadExecutor;
 
@@ -273,9 +275,13 @@ public final class DisplayLeakActivity extends Activity {
       if (result.failure != null) {
         listView.setVisibility(GONE);
         failureView.setVisibility(VISIBLE);
-        failureView.setText(
-            getString(R.string.leak_canary_failure_report) + Log.getStackTraceString(
-                result.failure));
+        String failureMessage = getString(R.string.leak_canary_failure_report)
+            + LIBRARY_VERSION
+            + " "
+            + GIT_SHA
+            + "\n"
+            + Log.getStackTraceString(result.failure);
+        failureView.setText(failureMessage);
         setTitle(R.string.leak_canary_analysis_failed);
         invalidateOptionsMenu();
         getActionBar().setDisplayHomeAsUpEnabled(true);


### PR DESCRIPTION
This way, no more empty reports without version info. We can go straight to "please upgrade"!

Fixes #473.

```
In com.example.leakcanary:1.0:1.
* FAILURE in 1.4-SNAPSHOT 9e74a85:java.lang.RuntimeException: Yo!
	at com.squareup.leakcanary.HeapAnalyzer.checkForLeak(HeapAnalyzer.java:81)
	at com.squareup.leakcanary.internal.HeapAnalyzerService.onHandleIntent(HeapAnalyze
	at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:66)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:148)
	at android.os.HandlerThread.run(HandlerThread.java:61)
```

![Uploading screenshot-2016-03-29_17.42.47.447.png…]()
