### PR TITLE
Update Samsung ClipboardUIManager Excluded Ref

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -281,8 +281,8 @@ public enum AndroidExcludedRefs {
           .reason("ClipboardUIManager is a static singleton that leaks an activity context."
               + " Fix: trigger a call to ClipboardUIManager.getInstance() in Application.onCreate()"
               + " , so that the ClipboardUIManager instance gets cached with a reference to the"
-              + " application context. Example: https://gist.github.com/pepyakin"
-              + "/8d2221501fd572d4a61c");
+              + " application context. Example: https://gist.github.com/cypressious/"
+              + "91c4fb1455470d803a602838dfcd5774");
     }
   },
 


### PR DESCRIPTION
The leak was actually introduced on Lollipop, not on Kitkat. I don't have a Samsung device with 5.1 and 6.0 though, so someone should check if it's present there, too.

#133 