### PR TITLE
Added more structured information to LeakTraceElement

### DIFF
--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HahaHelper.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HahaHelper.java
@@ -18,7 +18,6 @@ package com.squareup.leakcanary;
 import com.squareup.haha.perflib.ArrayInstance;
 import com.squareup.haha.perflib.ClassInstance;
 import com.squareup.haha.perflib.ClassObj;
-import com.squareup.haha.perflib.Field;
 import com.squareup.haha.perflib.Instance;
 import com.squareup.haha.perflib.Type;
 import java.lang.reflect.InvocationTargetException;
@@ -26,7 +25,6 @@ import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static com.squareup.leakcanary.Preconditions.checkNotNull;
@@ -38,18 +36,6 @@ public final class HahaHelper {
       asList(Boolean.class.getName(), Character.class.getName(), Float.class.getName(),
           Double.class.getName(), Byte.class.getName(), Short.class.getName(),
           Integer.class.getName(), Long.class.getName()));
-
-  static String fieldToString(Map.Entry<Field, Object> entry) {
-    return fieldToString(entry.getKey(), entry.getValue());
-  }
-
-  static String fieldToString(ClassInstance.FieldValue fieldValue) {
-    return fieldToString(fieldValue.getField(), fieldValue.getValue());
-  }
-
-  static String fieldToString(Field field, Object value) {
-    return field.getName() + " = " + value;
-  }
 
   static String threadName(Instance holder) {
     List<ClassInstance.FieldValue> values = classInstanceValues(holder);

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakNode.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakNode.java
@@ -22,15 +22,12 @@ final class LeakNode {
   final Exclusion exclusion;
   final Instance instance;
   final LeakNode parent;
-  final String referenceName;
-  final LeakTraceElement.Type referenceType;
+  final LeakReference leakReference;
 
-  LeakNode(Exclusion exclusion, Instance instance, LeakNode parent,
-      String referenceName, LeakTraceElement.Type referenceType) {
+  LeakNode(Exclusion exclusion, Instance instance, LeakNode parent, LeakReference leakReference) {
     this.exclusion = exclusion;
     this.instance = instance;
     this.parent = parent;
-    this.referenceName = referenceName;
-    this.referenceType = referenceType;
+    this.leakReference = leakReference;
   }
 }

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakReference.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakReference.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.leakcanary;
+
+import java.io.Serializable;
+
+/**
+ * A single field in a {@link LeakTraceElement}.
+ */
+public final class LeakReference implements Serializable {
+
+  public final LeakTraceElement.Type type;
+  public final String name;
+  public final String value;
+
+  public LeakReference(LeakTraceElement.Type type, String name, String value) {
+    this.type = type;
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getDisplayName() {
+    switch (type) {
+      case ARRAY_ENTRY:
+        return "[" + name + "]";
+      case STATIC_FIELD:
+      case INSTANCE_FIELD:
+        return name;
+      case LOCAL:
+        return "<Java Local>";
+      default:
+        throw new IllegalStateException(
+            "Unexpected type " + type + " name = " + name + " value = " + value);
+    }
+  }
+
+  @Override public String toString() {
+    switch (type) {
+      case ARRAY_ENTRY:
+      case INSTANCE_FIELD:
+        return getDisplayName() + " = " + value;
+      case STATIC_FIELD:
+        return "static " + getDisplayName() + " = " + value;
+      case LOCAL:
+        return getDisplayName();
+      default:
+        throw new IllegalStateException(
+            "Unexpected type " + type + " name = " + name + " value = " + value);
+    }
+  }
+}

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTraceElement.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTraceElement.java
@@ -17,6 +17,7 @@ package com.squareup.leakcanary;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.squareup.leakcanary.LeakTraceElement.Holder.ARRAY;
@@ -38,11 +39,30 @@ public final class LeakTraceElement implements Serializable {
   }
 
   /** Null if this is the last element in the leak trace, ie the leaking object. */
+  public final LeakReference reference;
+
+  /**
+   * @deprecated Use {@link #reference} and {@link LeakReference#getDisplayName()} instead.
+   * Null if this is the last element in the leak trace, ie the leaking object.
+   */
+  @Deprecated
   public final String referenceName;
 
-  /** Null if this is the last element in the leak trace, ie the leaking object. */
+  /**
+   * @deprecated Use {@link #reference} and {@link LeakReference#type} instead.
+   * Null if this is the last element in the leak trace, ie the leaking object.
+   */
+  @Deprecated
   public final Type type;
+
   public final Holder holder;
+
+  /**
+   * Class hierarchy for that object. The first element is {@link #className}. {@link Object}
+   * is excluded. There is always at least one element.
+   */
+  public final List<String> classHierarchy;
+
   public final String className;
 
   /** Additional information, may be null. */
@@ -52,23 +72,36 @@ public final class LeakTraceElement implements Serializable {
   public final Exclusion exclusion;
 
   /** List of all fields (member and static) for that object. */
+  public final List<LeakReference> fieldReferences;
+
+  /**
+   * @deprecated Use {@link #fieldReferences} instead.
+   */
+  @Deprecated
   public final List<String> fields;
 
-  LeakTraceElement(String referenceName, Type type, Holder holder, String className, String extra,
-      Exclusion exclusion, List<String> fields) {
-    this.referenceName = referenceName;
-    this.type = type;
+  LeakTraceElement(LeakReference reference, Holder holder, List<String> classHierarchy,
+      String extra, Exclusion exclusion, List<LeakReference> leakReferences) {
+    this.reference = reference;
+    this.referenceName = reference == null ? null : reference.getDisplayName();
+    this.type = reference == null ? null : reference.type;
     this.holder = holder;
-    this.className = className;
+    this.classHierarchy = Collections.unmodifiableList(new ArrayList<>(classHierarchy));
+    this.className = classHierarchy.get(0);
     this.extra = extra;
     this.exclusion = exclusion;
-    this.fields = unmodifiableList(new ArrayList<>(fields));
+    this.fieldReferences = unmodifiableList(new ArrayList<>(leakReferences));
+    List<String> stringFields = new ArrayList<>();
+    for (LeakReference leakReference : leakReferences) {
+      stringFields.add(leakReference.toString());
+    }
+    fields = Collections.unmodifiableList(stringFields);
   }
 
   @Override public String toString() {
     String string = "";
 
-    if (type == STATIC_FIELD) {
+    if (reference != null && reference.type == STATIC_FIELD) {
       string += "static ";
     }
 
@@ -76,10 +109,10 @@ public final class LeakTraceElement implements Serializable {
       string += holder.name().toLowerCase(US) + " ";
     }
 
-    string += className;
+    string += classHierarchy.get(0);
 
-    if (referenceName != null) {
-      string += "." + referenceName;
+    if (reference != null) {
+      string += "." + reference.getDisplayName();
     } else {
       string += " instance";
     }
@@ -105,8 +138,8 @@ public final class LeakTraceElement implements Serializable {
       string += "Instance of";
     }
     string += " " + className + "\n";
-    for (String field : fields) {
-      string += "|   " + field + "\n";
+    for (LeakReference leakReference : fieldReferences) {
+      string += "|   " + leakReference + "\n";
     }
     return string;
   }

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/TrackedReference.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/TrackedReference.java
@@ -20,9 +20,9 @@ public class TrackedReference {
   public final String className;
 
   /** List of all fields (member and static) for that instance. */
-  public final List<String> fields;
+  public final List<LeakReference> fields;
 
-  public TrackedReference(String key, String name, String className, List<String> fields) {
+  public TrackedReference(String key, String name, String className, List<LeakReference> fields) {
     this.key = key;
     this.name = name;
     this.className = className;


### PR DESCRIPTION
This will be needed for #727

* New structured description for references: LeakReference(type, name, value)
* Added class hierarchy to LeakTraceElement
* LeakTraceElement.fields (String) is deprecated, replaced with fieldReferences (LeakReference)
* LeakTraceElement.referenceName and LeakTraceElement.type are deprecated, replaced with LeakTraceElement.reference
* LeakTraceElement.className is deprecated, replaced with LeakTraceElement.classHierarchy.get(0)