### PR TITLE
Add excluded ref for memory leak in SystemSensorManager in Wiko devices

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -40,6 +40,7 @@ import static com.squareup.leakcanary.internal.LeakCanaryInternals.MOTOROLA;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.NVIDIA;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.SAMSUNG;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.VIVO;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.WIKO;
 
 /**
  * This class is a work in progress. You can help by reporting leak traces that seem to be caused
@@ -452,7 +453,7 @@ public enum AndroidExcludedRefs {
   },
 
   SYSTEM_SENSOR_MANAGER__MAPPCONTEXTIMPL((LENOVO.equals(MANUFACTURER) && SDK_INT == KITKAT) //
-      || (VIVO.equals(MANUFACTURER) && SDK_INT == LOLLIPOP_MR1)) {
+      || (VIVO.equals(MANUFACTURER) && SDK_INT == LOLLIPOP_MR1) || (WIKO.equals(MANUFACTURER) && SDK_INT == KITKAT)) {
     @Override void add(ExcludedRefs.Builder excluded) {
       excluded.staticField("android.hardware.SystemSensorManager", "mAppContextImpl")
           .reason("SystemSensorManager stores a reference to context "

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -51,6 +51,7 @@ public final class LeakCanaryInternals {
   public static final String MEIZU = "Meizu";
   public static final String HUAWEI = "HUAWEI";
   public static final String VIVO = "vivo";
+  public static final String WIKO = "WIKO";
 
   private static final Executor fileIoExecutor = newSingleThreadExecutor("File-IO");
 


### PR DESCRIPTION
The memory leak that was found in #571 also in Vivo:

```
In com.foobar.android.app:7.8.0-SNAPSHOT:60013.
* com.foobar.android.app.activities.MapActivity has leaked:
* GC ROOT static android.hardware.SystemSensorManager.mAppContextImpl
* leaks com.foobar.android.app.activities.MapActivity instance

* Retaining: 1,3 Mo.
* Reference Key: abbcfe55-1656-4544-b419-656c9c82fa45
* Device: WIKO WIKO RAINBOW 4G wiko
* Android Version: 4.4.2 API: 19 LeakCanary: 1.5.1 1be44b3
* Durations: watch=35627ms, gc=269ms, heap dump=1328ms, analysis=29173ms

* Details:
* Class android.hardware.SystemSensorManager
|   static first_time_stamp = 0
|   static sSensorModuleInitialized = true
|   static mAppContextImpl = com.foobar.android.app.activities.MapActivity@1105764816 (0x41e8a1d0)
|   static SensorFirstUsed = false
|   static $staticOverhead = byte[192]@1102657025 (0x41b93601)
|   static sSensorModuleLock = java.lang.Object@1102636936 (0x41b8e788)
|   static sHandleToSensor = android.util.SparseArray@1103146776 (0x41c0af18)
|   static callerPid = 0
|   static sFullSensorsList = java.util.ArrayList@1103152720 (0x41c0c650)
* Instance of com.foobar.android.app.activities.MapActivity
|   static PERMISSIONS_REQUEST_READ_CONTACTS = 1
|   static PERMISSIONS_REQUEST_LOCATION = 0
|   static $staticOverhead = byte[120]@1110000377 (0x422942f9)
|   static ajc$tjp_0 = org.aspectj.runtime.reflect.JoinPointImpl$StaticPartImpl@1105764760 (0x41e8a198)
|   static REQUEST_CODE_CHECK_GPS_FOR_TRACKING_BUTTON_3D = 7
|   static TAG = java.lang.String@1105762792 (0x41e899e8)
```