### PR TITLE
Add isInAnalyzerProcess to android-no-op

### DIFF
--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -1,6 +1,7 @@
 package com.squareup.leakcanary;
 
 import android.app.Application;
+import android.content.Context;
 
 /**
  * A no-op version of {@link LeakCanary} that can be used in release builds.
@@ -9,6 +10,10 @@ public final class LeakCanary {
 
   public static RefWatcher install(Application application) {
     return RefWatcher.DISABLED;
+  }
+
+  public static boolean isInAnalyzerProcess(Context context) {
+    return false;
   }
 
   private LeakCanary() {


### PR DESCRIPTION
Fixes #617 

An alternative would be to replace:
```
    if (LeakCanary.isInAnalyzerProcess(this)) {
      return;
    }
```
with:
```
    if (BuildConfig.DEBUG && LeakCanary.install(this) == RefWatcher.DISABLED) {
      return;
    }
```