### PR TITLE
Remove synthetic accessor methods.

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -30,7 +30,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class AndroidHeapDumper implements HeapDumper {
 
-  private final Context context;
+  final Context context;
   private final LeakDirectoryProvider leakDirectoryProvider;
   private final Handler mainHandler;
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
@@ -52,7 +52,7 @@ public final class AndroidWatchExecutor implements WatchExecutor {
     }
   }
 
-  private void postWaitForIdle(final Retryable retryable, final int failedAttempts) {
+  void postWaitForIdle(final Retryable retryable, final int failedAttempts) {
     mainHandler.post(new Runnable() {
       @Override public void run() {
         waitForIdle(retryable, failedAttempts);
@@ -70,7 +70,7 @@ public final class AndroidWatchExecutor implements WatchExecutor {
     });
   }
 
-  private void postToBackgroundWithDelay(final Retryable retryable, final int failedAttempts) {
+  void postToBackgroundWithDelay(final Retryable retryable, final int failedAttempts) {
     long exponentialBackoffFactor = (long) Math.min(Math.pow(2, failedAttempts), maxBackoffFactor);
     long delayMillis = initialDelayMillis * exponentialBackoffFactor;
     backgroundHandler.postDelayed(new Runnable() {


### PR DESCRIPTION
Being a dev tool, it might not be worth it; it just cleans up my `dex-method-list internal-debug.apk | grep 'access\$'` output.