### PR TITLE
Add inner class leak back

### DIFF
--- a/leakcanary-sample/src/main/java/com/example/leakcanary/MainActivity.kt
+++ b/leakcanary-sample/src/main/java/com/example/leakcanary/MainActivity.kt
@@ -19,38 +19,40 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
 import android.os.SystemClock
+import android.util.Log
 import android.view.View
 
 class MainActivity : Activity() {
 
-    private var httpRequestHelper: HttpRequestHelper? = null
+  private var httpRequestHelper: HttpRequestHelper? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.main_activity)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.main_activity)
 
-        val button = findViewById<View>(R.id.async_work)
-        button.setOnClickListener { startAsyncWork() }
+    val button = findViewById<View>(R.id.async_work)
+    button.setOnClickListener { startAsyncWork() }
 
-        httpRequestHelper = lastNonConfigurationInstance as HttpRequestHelper?
-        if (httpRequestHelper == null) {
-            httpRequestHelper = HttpRequestHelper(button)
-        }
+    httpRequestHelper = lastNonConfigurationInstance as HttpRequestHelper?
+    if (httpRequestHelper == null) {
+      httpRequestHelper = HttpRequestHelper(button)
     }
+  }
 
-    override fun onRetainNonConfigurationInstance(): Any? {
-        return httpRequestHelper
-    }
+  override fun onRetainNonConfigurationInstance(): Any? {
+    return httpRequestHelper
+  }
 
-    @SuppressLint("StaticFieldLeak")
-    internal fun startAsyncWork() {
-        // This runnable is an anonymous class and therefore has a hidden reference to the outer
-        // class MainActivity. If the activity gets destroyed before the thread finishes (e.g. rotation),
-        // the activity instance will leak.
-        val work = Runnable {
-            // Do some slow work in background
-            SystemClock.sleep(20000)
-        }
-        Thread(work).start()
+  @SuppressLint("StaticFieldLeak")
+  internal fun startAsyncWork() {
+    // This runnable is an anonymous class and therefore has a hidden reference to the outer
+    // class MainActivity. If the activity gets destroyed before the thread finishes (e.g. rotation),
+    // the activity instance will leak.
+    val work = Runnable {
+      // Do some slow work in background
+      SystemClock.sleep(20000)
+      Log.d("MainActivity", "Leaking $this")
     }
+    Thread(work).start()
+  }
 }


### PR DESCRIPTION
Unlike Java anonymous classes, Kotlin lambdas don't leak unless we use the outer reference.

Also reformated the file back to 2 spaces. We'll need to update this.