### PR TITLE
Don't loop when storage permission denied

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/RequestStoragePermissionActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/RequestStoragePermissionActivity.java
@@ -20,6 +20,9 @@ import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Toast;
+import com.squareup.leakcanary.R;
 
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
@@ -27,6 +30,7 @@ import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP;
 import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.os.Build.VERSION_CODES.M;
+import static android.widget.Toast.LENGTH_LONG;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabledBlocking;
 
 @TargetApi(M) //
@@ -39,18 +43,31 @@ public class RequestStoragePermissionActivity extends Activity {
     return PendingIntent.getActivity(context, 1, intent, FLAG_UPDATE_CURRENT);
   }
 
-  @Override protected void onResume() {
-    super.onResume();
-    // This won't work well if the user doesn't enable the permission.
-    // Seems ok for a dev tool, especially since you have to click a notification
-    // to get here.
-    if (checkSelfPermission(WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED) {
-      finish();
-    } else {
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    if (savedInstanceState == null) {
+      if (hasStoragePermission()) {
+        finish();
+        return;
+      }
       String[] permissions = {
           WRITE_EXTERNAL_STORAGE
       };
       requestPermissions(permissions, 42);
     }
+  }
+
+  @Override public void onRequestPermissionsResult(int requestCode, String[] permissions,
+      int[] grantResults) {
+    if (!hasStoragePermission()) {
+      Toast.makeText(getApplication(), R.string.leak_canary_permission_not_granted, LENGTH_LONG)
+          .show();
+    }
+    finish();
+  }
+
+  private boolean hasStoragePermission() {
+    return checkSelfPermission(WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED;
   }
 }

--- a/leakcanary-android/src/main/res/values-de/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values-de/leak_canary_strings.xml
@@ -33,6 +33,7 @@
     <string name="leak_canary_no_leak_title">Kein Leak gefunden</string>
     <string name="leak_canary_no_leak_text">Der GC war untätig.</string>
     <string name="leak_canary_excluded_row">[Ausgeschlossen] %s</string>
+    <string name="leak_canary_permission_not_granted">Please grant external storage permission, otherwise memory leaks will not be detected.</string>
     <string name="leak_canary_permission_notification_title">Leak detektiert, benötige Berechtigung</string>
     <string name="leak_canary_permission_notification_text">Hier klicken um Storage Berechtigung für %s zu aktivieren.</string>
 </resources>

--- a/leakcanary-android/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_strings.xml
@@ -34,6 +34,7 @@
   <string name="leak_canary_no_leak_title">No leak found</string>
   <string name="leak_canary_no_leak_text">The GC was being lazy.</string>
   <string name="leak_canary_excluded_row">[Excluded] %s</string>
+  <string name="leak_canary_permission_not_granted">Please grant external storage permission, otherwise memory leaks will not be detected.</string>
   <string name="leak_canary_permission_notification_title">Leak detected, need permission</string>
   <string name="leak_canary_permission_notification_text">Click to enable storage permission for %s.</string>
 </resources>


### PR DESCRIPTION
If the storage permission is denied, don't retry, just show a toast.

Fixes #422