### PR TITLE
Moving LeakDirectoryProvider to LeakCanaryInternals

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -48,17 +48,16 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
   }
 
   /**
-   * Sets the maximum number of heap dumps stored. This overrides any call to {@link
-   * #heapDumper(HeapDumper)} as well as any call to
-   * {@link LeakCanary#setDisplayLeakActivityDirectoryProvider(LeakDirectoryProvider)})}
+   * Sets the maximum number of heap dumps stored. This overrides any call to
+   * {@link LeakCanary#setLeakDirectoryProvider(LeakDirectoryProvider)}
    *
    * @throws IllegalArgumentException if maxStoredHeapDumps < 1.
    */
   public AndroidRefWatcherBuilder maxStoredHeapDumps(int maxStoredHeapDumps) {
     LeakDirectoryProvider leakDirectoryProvider =
         new DefaultLeakDirectoryProvider(context, maxStoredHeapDumps);
-    LeakCanary.setDisplayLeakActivityDirectoryProvider(leakDirectoryProvider);
-    return heapDumper(new AndroidHeapDumper(context, leakDirectoryProvider));
+    LeakCanary.setLeakDirectoryProvider(leakDirectoryProvider);
+    return self();
   }
 
   /**
@@ -89,7 +88,8 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
   }
 
   @Override protected HeapDumper defaultHeapDumper() {
-    LeakDirectoryProvider leakDirectoryProvider = new DefaultLeakDirectoryProvider(context);
+    LeakDirectoryProvider leakDirectoryProvider =
+        LeakCanaryInternals.getLeakDirectoryProvider(context);
     return new AndroidHeapDumper(context, leakDirectoryProvider);
   }
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -63,13 +63,23 @@ public final class LeakCanary {
   }
 
   /**
-   * If you build a {@link RefWatcher} with a {@link AndroidHeapDumper} that has a custom {@link
-   * LeakDirectoryProvider}, then you should also call this method to make sure the activity in
-   * charge of displaying leaks can find those on the file system.
+   * @deprecated Use {@link #setLeakDirectoryProvider(LeakDirectoryProvider)} instead.
    */
+  @Deprecated
   public static void setDisplayLeakActivityDirectoryProvider(
       LeakDirectoryProvider leakDirectoryProvider) {
-    DisplayLeakActivity.setLeakDirectoryProvider(leakDirectoryProvider);
+    setLeakDirectoryProvider(leakDirectoryProvider);
+  }
+
+  /**
+   * Used to customize the location for the storage of heap dumps. The default implementation is
+   * {@link DefaultLeakDirectoryProvider}.
+   *
+   * @throws IllegalStateException if a LeakDirectoryProvider has already been set, including
+   * if the default has been automatically set when installing the ref watcher.
+   */
+  public static void setLeakDirectoryProvider(LeakDirectoryProvider leakDirectoryProvider) {
+    LeakCanaryInternals.setLeakDirectoryProvider(leakDirectoryProvider);
   }
 
   /** Returns a string representation of the result of a heap analysis. */

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -42,7 +42,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 import com.squareup.leakcanary.AnalysisResult;
 import com.squareup.leakcanary.CanaryLog;
-import com.squareup.leakcanary.DefaultLeakDirectoryProvider;
 import com.squareup.leakcanary.HeapDump;
 import com.squareup.leakcanary.LeakDirectoryProvider;
 import com.squareup.leakcanary.R;
@@ -67,6 +66,7 @@ import static android.view.View.VISIBLE;
 import static com.squareup.leakcanary.BuildConfig.GIT_SHA;
 import static com.squareup.leakcanary.BuildConfig.LIBRARY_VERSION;
 import static com.squareup.leakcanary.LeakCanary.leakInfo;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.getLeakDirectoryProvider;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.newSingleThreadExecutor;
 
 @SuppressWarnings("ConstantConditions")
@@ -87,18 +87,6 @@ public final class DisplayLeakActivity extends Activity {
     intent.putExtra(SHOW_LEAK_EXTRA, referenceKey);
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
     return PendingIntent.getActivity(context, 1, intent, FLAG_UPDATE_CURRENT);
-  }
-
-  public static void setLeakDirectoryProvider(LeakDirectoryProvider leakDirectoryProvider) {
-    DisplayLeakActivity.leakDirectoryProvider = leakDirectoryProvider;
-  }
-
-  private static LeakDirectoryProvider leakDirectoryProvider(Context context) {
-    LeakDirectoryProvider leakDirectoryProvider = DisplayLeakActivity.leakDirectoryProvider;
-    if (leakDirectoryProvider == null) {
-      leakDirectoryProvider = new DefaultLeakDirectoryProvider(context);
-    }
-    return leakDirectoryProvider;
   }
 
   // null until it's been first loaded.
@@ -144,7 +132,7 @@ public final class DisplayLeakActivity extends Activity {
 
   @Override protected void onResume() {
     super.onResume();
-    LoadLeaks.load(this, leakDirectoryProvider(this));
+    LoadLeaks.load(this, getLeakDirectoryProvider(this));
   }
 
   @Override public void setTheme(int resid) {
@@ -244,7 +232,7 @@ public final class DisplayLeakActivity extends Activity {
   }
 
   void deleteAllLeaks() {
-    leakDirectoryProvider(DisplayLeakActivity.this).clearLeakDirectory();
+    getLeakDirectoryProvider(this).clearLeakDirectory();
     leaks = Collections.emptyList();
     updateUi();
   }


### PR DESCRIPTION
On top of the AndroidHeapDumper, we also need to access LeakDirectoryProvider from DisplayLeakActivity. We'll soon need to also access it from the UI test run listener. We can't keep the instance as a field of the RefWatcher singleton because DisplayLeakActivity lives in a different process.

This change renames LeakCanary.setDisplayLeakActivityDirectoryProvider to LeakCanary.setLeakDirectoryProvider and makes sure we use that global LeakDirectoryProvider everywhere.