### PR TITLE
Fix travis caching and improve build time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_install:
   # Install the rest of tools (e.g., avdmanager)
   - sdkmanager tools
   # Install the system image
-  - sdkmanager "system-images;android-18;default;armeabi-v7a"
+  - sdkmanager "system-images;android-16;default;armeabi-v7a"
   # Create and start emulator for the script. Meant to race the install task.
-  - echo no | avdmanager create avd --force -n test -k "system-images;android-18;default;armeabi-v7a"
+  - echo no | avdmanager create avd --force -n test -k "system-images;android-16;default;armeabi-v7a"
   - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
 install: ./gradlew clean build assembleAndroidTest --stacktrace
@@ -27,7 +27,7 @@ script:
   - ./gradlew leakcanary-support-fragment:connectedCheck --stacktrace
 
 after_success:
-  - .buildscript/deploy_snapshot.sh
+  - .buildscript/deploy_snapshot.sh || test true
 
 env:
   global:


### PR DESCRIPTION
Travis CI caching was not working due to execution of deploy script.
I've added `|| test true` at the end of deploy script execution command to fix this problem.
Reference: https://stackoverflow.com/questions/45265195/travis-is-not-uploading-cache-directory-why

Also, I've changed emulator platform from android-18 to android-16 because it's size is much lower and tests execution is faster.
Reference: https://medium.com/zendesk-engineering/speeding-up-android-builds-on-travis-ci-1bb4cdbd9c62

My own tests:
android-18 build (16 minutes 23 seconds): https://travis-ci.org/IlyaGulya/leakcanary/builds/431925507
android-16 build (8 minutes 27 seconds): https://travis-ci.org/IlyaGulya/leakcanary/builds/431937866
