### PR TITLE
Extend TEXT_VIEW__MLAST_HOVERED_VIEW known leak to LOLLIPOP_MR1

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -366,7 +366,7 @@ public enum AndroidExcludedRefs {
   },
 
   TEXT_VIEW__MLAST_HOVERED_VIEW(
-      SAMSUNG.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= LOLLIPOP) {
+      SAMSUNG.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= LOLLIPOP_MR1) {
     @Override void add(ExcludedRefs.Builder excluded) {
       excluded.staticField("android.widget.TextView", "mLastHoveredView")
           .reason("mLastHoveredView is a static field in TextView that leaks the last hovered"


### PR DESCRIPTION
As title says, i've extended the leak exclusion here https://github.com/square/leakcanary/issues/220 to Android 5.1.1 because it's still present on Samsung Devices with this Android version.

CLA signed.