### PR TITLE
Fix NPE when KeyedWeakReference not in dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Future release
 
+* [#1186](https://github.com/square/leakcanary/issues/1186) Fix NPE when KeyedWeakReference was not found in heap dump.
+
 ## Version 1.6.3 (2019-01-10)
 
 * [#1163](https://github.com/square/leakcanary/issues/1163) Fixed leaks being incorrectly classified as "no leak" due to missed GC Roots.

--- a/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HeapAnalyzer.java
+++ b/leakcanary-analyzer/src/main/java/com/squareup/leakcanary/HeapAnalyzer.java
@@ -177,8 +177,7 @@ public final class HeapAnalyzer {
 
       // False alarm, weak reference was cleared in between key check and heap dump.
       if (leakingRef == null) {
-        String className = leakingRef.getClassObj().getClassName();
-        return noLeak(className, since(analysisStartNanoTime));
+        return noLeak("UnknownNoKeyedWeakReference", since(analysisStartNanoTime));
       }
       return findLeakTrace(analysisStartNanoTime, snapshot, leakingRef, computeRetainedSize);
     } catch (Throwable e) {


### PR DESCRIPTION
Introduced because I'm stupid.

Fixes #1186