### PR TITLE
#643: java.util.MissingFormatArgumentException: Format specifier: 22ty

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
@@ -42,7 +42,7 @@ public class DisplayLeakService extends AbstractAnalysisResultService {
 
   @Override protected final void onHeapAnalyzed(HeapDump heapDump, AnalysisResult result) {
     String leakInfo = leakInfo(this, heapDump, result, true);
-    CanaryLog.d(leakInfo);
+    CanaryLog.d("%s", leakInfo);
 
     boolean resultSaved = false;
     boolean shouldSaveResult = result.leakFound || result.failure != null;

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -134,7 +134,7 @@ public final class LeakCanary {
         + "\n"
         + detailedString;
 
-    return info;
+    return info.replace("%", "%%");
   }
 
   /**

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -134,7 +134,7 @@ public final class LeakCanary {
         + "\n"
         + detailedString;
 
-    return info.replace("%", "%%");
+    return info;
   }
 
   /**


### PR DESCRIPTION
Escaping % characters in `LeakCanary.leakInfo()` to avoid StringFormatter crashes. Fix for https://github.com/square/leakcanary/issues/643
