### PR TITLE
Perform DisplayLeakActivity IO in background

### DIFF
--- a/leakcanary-sample/src/main/java/com/example/leakcanary/ExampleApplication.java
+++ b/leakcanary-sample/src/main/java/com/example/leakcanary/ExampleApplication.java
@@ -26,12 +26,12 @@ public class ExampleApplication extends Application {
   }
 
   protected void setupLeakCanary() {
+    enabledStrictMode();
     if (LeakCanary.isInAnalyzerProcess(this)) {
       // This process is dedicated to LeakCanary for heap analysis.
       // You should not init your app in this process.
       return;
     }
-    enabledStrictMode();
     LeakCanary.install(this);
   }
 


### PR DESCRIPTION
- Moved enabledStrictMode() so that we also have strict mode in the analyzer process (since DisplayLeakActivity lives in that process)
- Updated all code sites triggering strict mode disk read checks

Fixes #685