### PR TITLE
Undo binary incompatible change

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -1,7 +1,6 @@
 package com.squareup.leakcanary;
 
 import android.content.Context;
-import com.squareup.leakcanary.internal.ActivityRefWatcher;
 import com.squareup.leakcanary.internal.FragmentRefWatcher;
 import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
In #1010 we introduced a binary incompatible change by moving ActivityRefWatcher to an internal package and removing method. This change undoes that, while also marking the class as deprecated from an API standpoint.