### PR TITLE
Add LeakCanary.installedRefWatcher() to no-op

### DIFF
--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -12,6 +12,10 @@ public final class LeakCanary {
     return RefWatcher.DISABLED;
   }
 
+  public static RefWatcher installedRefWatcher() {
+    return RefWatcher.DISABLED;
+  }
+
   public static boolean isInAnalyzerProcess(Context context) {
     return false;
   }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -43,12 +43,14 @@ public final class LeakCanary {
   }
 
   /**
-   * @return the {@link RefWatcher} installed via {@link AndroidRefWatcherBuilder#buildAndInstall()}.
+   * Returns the {@link RefWatcher} installed via
+   * {@link AndroidRefWatcherBuilder#buildAndInstall()}, and {@link RefWatcher#DISABLED} is no
+   * {@link RefWatcher} has been installed.
    */
   public static RefWatcher installedRefWatcher() {
     RefWatcher refWatcher = LeakCanaryInternals.installedRefWatcher;
     if (refWatcher == null) {
-      throw new IllegalStateException("AndroidRefWatcherBuilder.buildAndInstall() was not called");
+      return RefWatcher.DISABLED;
     }
     return refWatcher;
   }


### PR DESCRIPTION
Also changing the default behavior to disabled (rather than throwing).

Fixes #1058