### PR TITLE
Add nullability annotations to public API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     maven { url 'https://plugins.gradle.org/m2/' }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.4'
+    classpath 'com.android.tools.build:gradle:3.2.0-rc03'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.16'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
   }

--- a/leakcanary-analyzer/build.gradle
+++ b/leakcanary-analyzer/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   api project(':leakcanary-watcher')
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.assertj:assertj-core:3.9.1'
+  implementation 'com.android.support:support-annotations:26.0.0'
 }
 
 android {
@@ -16,6 +17,7 @@ android {
 
   lintOptions {
     disable 'GoogleAppIndexingWarning'
+    check 'Interoperability'
   }
 
   // TODO replace with https://issuetracker.google.com/issues/72050365 once released.

--- a/leakcanary-analyzer/src/main/java/com/squareup/haha/perflib/HahaSpy.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/haha/perflib/HahaSpy.java
@@ -15,9 +15,11 @@
  */
 package com.squareup.haha.perflib;
 
+import android.support.annotation.NonNull;
+
 public final class HahaSpy {
 
-  public static Instance allocatingThread(Instance instance) {
+  public static @NonNull Instance allocatingThread(@NonNull Instance instance) {
     Snapshot snapshot = instance.mHeap.mSnapshot;
     int threadSerialNumber;
     if (instance instanceof RootObj) {

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalysisResult.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalysisResult.java
@@ -52,16 +52,16 @@ public final class AnalysisResult implements Serializable {
    * Class name of the object that leaked if {@link #leakFound} is true, null otherwise.
    * The class name format is the same as what would be returned by {@link Class#getName()}.
    */
-  public final @Nullable String className;
+  @Nullable public final String className;
 
   /**
    * Shortest path to GC roots for the leaking object if {@link #leakFound} is true, null
    * otherwise. This can be used as a unique signature for the leak.
    */
-  public final @Nullable LeakTrace leakTrace;
+  @Nullable public final LeakTrace leakTrace;
 
   /** Null unless the analysis failed. */
-  public final @Nullable Throwable failure;
+  @Nullable public final Throwable failure;
 
   /**
    * The number of bytes which would be freed if all references to the leaking object were

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalysisResult.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalysisResult.java
@@ -15,23 +15,27 @@
  */
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import java.io.Serializable;
 
 public final class AnalysisResult implements Serializable {
 
   public static final long RETAINED_HEAP_SKIPPED = -1;
 
-  public static AnalysisResult noLeak(long analysisDurationMs) {
+  public static @NonNull AnalysisResult noLeak(long analysisDurationMs) {
     return new AnalysisResult(false, false, null, null, null, 0, analysisDurationMs);
   }
 
-  public static AnalysisResult leakDetected(boolean excludedLeak, String className,
-      LeakTrace leakTrace, long retainedHeapSize, long analysisDurationMs) {
+  public static @NonNull AnalysisResult leakDetected(boolean excludedLeak,
+      @NonNull String className,
+      @NonNull LeakTrace leakTrace, long retainedHeapSize, long analysisDurationMs) {
     return new AnalysisResult(true, excludedLeak, className, leakTrace, null, retainedHeapSize,
         analysisDurationMs);
   }
 
-  public static AnalysisResult failure(Throwable failure, long analysisDurationMs) {
+  public static @NonNull AnalysisResult failure(@NonNull Throwable failure,
+      long analysisDurationMs) {
     return new AnalysisResult(false, false, null, null, failure, 0, analysisDurationMs);
   }
 
@@ -48,16 +52,16 @@ public final class AnalysisResult implements Serializable {
    * Class name of the object that leaked if {@link #leakFound} is true, null otherwise.
    * The class name format is the same as what would be returned by {@link Class#getName()}.
    */
-  public final String className;
+  public final @Nullable String className;
 
   /**
    * Shortest path to GC roots for the leaking object if {@link #leakFound} is true, null
    * otherwise. This can be used as a unique signature for the leak.
    */
-  public final LeakTrace leakTrace;
+  public final @Nullable LeakTrace leakTrace;
 
   /** Null unless the analysis failed. */
-  public final Throwable failure;
+  public final @Nullable Throwable failure;
 
   /**
    * The number of bytes which would be freed if all references to the leaking object were
@@ -97,7 +101,7 @@ public final class AnalysisResult implements Serializable {
    *         at com.foo.WibbleActivity.leaking(WibbleActivity.java:42)
    * </pre>
    */
-  public RuntimeException leakTraceAsFakeException() {
+  public @NonNull RuntimeException leakTraceAsFakeException() {
     if (!leakFound) {
       throw new UnsupportedOperationException(
           "leakTraceAsFakeException() can only be called when leakFound is true");

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalyzerProgressListener.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalyzerProgressListener.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 
 public interface AnalyzerProgressListener {
 
-  AnalyzerProgressListener NONE = new AnalyzerProgressListener() {
+  @NonNull AnalyzerProgressListener NONE = new AnalyzerProgressListener() {
     @Override public void onProgressUpdate(@NonNull Step step) {
     }
   };

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalyzerProgressListener.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/AnalyzerProgressListener.java
@@ -1,9 +1,11 @@
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
+
 public interface AnalyzerProgressListener {
 
   AnalyzerProgressListener NONE = new AnalyzerProgressListener() {
-    @Override public void onProgressUpdate(Step step) {
+    @Override public void onProgressUpdate(@NonNull Step step) {
     }
   };
 
@@ -19,5 +21,5 @@ public interface AnalyzerProgressListener {
     COMPUTING_BITMAP_SIZE,
   }
 
-  void onProgressUpdate(Step step);
+  void onProgressUpdate(@NonNull Step step);
 }

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HeapAnalyzer.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HeapAnalyzer.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
 import com.squareup.haha.perflib.ArrayInstance;
 import com.squareup.haha.perflib.ClassInstance;
 import com.squareup.haha.perflib.ClassObj;
@@ -84,13 +85,14 @@ public final class HeapAnalyzer {
    * @deprecated Use {@link #HeapAnalyzer(ExcludedRefs, AnalyzerProgressListener, List)}.
    */
   @Deprecated
-  public HeapAnalyzer(ExcludedRefs excludedRefs) {
+  public HeapAnalyzer(@NonNull ExcludedRefs excludedRefs) {
     this(excludedRefs, AnalyzerProgressListener.NONE,
         Collections.<Class<? extends Reachability.Inspector>>emptyList());
   }
 
-  public HeapAnalyzer(ExcludedRefs excludedRefs, AnalyzerProgressListener listener,
-      List<Class<? extends Reachability.Inspector>> reachabilityInspectorClasses) {
+  public HeapAnalyzer(@NonNull ExcludedRefs excludedRefs,
+      @NonNull AnalyzerProgressListener listener,
+      @NonNull List<Class<? extends Reachability.Inspector>> reachabilityInspectorClasses) {
     this.excludedRefs = excludedRefs;
     this.listener = listener;
 
@@ -107,7 +109,7 @@ public final class HeapAnalyzer {
     }
   }
 
-  public List<TrackedReference> findTrackedReferences(File heapDumpFile) {
+  public @NonNull List<TrackedReference> findTrackedReferences(@NonNull File heapDumpFile) {
     if (!heapDumpFile.exists()) {
       throw new IllegalArgumentException("File does not exist: " + heapDumpFile);
     }
@@ -143,7 +145,8 @@ public final class HeapAnalyzer {
    * @deprecated Use {@link #checkForLeak(File, String, boolean)} instead.
    */
   @Deprecated
-  public AnalysisResult checkForLeak(File heapDumpFile, String referenceKey) {
+  public @NonNull AnalysisResult checkForLeak(@NonNull File heapDumpFile,
+      @NonNull String referenceKey) {
     return checkForLeak(heapDumpFile, referenceKey, true);
   }
 
@@ -151,7 +154,8 @@ public final class HeapAnalyzer {
    * Searches the heap dump for a {@link KeyedWeakReference} instance with the corresponding key,
    * and then computes the shortest strong reference path from that instance to the GC roots.
    */
-  public AnalysisResult checkForLeak(File heapDumpFile, String referenceKey,
+  public @NonNull AnalysisResult checkForLeak(@NonNull File heapDumpFile,
+      @NonNull String referenceKey,
       boolean computeRetainedSize) {
     long analysisStartNanoTime = System.nanoTime();
 

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTrace.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTrace.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
 import java.io.Serializable;
 import java.util.List;
 
@@ -24,8 +25,8 @@ import java.util.List;
  */
 public final class LeakTrace implements Serializable {
 
-  public final List<LeakTraceElement> elements;
-  public final List<Reachability> expectedReachability;
+  public final @NonNull List<LeakTraceElement> elements;
+  public final @NonNull List<Reachability> expectedReachability;
 
   LeakTrace(List<LeakTraceElement> elements, List<Reachability> expectedReachability) {
     this.elements = elements;
@@ -55,7 +56,7 @@ public final class LeakTrace implements Serializable {
     return sb.toString();
   }
 
-  public String toDetailedString() {
+  public @NonNull String toDetailedString() {
     String string = "";
     for (LeakTraceElement element : elements) {
       string += element.toDetailedString();

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTrace.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/LeakTrace.java
@@ -25,8 +25,8 @@ import java.util.List;
  */
 public final class LeakTrace implements Serializable {
 
-  public final @NonNull List<LeakTraceElement> elements;
-  public final @NonNull List<Reachability> expectedReachability;
+  @NonNull public final List<LeakTraceElement> elements;
+  @NonNull public final List<Reachability> expectedReachability;
 
   LeakTrace(List<LeakTraceElement> elements, List<Reachability> expectedReachability) {
     this.elements = elements;

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/TrackedReference.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/TrackedReference.java
@@ -1,5 +1,6 @@
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,18 +12,19 @@ import java.util.List;
 public class TrackedReference {
 
   /** Corresponds to {@link KeyedWeakReference#key}. */
-  public final String key;
+  public final @NonNull String key;
 
   /** Corresponds to {@link KeyedWeakReference#name}. */
-  public final String name;
+  public final @NonNull String name;
 
   /** Class of the tracked instance. */
-  public final String className;
+  public final @NonNull String className;
 
   /** List of all fields (member and static) for that instance. */
   public final List<LeakReference> fields;
 
-  public TrackedReference(String key, String name, String className, List<LeakReference> fields) {
+  public TrackedReference(@NonNull String key, @NonNull String name, @NonNull String className,
+      @NonNull List<LeakReference> fields) {
     this.key = key;
     this.name = name;
     this.className = className;

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/TrackedReference.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/TrackedReference.java
@@ -12,16 +12,16 @@ import java.util.List;
 public class TrackedReference {
 
   /** Corresponds to {@link KeyedWeakReference#key}. */
-  public final @NonNull String key;
+  @NonNull public final String key;
 
   /** Corresponds to {@link KeyedWeakReference#name}. */
-  public final @NonNull String name;
+  @NonNull public final String name;
 
   /** Class of the tracked instance. */
-  public final @NonNull String className;
+  @NonNull public final String className;
 
   /** List of all fields (member and static) for that instance. */
-  public final List<LeakReference> fields;
+  @NonNull public final List<LeakReference> fields;
 
   public TrackedReference(@NonNull String key, @NonNull String name, @NonNull String className,
       @NonNull List<LeakReference> fields) {

--- a/leakcanary-android-instrumentation/build.gradle
+++ b/leakcanary-android-instrumentation/build.gradle
@@ -15,6 +15,7 @@ android {
     disable 'GoogleAppIndexingWarning'
     // junit references java.lang.management
     ignore 'InvalidPackage'
+    check 'Interoperability'
   }
 }
 

--- a/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/FailTestOnLeakRunListener.java
+++ b/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/FailTestOnLeakRunListener.java
@@ -68,7 +68,7 @@ public class FailTestOnLeakRunListener extends RunListener {
    * is started. Returns null to continue leak detection, or a string describing the reason for
    * skipping otherwise.
    */
-  @Nullable protected String skipLeakDetectionReason(@NonNull Description description) {
+  protected @Nullable String skipLeakDetectionReason(@NonNull Description description) {
     return null;
   }
 
@@ -120,8 +120,7 @@ public class FailTestOnLeakRunListener extends RunListener {
   }
 
   /** Can be overridden to customize the failure string message. */
-  @NonNull
-  protected String buildLeakDetectedMessage(
+  protected @NonNull String buildLeakDetectedMessage(
       @NonNull List<InstrumentationLeakResults.Result> detectedLeaks) {
     StringBuilder failureMessage = new StringBuilder();
     failureMessage.append(

--- a/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakDetector.java
+++ b/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakDetector.java
@@ -20,6 +20,7 @@ import android.app.Instrumentation;
 import android.content.Context;
 import android.os.Debug;
 import android.os.SystemClock;
+import android.support.annotation.NonNull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -109,7 +110,8 @@ public final class InstrumentationLeakDetector {
    * {@link RunListener} that calls {@link #detectLeaks()}, for instance
    * {@link FailTestOnLeakRunListener}.
    */
-  public static AndroidRefWatcherBuilder instrumentationRefWatcher(Application application) {
+  public static @NonNull AndroidRefWatcherBuilder instrumentationRefWatcher(
+      @NonNull Application application) {
     return LeakCanary.refWatcher(application)
         .watchExecutor(new WatchExecutor() {
           // Storing weak refs to ensure they make it to the queue.
@@ -121,7 +123,7 @@ public final class InstrumentationLeakDetector {
         });
   }
 
-  public InstrumentationLeakResults detectLeaks() {
+  public @NonNull InstrumentationLeakResults detectLeaks() {
     Instrumentation instrumentation = getInstrumentation();
     Context context = instrumentation.getTargetContext();
     RefWatcher refWatcher = LeakCanary.installedRefWatcher();

--- a/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakResults.java
+++ b/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakResults.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,30 +29,30 @@ public final class InstrumentationLeakResults {
           Collections.<Result>emptyList(), Collections.<Result>emptyList());
 
   /** Proper leaks found during instrumentation tests. */
-  public final List<Result> detectedLeaks;
+  public final @NonNull List<Result> detectedLeaks;
 
   /**
    * Excluded leaks found during instrumentation tests, based on {@link RefWatcher#excludedRefs}
    */
-  public final List<Result> excludedLeaks;
+  public final @NonNull List<Result> excludedLeaks;
 
   /**
    * Leak analysis failures that happened when we tried to detect leaks.
    */
-  public final List<Result> failures;
+  public final @NonNull List<Result> failures;
 
-  public InstrumentationLeakResults(List<Result> detectedLeaks, List<Result> excludedLeaks,
-      List<Result> failures) {
+  public InstrumentationLeakResults(@NonNull List<Result> detectedLeaks,
+      @NonNull List<Result> excludedLeaks, @NonNull List<Result> failures) {
     this.detectedLeaks = unmodifiableList(new ArrayList<>(detectedLeaks));
     this.excludedLeaks = unmodifiableList(new ArrayList<>(excludedLeaks));
     this.failures = unmodifiableList(new ArrayList<>(failures));
   }
 
   public static final class Result {
-    public final HeapDump heapDump;
-    public final AnalysisResult analysisResult;
+    public final @NonNull HeapDump heapDump;
+    public final @NonNull AnalysisResult analysisResult;
 
-    public Result(HeapDump heapDump, AnalysisResult analysisResult) {
+    public Result(@NonNull HeapDump heapDump, @NonNull AnalysisResult analysisResult) {
       this.heapDump = heapDump;
       this.analysisResult = analysisResult;
     }

--- a/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakResults.java
+++ b/leakcanary-android-instrumentation/src/main/java/com/squareup/leakcanary/InstrumentationLeakResults.java
@@ -24,22 +24,22 @@ import static java.util.Collections.unmodifiableList;
 
 public final class InstrumentationLeakResults {
 
-  public static final InstrumentationLeakResults NONE =
+  @NonNull public static final InstrumentationLeakResults NONE =
       new InstrumentationLeakResults(Collections.<Result>emptyList(),
           Collections.<Result>emptyList(), Collections.<Result>emptyList());
 
   /** Proper leaks found during instrumentation tests. */
-  public final @NonNull List<Result> detectedLeaks;
+  @NonNull public final List<Result> detectedLeaks;
 
   /**
    * Excluded leaks found during instrumentation tests, based on {@link RefWatcher#excludedRefs}
    */
-  public final @NonNull List<Result> excludedLeaks;
+  @NonNull public final List<Result> excludedLeaks;
 
   /**
    * Leak analysis failures that happened when we tried to detect leaks.
    */
-  public final @NonNull List<Result> failures;
+  @NonNull public final List<Result> failures;
 
   public InstrumentationLeakResults(@NonNull List<Result> detectedLeaks,
       @NonNull List<Result> excludedLeaks, @NonNull List<Result> failures) {
@@ -49,8 +49,8 @@ public final class InstrumentationLeakResults {
   }
 
   public static final class Result {
-    public final @NonNull HeapDump heapDump;
-    public final @NonNull AnalysisResult analysisResult;
+    @NonNull public final HeapDump heapDump;
+    @NonNull public final AnalysisResult analysisResult;
 
     public Result(@NonNull HeapDump heapDump, @NonNull AnalysisResult analysisResult) {
       this.heapDump = heapDump;

--- a/leakcanary-android-no-op/build.gradle
+++ b/leakcanary-android-no-op/build.gradle
@@ -11,6 +11,13 @@ android {
   libraryVariants.all {
     it.generateBuildConfig.enabled = false
   }
+  lintOptions {
+    check 'Interoperability'
+  }
+}
+
+dependencies {
+  implementation 'com.android.support:support-annotations:26.0.0'
 }
 
 apply from: rootProject.file('gradle/checkstyle.gradle')

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -2,21 +2,22 @@ package com.squareup.leakcanary;
 
 import android.app.Application;
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 /**
  * A no-op version of {@link LeakCanary} that can be used in release builds.
  */
 public final class LeakCanary {
 
-  public static RefWatcher install(Application application) {
+  public static @NonNull RefWatcher install(@NonNull Application application) {
     return RefWatcher.DISABLED;
   }
 
-  public static RefWatcher installedRefWatcher() {
+  public static @NonNull RefWatcher installedRefWatcher() {
     return RefWatcher.DISABLED;
   }
 
-  public static boolean isInAnalyzerProcess(Context context) {
+  public static boolean isInAnalyzerProcess(@NonNull Context context) {
     return false;
   }
 

--- a/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/RefWatcher.java
+++ b/leakcanary-android-no-op/src/main/java/com/squareup/leakcanary/RefWatcher.java
@@ -1,19 +1,21 @@
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
+
 /**
  * No-op implementation of {@link RefWatcher} for release builds. Please use {@link
  * RefWatcher#DISABLED}.
  */
 public final class RefWatcher {
 
-  public static final RefWatcher DISABLED = new RefWatcher();
+  @NonNull public static final RefWatcher DISABLED = new RefWatcher();
 
   private RefWatcher() {
   }
 
-  public void watch(Object watchedReference) {
+  public void watch(@NonNull Object watchedReference) {
   }
 
-  public void watch(Object watchedReference, String referenceName) {
+  public void watch(@NonNull Object watchedReference, @NonNull String referenceName) {
   }
 }

--- a/leakcanary-android/build.gradle
+++ b/leakcanary-android/build.gradle
@@ -27,6 +27,7 @@ android {
   lintOptions {
     disable 'GoogleAppIndexingWarning'
     error 'ObsoleteSdkInt'
+    check 'Interoperability'
   }
 }
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AbstractAnalysisResultService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AbstractAnalysisResultService.java
@@ -17,6 +17,8 @@ package com.squareup.leakcanary;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import com.squareup.leakcanary.internal.ForegroundService;
 
@@ -25,8 +27,10 @@ public abstract class AbstractAnalysisResultService extends ForegroundService {
   private static final String HEAP_DUMP_EXTRA = "heap_dump_extra";
   private static final String RESULT_EXTRA = "result_extra";
 
-  public static void sendResultToListener(Context context, String listenerServiceClassName,
-      HeapDump heapDump, AnalysisResult result) {
+  public static void sendResultToListener(@NonNull Context context,
+                                          @NonNull String listenerServiceClassName,
+                                          @NonNull HeapDump heapDump,
+                                          @NonNull AnalysisResult result) {
     Class<?> listenerServiceClass;
     try {
       listenerServiceClass = Class.forName(listenerServiceClassName);
@@ -44,7 +48,7 @@ public abstract class AbstractAnalysisResultService extends ForegroundService {
         R.string.leak_canary_notification_reporting);
   }
 
-  @Override protected final void onHandleIntentInForeground(Intent intent) {
+  @Override protected final void onHandleIntentInForeground(@Nullable Intent intent) {
     HeapDump heapDump = (HeapDump) intent.getSerializableExtra(HEAP_DUMP_EXTRA);
     AnalysisResult result = (AnalysisResult) intent.getSerializableExtra(RESULT_EXTRA);
     try {
@@ -66,5 +70,6 @@ public abstract class AbstractAnalysisResultService extends ForegroundService {
    * <p>
    * The heap dump file will be deleted immediately after this callback returns.
    */
-  protected abstract void onHeapAnalyzed(HeapDump heapDump, AnalysisResult result);
+  protected abstract void onHeapAnalyzed(@NonNull HeapDump heapDump,
+                                         @NonNull AnalysisResult result);
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AbstractAnalysisResultService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AbstractAnalysisResultService.java
@@ -28,9 +28,9 @@ public abstract class AbstractAnalysisResultService extends ForegroundService {
   private static final String RESULT_EXTRA = "result_extra";
 
   public static void sendResultToListener(@NonNull Context context,
-                                          @NonNull String listenerServiceClassName,
-                                          @NonNull HeapDump heapDump,
-                                          @NonNull AnalysisResult result) {
+      @NonNull String listenerServiceClassName,
+      @NonNull HeapDump heapDump,
+      @NonNull AnalysisResult result) {
     Class<?> listenerServiceClass;
     try {
       listenerServiceClass = Class.forName(listenerServiceClassName);
@@ -71,5 +71,5 @@ public abstract class AbstractAnalysisResultService extends ForegroundService {
    * The heap dump file will be deleted immediately after this callback returns.
    */
   protected abstract void onHeapAnalyzed(@NonNull HeapDump heapDump,
-                                         @NonNull AnalysisResult result);
+      @NonNull AnalysisResult result);
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/ActivityRefWatcher.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/ActivityRefWatcher.java
@@ -19,7 +19,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.support.annotation.NonNull;
-
 import com.squareup.leakcanary.internal.ActivityLifecycleCallbacksAdapter;
 
 /**
@@ -32,7 +31,7 @@ import com.squareup.leakcanary.internal.ActivityLifecycleCallbacksAdapter;
 public final class ActivityRefWatcher {
 
   public static void installOnIcsPlus(@NonNull Application application,
-                                      @NonNull RefWatcher refWatcher) {
+      @NonNull RefWatcher refWatcher) {
     install(application, refWatcher);
   }
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/ActivityRefWatcher.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/ActivityRefWatcher.java
@@ -18,6 +18,8 @@ package com.squareup.leakcanary;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.support.annotation.NonNull;
+
 import com.squareup.leakcanary.internal.ActivityLifecycleCallbacksAdapter;
 
 /**
@@ -29,11 +31,12 @@ import com.squareup.leakcanary.internal.ActivityLifecycleCallbacksAdapter;
 @Deprecated
 public final class ActivityRefWatcher {
 
-  public static void installOnIcsPlus(Application application, RefWatcher refWatcher) {
+  public static void installOnIcsPlus(@NonNull Application application,
+                                      @NonNull RefWatcher refWatcher) {
     install(application, refWatcher);
   }
 
-  public static void install(Context context, RefWatcher refWatcher) {
+  public static void install(@NonNull Context context, @NonNull RefWatcher refWatcher) {
     Application application = (Application) context.getApplicationContext();
     ActivityRefWatcher activityRefWatcher = new ActivityRefWatcher(application, refWatcher);
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -16,7 +16,6 @@
 package com.squareup.leakcanary;
 
 import android.support.annotation.NonNull;
-
 import java.lang.ref.PhantomReference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
@@ -592,7 +591,7 @@ public enum AndroidExcludedRefs {
   /**
    * This returns the references in the leak path that should be ignored by all on Android.
    */
-  @NonNull public static ExcludedRefs.Builder createAndroidDefaults() {
+  public static @NonNull ExcludedRefs.Builder createAndroidDefaults() {
     return createBuilder(
         EnumSet.of(SOFT_REFERENCES, FINALIZER_WATCHDOG_DAEMON, MAIN, LEAK_CANARY_THREAD,
             EVENT_RECEIVER__MMESSAGE_QUEUE));
@@ -604,11 +603,11 @@ public enum AndroidExcludedRefs {
    * in AOSP or manufacturer forks of AOSP. In such cases, there is very little we can do as app
    * developers except by resorting to serious hacks, so we remove the noise caused by those leaks.
    */
-  @NonNull public static ExcludedRefs.Builder createAppDefaults() {
+  public static @NonNull ExcludedRefs.Builder createAppDefaults() {
     return createBuilder(EnumSet.allOf(AndroidExcludedRefs.class));
   }
 
-  @NonNull public static ExcludedRefs.Builder createBuilder(EnumSet<AndroidExcludedRefs> refs) {
+  public static @NonNull ExcludedRefs.Builder createBuilder(EnumSet<AndroidExcludedRefs> refs) {
     ExcludedRefs.Builder excluded = ExcludedRefs.builder();
     for (AndroidExcludedRefs ref : refs) {
       if (ref.applies) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidExcludedRefs.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
+
 import java.lang.ref.PhantomReference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
@@ -590,7 +592,7 @@ public enum AndroidExcludedRefs {
   /**
    * This returns the references in the leak path that should be ignored by all on Android.
    */
-  public static ExcludedRefs.Builder createAndroidDefaults() {
+  @NonNull public static ExcludedRefs.Builder createAndroidDefaults() {
     return createBuilder(
         EnumSet.of(SOFT_REFERENCES, FINALIZER_WATCHDOG_DAEMON, MAIN, LEAK_CANARY_THREAD,
             EVENT_RECEIVER__MMESSAGE_QUEUE));
@@ -602,11 +604,11 @@ public enum AndroidExcludedRefs {
    * in AOSP or manufacturer forks of AOSP. In such cases, there is very little we can do as app
    * developers except by resorting to serious hacks, so we remove the noise caused by those leaks.
    */
-  public static ExcludedRefs.Builder createAppDefaults() {
+  @NonNull public static ExcludedRefs.Builder createAppDefaults() {
     return createBuilder(EnumSet.allOf(AndroidExcludedRefs.class));
   }
 
-  public static ExcludedRefs.Builder createBuilder(EnumSet<AndroidExcludedRefs> refs) {
+  @NonNull public static ExcludedRefs.Builder createBuilder(EnumSet<AndroidExcludedRefs> refs) {
     ExcludedRefs.Builder excluded = ExcludedRefs.builder();
     for (AndroidExcludedRefs ref : refs) {
       if (ref.applies) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -49,7 +49,7 @@ public final class AndroidHeapDumper implements HeapDumper {
   private final Handler mainHandler;
 
   public AndroidHeapDumper(@NonNull Context context,
-                           @NonNull LeakDirectoryProvider leakDirectoryProvider) {
+      @NonNull LeakDirectoryProvider leakDirectoryProvider) {
     this.leakDirectoryProvider = leakDirectoryProvider;
     this.context = context.getApplicationContext();
     mainHandler = new Handler(Looper.getMainLooper());
@@ -161,7 +161,8 @@ public final class AndroidHeapDumper implements HeapDumper {
     View view = toast.getView();
     if (view.getParent() != null) {
       Context context = toast.getView().getContext();
-      WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+      WindowManager windowManager =
+          (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
       windowManager.removeView(view);
     }
   }
@@ -195,6 +196,4 @@ public final class AndroidHeapDumper implements HeapDumper {
     view.dispatchPopulateAccessibilityEvent(event);
     accessibilityManager.sendAccessibilityEvent(event);
   }
-
-
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -26,6 +26,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.MessageQueue;
 import android.os.SystemClock;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -46,14 +48,16 @@ public final class AndroidHeapDumper implements HeapDumper {
   private final LeakDirectoryProvider leakDirectoryProvider;
   private final Handler mainHandler;
 
-  public AndroidHeapDumper(Context context, LeakDirectoryProvider leakDirectoryProvider) {
+  public AndroidHeapDumper(@NonNull Context context,
+                           @NonNull LeakDirectoryProvider leakDirectoryProvider) {
     this.leakDirectoryProvider = leakDirectoryProvider;
     this.context = context.getApplicationContext();
     mainHandler = new Handler(Looper.getMainLooper());
   }
 
   @SuppressWarnings("ReferenceEquality") // Explicitly checking for named null.
-  @Override public File dumpHeap() {
+  @Override @Nullable
+  public File dumpHeap() {
     File heapDumpFile = leakDirectoryProvider.newHeapDumpFile();
 
     if (heapDumpFile == RETRY_LATER) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidReachabilityInspectors.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidReachabilityInspectors.java
@@ -67,7 +67,7 @@ public enum AndroidReachabilityInspectors {
     this.inspectorClass = inspectorClass;
   }
 
-  @NonNull public static List<Class<? extends Reachability.Inspector>> defaultAndroidInspectors() {
+  public static @NonNull List<Class<? extends Reachability.Inspector>> defaultAndroidInspectors() {
     List<Class<? extends Reachability.Inspector>> inspectorClasses = new ArrayList<>();
     for (AndroidReachabilityInspectors enumValue : AndroidReachabilityInspectors.values()) {
       inspectorClasses.add(enumValue.inspectorClass);
@@ -76,7 +76,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ViewInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(View.class)) {
         return Reachability.UNKNOWN;
       }
@@ -89,7 +89,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ActivityInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Activity.class)) {
         return Reachability.UNKNOWN;
       }
@@ -102,7 +102,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class DialogInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Dialog.class)) {
         return Reachability.UNKNOWN;
       }
@@ -115,7 +115,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ApplicationInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (element.isInstanceOf(Application.class)) {
         return Reachability.REACHABLE;
       }
@@ -124,7 +124,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class FragmentInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Fragment.class)) {
         return Reachability.UNKNOWN;
       }
@@ -137,7 +137,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class SupportFragmentInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf("android.support.v4.app.Fragment")) {
         return Reachability.UNKNOWN;
       }
@@ -150,7 +150,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class MessageQueueInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(MessageQueue.class)) {
         return Reachability.UNKNOWN;
       }
@@ -165,7 +165,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class MortarPresenterInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf("mortar.Presenter")) {
         return Reachability.UNKNOWN;
       }
@@ -182,7 +182,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ViewImplInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf("android.view.ViewRootImpl")) {
         return Reachability.UNKNOWN;
       }
@@ -195,7 +195,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class MainThreadInspector implements Reachability.Inspector {
-    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
+    @Override public @NonNull Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Thread.class)) {
         return Reachability.UNKNOWN;
       }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidReachabilityInspectors.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidReachabilityInspectors.java
@@ -20,6 +20,7 @@ import android.app.Application;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.os.MessageQueue;
+import android.support.annotation.NonNull;
 import android.view.View;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +67,7 @@ public enum AndroidReachabilityInspectors {
     this.inspectorClass = inspectorClass;
   }
 
-  public static List<Class<? extends Reachability.Inspector>> defaultAndroidInspectors() {
+  @NonNull public static List<Class<? extends Reachability.Inspector>> defaultAndroidInspectors() {
     List<Class<? extends Reachability.Inspector>> inspectorClasses = new ArrayList<>();
     for (AndroidReachabilityInspectors enumValue : AndroidReachabilityInspectors.values()) {
       inspectorClasses.add(enumValue.inspectorClass);
@@ -75,7 +76,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ViewInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(View.class)) {
         return Reachability.UNKNOWN;
       }
@@ -88,7 +89,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ActivityInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Activity.class)) {
         return Reachability.UNKNOWN;
       }
@@ -101,7 +102,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class DialogInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Dialog.class)) {
         return Reachability.UNKNOWN;
       }
@@ -114,7 +115,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ApplicationInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (element.isInstanceOf(Application.class)) {
         return Reachability.REACHABLE;
       }
@@ -123,7 +124,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class FragmentInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Fragment.class)) {
         return Reachability.UNKNOWN;
       }
@@ -136,7 +137,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class SupportFragmentInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf("android.support.v4.app.Fragment")) {
         return Reachability.UNKNOWN;
       }
@@ -149,7 +150,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class MessageQueueInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(MessageQueue.class)) {
         return Reachability.UNKNOWN;
       }
@@ -164,7 +165,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class MortarPresenterInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf("mortar.Presenter")) {
         return Reachability.UNKNOWN;
       }
@@ -181,7 +182,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class ViewImplInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf("android.view.ViewRootImpl")) {
         return Reachability.UNKNOWN;
       }
@@ -194,7 +195,7 @@ public enum AndroidReachabilityInspectors {
   }
 
   public static class MainThreadInspector implements Reachability.Inspector {
-    @Override public Reachability expectedReachability(LeakTraceElement element) {
+    @Override @NonNull public Reachability expectedReachability(@NonNull LeakTraceElement element) {
       if (!element.isInstanceOf(Thread.class)) {
         return Reachability.UNKNOWN;
       }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -27,7 +27,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * Sets a custom {@link AbstractAnalysisResultService} to listen to analysis results. This
    * overrides any call to {@link #heapDumpListener(HeapDump.Listener)}.
    */
-  @NonNull public AndroidRefWatcherBuilder listenerServiceClass(
+  public @NonNull AndroidRefWatcherBuilder listenerServiceClass(
       @NonNull Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
     return heapDumpListener(new ServiceHeapDumpListener(context, listenerServiceClass));
   }
@@ -37,7 +37,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * tracked object has been garbage collected. This overrides any call to {@link
    * #watchExecutor(WatchExecutor)}.
    */
-  @NonNull public AndroidRefWatcherBuilder watchDelay(long delay, @NonNull TimeUnit unit) {
+  public @NonNull AndroidRefWatcherBuilder watchDelay(long delay, @NonNull TimeUnit unit) {
     return watchExecutor(new AndroidWatchExecutor(unit.toMillis(delay)));
   }
 
@@ -45,7 +45,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * Whether we should automatically watch activities when calling {@link #buildAndInstall()}.
    * Default is true.
    */
-  @NonNull public AndroidRefWatcherBuilder watchActivities(boolean watchActivities) {
+  public @NonNull AndroidRefWatcherBuilder watchActivities(boolean watchActivities) {
     this.watchActivities = watchActivities;
     return this;
   }
@@ -55,7 +55,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * Default is true. When true, LeakCanary watches native fragments on Android O+ and support
    * fragments if the leakcanary-support-fragment dependency is in the classpath.
    */
-  @NonNull public AndroidRefWatcherBuilder watchFragments(boolean watchFragments) {
+  public @NonNull AndroidRefWatcherBuilder watchFragments(boolean watchFragments) {
     this.watchFragments = watchFragments;
     return this;
   }
@@ -66,7 +66,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    *
    * @throws IllegalArgumentException if maxStoredHeapDumps < 1.
    */
-  @NonNull public AndroidRefWatcherBuilder maxStoredHeapDumps(int maxStoredHeapDumps) {
+  public @NonNull AndroidRefWatcherBuilder maxStoredHeapDumps(int maxStoredHeapDumps) {
     LeakDirectoryProvider leakDirectoryProvider =
         new DefaultLeakDirectoryProvider(context, maxStoredHeapDumps);
     LeakCanary.setLeakDirectoryProvider(leakDirectoryProvider);
@@ -81,7 +81,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    *
    * @throws UnsupportedOperationException if called more than once per Android process.
    */
-  @NonNull public RefWatcher buildAndInstall() {
+  public @NonNull RefWatcher buildAndInstall() {
     if (LeakCanaryInternals.installedRefWatcher != null) {
       throw new UnsupportedOperationException("buildAndInstall() should only be called once.");
     }
@@ -102,30 +102,30 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
     return LeakCanary.isInAnalyzerProcess(context);
   }
 
-  @Override @NonNull protected HeapDumper defaultHeapDumper() {
+  @Override protected @NonNull HeapDumper defaultHeapDumper() {
     LeakDirectoryProvider leakDirectoryProvider =
         LeakCanaryInternals.getLeakDirectoryProvider(context);
     return new AndroidHeapDumper(context, leakDirectoryProvider);
   }
 
-  @Override @NonNull protected DebuggerControl defaultDebuggerControl() {
+  @Override protected @NonNull DebuggerControl defaultDebuggerControl() {
     return new AndroidDebuggerControl();
   }
 
-  @Override @NonNull protected HeapDump.Listener defaultHeapDumpListener() {
+  @Override protected @NonNull HeapDump.Listener defaultHeapDumpListener() {
     return new ServiceHeapDumpListener(context, DisplayLeakService.class);
   }
 
-  @Override @NonNull protected ExcludedRefs defaultExcludedRefs() {
+  @Override protected @NonNull ExcludedRefs defaultExcludedRefs() {
     return AndroidExcludedRefs.createAppDefaults().build();
   }
 
-  @Override @NonNull protected WatchExecutor defaultWatchExecutor() {
+  @Override protected @NonNull WatchExecutor defaultWatchExecutor() {
     return new AndroidWatchExecutor(DEFAULT_WATCH_DELAY_MILLIS);
   }
 
-  @Override @NonNull
-  protected List<Class<? extends Reachability.Inspector>> defaultReachabilityInspectorClasses() {
+  @Override protected @NonNull
+  List<Class<? extends Reachability.Inspector>> defaultReachabilityInspectorClasses() {
     return AndroidReachabilityInspectors.defaultAndroidInspectors();
   }
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -1,6 +1,8 @@
 package com.squareup.leakcanary;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+
 import com.squareup.leakcanary.internal.FragmentRefWatcher;
 import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.util.List;
@@ -18,7 +20,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
   private boolean watchActivities = true;
   private boolean watchFragments = true;
 
-  AndroidRefWatcherBuilder(Context context) {
+  AndroidRefWatcherBuilder(@NonNull Context context) {
     this.context = context.getApplicationContext();
   }
 
@@ -26,8 +28,8 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * Sets a custom {@link AbstractAnalysisResultService} to listen to analysis results. This
    * overrides any call to {@link #heapDumpListener(HeapDump.Listener)}.
    */
-  public AndroidRefWatcherBuilder listenerServiceClass(
-      Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
+  @NonNull public AndroidRefWatcherBuilder listenerServiceClass(
+      @NonNull Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
     return heapDumpListener(new ServiceHeapDumpListener(context, listenerServiceClass));
   }
 
@@ -36,7 +38,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * tracked object has been garbage collected. This overrides any call to {@link
    * #watchExecutor(WatchExecutor)}.
    */
-  public AndroidRefWatcherBuilder watchDelay(long delay, TimeUnit unit) {
+  @NonNull public AndroidRefWatcherBuilder watchDelay(long delay, @NonNull TimeUnit unit) {
     return watchExecutor(new AndroidWatchExecutor(unit.toMillis(delay)));
   }
 
@@ -44,7 +46,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * Whether we should automatically watch activities when calling {@link #buildAndInstall()}.
    * Default is true.
    */
-  public AndroidRefWatcherBuilder watchActivities(boolean watchActivities) {
+  @NonNull public AndroidRefWatcherBuilder watchActivities(boolean watchActivities) {
     this.watchActivities = watchActivities;
     return this;
   }
@@ -54,7 +56,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    * Default is true. When true, LeakCanary watches native fragments on Android O+ and support
    * fragments if the leakcanary-support-fragment dependency is in the classpath.
    */
-  public AndroidRefWatcherBuilder watchFragments(boolean watchFragments) {
+  @NonNull public AndroidRefWatcherBuilder watchFragments(boolean watchFragments) {
     this.watchFragments = watchFragments;
     return this;
   }
@@ -65,7 +67,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    *
    * @throws IllegalArgumentException if maxStoredHeapDumps < 1.
    */
-  public AndroidRefWatcherBuilder maxStoredHeapDumps(int maxStoredHeapDumps) {
+  @NonNull public AndroidRefWatcherBuilder maxStoredHeapDumps(int maxStoredHeapDumps) {
     LeakDirectoryProvider leakDirectoryProvider =
         new DefaultLeakDirectoryProvider(context, maxStoredHeapDumps);
     LeakCanary.setLeakDirectoryProvider(leakDirectoryProvider);
@@ -80,7 +82,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
    *
    * @throws UnsupportedOperationException if called more than once per Android process.
    */
-  public RefWatcher buildAndInstall() {
+  @NonNull public RefWatcher buildAndInstall() {
     if (LeakCanaryInternals.installedRefWatcher != null) {
       throw new UnsupportedOperationException("buildAndInstall() should only be called once.");
     }
@@ -101,29 +103,29 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
     return LeakCanary.isInAnalyzerProcess(context);
   }
 
-  @Override protected HeapDumper defaultHeapDumper() {
+  @Override @NonNull protected HeapDumper defaultHeapDumper() {
     LeakDirectoryProvider leakDirectoryProvider =
         LeakCanaryInternals.getLeakDirectoryProvider(context);
     return new AndroidHeapDumper(context, leakDirectoryProvider);
   }
 
-  @Override protected DebuggerControl defaultDebuggerControl() {
+  @Override @NonNull protected DebuggerControl defaultDebuggerControl() {
     return new AndroidDebuggerControl();
   }
 
-  @Override protected HeapDump.Listener defaultHeapDumpListener() {
+  @Override @NonNull protected HeapDump.Listener defaultHeapDumpListener() {
     return new ServiceHeapDumpListener(context, DisplayLeakService.class);
   }
 
-  @Override protected ExcludedRefs defaultExcludedRefs() {
+  @Override @NonNull protected ExcludedRefs defaultExcludedRefs() {
     return AndroidExcludedRefs.createAppDefaults().build();
   }
 
-  @Override protected WatchExecutor defaultWatchExecutor() {
+  @Override @NonNull protected WatchExecutor defaultWatchExecutor() {
     return new AndroidWatchExecutor(DEFAULT_WATCH_DELAY_MILLIS);
   }
 
-  @Override protected List<Class<? extends Reachability.Inspector>> defaultReachabilityInspectorClasses() {
+  @Override @NonNull protected List<Class<? extends Reachability.Inspector>> defaultReachabilityInspectorClasses() {
     return AndroidReachabilityInspectors.defaultAndroidInspectors();
   }
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -2,7 +2,6 @@ package com.squareup.leakcanary;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-
 import com.squareup.leakcanary.internal.FragmentRefWatcher;
 import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.util.List;
@@ -125,7 +124,8 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
     return new AndroidWatchExecutor(DEFAULT_WATCH_DELAY_MILLIS);
   }
 
-  @Override @NonNull protected List<Class<? extends Reachability.Inspector>> defaultReachabilityInspectorClasses() {
+  @Override @NonNull
+  protected List<Class<? extends Reachability.Inspector>> defaultReachabilityInspectorClasses() {
     return AndroidReachabilityInspectors.defaultAndroidInspectors();
   }
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
@@ -19,6 +19,8 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.MessageQueue;
+import android.support.annotation.NonNull;
+
 import java.util.concurrent.TimeUnit;
 
 import static com.squareup.leakcanary.Retryable.Result.RETRY;
@@ -45,7 +47,7 @@ public final class AndroidWatchExecutor implements WatchExecutor {
     maxBackoffFactor = Long.MAX_VALUE / initialDelayMillis;
   }
 
-  @Override public void execute(Retryable retryable) {
+  @Override public void execute(@NonNull Retryable retryable) {
     if (Looper.getMainLooper().getThread() == Thread.currentThread()) {
       waitForIdle(retryable, 0);
     } else {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidWatchExecutor.java
@@ -20,7 +20,6 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.MessageQueue;
 import android.support.annotation.NonNull;
-
 import java.util.concurrent.TimeUnit;
 
 import static com.squareup.leakcanary.Retryable.Result.RETRY;

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/CanaryLog.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/CanaryLog.java
@@ -15,7 +15,8 @@ public final class CanaryLog {
   }
 
   private static class DefaultLogger implements Logger {
-    DefaultLogger() { }
+    DefaultLogger() {
+    }
 
     @Override public void d(@NonNull String message, @NonNull Object... args) {
       String formatted = String.format(message, args);
@@ -30,8 +31,8 @@ public final class CanaryLog {
     }
 
     @Override public void d(@Nullable Throwable throwable,
-                            @NonNull String message,
-                            @NonNull Object... args) {
+        @NonNull String message,
+        @NonNull Object... args) {
       d(String.format(message, args) + '\n' + Log.getStackTraceString(throwable));
     }
   }
@@ -50,8 +51,8 @@ public final class CanaryLog {
   }
 
   public static void d(@Nullable Throwable throwable,
-                       @NonNull String message,
-                       @NonNull Object... args) {
+      @NonNull String message,
+      @NonNull Object... args) {
     // Local variable to prevent the ref from becoming null after the null check.
     Logger logger = CanaryLog.logger;
     if (logger == null) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/CanaryLog.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/CanaryLog.java
@@ -1,5 +1,7 @@
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 public final class CanaryLog {
@@ -7,15 +9,15 @@ public final class CanaryLog {
   private static volatile Logger logger = new DefaultLogger();
 
   public interface Logger {
-    void d(String message, Object... args);
+    void d(@NonNull String message, @NonNull Object... args);
 
-    void d(Throwable throwable, String message, Object... args);
+    void d(@Nullable Throwable throwable, @NonNull String message, @NonNull Object... args);
   }
 
   private static class DefaultLogger implements Logger {
     DefaultLogger() { }
 
-    @Override public void d(String message, Object... args) {
+    @Override public void d(@NonNull String message, @NonNull Object... args) {
       String formatted = String.format(message, args);
       if (formatted.length() < 4000) {
         Log.d("LeakCanary", formatted);
@@ -27,16 +29,18 @@ public final class CanaryLog {
       }
     }
 
-    @Override public void d(Throwable throwable, String message, Object... args) {
+    @Override public void d(@Nullable Throwable throwable,
+                            @NonNull String message,
+                            @NonNull Object... args) {
       d(String.format(message, args) + '\n' + Log.getStackTraceString(throwable));
     }
   }
 
-  public static void setLogger(Logger logger) {
+  public static void setLogger(@Nullable Logger logger) {
     CanaryLog.logger = logger;
   }
 
-  public static void d(String message, Object... args) {
+  public static void d(@NonNull String message, @NonNull Object... args) {
     // Local variable to prevent the ref from becoming null after the null check.
     Logger logger = CanaryLog.logger;
     if (logger == null) {
@@ -45,7 +49,9 @@ public final class CanaryLog {
     logger.d(message, args);
   }
 
-  public static void d(Throwable throwable, String message, Object... args) {
+  public static void d(@Nullable Throwable throwable,
+                       @NonNull String message,
+                       @NonNull Object... args) {
     // Local variable to prevent the ref from becoming null after the null check.
     Logger logger = CanaryLog.logger;
     if (logger == null) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
@@ -19,6 +19,9 @@ import android.annotation.TargetApi;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.os.Environment;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.squareup.leakcanary.internal.RequestStoragePermissionActivity;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -53,11 +56,11 @@ public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider
   private volatile boolean writeExternalStorageGranted;
   private volatile boolean permissionNotificationDisplayed;
 
-  public DefaultLeakDirectoryProvider(Context context) {
+  public DefaultLeakDirectoryProvider(@NonNull Context context) {
     this(context, DEFAULT_MAX_STORED_HEAP_DUMPS);
   }
 
-  public DefaultLeakDirectoryProvider(Context context, int maxStoredHeapDumps) {
+  public DefaultLeakDirectoryProvider(@NonNull Context context, int maxStoredHeapDumps) {
     if (maxStoredHeapDumps < 1) {
       throw new IllegalArgumentException("maxStoredHeapDumps must be at least 1");
     }
@@ -65,7 +68,8 @@ public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider
     this.maxStoredHeapDumps = maxStoredHeapDumps;
   }
 
-  @Override public List<File> listFiles(FilenameFilter filter) {
+  @NonNull
+  @Override public List<File> listFiles(@NonNull FilenameFilter filter) {
     if (!hasStoragePermission()) {
       requestWritePermissionNotification();
     }
@@ -83,6 +87,7 @@ public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider
     return files;
   }
 
+  @Nullable
   @Override public File newHeapDumpFile() {
     List<File> pendingHeapDumps = listFiles(new FilenameFilter() {
       @Override public boolean accept(File dir, String filename) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
@@ -67,8 +67,7 @@ public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider
     this.maxStoredHeapDumps = maxStoredHeapDumps;
   }
 
-  @NonNull
-  @Override public List<File> listFiles(@NonNull FilenameFilter filter) {
+  @Override public @NonNull List<File> listFiles(@NonNull FilenameFilter filter) {
     if (!hasStoragePermission()) {
       requestWritePermissionNotification();
     }
@@ -86,8 +85,7 @@ public final class DefaultLeakDirectoryProvider implements LeakDirectoryProvider
     return files;
   }
 
-  @Nullable
-  @Override public File newHeapDumpFile() {
+  @Override public @Nullable File newHeapDumpFile() {
     List<File> pendingHeapDumps = listFiles(new FilenameFilter() {
       @Override public boolean accept(File dir, String filename) {
         return filename.endsWith(PENDING_HEAPDUMP_SUFFIX);

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DefaultLeakDirectoryProvider.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import com.squareup.leakcanary.internal.RequestStoragePermissionActivity;
 import java.io.File;
 import java.io.FilenameFilter;

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
@@ -17,6 +17,8 @@ package com.squareup.leakcanary;
 
 import android.app.PendingIntent;
 import android.os.SystemClock;
+import android.support.annotation.NonNull;
+
 import com.squareup.leakcanary.internal.DisplayLeakActivity;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -40,7 +42,7 @@ import static com.squareup.leakcanary.internal.LeakCanaryInternals.showNotificat
  */
 public class DisplayLeakService extends AbstractAnalysisResultService {
 
-  @Override protected final void onHeapAnalyzed(HeapDump heapDump, AnalysisResult result) {
+  @Override protected final void onHeapAnalyzed(@NonNull HeapDump heapDump, @NonNull AnalysisResult result) {
     String leakInfo = leakInfo(this, heapDump, result, true);
     CanaryLog.d("%s", leakInfo);
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
@@ -138,6 +138,7 @@ public class DisplayLeakService extends AbstractAnalysisResultService {
    * the heap dump. Don't forget to check {@link AnalysisResult#leakFound} and {@link
    * AnalysisResult#excludedLeak} first.
    */
-  protected void afterDefaultHandling(HeapDump heapDump, AnalysisResult result, String leakInfo) {
+  protected void afterDefaultHandling(@NonNull HeapDump heapDump, @NonNull AnalysisResult result,
+      @NonNull String leakInfo) {
   }
 }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/DisplayLeakService.java
@@ -18,7 +18,6 @@ package com.squareup.leakcanary;
 import android.app.PendingIntent;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
-
 import com.squareup.leakcanary.internal.DisplayLeakActivity;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -42,7 +41,8 @@ import static com.squareup.leakcanary.internal.LeakCanaryInternals.showNotificat
  */
 public class DisplayLeakService extends AbstractAnalysisResultService {
 
-  @Override protected final void onHeapAnalyzed(@NonNull HeapDump heapDump, @NonNull AnalysisResult result) {
+  @Override
+  protected final void onHeapAnalyzed(@NonNull HeapDump heapDump, @NonNull AnalysisResult result) {
     String leakInfo = leakInfo(this, heapDump, result, true);
     CanaryLog.d("%s", leakInfo);
 

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -37,7 +37,7 @@ public final class LeakCanary {
    * Creates a {@link RefWatcher} that works out of the box, and starts watching activity
    * references (on ICS+).
    */
-  @NonNull public static RefWatcher install(@NonNull Application application) {
+  public static @NonNull RefWatcher install(@NonNull Application application) {
     return refWatcher(application).listenerServiceClass(DisplayLeakService.class)
         .excludedRefs(AndroidExcludedRefs.createAppDefaults().build())
         .buildAndInstall();
@@ -48,7 +48,7 @@ public final class LeakCanary {
    * {@link AndroidRefWatcherBuilder#buildAndInstall()}, and {@link RefWatcher#DISABLED} is no
    * {@link RefWatcher} has been installed.
    */
-  @NonNull public static RefWatcher installedRefWatcher() {
+  public static @NonNull RefWatcher installedRefWatcher() {
     RefWatcher refWatcher = LeakCanaryInternals.installedRefWatcher;
     if (refWatcher == null) {
       return RefWatcher.DISABLED;
@@ -56,7 +56,7 @@ public final class LeakCanary {
     return refWatcher;
   }
 
-  @NonNull public static AndroidRefWatcherBuilder refWatcher(@NonNull Context context) {
+  public static @NonNull AndroidRefWatcherBuilder refWatcher(@NonNull Context context) {
     return new AndroidRefWatcherBuilder(context);
   }
 
@@ -92,7 +92,7 @@ public final class LeakCanary {
   }
 
   /** Returns a string representation of the result of a heap analysis. */
-  @NonNull public static String leakInfo(@NonNull Context context,
+  public static @NonNull String leakInfo(@NonNull Context context,
       @NonNull HeapDump heapDump,
       @NonNull AnalysisResult result,
       boolean detailed) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.squareup.leakcanary.internal.DisplayLeakActivity;
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
@@ -36,7 +37,7 @@ public final class LeakCanary {
    * Creates a {@link RefWatcher} that works out of the box, and starts watching activity
    * references (on ICS+).
    */
-  public static RefWatcher install(Application application) {
+  @NonNull public static RefWatcher install(@NonNull Application application) {
     return refWatcher(application).listenerServiceClass(DisplayLeakService.class)
         .excludedRefs(AndroidExcludedRefs.createAppDefaults().build())
         .buildAndInstall();
@@ -47,7 +48,7 @@ public final class LeakCanary {
    * {@link AndroidRefWatcherBuilder#buildAndInstall()}, and {@link RefWatcher#DISABLED} is no
    * {@link RefWatcher} has been installed.
    */
-  public static RefWatcher installedRefWatcher() {
+  @NonNull public static RefWatcher installedRefWatcher() {
     RefWatcher refWatcher = LeakCanaryInternals.installedRefWatcher;
     if (refWatcher == null) {
       return RefWatcher.DISABLED;
@@ -55,7 +56,7 @@ public final class LeakCanary {
     return refWatcher;
   }
 
-  public static AndroidRefWatcherBuilder refWatcher(Context context) {
+  @NonNull public static AndroidRefWatcherBuilder refWatcher(@NonNull Context context) {
     return new AndroidRefWatcherBuilder(context);
   }
 
@@ -65,7 +66,7 @@ public final class LeakCanary {
    * once a potential leak has been found and the analysis starts. You can call this method to
    * enable {@link DisplayLeakActivity} before any potential leak has been detected.
    */
-  public static void enableDisplayLeakActivity(Context context) {
+  public static void enableDisplayLeakActivity(@NonNull Context context) {
     LeakCanaryInternals.setEnabledBlocking(context, DisplayLeakActivity.class, true);
   }
 
@@ -74,7 +75,7 @@ public final class LeakCanary {
    */
   @Deprecated
   public static void setDisplayLeakActivityDirectoryProvider(
-      LeakDirectoryProvider leakDirectoryProvider) {
+      @NonNull LeakDirectoryProvider leakDirectoryProvider) {
     setLeakDirectoryProvider(leakDirectoryProvider);
   }
 
@@ -85,12 +86,14 @@ public final class LeakCanary {
    * @throws IllegalStateException if a LeakDirectoryProvider has already been set, including
    * if the default has been automatically set when installing the ref watcher.
    */
-  public static void setLeakDirectoryProvider(LeakDirectoryProvider leakDirectoryProvider) {
+  public static void setLeakDirectoryProvider(@NonNull LeakDirectoryProvider leakDirectoryProvider) {
     LeakCanaryInternals.setLeakDirectoryProvider(leakDirectoryProvider);
   }
 
   /** Returns a string representation of the result of a heap analysis. */
-  public static String leakInfo(Context context, HeapDump heapDump, AnalysisResult result,
+  @NonNull public static String leakInfo(@NonNull Context context,
+                                         @NonNull HeapDump heapDump,
+                                         @NonNull AnalysisResult result,
       boolean detailed) {
     PackageManager packageManager = context.getPackageManager();
     String packageName = context.getPackageName();
@@ -171,7 +174,7 @@ public final class LeakCanary {
    * Whether the current process is the process running the {@link HeapAnalyzerService}, which is
    * a different process than the normal app process.
    */
-  public static boolean isInAnalyzerProcess(Context context) {
+  public static boolean isInAnalyzerProcess(@NonNull Context context) {
     Boolean isInAnalyzerProcess = LeakCanaryInternals.isInAnalyzerProcess;
     // This only needs to be computed once per process.
     if (isInAnalyzerProcess == null) {

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakCanary.java
@@ -86,14 +86,15 @@ public final class LeakCanary {
    * @throws IllegalStateException if a LeakDirectoryProvider has already been set, including
    * if the default has been automatically set when installing the ref watcher.
    */
-  public static void setLeakDirectoryProvider(@NonNull LeakDirectoryProvider leakDirectoryProvider) {
+  public static void setLeakDirectoryProvider(
+      @NonNull LeakDirectoryProvider leakDirectoryProvider) {
     LeakCanaryInternals.setLeakDirectoryProvider(leakDirectoryProvider);
   }
 
   /** Returns a string representation of the result of a heap analysis. */
   @NonNull public static String leakInfo(@NonNull Context context,
-                                         @NonNull HeapDump heapDump,
-                                         @NonNull AnalysisResult result,
+      @NonNull HeapDump heapDump,
+      @NonNull AnalysisResult result,
       boolean detailed) {
     PackageManager packageManager = context.getPackageManager();
     String packageName = context.getPackageName();

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
@@ -17,7 +17,6 @@ package com.squareup.leakcanary;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.List;

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/LeakDirectoryProvider.java
@@ -15,6 +15,9 @@
  */
 package com.squareup.leakcanary;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.List;
@@ -27,12 +30,12 @@ import java.util.List;
  */
 public interface LeakDirectoryProvider {
 
-  List<File> listFiles(FilenameFilter filter);
+  @NonNull List<File> listFiles(@NonNull FilenameFilter filter);
 
   /**
    * @return {@link HeapDumper#RETRY_LATER} if a new heap dump file could not be created.
    */
-  File newHeapDumpFile();
+  @Nullable File newHeapDumpFile();
 
   /**
    * Removes all heap dumps and analysis results, except for heap dumps that haven't been

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
@@ -17,7 +17,6 @@ package com.squareup.leakcanary;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
 
 import static com.squareup.leakcanary.Preconditions.checkNotNull;

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/ServiceHeapDumpListener.java
@@ -16,6 +16,8 @@
 package com.squareup.leakcanary;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+
 import com.squareup.leakcanary.internal.HeapAnalyzerService;
 
 import static com.squareup.leakcanary.Preconditions.checkNotNull;
@@ -25,13 +27,13 @@ public final class ServiceHeapDumpListener implements HeapDump.Listener {
   private final Context context;
   private final Class<? extends AbstractAnalysisResultService> listenerServiceClass;
 
-  public ServiceHeapDumpListener(final Context context,
-      final Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
+  public ServiceHeapDumpListener(@NonNull final Context context,
+      @NonNull final Class<? extends AbstractAnalysisResultService> listenerServiceClass) {
     this.listenerServiceClass = checkNotNull(listenerServiceClass, "listenerServiceClass");
     this.context = checkNotNull(context, "context").getApplicationContext();
   }
 
-  @Override public void analyze(HeapDump heapDump) {
+  @Override public void analyze(@NonNull HeapDump heapDump) {
     checkNotNull(heapDump, "heapDump");
     HeapAnalyzerService.runAnalysis(context, heapDump, listenerServiceClass);
   }

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDumper.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDumper.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.leakcanary;
 
+import com.sun.istack.internal.Nullable;
+
 import java.io.File;
 
 /** Dumps the heap into a file. */
@@ -31,5 +33,5 @@ public interface HeapDumper {
    * @return a {@link File} referencing the dumped heap, or {@link #RETRY_LATER} if the heap could
    * not be dumped.
    */
-  File dumpHeap();
+  @Nullable File dumpHeap();
 }

--- a/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDumper.java
+++ b/leakcanary-watcher/src/main/java/com/squareup/leakcanary/HeapDumper.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.leakcanary;
 
-import com.sun.istack.internal.Nullable;
-
 import java.io.File;
 
 /** Dumps the heap into a file. */
@@ -33,5 +31,5 @@ public interface HeapDumper {
    * @return a {@link File} referencing the dumped heap, or {@link #RETRY_LATER} if the heap could
    * not be dumped.
    */
-  @Nullable File dumpHeap();
+  File dumpHeap();
 }


### PR DESCRIPTION
Adds nullability annotations to the public API in the `leakcanary-android` module, which improves Kotlin support. This changeset alters:

- Android Gradle Plugin bumped to `3.2.0-rc03` (the `UnknownNullness` lint inspection was only introduced in `3.2.0-alpha10`)
- Enables [Kotlin interoperability checks](https://android.github.io/kotlin-guides/interop.html#command-line-builds) for the `leakcanary-android` module

Points of discussion:

- I've avoided adding annotations to the other android library modules which have public classes, as that would require adding the support library, and I'm unfamiliar with the project's architecture. If that's not an issue, I can update the PR to annotate those classes also
- I've avoided making `UnknownNullness` fail the build, as the plan was only to add annotations to the public API surface
- The Gradle plugin version might need to be bumped to `v3.2.0` once that's released

To test this change I auto-converted the sample project to Kotlin and ensured that passing null to public methods on the `LeakCanary` class resulted in compiler methods, on a debug build. I also ran `./gradlew clean build` which passed locally.

Give me a shout if you have any questions or comments and I'll be happy to respond.

Fixes #1016 