### PR TITLE
No log for bad token exception

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -146,8 +146,8 @@ public final class AndroidHeapDumper implements HeapDumper {
     params.packageName = context.getPackageName();
     try {
       windowManager.addView(view, params);
-    } catch (WindowManager.BadTokenException e) {
-      CanaryLog.d(e, "Could not show leak toast, the window token has been canceled");
+    } catch (WindowManager.BadTokenException ignored) {
+      CanaryLog.d("Could not show leak toast, the window token has been canceled");
       return;
     }
     trySendAccessibilityEvent(view);


### PR DESCRIPTION
We're expecting this exception and handling it. Having it in the logs can be confusing: https://github.com/square/leakcanary/issues/844#issuecomment-407453129