### PR TITLE
Work around null KeyedWeakReference.key

### DIFF
--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HahaHelper.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HahaHelper.java
@@ -83,6 +83,7 @@ public final class HahaHelper {
 
   /** Given a string instance from the heap dump, this returns its actual string value. */
   static String asString(Object stringObject) {
+    checkNotNull(stringObject, "stringObject");
     Instance instance = (Instance) stringObject;
     List<ClassInstance.FieldValue> values = classInstanceValues(instance);
 

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HeapAnalyzer.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HeapAnalyzer.java
@@ -211,10 +211,19 @@ public final class HeapAnalyzer {
 
   private Instance findLeakingReference(String key, Snapshot snapshot) {
     ClassObj refClass = snapshot.findClass(KeyedWeakReference.class.getName());
+    if (refClass == null) {
+      throw new IllegalStateException(
+          "Could not find the " + KeyedWeakReference.class.getName() + " class in the heap dump.");
+    }
     List<String> keysFound = new ArrayList<>();
     for (Instance instance : refClass.getInstancesList()) {
       List<ClassInstance.FieldValue> values = classInstanceValues(instance);
-      String keyCandidate = asString(fieldValue(values, "key"));
+      Object keyFieldValue = fieldValue(values, "key");
+      if (keyFieldValue == null) {
+        keysFound.add(null);
+        continue;
+      }
+      String keyCandidate = asString(keyFieldValue);
       if (keyCandidate.equals(key)) {
         return fieldValue(values, "referent");
       }

--- a/leakcanary-android/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android/src/main/res/values/leak_canary_strings.xml
@@ -34,7 +34,7 @@
   <string name="leak_canary_storage_permission_activity_label">Storage permission</string>
   <string name="leak_canary_toast_heap_dump">Dumping memory, app will freeze. Brrrr.</string>
   <string name="leak_canary_delete">Delete</string>
-  <string name="leak_canary_failure_report">"Please report this failure to http://github.com/square/leakcanary\n"</string>
+  <string name="leak_canary_failure_report">"Please report this failure to http://github.com/square/leakcanary and share the heapdump file that caused it.\n"</string>
   <string name="leak_canary_delete_all">Delete all</string>
   <string name="leak_canary_delete_all_leaks_title">Are you sure you want to delete all leaks?</string>
   <string name="leak_canary_could_not_save_title">Could not save result.</string>


### PR DESCRIPTION
- Make HahaHelper.asString() explicitly non nullable instead of crashing later with NPE
- If KeyedWeakReference.key is null (which should never happen at runtime), then we skip and keep looking for keys, but report all the null keys if we couldn't find any.

If this was caused by some malformed object then we have a chance of actually finding the right KeyedWeakReference instance. However, if this was caused by a heap dump parsing issue then we'll
still crash but at least we'll have an exception closer to the source.

Fixes #874