### PR TITLE
Allow Android O devices to share heap dumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ subprojects {
 
   repositories {
     jcenter()
+    google()
 //    maven {
 //      url 'https://oss.sonatype.org/content/repositories/snapshots/'
 //    }

--- a/leakcanary-android/build.gradle
+++ b/leakcanary-android/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
   api project(':leakcanary-analyzer')
+  implementation 'com.android.support:support-core-utils:27.1.0'
 }
 
 def gitSha() {

--- a/leakcanary-android/src/main/AndroidManifest.xml
+++ b/leakcanary-android/src/main/AndroidManifest.xml
@@ -34,6 +34,16 @@
         android:process=":leakcanary"
         android:enabled="false"
         />
+    <provider
+        android:name="android.support.v4.content.FileProvider"
+        android:authorities="com.squareup.leakcanary.fileprovider.${applicationId}"
+        android:exported="false"
+        android:grantUriPermissions="true"
+        >
+      <meta-data
+          android:name="android.support.FILE_PROVIDER_PATHS"
+          android:resource="@xml/leak_canary_file_paths"/>
+    </provider>
     <activity
         android:theme="@style/leak_canary_LeakCanary.Base"
         android:name=".internal.DisplayLeakActivity"

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
+import static android.support.v4.content.FileProvider.getUriForFile;
 import static android.text.format.DateUtils.FORMAT_SHOW_DATE;
 import static android.text.format.DateUtils.FORMAT_SHOW_TIME;
 import static android.text.format.Formatter.formatShortFileSize;
@@ -213,7 +214,9 @@ public final class DisplayLeakActivity extends Activity {
     heapDumpFile.setReadable(true, false);
     Intent intent = new Intent(Intent.ACTION_SEND);
     intent.setType("application/octet-stream");
-    intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(heapDumpFile));
+    Uri heapDumpUri = getUriForFile(getBaseContext(),
+        "com.squareup.leakcanary.fileprovider." + getApplication().getPackageName(), heapDumpFile);
+    intent.putExtra(Intent.EXTRA_STREAM, heapDumpUri);
     startActivity(Intent.createChooser(intent, getString(R.string.leak_canary_share_with)));
   }
 

--- a/leakcanary-android/src/main/res/xml/leak_canary_file_paths.xml
+++ b/leakcanary-android/src/main/res/xml/leak_canary_file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+  <external-path name="downloads" path="Download/" />
+</paths>


### PR DESCRIPTION
Android O (and maybe N) requires the use of a `FileProvider` to share files to another app. The `FileProvider` in this commit uses the external Download folder, but we might want to consider a different spot for the files.

https://github.com/square/leakcanary/issues/775