### PR TITLE
Leak traces have hard coded starting spaces.

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
@@ -21,16 +21,15 @@ data class LeakTrace(
     elements.dropLast(1)
         .forEachIndexed { index, leakTraceElement ->
           val currentReachability = expectedReachability[index]
-          val numOfSpaces = leakTraceElement.className.lastIndexOf('.') + 3 // 3 indexes from "├─ " in the first line
           leakInfo += """
         #├─ ${leakTraceElement.className}
-        #│${getReachabilityString(currentReachability, numOfSpaces)}
-        #│${getPossibleLeakString(currentReachability, leakTraceElement, index, numOfSpaces)}
+        #│${getReachabilityString(currentReachability)}
+        #│${getPossibleLeakString(currentReachability, leakTraceElement, index)}
         #
         """.trimMargin("#")
         }
     leakInfo += """╰→ ${lastElement.className}
-      #$ZERO_WIDTH_SPACE${getReachabilityString(lastReachability, lastElement.className.lastIndexOf('.') + 3)}
+      #$ZERO_WIDTH_SPACE ${getReachabilityString(lastReachability)}
     """.trimMargin("#")
 
     return leakInfo
@@ -45,8 +44,7 @@ data class LeakTrace(
   private fun getPossibleLeakString(
     reachability: Reachability,
     leakTraceElement: LeakTraceElement,
-    index: Int,
-    numOfSpaces: Int
+    index: Int
   ): String {
     val maybeLeakCause = when (reachability.status) {
       UNKNOWN -> true
@@ -60,14 +58,13 @@ data class LeakTrace(
       }
       else -> false
     }
-    return " ".repeat(numOfSpaces) + "↓" + " " + leakTraceElement.toString(maybeLeakCause)
+    return DEFAULT_NEW_LINE_SPACE + "↓" + " " + leakTraceElement.toString(maybeLeakCause)
   }
 
   private fun getReachabilityString(
-    reachability: Reachability,
-    numOfSpaces: Int
+    reachability: Reachability
   ): String {
-    return " ".repeat(numOfSpaces) + "Leaking: " + when (reachability.status!!) {
+    return DEFAULT_NEW_LINE_SPACE + "Leaking: " + when (reachability.status!!) {
       UNKNOWN -> "UNKNOWN"
       REACHABLE -> "NO (${reachability.reason})"
       UNREACHABLE -> "YES (${reachability.reason})"
@@ -75,6 +72,7 @@ data class LeakTrace(
   }
 
   companion object {
+    private val DEFAULT_NEW_LINE_SPACE = "    "
     private val ZERO_WIDTH_SPACE = '\u200b'
   }
 }

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
@@ -90,7 +90,6 @@ data class LeakTraceElement(
   }
 
   fun toString(maybeLeakCause: Boolean): String {
-    val numOfSpaces = className.lastIndexOf('.') + 6 // Accounts for the additional spacing from the down error, space and 3 indexes from "├─ "
     val staticString = if (reference != null && reference.type == STATIC_FIELD) "static" else ""
     val holderString =
       if (holder == ARRAY || holder == THREAD) "${holder.name.toLowerCase(US)} " else ""
@@ -99,9 +98,9 @@ data class LeakTraceElement(
     val extraString = if (extra != null) " $extra" else ""
     val exclusionString =
       if (exclusion != null) " , matching exclusion ${exclusion.matching}" else ""
-    val requiredSpaces = staticString.length + holderString.length + simpleClassName.length + numOfSpaces
+    val requiredSpaces = staticString.length + holderString.length + simpleClassName.length + "├─".length
     val leakString = if (maybeLeakCause) {
-      "\n${ZERO_WIDTH_SPACE}" + "│" + " ".repeat(requiredSpaces) + "~".repeat(
+      "\n${ZERO_WIDTH_SPACE}" + "│" + DEFAULT_NEW_LINE_SPACE + " ".repeat(requiredSpaces) + "~".repeat(
           referenceName.length - 1
       )
     } else {
@@ -124,6 +123,7 @@ data class LeakTraceElement(
   }
 
   companion object {
+    private val DEFAULT_NEW_LINE_SPACE = "     "
     private val ZERO_WIDTH_SPACE = '\u200b'
   }
 }


### PR DESCRIPTION
Previously leak traces would align to the simple class name, but for some classes their full class name is too long and truncates the text.
Before:
```
Need new heapdump with className in KeyedWeakReference
┬
├─ com.example.leakcanary.MainActivity$Lol
│                         Leaking: NO (it's a GC root)
│                         ↓ staticMainActivity$Lol.foo
​│                                            ~~~
╰→ com.example.leakcanary.MainActivity
​                    Leaking: YES (it's the leaking instance)
```

After:
```
Need new heapdump with className in KeyedWeakReference
┬
├─ com.example.leakcanary.MainActivity$Lol
│    Leaking: NO (it's a GC root)
│    ↓ staticMainActivity$Lol.foo
​│                             ~~~
╰→ com.example.leakcanary.MainActivity
​     Leaking: YES (it's the leaking instance)
```