### PR TITLE
Improvements to heap dumping

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -24,18 +24,14 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.widget.Toast;
 import com.squareup.leakcanary.internal.FutureResult;
-import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.io.File;
-import java.io.IOException;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class AndroidHeapDumper implements HeapDumper {
 
-  private static final String HEAPDUMP_FILE = "suspected_leak_heapdump.hprof";
-
-  final Context context;
-  final LeakDirectoryProvider leakDirectoryProvider;
+  private final Context context;
+  private final LeakDirectoryProvider leakDirectoryProvider;
   private final Handler mainHandler;
 
   public AndroidHeapDumper(Context context, LeakDirectoryProvider leakDirectoryProvider) {
@@ -45,27 +41,10 @@ public final class AndroidHeapDumper implements HeapDumper {
   }
 
   @Override public File dumpHeap() {
-    if (!leakDirectoryProvider.isLeakStorageWritable()) {
-      CanaryLog.d("Could not write to leak storage to dump heap.");
-      leakDirectoryProvider.requestWritePermissionNotification();
-      return NO_DUMP;
-    }
-    File heapDumpFile = getHeapDumpFile();
-    // Atomic way to check for existence & create the file if it doesn't exist.
-    // Prevents several processes in the same app to attempt a heapdump at the same time.
-    boolean fileCreated;
-    try {
-      fileCreated = heapDumpFile.createNewFile();
-    } catch (IOException e) {
-      cleanup();
-      CanaryLog.d(e, "Could not check if heap dump file exists");
-      return NO_DUMP;
-    }
+    File heapDumpFile = leakDirectoryProvider.newHeapDumpFile();
 
-    if (!fileCreated) {
-      CanaryLog.d("Could not dump heap, previous analysis still is in progress.");
-      // Heap analysis in progress, let's not put too much pressure on the device.
-      return NO_DUMP;
+    if (heapDumpFile == RETRY_LATER) {
+      return RETRY_LATER;
     }
 
     FutureResult<Toast> waitingForToast = new FutureResult<>();
@@ -73,7 +52,7 @@ public final class AndroidHeapDumper implements HeapDumper {
 
     if (!waitingForToast.wait(5, SECONDS)) {
       CanaryLog.d("Did not dump heap, too much time waiting for Toast.");
-      return NO_DUMP;
+      return RETRY_LATER;
     }
 
     Toast toast = waitingForToast.get();
@@ -82,38 +61,10 @@ public final class AndroidHeapDumper implements HeapDumper {
       cancelToast(toast);
       return heapDumpFile;
     } catch (Exception e) {
-      cleanup();
-      CanaryLog.d(e, "Could not perform heap dump");
+      CanaryLog.d(e, "Could not dump heap");
       // Abort heap dump
-      return NO_DUMP;
+      return RETRY_LATER;
     }
-  }
-
-  /**
-   * Call this on app startup to clean up all heap dump files that had not been handled yet when
-   * the app process was killed.
-   */
-  public void cleanup() {
-    LeakCanaryInternals.executeOnFileIoThread(new Runnable() {
-      @Override public void run() {
-        if (!leakDirectoryProvider.isLeakStorageWritable()) {
-          CanaryLog.d("Could not attempt cleanup, leak storage not writable.");
-          return;
-        }
-        File heapDumpFile = getHeapDumpFile();
-        if (heapDumpFile.exists()) {
-          CanaryLog.d("Previous analysis did not complete correctly, cleaning: %s", heapDumpFile);
-          boolean success = heapDumpFile.delete();
-          if (!success) {
-            CanaryLog.d("Could not delete file %s", heapDumpFile.getPath());
-          }
-        }
-      }
-    });
-  }
-
-  File getHeapDumpFile() {
-    return new File(leakDirectoryProvider.leakDirectory(), HEAPDUMP_FILE);
   }
 
   private void showToast(final FutureResult<Toast> waitingForToast) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
@@ -16,92 +16,189 @@
 package com.squareup.leakcanary;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Environment;
 import com.squareup.leakcanary.internal.RequestStoragePermissionActivity;
 import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
 
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Environment.DIRECTORY_DOWNLOADS;
+import static com.squareup.leakcanary.HeapDumper.RETRY_LATER;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.showNotification;
 
 public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider {
 
+  private static final String HPROF_SUFFIX = ".hprof";
+  private static final String PENDING_HEAPDUMP_SUFFIX = "_pending" + HPROF_SUFFIX;
+
+  /** 10 minutes */
+  private static final int ANALYSIS_MAX_DURATION_MS = 10 * 60 * 1000;
+
   private final Context context;
+
+  private boolean writeExternalStorageGranted;
+  private boolean permissionNotificationDisplayed;
 
   public DefaultLeakDirectoryProvider(Context context) {
     this.context = context.getApplicationContext();
   }
 
-  @Override public File leakDirectory() {
-    File directory = leakDirectoryUnsafe();
-    if (directoryExistsAfterMkdirs(directory)) {
-      throw new UnsupportedOperationException(
-          "Could not create leak directory " + directory.getPath());
-    }
-    return directory;
-  }
-
-  private File leakDirectoryUnsafe() {
-    File downloadsDirectory = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS);
-    return new File(downloadsDirectory, "leakcanary-" + context.getPackageName());
-  }
-
-  private boolean directoryExistsAfterMkdirs(File directory) {
-    boolean success = directory.mkdirs();
-    return !success && !directory.exists();
-  }
-
-  @Override public void requestWritePermissionNotification() {
-    if (hasStoragePermission()) {
-      return;
-    }
-    PendingIntent pendingIntent = RequestStoragePermissionActivity.createPendingIntent(context);
-    String contentTitle = context.getString(R.string.leak_canary_permission_notification_title);
-    CharSequence packageName = context.getPackageName();
-    String contentText =
-        context.getString(R.string.leak_canary_permission_notification_text, packageName);
-    showNotification(context, contentTitle, contentText, pendingIntent);
-  }
-
-  @TargetApi(M) @Override public void requestPermission(Activity activity) {
-    if (hasStoragePermission()) {
-      return;
-    }
-    String[] permissions = {
-        WRITE_EXTERNAL_STORAGE
-    };
-    activity.requestPermissions(permissions, 42);
-  }
-
-  @Override public boolean isLeakStorageWritable() {
+  @Override public List<File> listFiles(FilenameFilter filter) {
     if (!hasStoragePermission()) {
-      CanaryLog.d("Leak storage not writable, WRITE_EXTERNAL_STORAGE permission not granted");
-      return false;
+      requestWritePermissionNotification();
     }
-    String state = Environment.getExternalStorageState();
-    if (!Environment.MEDIA_MOUNTED.equals(state)) {
-      CanaryLog.d("Leak storage not writable, external storage not mounted, state: " + state);
-      return false;
+    List<File> files = new ArrayList<>();
+
+    File[] externalFiles = externalStorageDirectory().listFiles(filter);
+    if (externalFiles != null) {
+      files.addAll(Arrays.asList(externalFiles));
     }
-    File directory = leakDirectoryUnsafe();
-    if (!directoryExistsAfterMkdirs(directory)) {
-      CanaryLog.d(
-          "Leak storage not writable, leak directory cannot be created at " + directory.getPath());
-      return false;
+
+    File[] appFiles = appStorageDirectory().listFiles(filter);
+    if (appFiles != null) {
+      files.addAll(Arrays.asList(appFiles));
     }
-    return true;
+    return files;
+  }
+
+  @Override public File newHeapDumpFile() {
+    List<File> pendingHeapDumps = listFiles(new FilenameFilter() {
+      @Override public boolean accept(File dir, String filename) {
+        return filename.endsWith(PENDING_HEAPDUMP_SUFFIX);
+      }
+    });
+
+    // If a new heap dump file has been created recently and hasn't been processed yet, we skip.
+    // Otherwise we move forward and assume that the analyzer process crashes. The file will
+    // eventually be removed with heap dump file rotation.
+    for (File file : pendingHeapDumps) {
+      if (System.currentTimeMillis() - file.lastModified() < ANALYSIS_MAX_DURATION_MS) {
+        CanaryLog.d("Could not dump heap, previous analysis still is in progress.");
+        return RETRY_LATER;
+      }
+    }
+
+    cleanupOldHeapDumps();
+
+    File storageDirectory = externalStorageDirectory();
+    if (!directoryWritableAfterMkdirs(storageDirectory)) {
+      if (!hasStoragePermission()) {
+        CanaryLog.d("WRITE_EXTERNAL_STORAGE permission not granted");
+        requestWritePermissionNotification();
+      } else {
+        String state = Environment.getExternalStorageState();
+        if (!Environment.MEDIA_MOUNTED.equals(state)) {
+          CanaryLog.d("External storage not mounted, state: %s", state);
+        } else {
+          CanaryLog.d("Could not create heap dump directory in external storage: [%s]",
+              storageDirectory.getAbsolutePath());
+        }
+      }
+      // Fallback to app storage.
+      storageDirectory = appStorageDirectory();
+      if (!directoryWritableAfterMkdirs(storageDirectory)) {
+        CanaryLog.d("Could not create heap dump directory in app storage: [%s]",
+            storageDirectory.getAbsolutePath());
+        return RETRY_LATER;
+      }
+    }
+    // If two processes from the same app get to this step at the same time, they could both
+    // create a heap dump. This is an edge case we ignore.
+    return new File(storageDirectory, UUID.randomUUID().toString() + PENDING_HEAPDUMP_SUFFIX);
+  }
+
+  @Override public void clearLeakDirectory() {
+    List<File> allFilesExceptPending = listFiles(new FilenameFilter() {
+      @Override public boolean accept(File dir, String filename) {
+        return !filename.endsWith(PENDING_HEAPDUMP_SUFFIX);
+      }
+    });
+    for (File file : allFilesExceptPending) {
+      boolean deleted = file.delete();
+      if (!deleted) {
+        CanaryLog.d("Could not delete file %s", file.getPath());
+      }
+    }
   }
 
   @TargetApi(M) private boolean hasStoragePermission() {
     if (SDK_INT < M) {
       return true;
     }
-    return context.checkSelfPermission(WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED;
+    // Once true, this won't change for the life of the process so we can cache it.
+    if (writeExternalStorageGranted) {
+      return true;
+    }
+    writeExternalStorageGranted =
+        context.checkSelfPermission(WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED;
+    return writeExternalStorageGranted;
+  }
+
+  private void requestWritePermissionNotification() {
+    if (permissionNotificationDisplayed) {
+      return;
+    }
+    permissionNotificationDisplayed = true;
+
+    PendingIntent pendingIntent = RequestStoragePermissionActivity.createPendingIntent(context);
+    String contentTitle = context.getString(R.string.leak_canary_permission_notification_title);
+    CharSequence packageName = context.getPackageName();
+    String contentText =
+        context.getString(R.string.leak_canary_permission_notification_text, packageName);
+    showNotification(context, contentTitle, contentText, pendingIntent, 0xDEAFBEEF);
+  }
+
+  private File externalStorageDirectory() {
+    File downloadsDirectory = Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS);
+    return new File(downloadsDirectory, "leakcanary-" + context.getPackageName());
+  }
+
+  private File appStorageDirectory() {
+    File appFilesDirectory = context.getFilesDir();
+    return new File(appFilesDirectory, "leakcanary");
+  }
+
+  private boolean directoryWritableAfterMkdirs(File directory) {
+    boolean success = directory.mkdirs();
+    return (success || directory.exists()) && directory.canWrite();
+  }
+
+  private void cleanupOldHeapDumps() {
+    Resources resources = context.getResources();
+    int configStoredHeapDumps = resources.getInteger(R.integer.leak_canary_max_stored_leaks);
+    int maxStoredHeapDumps = Math.max(configStoredHeapDumps, 1);
+    List<File> hprofFiles = listFiles(new FilenameFilter() {
+      @Override public boolean accept(File dir, String filename) {
+        return filename.endsWith(HPROF_SUFFIX);
+      }
+    });
+    int filesToRemove = hprofFiles.size() - maxStoredHeapDumps;
+    if (filesToRemove > 0) {
+      CanaryLog.d("Removing %d heap dumps", filesToRemove);
+      // Sort with oldest modified first.
+      Collections.sort(hprofFiles, new Comparator<File>() {
+        @Override public int compare(File lhs, File rhs) {
+          return Long.valueOf(lhs.lastModified()).compareTo(rhs.lastModified());
+        }
+      });
+      for (int i = 0; i < filesToRemove; i++) {
+        boolean deleted = hprofFiles.get(i).delete();
+        if (!deleted) {
+          CanaryLog.d("Could not delete old hprof file %s", hprofFiles.get(i).getPath());
+        }
+      }
+    }
   }
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -68,7 +68,6 @@ public final class LeakCanary {
     LeakDirectoryProvider leakDirectoryProvider = new DefaultLeakDirectoryProvider(context);
     DebuggerControl debuggerControl = new AndroidDebuggerControl();
     AndroidHeapDumper heapDumper = new AndroidHeapDumper(context, leakDirectoryProvider);
-    heapDumper.cleanup();
     Resources resources = context.getResources();
     int watchDelayMillis = resources.getInteger(R.integer.leak_canary_watch_delay_millis);
     AndroidWatchExecutor executor = new AndroidWatchExecutor(watchDelayMillis);

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
@@ -15,23 +15,28 @@
  */
 package com.squareup.leakcanary;
 
-import android.app.Activity;
 import java.io.File;
+import java.io.FilenameFilter;
+import java.util.List;
 
 /**
- * Provides the directory in which heap dumps and analysis results will be stored.
- * When using your own implementation, you may also want to call {@link
- * LeakCanary#setDisplayLeakActivityDirectoryProvider(LeakDirectoryProvider)}.
+ * Provides access to where heap dumps and analysis results will be stored.
+ * When using your own implementation, you should also call {@link
+ * LeakCanary#setDisplayLeakActivityDirectoryProvider(LeakDirectoryProvider)} to ensure the
+ * provided activity is able to display the leaks.
  */
 public interface LeakDirectoryProvider {
 
-  /** Returns a path to an existing directory were leaks can be stored. */
-  File leakDirectory();
+  List<File> listFiles(FilenameFilter filter);
 
-  void requestWritePermissionNotification();
+  /**
+   * @return {@link HeapDumper#RETRY_LATER} if a new heap dump file could not be created.
+   */
+  File newHeapDumpFile();
 
-  void requestPermission(Activity activity);
-
-  /** True if we can currently write to the leak directory. */
-  boolean isLeakStorageWritable();
+  /**
+   * Removes all heap dumps and analysis results, except for heap dumps that haven't been
+   * analyzed yet.
+   */
+  void clearLeakDirectory();
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -133,7 +133,7 @@ public final class LeakCanaryInternals {
 
   @TargetApi(HONEYCOMB)
   public static void showNotification(Context context, CharSequence contentTitle,
-      CharSequence contentText, PendingIntent pendingIntent) {
+      CharSequence contentText, PendingIntent pendingIntent, int notificationId) {
     NotificationManager notificationManager =
         (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
@@ -165,7 +165,7 @@ public final class LeakCanaryInternals {
         notification = builder.build();
       }
     }
-    notificationManager.notify(0xDEAFBEEF, notification);
+    notificationManager.notify(notificationId, notification);
   }
 
   public static Executor newSingleThreadExecutor(String threadName) {

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDumper.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDumper.java
@@ -19,11 +19,11 @@ import java.io.File;
 
 public interface HeapDumper {
 
-  File NO_DUMP = null;
+  File RETRY_LATER = null;
 
   /**
-   * @return a {@link File} referencing the heap dump, or {@link #NO_DUMP} if the heap could not be
-   * dumped.
+   * @return a {@link File} referencing the dumped heap, or {@link #RETRY_LATER} if the heap could
+   * not be dumped.
    */
   File dumpHeap();
 }

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/RefWatcher.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/RefWatcher.java
@@ -20,9 +20,11 @@ import java.lang.ref.ReferenceQueue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.Executor;
 
+import static com.squareup.leakcanary.HeapDumper.RETRY_LATER;
 import static com.squareup.leakcanary.Preconditions.checkNotNull;
+import static com.squareup.leakcanary.Retryable.Result.DONE;
+import static com.squareup.leakcanary.Retryable.Result.RETRY;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -33,8 +35,8 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  */
 public final class RefWatcher {
 
-  public static final RefWatcher DISABLED = new RefWatcher(new Executor() {
-    @Override public void execute(Runnable command) {
+  public static final RefWatcher DISABLED = new RefWatcher(new WatchExecutor() {
+    @Override public void execute(Retryable retryable) {
     }
   }, new DebuggerControl() {
     @Override public boolean isDebuggerAttached() {
@@ -43,14 +45,14 @@ public final class RefWatcher {
     }
   }, GcTrigger.DEFAULT, new HeapDumper() {
     @Override public File dumpHeap() {
-      return null;
+      return RETRY_LATER;
     }
   }, new HeapDump.Listener() {
     @Override public void analyze(HeapDump heapDump) {
     }
   }, new ExcludedRefs.BuilderWithParams().build());
 
-  private final Executor watchExecutor;
+  private final WatchExecutor watchExecutor;
   private final DebuggerControl debuggerControl;
   private final GcTrigger gcTrigger;
   private final HeapDumper heapDumper;
@@ -59,8 +61,9 @@ public final class RefWatcher {
   private final HeapDump.Listener heapdumpListener;
   private final ExcludedRefs excludedRefs;
 
-  public RefWatcher(Executor watchExecutor, DebuggerControl debuggerControl, GcTrigger gcTrigger,
-      HeapDumper heapDumper, HeapDump.Listener heapdumpListener, ExcludedRefs excludedRefs) {
+  public RefWatcher(WatchExecutor watchExecutor, DebuggerControl debuggerControl,
+      GcTrigger gcTrigger, HeapDumper heapDumper, HeapDump.Listener heapdumpListener,
+      ExcludedRefs excludedRefs) {
     this.watchExecutor = checkNotNull(watchExecutor, "watchExecutor");
     this.debuggerControl = checkNotNull(debuggerControl, "debuggerControl");
     this.gcTrigger = checkNotNull(gcTrigger, "gcTrigger");
@@ -82,36 +85,43 @@ public final class RefWatcher {
 
   /**
    * Watches the provided references and checks if it can be GCed. This method is non blocking,
-   * the check is done on the {@link Executor} this {@link RefWatcher} has been constructed with.
+   * the check is done on the {@link WatchExecutor} this {@link RefWatcher} has been constructed
+   * with.
    *
    * @param referenceName An logical identifier for the watched object.
    */
   public void watch(Object watchedReference, String referenceName) {
     checkNotNull(watchedReference, "watchedReference");
     checkNotNull(referenceName, "referenceName");
-    if (debuggerControl.isDebuggerAttached()) {
-      return;
-    }
     final long watchStartNanoTime = System.nanoTime();
     String key = UUID.randomUUID().toString();
     retainedKeys.add(key);
     final KeyedWeakReference reference =
         new KeyedWeakReference(watchedReference, key, referenceName, queue);
 
-    watchExecutor.execute(new Runnable() {
-      @Override public void run() {
-        ensureGone(reference, watchStartNanoTime);
+    ensureGoneAsync(watchStartNanoTime, reference);
+  }
+
+  private void ensureGoneAsync(final long watchStartNanoTime, final KeyedWeakReference reference) {
+    watchExecutor.execute(new Retryable() {
+      @Override public Retryable.Result run() {
+        return ensureGone(reference, watchStartNanoTime);
       }
     });
   }
 
-  void ensureGone(KeyedWeakReference reference, long watchStartNanoTime) {
+  Retryable.Result ensureGone(final KeyedWeakReference reference, final long watchStartNanoTime) {
     long gcStartNanoTime = System.nanoTime();
-
     long watchDurationMs = NANOSECONDS.toMillis(gcStartNanoTime - watchStartNanoTime);
+
     removeWeaklyReachableReferences();
-    if (gone(reference) || debuggerControl.isDebuggerAttached()) {
-      return;
+
+    if (debuggerControl.isDebuggerAttached()) {
+      // The debugger can create false leaks.
+      return RETRY;
+    }
+    if (gone(reference)) {
+      return DONE;
     }
     gcTrigger.runGc();
     removeWeaklyReachableReferences();
@@ -120,16 +130,16 @@ public final class RefWatcher {
       long gcDurationMs = NANOSECONDS.toMillis(startDumpHeap - gcStartNanoTime);
 
       File heapDumpFile = heapDumper.dumpHeap();
-
-      if (heapDumpFile == HeapDumper.NO_DUMP) {
-        // Could not dump the heap, abort.
-        return;
+      if (heapDumpFile == RETRY_LATER) {
+        // Could not dump the heap.
+        return RETRY;
       }
       long heapDumpDurationMs = NANOSECONDS.toMillis(System.nanoTime() - startDumpHeap);
       heapdumpListener.analyze(
           new HeapDump(heapDumpFile, reference.key, reference.name, excludedRefs, watchDurationMs,
               gcDurationMs, heapDumpDurationMs));
     }
+    return DONE;
   }
 
   private boolean gone(KeyedWeakReference reference) {

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/Retryable.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/Retryable.java
@@ -1,0 +1,10 @@
+package com.squareup.leakcanary;
+
+public interface Retryable {
+
+  enum Result {
+    DONE, RETRY
+  }
+
+  Result run();
+}

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/WatchExecutor.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/WatchExecutor.java
@@ -1,0 +1,5 @@
+package com.squareup.leakcanary;
+
+public interface WatchExecutor {
+  void execute(Retryable retryable);
+}

--- a/leakcanary-watcher/src/test/java/com/squareup/leakcanary/RefWatcherTest.java
+++ b/leakcanary-watcher/src/test/java/com/squareup/leakcanary/RefWatcherTest.java
@@ -16,7 +16,6 @@
 package com.squareup.leakcanary;
 
 import java.io.File;
-import java.util.concurrent.Executor;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -42,11 +41,11 @@ public class RefWatcherTest {
 
   @SuppressWarnings("FieldCanBeLocal") Object ref;
 
-  static class TestExecutor implements Executor {
-    Runnable command;
+  static class TestExecutor implements WatchExecutor {
+    Retryable retryable;
 
-    @Override public void execute(Runnable command) {
-      this.command = command;
+    @Override public void execute(Retryable retryable) {
+      this.retryable = retryable;
     }
   }
 
@@ -59,7 +58,7 @@ public class RefWatcherTest {
     TestExecutor executor = new TestExecutor();
     RefWatcher refWatcher = defaultWatcher(dumper, executor);
     refWatcher.watch(new Object());
-    executor.command.run();
+    executor.retryable.run();
     assertFalse(dumper.called);
   }
 
@@ -69,7 +68,7 @@ public class RefWatcherTest {
     RefWatcher refWatcher = defaultWatcher(dumper, executor);
     ref = new Object();
     refWatcher.watch(ref);
-    executor.command.run();
+    executor.retryable.run();
     assertTrue(dumper.called);
   }
 


### PR DESCRIPTION
* No more cleanup on startup, and no hanging heap dump if the analysis crashes. We create a distinct "pending" hprof for each heap dump, and those are cleaned up as part of the hprof file rotation.
* If a pending hprof hasn't been removed in 10 minutes, LeakCanary now assumes no analysis is in progress, and starts dumping the heap again.
* We now use the app directory as a fallback if the external storage directory isn't available. This is transparent to the user.
* If the external storage permission isn't granted, we show the notification as before but we also immediately fallback to the app directory, so that leak isn't lost.
* Leak notifications now each use a distinct notification instead of erasing each other.
* If LeakCanary can't perform a heap dump for any reason (e.g. analysis in progress, debugger attached ), it retries later with an exponential backoff.

Fixes #595.
Fixes #612.