### PR TITLE
Remove end of line comments.

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
@@ -21,7 +21,7 @@ data class LeakTrace(
     elements.dropLast(1)
         .forEachIndexed { index, leakTraceElement ->
           val currentReachability = expectedReachability[index]
-          val numOfSpaces = leakTraceElement.className.lastIndexOf('.') + 3 // 3 indexes from "├─ " in the first line
+          val numOfSpaces =  "├─ ".length + leakTraceElement.className.lastIndexOf('.')
           leakInfo += """
         #├─ ${leakTraceElement.className}
         #│${getReachabilityString(currentReachability, numOfSpaces)}

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
@@ -90,7 +90,7 @@ data class LeakTraceElement(
   }
 
   fun toString(maybeLeakCause: Boolean): String {
-    val numOfSpaces = className.lastIndexOf('.') + 6 // Accounts for the additional spacing from the down error, space and 3 indexes from "├─ "
+    val numOfSpaces = "├─ ".length + className.lastIndexOf('.') + " ↓ ".length
     val staticString = if (reference != null && reference.type == STATIC_FIELD) "static" else ""
     val holderString =
       if (holder == ARRAY || holder == THREAD) "${holder.name.toLowerCase(US)} " else ""


### PR DESCRIPTION
Replaced end of line comments in LeakTrace and LeakTraceElement with its " ↓ ".length and "├─ ".length to illustrate why there are additional spaces more than just the className.lastIndexOf('.').