### PR TITLE
Check if serviceInfo.processName is null.

### DIFF
--- a/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
+++ b/leakcanary-android/src/main/java/com/squareup/leakcanary/internal/LeakCanaryInternals.java
@@ -111,7 +111,10 @@ public final class LeakCanaryInternals {
       return false;
     }
 
-    if (serviceInfo.processName.equals(mainProcess)) {
+    if (serviceInfo.processName == null) {
+      CanaryLog.d("Did not expect service %s to have a null process name", serviceClass);
+      return false;
+    } else if (serviceInfo.processName.equals(mainProcess)) {
       CanaryLog.d("Did not expect service %s to run in main process %s", serviceClass, mainProcess);
       // Technically we are in the service process, but we're not in the service dedicated process.
       return false;


### PR DESCRIPTION
When LeakCanary runs on a separate process and that process for some reason does not have a assigned processName, then we will crash on a NullPointerException. Also a debug log explaining this.