### PR TITLE
Set leakcanary-watcher source and target compatibility to 1.7

### DIFF
--- a/leakcanary-watcher/build.gradle
+++ b/leakcanary-watcher/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'java-library'
 
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
+
 dependencies {
   testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
Fixes #861 

BEFORE:
```
$ javap -cp ~/.gradle/caches/transforms-1/files-1.1/leakcanary-analyzer-1.5.3.aar/7a2d9f74d531255f0218e3018ca6d436/jars/classes.jar -verbose com.squareup.leakcanary.LeakNode | grep major
  major version: 51
$ javap -cp ~/.gradle/caches/modules-2/files-2.1/com.squareup.leakcanary/leakcanary-watcher/1.5.3/51fd776f9da598c6361699f90c1f82935778cdc4/leakcanary-watcher-1.5.3.jar -verbose com.squareup.leakcanary.HeapDump | grep major
  major version: 52
$ javap -cp ~/.gradle/caches/transforms-1/files-1.1/leakcanary-android-no-op-1.5.3.aar/af5b619b57f6df08293c36269006bb49/jars/classes.jar -verbose com.squareup.leakcanary.LeakCanary | grep major
  major version: 51
$ javap -cp ~/.gradle/caches/transforms-1/files-1.1/leakcanary-android-1.5.3.aar/80720c02200df151a634bd23a0710442/jars/classes.jar -verbose com.squareup.leakcanary.LeakCanary | grep major
  major version: 51
```

AFTER:
```
$ javap -cp ~/.m2/repository/com/squareup/leakcanaryleakcanary-analyzer/1.6-SNAPSHOT/classes.jar -verbose com.squareup.leakcanary.LeakNode | grep major
  major version: 51
$ javap -cp ~/.m2/repository/com/squareup/leakcanaryleakcanary-watcher/1.6-SNAPSHOT/leakcanary-watcher-1.6-20170917.195132-2.jar -verbose com.squareup.leakcanary.HeapDump | grep major
  major version: 51
$ javap -cp ~/.m2/repository/com/squareup/leakcanaryleakcanary-android-no-op/1.6-SNAPSHOT/classes.jar -verbose com.squareup.leakcanary.LeakCanary | grep major
  major version: 51
$ javap -cp ~/.m2/repository/com/squareup/leakcanaryleakcanary-android/1.6-SNAPSHOT/classes.jar -verbose com.squareup.leakcanary.LeakCanary | grep major
  major version: 51
```