### PR TITLE
Add excluded ref for memory leak in SystemSensorManager in Vivo devices

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -32,6 +32,7 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.N_MR1;
 import static com.squareup.leakcanary.AndroidWatchExecutor.LEAK_CANARY_THREAD_NAME;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.VIVO;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.HUAWEI;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.LENOVO;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.LG;
@@ -451,12 +452,13 @@ public enum AndroidExcludedRefs {
     }
   },
 
-  SYSTEM_SENSOR_MANAGER_LENOVO(LENOVO.equals(MANUFACTURER) && SDK_INT == KITKAT) {
+  SYSTEM_SENSOR_MANAGER_MAPPCONTEXTIMPL((LENOVO.equals(MANUFACTURER) && SDK_INT == KITKAT) ||
+      (VIVO.equals(MANUFACTURER) && SDK_INT == LOLLIPOP_MR1)) {
     @Override void add(ExcludedRefs.Builder excluded) {
       excluded.staticField("android.hardware.SystemSensorManager", "mAppContextImpl")
-              .reason("Lenovo specific leak. SystemSensorManager stores a reference to context "
-                      + "in a static field in its constructor. Found on LENOVO 4.4.2. "
-                      + "Fix: use application context to get SensorManager");
+          .reason("Lenovo and Vivo specific leak. SystemSensorManager stores a reference to context "
+              + "in a static field in its constructor. Found in LENOVO 4.4.2 and VIVO 5.1."
+              + "Fix: use application context to get SensorManager");
     }
   },
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -50,6 +50,7 @@ public final class LeakCanaryInternals {
   public static final String NVIDIA = "NVIDIA";
   public static final String MEIZU = "Meizu";
   public static final String HUAWEI = "HUAWEI";
+  public static final String VIVO = "vivo";
 
   private static final Executor fileIoExecutor = newSingleThreadExecutor("File-IO");
 


### PR DESCRIPTION
The memory leak that was found in #571 also in Vivo:

> In com.foobar:8.2.3.1:820.
> * com.foobar.activity.UserWorkPlayerActivity has leaked:
> * GC ROOT static android.hardware.SystemSensorManager.mAppContextImpl
> * leaks com.foobar.player.activity.UserWorkPlayerActivity instance
> * Retaining: 312 KB.
> * Reference Key: f7448b54-3abc-433a-8c2e-067e956bf680
> * _Device: vivo vivo vivo X6D PD1415D_
> * _Android Version: 5.1 API: 22 LeakCanary: 1.5.1 1be44b3_
> * Durations: watch=5038ms, gc=281ms, heap dump=5416ms, analysis=70405ms
> * Details:
> * Class android.hardware.SystemSensorManager
> |   static sFullSensorsList = java.util.ArrayList@1888834072 (0x70955218)
> |   static PD1225_HARDWARE_VER_C = java.lang.String@1879186152 (0x70021ae8)
> |   static GESTURE_LEFT = 4.0
> |   static GESTURE_RIGHT = 8.0
> |   static TOUCHPANEL_ID_PATH = java.lang.String@1879365312 (0x7004d6c0)
> |   static PD1225_HARDWARE_VER_F = java.lang.String@1879187088 (0x70021e90)
> |   static PD1225_HARDWARE_VER_E = java.lang.String@1879186896 (0x70021dd0)
> |   static PD1225_HARDWARE_VER_A = java.lang.String@1879166976 (0x7001d000)
> |   static NEED_CHANGE_PROXIMITY_PULSE = java.lang.String@1879656768 (0x70094940)
> |   static PS_PARA_INDEX_PATH = java.lang.String@1879365144 (0x7004d618)
> |   static mWm = android.view.WindowManagerImpl@326181696 (0x13712340)
> |   static PHONE_COLOR_BLACK = 1
> |   static ALS_PARA_INDEX_PATH = java.lang.String@1879365072 (0x7004d5d0)
> |   static callerPid = 0
> |   static GESTURE_DOWN = 1.0
> |   static BASE_THRESHOLD_SENSOR = java.lang.String@1879656696 (0x700948f8)
> |   static PD1225_HARDWARE_VER_B = java.lang.String@1879184616 (0x700214e8)
> |   static last_a_timestamp = 0
> |   static sHandleToSensor = android.util.SparseArray@1888834096 (0x70955230)
> |   static debug = false
> |   static BOARD_VERSION_PATH = java.lang.String@1879365264 (0x7004d690)
> |   static mAppContextImpl = com.foobar.player.activity.UserWorkPlayerActivity@346261504 (0x14a38800)
> |   static TMP_BASE_THRESHOLD_SENSOR = java.lang.String@1879656864 (0x700949a0)
> |   static sSensorModuleLock = java.lang.Object@1888831920 (0x709549b0)
> |   static $staticOverhead = byte[264]@1890062089 (0x70a80f09)
> |   static PS_PULSE_VALUE_PATH = java.lang.String@1879365168 (0x7004d630)
> |   static PHONE_COLOR_WHITE = 2
> |   static last_o_timestamp = 0
> |   static sSensorModuleInitialized = true
> |   static PHONE_COLOR_PROPERTIE = java.lang.String@1879689696 (0x7009c9e0)
> |   static PHONE_COLOR_DEFAULT = -1
> |   static GESTURE_TOP = 2.0
> |   static last_m_timestamp = 0
> |   static PD1225_HARDWARE_VER_D = java.lang.String@1879186512 (0x70021c50)
