### PR TITLE
Always enable DisplayLeakActivity when leakcanary is enabled

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/AndroidRefWatcherBuilder.java
@@ -2,6 +2,7 @@ package com.squareup.leakcanary;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import com.squareup.leakcanary.internal.DisplayLeakActivity;
 import com.squareup.leakcanary.internal.FragmentRefWatcher;
 import com.squareup.leakcanary.internal.LeakCanaryInternals;
 import java.util.List;
@@ -87,6 +88,7 @@ public final class AndroidRefWatcherBuilder extends RefWatcherBuilder<AndroidRef
     }
     RefWatcher refWatcher = build();
     if (refWatcher != DISABLED) {
+      LeakCanaryInternals.setEnabledAsync(context, DisplayLeakActivity.class, true);
       if (watchActivities) {
         ActivityRefWatcher.install(context, refWatcher);
       }

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
+import android.os.AsyncTask;
 import com.squareup.leakcanary.CanaryLog;
 import com.squareup.leakcanary.DefaultLeakDirectoryProvider;
 import com.squareup.leakcanary.LeakDirectoryProvider;
@@ -69,6 +70,16 @@ public final class LeakCanaryInternals {
     } else {
       return className.substring(separator + 1);
     }
+  }
+
+  public static void setEnabledAsync(Context context, final Class<?> componentClass,
+      final boolean enabled) {
+    final Context appContext = context.getApplicationContext();
+    AsyncTask.THREAD_POOL_EXECUTOR.execute(new Runnable() {
+      @Override public void run() {
+        setEnabledBlocking(appContext, componentClass, enabled);
+      }
+    });
   }
 
   public static void setEnabledBlocking(Context appContext, Class<?> componentClass,


### PR DESCRIPTION
Feedback shows that people get confused when the icon goes missing because no leak has been found yet. They want to be able to go, see there's nothing leaking, and be reassured.

Fixes #1115