### PR TITLE
Remove unnecessary Gradle task

### DIFF
--- a/leakcanary-analyzer/build.gradle
+++ b/leakcanary-analyzer/build.gradle
@@ -31,17 +31,6 @@ android.libraryVariants.all { variant ->
   artifacts.add('archives', task);
 }
 
-
-// See: https://code.google.com/p/android/issues/detail?id=64887#c13
-task copyTestResources(type: Copy) {
-  from "${projectDir}/src/test/resources"
-  into "${buildDir}/classes/test"
-}
-
-afterEvaluate { project ->
-  testDebugUnitTest.dependsOn copyTestResources
-}
-
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
   buildToolsVersion rootProject.ext.buildToolsVersion


### PR DESCRIPTION
As of Android Studio 1.3.0.10, test resources are added to the classpath
when unit tests are run in the IDE.