### PR TITLE
Link to fix for #762

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -374,7 +374,8 @@ public enum AndroidExcludedRefs {
       SAMSUNG.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= N) {
     @Override void add(ExcludedRefs.Builder excluded) {
       excluded.instanceField("com.samsung.android.emergencymode.SemEmergencyManager", "mContext")
-          .reason("SemEmergencyManager is a static singleton that leaks a DecorContext.");
+          .reason("SemEmergencyManager is a static singleton that leaks a DecorContext. "
+              + "Fix: https://gist.github.com/jankovd/a210460b814c04d500eb12025902d60d");
     }
   },
 


### PR DESCRIPTION
Registers an `ActivityLifecycleCallbacks` that tries to swap the activity context with the application context, the first time an activity is detroyed. 'Try' because the process can fail, in which case it will not be retried and the activity will be leaked. Potential issues with this approach:
- `SemEmergencyManager.mContext` is declared as an Activity: ClassCastException will stop the process, the fix cannot be applied, move on
-  `SemEmergencyManager.mContext` does not exist: fix cannot be applied, move on
- `SemEmergencyManager.mContext` is declared as a Context, but Activity is expected: don't think this would ever be the case, but if it happens it will certainly cause problems for the application.

The fix has been included in release for about a week, and I have not observered any issues caused by it. The list of devices where this fix has been activated includes the Galaxy S8 with latest OS version.