### PR TITLE
Add the FOREGROUND_SERVICE permission for Android P

### DIFF
--- a/leakcanary-android/src/main/AndroidManifest.xml
+++ b/leakcanary-android/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
   <!-- To store the heap dumps and leak analysis results. -->
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-  <!-- To allow starting foreground services on Android P+ -->
+  <!-- To allow starting foreground services on Android P+ - https://developer.android.com/preview/behavior-changes#fg-svc -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
   <application>

--- a/leakcanary-android/src/main/AndroidManifest.xml
+++ b/leakcanary-android/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
   <!-- To store the heap dumps and leak analysis results. -->
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <!-- To allow starting foreground services on Android P+ -->
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
   <application>
     <service


### PR DESCRIPTION
Per https://developer.android.com/preview/behavior-changes#fg-svc, this permission is now required to start a foreground service.  Otherwise, it crashes.