### PR TITLE
Disable finish animations in RequestStoragePermissionActivity.

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/RequestStoragePermissionActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/RequestStoragePermissionActivity.java
@@ -67,6 +67,12 @@ public class RequestStoragePermissionActivity extends Activity {
     finish();
   }
 
+  @Override public void finish() {
+    // Reset the animation to avoid flickering.
+    overridePendingTransition(0, 0);
+    super.finish();
+  }
+
   private boolean hasStoragePermission() {
     return checkSelfPermission(WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED;
   }


### PR DESCRIPTION
This avoid the flickering that can be seen in the top half of the device, when the activity is dismissed.