### PR TITLE
ignore Meizu RecommendActivity leaked in Android Instrumentation

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -35,6 +35,7 @@ import static com.squareup.leakcanary.internal.LeakCanaryInternals.LG;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.MOTOROLA;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.NVIDIA;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.SAMSUNG;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.MEIZU;
 
 /**
  * This class is a work in progress. You can help by reporting leak traces that seem to be caused
@@ -304,6 +305,14 @@ public enum AndroidExcludedRefs {
   },
 
   // ######## Manufacturer specific Excluded refs ########
+
+  INSTRUMENTATION_RECOMMEND_ACTIVITY(MEIZU.equals(MANUFACTURER) && SDK_INT >= LOLLIPOP && SDK_INT <= LOLLIPOP_MR1) {
+    @Override void add(ExcludedRefs.Builder excluded) {
+      excluded.staticField("android.app.Instrumentation", "mRecommendActivity")
+              .reason("Instrumentation would leak com.android.internal.app.RecommendActivity (in framework.jar)"
+                  + " in Meizu FlymeOS 4.5 and above, which is based on Android 5.0 and above");
+    }
+  },
 
   DEVICE_POLICY_MANAGER__SETTINGS_OBSERVER(
       MOTOROLA.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= LOLLIPOP_MR1) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -47,6 +47,7 @@ public final class LeakCanaryInternals {
   public static final String MOTOROLA = "motorola";
   public static final String LG = "LGE";
   public static final String NVIDIA = "NVIDIA";
+  public static final String MEIZU = "Meizu";
 
   private static final Executor fileIoExecutor = newSingleThreadExecutor("File-IO");
 


### PR DESCRIPTION
When running UI automation tests using Instrumentation on Meizu devices, some page would report a memory leak in 

```
* GC ROOT static android.app.Instrumentation.mRecommendActivity
* references android.app.Instrumentation$RecommendActivity.mTarget
* leaks com.example.ExampleActivity instance
```

I digged and found `RecommendActivity` is a class in `framework.jar` in Meizu FlymeOS ([smali source](https://github.com/truebit/FlymeOS-hima/blob/master/framework.jar.out/smali/com/android/internal/app/RecommendActivity.smali)). I do not know what it does and when it would be invoked. Maybe it relates to permission alerts prompted by FlymeOS
But I found many people got this memory leak.([google result](https://www.google.com.hk/search?q=mTarget+RecommendActivity)) I also reported an issue #590 . and found a similar issue earlier #506 
