### PR TITLE
Make installed RefWatcher a singleton

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -2,6 +2,7 @@ package com.squareup.leakcanary;
 
 import android.app.Application;
 import android.content.Context;
+import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.util.concurrent.TimeUnit;
 
 import static com.squareup.leakcanary.RefWatcher.DISABLED;
@@ -13,6 +14,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
   private static final long DEFAULT_WATCH_DELAY_MILLIS = SECONDS.toMillis(5);
 
   private final Context context;
+  private boolean watchActivities = true;
 
   AndroidRefWatcherBuilder(Context context) {
     this.context = context.getApplicationContext();
@@ -37,6 +39,15 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
   }
 
   /**
+   * Whether we should automatically watch activities when {@link #buildAndInstall()}. Default is
+   * true.
+   */
+  public AndroidRefWatcherBuilder watchActivities(boolean watchActivities) {
+    this.watchActivities = watchActivities;
+    return this;
+  }
+
+  /**
    * Sets the maximum number of heap dumps stored. This overrides any call to {@link
    * #heapDumper(HeapDumper)} as well as any call to
    * {@link LeakCanary#setDisplayLeakActivityDirectoryProvider(LeakDirectoryProvider)})}
@@ -51,14 +62,25 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
   }
 
   /**
-   * Creates a {@link RefWatcher} instance and starts watching activity references (on ICS+).
+   * Creates a {@link RefWatcher} instance and makes it available through {@link
+   * LeakCanary#installedRefWatcher()}.
+   *
+   * Also starts watching activity references if {@link #watchActivities(boolean)} was set to true.
+   *
+   * @throws UnsupportedOperationException if called more than once per Android process.
    */
   public RefWatcher buildAndInstall() {
+    if (LeakCanaryInternals.installedRefWatcher != null) {
+      throw new UnsupportedOperationException("buildAndInstall() should only be called once.");
+    }
     RefWatcher refWatcher = build();
     if (refWatcher != DISABLED) {
       LeakCanary.enableDisplayLeakActivity(context);
-      ActivityRefWatcher.install((Application) context, refWatcher);
+      if (watchActivities) {
+        ActivityRefWatcher.install((Application) context, refWatcher);
+      }
     }
+    LeakCanaryInternals.installedRefWatcher = refWatcher;
     return refWatcher;
   }
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -23,6 +23,7 @@ import android.os.Build;
 import android.util.Log;
 import com.squareup.leakcanary.internal.DisplayLeakActivity;
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
+import com.squareup.leakcanary.internal.LeakCanaryInternals;
 
 import static android.text.format.Formatter.formatShortFileSize;
 import static com.squareup.leakcanary.BuildConfig.GIT_SHA;
@@ -42,7 +43,17 @@ public final class LeakCanary {
         .buildAndInstall();
   }
 
-  /** Builder to create a customized {@link RefWatcher} with appropriate Android defaults. */
+  /**
+   * @return the {@link RefWatcher} installed via {@link AndroidRefWatcherBuilder#buildAndInstall()}.
+   */
+  public static RefWatcher installedRefWatcher() {
+    RefWatcher refWatcher = LeakCanaryInternals.installedRefWatcher;
+    if (refWatcher == null) {
+      throw new IllegalStateException("AndroidRefWatcherBuilder.buildAndInstall() was not called");
+    }
+    return refWatcher;
+  }
+
   public static AndroidRefWatcherBuilder refWatcher(Context context) {
     return new AndroidRefWatcherBuilder(context);
   }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -29,6 +29,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
 import com.squareup.leakcanary.CanaryLog;
 import com.squareup.leakcanary.R;
+import com.squareup.leakcanary.RefWatcher;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -53,6 +54,7 @@ public final class LeakCanaryInternals {
   public static final String VIVO = "vivo";
 
   private static final Executor fileIoExecutor = newSingleThreadExecutor("File-IO");
+  public static volatile RefWatcher installedRefWatcher;
 
   private static final String NOTIFICATION_CHANNEL_ID = "leakcanary";
 


### PR DESCRIPTION
- This change is needed for the incoming work on detecting leaks in instrumentation tests.
- This changes the semantic meaning of "install" from "add an activity watcher" to "keep a reference to the ref watcher and maybe add an activity watcher".
- As a result, we introduce AndroidRefWatcherBuilder#watchActivity (defaults true) so that an instance can be installed without watching activities.
- This also means user code will not need to keep the installed ref watcher instance around on their own (they can, especially for injection, but don't have to anymore)