### PR TITLE
Lazily enable the Android components

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -75,7 +75,6 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
     }
     RefWatcher refWatcher = build();
     if (refWatcher != DISABLED) {
-      LeakCanary.enableDisplayLeakActivity(context);
       if (watchActivities) {
         ActivityRefWatcher.install((Application) context, refWatcher);
       }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -58,8 +58,14 @@ public final class LeakCanary {
     return new AndroidRefWatcherBuilder(context);
   }
 
+  /**
+   * Blocking inter process call that enables the {@link DisplayLeakActivity}. When you first
+   * install the app, {@link DisplayLeakActivity} is disabled by default and will only be enabled
+   * once a potential leak has been found and the analysis starts. You can call this method to
+   * enable {@link DisplayLeakActivity} before any potential leak has been detected.
+   */
   public static void enableDisplayLeakActivity(Context context) {
-    setEnabled(context, DisplayLeakActivity.class, true);
+    LeakCanaryInternals.setEnabledBlocking(context, DisplayLeakActivity.class, true);
   }
 
   /**

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
@@ -19,17 +19,14 @@ import android.content.Context;
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
 
 import static com.squareup.leakcanary.Preconditions.checkNotNull;
-import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabled;
 
 public final class ServiceHeapDumpListener implements HeapDump.Listener {
 
   private final Context context;
   private final Class<? extends AbstractAnalysisResultService> listenerServiceClass;
 
-  public ServiceHeapDumpListener(Context context,
-      Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
-    setEnabled(context, listenerServiceClass, true);
-    setEnabled(context, HeapAnalyzerService.class, true);
+  public ServiceHeapDumpListener(final Context context,
+      final Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
     this.listenerServiceClass = checkNotNull(listenerServiceClass, "listenerServiceClass");
     this.context = checkNotNull(context, "context").getApplicationContext();
   }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -68,6 +68,7 @@ import static com.squareup.leakcanary.BuildConfig.GIT_SHA;
 import static com.squareup.leakcanary.BuildConfig.LIBRARY_VERSION;
 import static com.squareup.leakcanary.LeakCanary.leakInfo;
 import static com.squareup.leakcanary.internal.LeakCanaryInternals.newSingleThreadExecutor;
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabledBlocking;
 
 @SuppressWarnings("ConstantConditions")
 public final class DisplayLeakActivity extends Activity {
@@ -83,6 +84,7 @@ public final class DisplayLeakActivity extends Activity {
   }
 
   public static PendingIntent createPendingIntent(Context context, String referenceKey) {
+    setEnabledBlocking(context, DisplayLeakActivity.class, true);
     Intent intent = new Intent(context, DisplayLeakActivity.class);
     intent.putExtra(SHOW_LEAK_EXTRA, referenceKey);
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/HeapAnalyzerService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/HeapAnalyzerService.java
@@ -24,6 +24,8 @@ import com.squareup.leakcanary.CanaryLog;
 import com.squareup.leakcanary.HeapAnalyzer;
 import com.squareup.leakcanary.HeapDump;
 
+import static com.squareup.leakcanary.internal.LeakCanaryInternals.setEnabledBlocking;
+
 /**
  * This service runs in a separate process to avoid slowing down the app process or making it run
  * out of memory.
@@ -35,6 +37,8 @@ public final class HeapAnalyzerService extends IntentService {
 
   public static void runAnalysis(Context context, HeapDump heapDump,
       Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
+    setEnabledBlocking(context, HeapAnalyzerService.class, true);
+    setEnabledBlocking(context, listenerServiceClass, true);
     Intent intent = new Intent(context, HeapAnalyzerService.class);
     intent.putExtra(LISTENER_CLASS_EXTRA, listenerServiceClass.getName());
     intent.putExtra(HEAPDUMP_EXTRA, heapDump);

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -53,16 +53,11 @@ public final class LeakCanaryInternals {
   public static final String HUAWEI = "HUAWEI";
   public static final String VIVO = "vivo";
 
-  private static final Executor fileIoExecutor = newSingleThreadExecutor("File-IO");
   public static volatile RefWatcher installedRefWatcher;
 
   private static final String NOTIFICATION_CHANNEL_ID = "leakcanary";
 
   public static volatile Boolean isInAnalyzerProcess;
-
-  public static void executeOnFileIoThread(Runnable runnable) {
-    fileIoExecutor.execute(runnable);
-  }
 
   /** Extracts the class simple name out of a string containing a fully qualified class name. */
   public static String classSimpleName(String className) {
@@ -72,16 +67,6 @@ public final class LeakCanaryInternals {
     } else {
       return className.substring(separator + 1);
     }
-  }
-
-  public static void setEnabled(Context context, final Class<?> componentClass,
-      final boolean enabled) {
-    final Context appContext = context.getApplicationContext();
-    executeOnFileIoThread(new Runnable() {
-      @Override public void run() {
-        setEnabledBlocking(appContext, componentClass, enabled);
-      }
-    });
   }
 
   public static void setEnabledBlocking(Context appContext, Class<?> componentClass,


### PR DESCRIPTION
HeapAnalyzerService, AnalysisResultService and DisplayLeakActivity are all disabled by default. They're now enabled only as needed.

This means they won't be enabled when LeakCanary is used in CI, or when there are no leak.