### PR TITLE
Add `@RunWith(JUnit.class)` to un-annotated test classes

### DIFF
--- a/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/HahaHelperTest.java
+++ b/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/HahaHelperTest.java
@@ -9,10 +9,13 @@ import com.squareup.haha.perflib.Type;
 import com.squareup.haha.perflib.io.HprofBuffer;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public class HahaHelperTest {
   private static final int STRING_CLASS_ID = 100;
   private static final int CHAR_ARRAY_CLASS_ID = 101;

--- a/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/HeapAnalyzerTest.java
+++ b/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/HeapAnalyzerTest.java
@@ -5,6 +5,8 @@ import com.squareup.haha.perflib.Snapshot;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,6 +19,7 @@ import static com.squareup.leakcanary.TestUtil.NO_EXCLUDED_REFS;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(JUnit4.class)
 public class HeapAnalyzerTest {
   private static final List<RootObj> DUP_ROOTS =
           asList(new RootObj(SYSTEM_CLASS, 6L),

--- a/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/TrackedReferencesTest.java
+++ b/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/TrackedReferencesTest.java
@@ -2,12 +2,15 @@ package com.squareup.leakcanary;
 
 import java.util.List;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static com.squareup.leakcanary.TestUtil.HeapDumpFile.ASYNC_TASK_PRE_M;
 import static com.squareup.leakcanary.TestUtil.HeapDumpFile.ASYNC_TASK_M;
 import static com.squareup.leakcanary.TestUtil.findTrackedReferences;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RunWith(JUnit4.class)
 public class TrackedReferencesTest {
 
   @Test public void findsExpectedRef() {

--- a/leakcanary-watcher/src/test/java/com/squareup/leakcanary/RefWatcherTest.java
+++ b/leakcanary-watcher/src/test/java/com/squareup/leakcanary/RefWatcherTest.java
@@ -17,10 +17,13 @@ package com.squareup.leakcanary;
 
 import java.io.File;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(JUnit4.class)
 public class RefWatcherTest {
 
   static class TestDumper implements HeapDumper {


### PR DESCRIPTION
Google has an internal Errorprone rule requiring the annotation, and upstreaming this patch will make integrating future updates easier.