### PR TITLE
Leaking information aligned below simple class name.

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
@@ -21,17 +21,17 @@ data class LeakTrace(
     elements.dropLast(1)
         .forEachIndexed { index, leakTraceElement ->
           val currentReachability = expectedReachability[index]
-
+          val numOfSpaces = leakTraceElement.className.lastIndexOf('.') + 3 // 3 indexes from "├─ " in the first line
           leakInfo += """
-        |├─ ${leakTraceElement.className}
-        |│${getReachabilityString(currentReachability)}
-        |│${getPossibleLeakString(currentReachability, leakTraceElement, index)}
-        |
-        """.trimMargin()
+        #├─ ${leakTraceElement.className}
+        #│${getReachabilityString(currentReachability, numOfSpaces)}
+        #│${getPossibleLeakString(currentReachability, leakTraceElement, index, numOfSpaces)}
+        #
+        """.trimMargin("#")
         }
     leakInfo += """╰→ ${lastElement.className}
-      |$ZERO_WIDTH_SPACE${getReachabilityString(lastReachability)}
-    """.trimMargin()
+      #$ZERO_WIDTH_SPACE${getReachabilityString(lastReachability, lastElement.className.lastIndexOf('.') + 3)}
+    """.trimMargin("#")
 
     return leakInfo
   }
@@ -45,7 +45,8 @@ data class LeakTrace(
   private fun getPossibleLeakString(
     reachability: Reachability,
     leakTraceElement: LeakTraceElement,
-    index: Int
+    index: Int,
+    numOfSpaces: Int
   ): String {
     val maybeLeakCause = when (reachability.status) {
       UNKNOWN -> true
@@ -59,11 +60,14 @@ data class LeakTrace(
       }
       else -> false
     }
-    return DEFAULT_NEWLINE_SPACE + "↓" + " ${leakTraceElement.toString(maybeLeakCause)}"
+    return " ".repeat(numOfSpaces) + "↓" + " " + leakTraceElement.toString(maybeLeakCause)
   }
 
-  private fun getReachabilityString(reachability: Reachability): String {
-    return DEFAULT_NEWLINE_SPACE + "Leaking: " + when (reachability.status) {
+  private fun getReachabilityString(
+    reachability: Reachability,
+    numOfSpaces: Int
+  ): String {
+    return " ".repeat(numOfSpaces) + "Leaking: " + when (reachability.status!!) {
       UNKNOWN -> "UNKNOWN"
       REACHABLE -> "NO (${reachability.reason})"
       UNREACHABLE -> "YES (${reachability.reason})"
@@ -71,7 +75,6 @@ data class LeakTrace(
   }
 
   companion object {
-    private val DEFAULT_NEWLINE_SPACE = "                 "
     private val ZERO_WIDTH_SPACE = '\u200b'
   }
 }

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
@@ -90,6 +90,7 @@ data class LeakTraceElement(
   }
 
   fun toString(maybeLeakCause: Boolean): String {
+    val numOfSpaces = className.lastIndexOf('.') + 6 // Accounts for the additional spacing from the down error, space and 3 indexes from "├─ "
     val staticString = if (reference != null && reference.type == STATIC_FIELD) "static" else ""
     val holderString =
       if (holder == ARRAY || holder == THREAD) "${holder.name.toLowerCase(US)} " else ""
@@ -98,16 +99,16 @@ data class LeakTraceElement(
     val extraString = if (extra != null) " $extra" else ""
     val exclusionString =
       if (exclusion != null) " , matching exclusion ${exclusion.matching}" else ""
-    val requiredSpaces = staticString.length + holderString.length + simpleClassName.length
+    val requiredSpaces = staticString.length + holderString.length + simpleClassName.length + numOfSpaces
     val leakString = if (maybeLeakCause) {
-      "\n│                   " + " ".repeat(requiredSpaces) + "~".repeat(
-          referenceName.length
+      "\n${ZERO_WIDTH_SPACE}" + "│" + " ".repeat(requiredSpaces) + "~".repeat(
+          referenceName.length - 1
       )
     } else {
       ""
     }
 
-    return staticString + holderString + simpleClassName + referenceName + leakString + extraString + exclusionString
+    return staticString + holderString + simpleClassName + referenceName + extraString + exclusionString + leakString
   }
 
   fun toDetailedString(): String {
@@ -118,7 +119,11 @@ data class LeakTraceElement(
       else -> "Instance of"
     }
     val classNameString = " ${className}\n"
-    val leakReferenceString = fieldReferences.joinToString(separator = "\n", prefix = "|   ")
+    val leakReferenceString = fieldReferences.joinToString(separator = "\n", prefix = "│   ")
     return startingStarString + typeString + classNameString + leakReferenceString
+  }
+
+  companion object {
+    private val ZERO_WIDTH_SPACE = '\u200b'
   }
 }


### PR DESCRIPTION
Also fixed issue where extraString + exclusionString were showing after the squiggly line.
Before:
```
┬
├─ java.lang.Thread
│                 Leaking: NO (it's a GC root)
│                 ↓ thread Thread.<Java Local>
│                                ~~~~~~~~~~~~~ (named 'Thread-4')
├─ com.example.leakcanary.MainActivity$startAsyncWork$work$1
│                 Leaking: UNKNOWN
│                 ↓ MainActivity$startAsyncWork$work$1.this$0
│                                                     ~~~~~~~
╰→ com.example.leakcanary.MainActivity
​                 Leaking: YES (it's the leaking instance)
```

After:
```
┬
├─ java.lang.Thread
│            Leaking: NO (it's a GC root)
│            ↓ thread Thread.<Java Local> (named 'Thread-4')
​│                            ~~~~~~~~~~~~
├─ com.example.leakcanary.MainActivity$startAsyncWork$work$1
│                         Leaking: UNKNOWN
│                         ↓ MainActivity$startAsyncWork$work$1.this$0
​│                                                              ~~~~~~
╰→ com.example.leakcanary.MainActivity
​                         Leaking: YES (it's the leaking instance)
```