### PR TITLE
updated README.md with the Application from FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ dependencies {
 ```
 
 In your `Application` class:
-
 ```java
 public class ExampleApplication extends Application {
+
+  public static RefWatcher getRefWatcher(Context context) {
+    ExampleApplication application = (ExampleApplication) context.getApplicationContext();
+    return application.refWatcher;
+  }
+
+  private RefWatcher refWatcher;
 
   @Override public void onCreate() {
     super.onCreate();
@@ -32,8 +38,7 @@ public class ExampleApplication extends Application {
       // You should not init your app in this process.
       return;
     }
-    LeakCanary.install(this);
-    // Normal app init code...
+    refWatcher = LeakCanary.install(this);
   }
 }
 ```


### PR DESCRIPTION
I have noticed a difference between the FAQs and the example in the Getting started part of the README.
I has confused some users (me and others such as https://github.com/square/leakcanary/issues/648) and I have updated it. It basically now initializes `LearkCanary.install(this)` and stores the result in `refWatcher`, which is the field that can be retrieved when, for example, observing fragments with:
``` java
public abstract class BaseFragment extends Fragment {

  @Override public void onDestroy() {
    super.onDestroy();
    RefWatcher refWatcher = ExampleApplication.getRefWatcher(getActivity());
    refWatcher.watch(this);
  }
}
```