### PR TITLE
Stop computing Retained Size by default

### DIFF
--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalysisResult.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalysisResult.java
@@ -19,6 +19,8 @@ import java.io.Serializable;
 
 public final class AnalysisResult implements Serializable {
 
+  public static final long RETAINED_HEAP_SKIPPED = -1;
+
   public static AnalysisResult noLeak(long analysisDurationMs) {
     return new AnalysisResult(false, false, null, null, null, 0, analysisDurationMs);
   }
@@ -59,7 +61,8 @@ public final class AnalysisResult implements Serializable {
 
   /**
    * The number of bytes which would be freed if all references to the leaking object were
-   * released. 0 if {@link #leakFound} is false.
+   * released. {@link #RETAINED_HEAP_SKIPPED} if the retained heap size was not computed. 0 if
+   * {@link #leakFound} is false.
    */
   public final long retainedHeapSize;
 

--- a/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/TestUtil.java
+++ b/leakcanary-analyzer/src/test/java/com/squareup/leakcanary/TestUtil.java
@@ -56,7 +56,7 @@ final class TestUtil {
     String referenceKey = heapDumpFile.referenceKey;
     HeapAnalyzer heapAnalyzer = new HeapAnalyzer(excludedRefs.build());
     AnalysisResult result =
-        heapAnalyzer.checkForLeak(file, referenceKey);
+        heapAnalyzer.checkForLeak(file, referenceKey, true);
     if (result.failure != null) {
       result.failure.printStackTrace();
     }

--- a/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakDetector.java
+++ b/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakDetector.java
@@ -183,10 +183,12 @@ public final class InstrumentationLeakDetector {
         continue;
       }
 
+      HeapDump.Durations durations = new HeapDump.Durations(0, 0, 0);
       HeapDump heapDump =
-          new HeapDump(heapDumpFile, trackedReference.key, trackedReference.name, excludedRefs, 0,
-              0, 0);
-      AnalysisResult analysisResult = heapAnalyzer.checkForLeak(heapDumpFile, trackedReference.key);
+          new HeapDump(heapDumpFile, trackedReference.key, trackedReference.name, excludedRefs,
+              false, durations);
+      AnalysisResult analysisResult =
+          heapAnalyzer.checkForLeak(heapDumpFile, trackedReference.key, false);
 
       InstrumentationLeakResults.Result leakResult =
           new InstrumentationLeakResults.Result(heapDump, analysisResult);

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -111,7 +111,9 @@ public final class LeakCanary {
         info += " (" + heapDump.referenceName + ")";
       }
       info += " has leaked:\n" + result.leakTrace.toString() + "\n";
-      info += "* Retaining: " + formatShortFileSize(context, result.retainedHeapSize) + ".\n";
+      if (result.retainedHeapSize != AnalysisResult.RETAINED_HEAP_SKIPPED) {
+        info += "* Retaining: " + formatShortFileSize(context, result.retainedHeapSize) + ".\n";
+      }
       if (detailed) {
         detailedString = "\n* Details:\n" + result.leakTrace.toDetailedString();
       }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/DisplayLeakActivity.java
@@ -329,9 +329,14 @@ public final class DisplayLeakActivity extends Activity {
         }
         HeapDump heapDump = visibleLeak.heapDump;
         adapter.update(result.leakTrace, heapDump.referenceKey, heapDump.referenceName);
-        String size = formatShortFileSize(this, result.retainedHeapSize);
-        String className = classSimpleName(result.className);
-        setTitle(getString(R.string.leak_canary_class_has_leaked, className, size));
+        if (result.retainedHeapSize == AnalysisResult.RETAINED_HEAP_SKIPPED) {
+          String className = classSimpleName(result.className);
+          setTitle(getString(R.string.leak_canary_class_has_leaked, className));
+        } else {
+          String size = formatShortFileSize(this, result.retainedHeapSize);
+          String className = classSimpleName(result.className);
+          setTitle(getString(R.string.leak_canary_class_has_leaked_retaining, className, size));
+        }
       }
     } else {
       if (listAdapter instanceof LeakListAdapter) {
@@ -419,8 +424,12 @@ public final class DisplayLeakActivity extends Activity {
       String title;
       if (leak.result.failure == null) {
         String className = classSimpleName(leak.result.className);
-        String size = formatShortFileSize(DisplayLeakActivity.this, leak.result.retainedHeapSize);
-        title = getString(R.string.leak_canary_class_has_leaked, className, size);
+        if (leak.result.retainedHeapSize == AnalysisResult.RETAINED_HEAP_SKIPPED) {
+          title = getString(R.string.leak_canary_class_has_leaked, className);
+        } else {
+          String size = formatShortFileSize(DisplayLeakActivity.this, leak.result.retainedHeapSize);
+          title = getString(R.string.leak_canary_class_has_leaked_retaining, className, size);
+        }
         if (leak.result.excludedLeak) {
           title = getString(R.string.leak_canary_excluded_row, title);
         }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/HeapAnalyzerService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/HeapAnalyzerService.java
@@ -62,8 +62,8 @@ public final class HeapAnalyzerService extends ForegroundService
 
     HeapAnalyzer heapAnalyzer = new HeapAnalyzer(heapDump.excludedRefs, this);
 
-    AnalysisResult result =
-        heapAnalyzer.checkForLeak(heapDump.heapDumpFile, heapDump.referenceKey);
+    AnalysisResult result = heapAnalyzer.checkForLeak(heapDump.heapDumpFile, heapDump.referenceKey,
+        heapDump.computeRetainedHeapSize);
     AbstractAnalysisResultService.sendResultToListener(this, listenerClassName, heapDump, result);
   }
 

--- a/leakcanary-android/src/main/res/values-de/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values-de/leak_canary_strings.xml
@@ -14,8 +14,10 @@
   ~ limitations under the License.
   -->
 <resources>
-    <string name="leak_canary_class_has_leaked">%1$s hat %2$s geleaked</string>
-    <string name="leak_canary_leak_excluded">[Ausgeschlossen] %1$s hat %2$s geleaked</string>
+    <string name="leak_canary_class_has_leaked">%1$s hat geleaked</string>
+    <string name="leak_canary_class_has_leaked_retaining">%1$s hat %2$s geleaked</string>
+    <string name="leak_canary_leak_excluded">[Ausgeschlossen] %1$s hat geleaked</string>
+    <string name="leak_canary_leak_excluded_retaining">[Ausgeschlossen] %1$s hat %2$s geleaked</string>
     <string name="leak_canary_analysis_failed">Leak Analyse fehlgeschlagen</string>
     <string name="leak_canary_leak_list_title">Leaks in %s</string>
     <string name="leak_canary_notification_analysing">Analyzing Heap Dump</string>

--- a/leakcanary-android/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_strings.xml
@@ -15,8 +15,10 @@
   ~ limitations under the License.
   -->
 <resources>
-  <string name="leak_canary_class_has_leaked">%1$s leaked %2$s</string>
-  <string name="leak_canary_leak_excluded">[Excluded] %1$s leaked %2$s</string>
+  <string name="leak_canary_class_has_leaked">%1$s leaked</string>
+  <string name="leak_canary_class_has_leaked_retaining">%1$s leaked %2$s</string>
+  <string name="leak_canary_leak_excluded">[Excluded] %1$s leaked</string>
+  <string name="leak_canary_leak_excluded_retaining">[Excluded] %1$s leaked %2$s</string>
   <string name="leak_canary_analysis_failed">Leak analysis failed</string>
   <string name="leak_canary_leak_list_title">Leaks in %s</string>
   <string name="leak_canary_notification_analysing">Analyzing Heap Dump</string>

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDump.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDump.java
@@ -57,15 +57,46 @@ public final class HeapDump implements Serializable {
   public final long watchDurationMs;
   public final long gcDurationMs;
   public final long heapDumpDurationMs;
+  public final boolean computeRetainedHeapSize;
 
+  /**
+   * Calls {@link #HeapDump(File, String, String, ExcludedRefs, boolean, Durations)}
+   * with computeRetainedHeapSize set to true.
+   *
+   * @deprecated Use
+   * {@link #HeapDump(File, String, String, ExcludedRefs, boolean, Durations)}  instead.
+   */
+  @Deprecated
   public HeapDump(File heapDumpFile, String referenceKey, String referenceName,
       ExcludedRefs excludedRefs, long watchDurationMs, long gcDurationMs, long heapDumpDurationMs) {
+    this(heapDumpFile, referenceKey, referenceName, excludedRefs, true,
+        new Durations(watchDurationMs, gcDurationMs, heapDumpDurationMs));
+  }
+
+  public HeapDump(File heapDumpFile, String referenceKey, String referenceName,
+      ExcludedRefs excludedRefs, boolean computeRetainedHeapSize, Durations durations) {
     this.heapDumpFile = checkNotNull(heapDumpFile, "heapDumpFile");
     this.referenceKey = checkNotNull(referenceKey, "referenceKey");
     this.referenceName = checkNotNull(referenceName, "referenceName");
     this.excludedRefs = checkNotNull(excludedRefs, "excludedRefs");
-    this.watchDurationMs = watchDurationMs;
-    this.gcDurationMs = gcDurationMs;
-    this.heapDumpDurationMs = heapDumpDurationMs;
+    this.computeRetainedHeapSize = computeRetainedHeapSize;
+    this.watchDurationMs = durations.watchDurationMs;
+    this.gcDurationMs = durations.gcDurationMs;
+    this.heapDumpDurationMs = durations.heapDumpDurationMs;
+  }
+
+  /**
+   * A group of duration related parameters required when constructing a {@link HeapDump} instance.
+   */
+  public static final class Durations {
+    final long watchDurationMs;
+    final long gcDurationMs;
+    final long heapDumpDurationMs;
+
+    public Durations(long watchDurationMs, long gcDurationMs, long heapDumpDurationMs) {
+      this.watchDurationMs = watchDurationMs;
+      this.gcDurationMs = gcDurationMs;
+      this.heapDumpDurationMs = heapDumpDurationMs;
+    }
   }
 }

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/RefWatcherBuilder.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/RefWatcherBuilder.java
@@ -12,6 +12,7 @@ public class RefWatcherBuilder<T extends RefWatcherBuilder<T>> {
   private HeapDumper heapDumper;
   private WatchExecutor watchExecutor;
   private GcTrigger gcTrigger;
+  private boolean computeRetainedHeapSize;
 
   /** @see HeapDump.Listener */
   public final T heapDumpListener(HeapDump.Listener heapDumpListener) {
@@ -46,6 +47,15 @@ public class RefWatcherBuilder<T extends RefWatcherBuilder<T>> {
   /** @see GcTrigger */
   public final T gcTrigger(GcTrigger gcTrigger) {
     this.gcTrigger = gcTrigger;
+    return self();
+  }
+
+  /**
+   * Whether LeakCanary should compute the retained heap size when a leak is detected. False by
+   * default, because computing the retained heap size takes a long time.
+   */
+  public final T computeRetainedHeapSize(boolean computeRetainedHeapSize) {
+    this.computeRetainedHeapSize = computeRetainedHeapSize;
     return self();
   }
 
@@ -86,7 +96,7 @@ public class RefWatcherBuilder<T extends RefWatcherBuilder<T>> {
     }
 
     return new RefWatcher(watchExecutor, debuggerControl, gcTrigger, heapDumper, heapDumpListener,
-        excludedRefs);
+        excludedRefs, computeRetainedHeapSize);
   }
 
   protected boolean isDisabled() {


### PR DESCRIPTION
It turns out computing the retained size is really slow. This change turns it off by default (can be turned on if needed). LeakCanary is much faster now!

Fixes #1011