### PR TITLE
Using a unique class name for FileProvider

### DIFF
--- a/leakcanary-android/src/main/AndroidManifest.xml
+++ b/leakcanary-android/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         android:enabled="false"
         />
     <provider
-        android:name="android.support.v4.content.FileProvider"
+        android:name="com.squareup.leakcanary.internal.LeakCanaryFileProvider"
         android:authorities="com.squareup.leakcanary.fileprovider.${applicationId}"
         android:exported="false"
         android:grantUriPermissions="true"

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryFileProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryFileProvider.java
@@ -1,0 +1,10 @@
+package com.squareup.leakcanary.internal;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * There can only be one {@link FileProvider} provider registered per app, so we extend that class
+ * just to use a distinct name.
+ */
+public class LeakCanaryFileProvider extends FileProvider {
+}


### PR DESCRIPTION
Avoids creating downstream conflicts