### PR TITLE
Fix LeakCanary toasting

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidHeapDumper.java
@@ -15,12 +15,11 @@
  */
 package com.squareup.leakcanary;
 
+import android.app.Activity;
+import android.app.Application;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
-import android.content.res.Configuration;
-import android.graphics.PixelFormat;
-import android.os.Build;
 import android.os.Debug;
 import android.os.Handler;
 import android.os.Looper;
@@ -30,16 +29,12 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.Gravity;
 import android.view.LayoutInflater;
-import android.view.View;
-import android.view.WindowManager;
-import android.view.accessibility.AccessibilityEvent;
-import android.view.accessibility.AccessibilityManager;
 import android.widget.Toast;
+import com.squareup.leakcanary.internal.ActivityLifecycleCallbacksAdapter;
 import com.squareup.leakcanary.internal.FutureResult;
 import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.io.File;
 
-import static android.view.accessibility.AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class AndroidHeapDumper implements HeapDumper {
@@ -48,11 +43,26 @@ public final class AndroidHeapDumper implements HeapDumper {
   private final LeakDirectoryProvider leakDirectoryProvider;
   private final Handler mainHandler;
 
+  private Activity resumedActivity;
+
   public AndroidHeapDumper(@NonNull Context context,
       @NonNull LeakDirectoryProvider leakDirectoryProvider) {
     this.leakDirectoryProvider = leakDirectoryProvider;
     this.context = context.getApplicationContext();
     mainHandler = new Handler(Looper.getMainLooper());
+
+    Application application = (Application) context.getApplicationContext();
+    application.registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacksAdapter() {
+      @Override public void onActivityResumed(Activity activity) {
+        resumedActivity = activity;
+      }
+
+      @Override public void onActivityPaused(Activity activity) {
+        if (resumedActivity == activity) {
+          resumedActivity = null;
+        }
+      }
+    });
   }
 
   @SuppressWarnings("ReferenceEquality") // Explicitly checking for named null.
@@ -96,12 +106,16 @@ public final class AndroidHeapDumper implements HeapDumper {
   private void showToast(final FutureResult<Toast> waitingForToast) {
     mainHandler.post(new Runnable() {
       @Override public void run() {
-        final Toast toast = new Toast(context);
+        if (resumedActivity == null) {
+          waitingForToast.set(null);
+          return;
+        }
+        final Toast toast = new Toast(resumedActivity);
         toast.setGravity(Gravity.CENTER_VERTICAL, 0, 0);
         toast.setDuration(Toast.LENGTH_LONG);
-        LayoutInflater inflater = LayoutInflater.from(context);
+        LayoutInflater inflater = LayoutInflater.from(resumedActivity);
         toast.setView(inflater.inflate(R.layout.leak_canary_heap_dump_toast, null));
-        show(toast);
+        toast.show();
         // Waiting for Idle to make sure Toast gets rendered.
         Looper.myQueue().addIdleHandler(new MessageQueue.IdleHandler() {
           @Override public boolean queueIdle() {
@@ -114,86 +128,13 @@ public final class AndroidHeapDumper implements HeapDumper {
   }
 
   private void cancelToast(final Toast toast) {
+    if (toast == null) {
+      return;
+    }
     mainHandler.post(new Runnable() {
       @Override public void run() {
-        hide(toast);
+        toast.cancel();
       }
     });
-  }
-
-  private void show(Toast toast) {
-    View view = toast.getView();
-    Context context = toast.getView().getContext();
-
-    WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-
-    // We can resolve the Gravity here by using the Locale for getting
-    // the layout direction
-    Configuration config = view.getContext().getResources().getConfiguration();
-    int gravity = toast.getGravity();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      gravity = Gravity.getAbsoluteGravity(gravity, config.getLayoutDirection());
-    }
-
-    WindowManager.LayoutParams params = buildLayoutParams();
-    params.gravity = gravity;
-    if ((gravity & Gravity.HORIZONTAL_GRAVITY_MASK) == Gravity.FILL_HORIZONTAL) {
-      params.horizontalWeight = 1.0f;
-    }
-    if ((gravity & Gravity.VERTICAL_GRAVITY_MASK) == Gravity.FILL_VERTICAL) {
-      params.verticalWeight = 1.0f;
-    }
-    params.x = toast.getXOffset();
-    params.y = toast.getYOffset();
-    params.verticalMargin = toast.getVerticalMargin();
-    params.horizontalMargin = toast.getHorizontalMargin();
-    params.packageName = context.getPackageName();
-    try {
-      windowManager.addView(view, params);
-    } catch (WindowManager.BadTokenException ignored) {
-      CanaryLog.d("Could not show leak toast, the window token has been canceled");
-      return;
-    }
-    trySendAccessibilityEvent(view);
-  }
-
-  private void hide(Toast toast) {
-    View view = toast.getView();
-    if (view.getParent() != null) {
-      Context context = toast.getView().getContext();
-      WindowManager windowManager =
-          (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-      windowManager.removeView(view);
-    }
-  }
-
-  private WindowManager.LayoutParams buildLayoutParams() {
-    WindowManager.LayoutParams params = new WindowManager.LayoutParams();
-    params.height = WindowManager.LayoutParams.WRAP_CONTENT;
-    params.width = WindowManager.LayoutParams.WRAP_CONTENT;
-    params.format = PixelFormat.TRANSLUCENT;
-    params.windowAnimations = android.R.style.Animation_Toast;
-    params.type = WindowManager.LayoutParams.TYPE_TOAST;
-    params.setTitle("Toast");
-    params.flags = WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-        | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-        | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE;
-    return params;
-  }
-
-  private void trySendAccessibilityEvent(View view) {
-    Context context = view.getContext();
-    AccessibilityManager accessibilityManager =
-        (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
-    if (!accessibilityManager.isEnabled()) {
-      return;
-    }
-    // treat toasts as notifications since they are used to
-    // announce a transient piece of information to the user
-    AccessibilityEvent event = AccessibilityEvent.obtain(TYPE_NOTIFICATION_STATE_CHANGED);
-    event.setClassName(getClass().getName());
-    event.setPackageName(context.getPackageName());
-    view.dispatchPopulateAccessibilityEvent(event);
-    accessibilityManager.sendAccessibilityEvent(event);
   }
 }


### PR DESCRIPTION
- Prior attempts to get it to work with the application context turned out to be buggy.
- This makes LeakCanary use whatever the current resumed activity is, if any.
- If there is no resumed activity, then the toast isn't displayed.

This supersedes #1080