### PR TITLE
Move buildscript out of subprojects block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,19 @@
-subprojects {
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:1.5.0'
+  }
+}
 
+subprojects {
   repositories {
     mavenCentral()
 //    maven {
 //      url 'https://oss.sonatype.org/content/repositories/snapshots/'
 //    }
 //    mavenLocal()
-  }
-
-  buildscript {
-    repositories {
-      mavenCentral()
-    }
-    dependencies {
-      classpath 'com.android.tools.build:gradle:1.5.0'
-    }
   }
 }
 


### PR DESCRIPTION
subprojects{} runs in configuration phase, while buildscript{} runs in initialization phase.  As a result, the "No resolved dependencies found when searching for the jacoco version" warning goes away.