### PR TITLE
Fixed wrong versions in AndroidExcludedRefs

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -25,6 +25,7 @@ import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH;
 import static android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
@@ -250,7 +251,7 @@ public enum AndroidExcludedRefs {
     }
   },
 
-  USER_MANAGER__SINSTANCE(SDK_INT >= JELLY_BEAN && SDK_INT <= M) {
+  USER_MANAGER__SINSTANCE(SDK_INT >= JELLY_BEAN_MR2 && SDK_INT < O) {
     @Override void add(ExcludedRefs.Builder excluded) {
       excluded.instanceField("android.os.UserManager", "mContext")
           .reason("UserManager has a static sInstance field that creates an instance and caches it"


### PR DESCRIPTION
Commit https://android.googlesource.com/platform/frameworks/base/+/27db46850b708070452c0ce49daf5f79503fbde6 introduced this issue. This commit was first included in Jelly Bean 4.3 (JELLY_BEAN_MR2), not Jelly Bean 4.1 (JELLY_BEAN)
Commit https://android.googlesource.com/platform/frameworks/base/+/5200e1cb07190a1f6874d72a4561064cad3ee3e0 fixes this issue and was first included in Oreo 8.0 (O). Nougat still has this memory leak.