### PR TITLE
`LeakCanary.isInAnalyzerProcess` correctly returns true in the analyzer process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Future release
+
+* [#1153](https://github.com/square/leakcanary/issues/1153) `LeakCanary.isInAnalyzerProcess` now correctly returns true in the analyzer process prior to any first leak (could be triggered by starting the leak result activity).
+
+
 ## Version 1.6.2 (2018-10-16)
 
 * [#1067](https://github.com/square/leakcanary/issues/1067) Fixed TransactionTooLargeException crash (leak analysis would never complete).

--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -105,7 +105,7 @@ public final class LeakCanaryInternals {
     ComponentName component = new ComponentName(context, serviceClass);
     ServiceInfo serviceInfo;
     try {
-      serviceInfo = packageManager.getServiceInfo(component, 0);
+      serviceInfo = packageManager.getServiceInfo(component, PackageManager.GET_DISABLED_COMPONENTS);
     } catch (PackageManager.NameNotFoundException ignored) {
       // Service is disabled.
       return false;


### PR DESCRIPTION
The leak result activity runs in the analyzer process. When starting it prior to any leak having been detected, `LeakCanary.isInAnalyzerProcess` would return false because the component we look for is initially disabled.

Fixes #1153