### PR TITLE
Watch destroyed Fragments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ subprojects {
 //      url 'https://oss.sonatype.org/content/repositories/snapshots/'
 //    }
 //    mavenLocal()
+      google()
   }
 
   apply plugin: 'net.ltgt.errorprone'

--- a/leakcanary-android/build.gradle
+++ b/leakcanary-android/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
   api project(':leakcanary-analyzer')
+  api 'com.android.support:support-fragment:27.0.1'
 }
 
 def gitSha() {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/FragmentRefWatcher.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/FragmentRefWatcher.java
@@ -1,0 +1,34 @@
+package com.squareup.leakcanary;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.Fragment;
+import android.app.FragmentManager.FragmentLifecycleCallbacks;
+import android.os.Build.VERSION_CODES;
+
+@TargetApi(VERSION_CODES.O)
+final class FragmentRefWatcher {
+
+  private final RefWatcher refWatcher;
+
+  FragmentRefWatcher(RefWatcher refWatcher) {
+    this.refWatcher = refWatcher;
+  }
+
+  void watch(Activity activity) {
+    activity.getFragmentManager().registerFragmentLifecycleCallbacks(fragmentLifecycleCallbacks, true);
+  }
+
+  void unwatch(Activity activity) {
+    activity.getFragmentManager().unregisterFragmentLifecycleCallbacks(fragmentLifecycleCallbacks);
+  }
+
+  private final FragmentLifecycleCallbacks fragmentLifecycleCallbacks = new android.app.FragmentManager.FragmentLifecycleCallbacks() {
+    @Override
+    public void onFragmentDestroyed(android.app.FragmentManager fm, Fragment f) {
+      refWatcher.watch(f);
+    }
+  };
+
+
+}

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/SupportFragmentRefWatcher.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/SupportFragmentRefWatcher.java
@@ -1,0 +1,30 @@
+package com.squareup.leakcanary;
+
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentManager.FragmentLifecycleCallbacks;
+
+final class SupportFragmentRefWatcher {
+
+  private final RefWatcher refWatcher;
+
+  SupportFragmentRefWatcher(RefWatcher refWatcher) {
+    this.refWatcher = refWatcher;
+  }
+
+  void watch(FragmentActivity activity) {
+      activity.getSupportFragmentManager().registerFragmentLifecycleCallbacks(supportFragmentLifecycleCallbacks, true);
+  }
+
+  void unwatch(FragmentActivity activity) {
+      activity.getSupportFragmentManager().unregisterFragmentLifecycleCallbacks(supportFragmentLifecycleCallbacks);
+  }
+
+  private final FragmentLifecycleCallbacks supportFragmentLifecycleCallbacks = new FragmentLifecycleCallbacks() {
+    @Override
+    public void onFragmentDestroyed(FragmentManager fm, android.support.v4.app.Fragment f) {
+      refWatcher.watch(f);
+    }
+  };
+
+}


### PR DESCRIPTION
This will catch leaked fragments before the activity is destroyed, additionally giving a more specific leak.
Only supported on O+.