### PR TITLE
Extended TextView#mLastHoveredView exclusion to O.

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -462,7 +462,7 @@ public enum AndroidExcludedRefs {
   },
 
   TEXT_VIEW__MLAST_HOVERED_VIEW(
-      SAMSUNG.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= LOLLIPOP_MR1) {
+      SAMSUNG.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= N) {
     @Override void add(ExcludedRefs.Builder excluded) {
       excluded.staticField("android.widget.TextView", "mLastHoveredView")
           .reason("mLastHoveredView is a static field in TextView that leaks the last hovered"

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -462,7 +462,7 @@ public enum AndroidExcludedRefs {
   },
 
   TEXT_VIEW__MLAST_HOVERED_VIEW(
-      SAMSUNG.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= N) {
+      SAMSUNG.equals(MANUFACTURER) && SDK_INT >= KITKAT && SDK_INT <= O) {
     @Override void add(ExcludedRefs.Builder excluded) {
       excluded.staticField("android.widget.TextView", "mLastHoveredView")
           .reason("mLastHoveredView is a static field in TextView that leaks the last hovered"


### PR DESCRIPTION
mLastHoveredView is still leaking on Samsung devices with Marshmallow and Nougat (EDIT: also on Oreo). Tested on Galaxy Tab A 10.1 (SM-P580) and Galaxy Tab S3 (SM-T825).

CLA signed.