### PR TITLE
Catch SecurityException in getRunningAppProcesses

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -119,8 +119,14 @@ public final class LeakCanaryInternals {
     ActivityManager activityManager =
         (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
     ActivityManager.RunningAppProcessInfo myProcess = null;
-    List<ActivityManager.RunningAppProcessInfo> runningProcesses =
-        activityManager.getRunningAppProcesses();
+    List<ActivityManager.RunningAppProcessInfo> runningProcesses;
+    try {
+      runningProcesses = activityManager.getRunningAppProcesses();
+    } catch (SecurityException exception) {
+      // https://github.com/square/leakcanary/issues/948
+      CanaryLog.d("Could not get running app processes %d", exception);
+      return false;
+    }
     if (runningProcesses != null) {
       for (ActivityManager.RunningAppProcessInfo process : runningProcesses) {
         if (process.pid == myPid) {


### PR DESCRIPTION
getRunningAppProcesses can throw a SecurityException when a service not related to LeakCanary is started with `android:isolatedProcess="true"`. When that happens, we're very likely not in the leakcanary service process.

Fixes #948