### PR TITLE
Import hprof for analysis

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/LeakCanaryUtils.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/LeakCanaryUtils.kt
@@ -33,8 +33,6 @@ import android.os.Build.VERSION_CODES.JELLY_BEAN
 import android.os.Build.VERSION_CODES.O
 import com.squareup.leakcanary.core.R
 import leakcanary.CanaryLog
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 internal object LeakCanaryUtils {
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
@@ -86,25 +86,6 @@ internal class LeakDirectoryProvider @JvmOverloads constructor(
   }
 
   fun newHeapDumpFile(): File? {
-    val pendingHeapDumps =
-      listFiles(FilenameFilter { _, filename ->
-        filename.endsWith(
-            PENDING_HEAPDUMP_SUFFIX
-        )
-      })
-
-    // If a new heap dump file has been created recently and hasn't been processed yet, we skip.
-    // Otherwise we move forward and assume that the analyzer process crashes. The file will
-    // eventually be removed with heap dump file rotation.
-    for (file in pendingHeapDumps) {
-      if (System.currentTimeMillis() - file.lastModified() < ANALYSIS_MAX_DURATION_MS) {
-        CanaryLog.d(
-            "Could not dump heap, previous analysis still is in progress."
-        )
-        return RETRY_LATER
-      }
-    }
-
     cleanupOldHeapDumps()
 
     var storageDirectory = externalStorageDirectory()

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -3,12 +3,21 @@ package leakcanary.internal.activity
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.os.AsyncTask
 import android.os.Bundle
 import com.squareup.leakcanary.core.R
+import leakcanary.CanaryLog
+import leakcanary.HeapDump
+import leakcanary.LeakCanary
+import leakcanary.internal.HeapAnalyzers
+import leakcanary.internal.LeakCanaryUtils
 import leakcanary.internal.activity.db.LeaksDbHelper
 import leakcanary.internal.activity.screen.GroupListScreen
 import leakcanary.internal.navigation.NavigatingActivity
 import leakcanary.internal.navigation.Screen
+import java.io.FileInputStream
+import java.io.IOException
 
 internal class LeakActivity : NavigatingActivity() {
 
@@ -35,6 +44,62 @@ internal class LeakActivity : NavigatingActivity() {
     return GroupListScreen()
   }
 
+  fun requestImportHprof() {
+    val requestFileIntent = Intent(Intent.ACTION_GET_CONTENT).apply {
+      type = "*/*"
+      addCategory(Intent.CATEGORY_OPENABLE)
+    }
+
+    // TODO String res
+    val chooserIntent = Intent.createChooser(requestFileIntent, "Import from")
+    startActivityForResult(chooserIntent, FILE_REQUEST_CODE)
+  }
+
+  override fun onActivityResult(
+    requestCode: Int,
+    resultCode: Int,
+    returnIntent: Intent?
+  ) {
+    CanaryLog.d(
+        "Got activity result with requestCode=$requestCode resultCode=$resultCode returnIntent=$returnIntent"
+    )
+    if (requestCode == FILE_REQUEST_CODE && resultCode == RESULT_OK && returnIntent != null) {
+      returnIntent.data?.let { fileUri ->
+        AsyncTask.THREAD_POOL_EXECUTOR.execute {
+          importHprof(fileUri)
+        }
+      }
+    }
+  }
+
+  private fun importHprof(fileUri: Uri) {
+    try {
+      contentResolver.openFileDescriptor(fileUri, "r")
+          ?.fileDescriptor?.let { fileDescriptor ->
+        val inputStream = FileInputStream(fileDescriptor)
+        LeakCanaryUtils.getLeakDirectoryProvider(this)
+            .newHeapDumpFile()
+            ?.let { target ->
+              inputStream.use { input ->
+                target.outputStream()
+                    .use { output ->
+                      input.copyTo(output, DEFAULT_BUFFER_SIZE)
+                    }
+              }
+              val config = LeakCanary.config
+              val heapDump = HeapDump.builder(target)
+                  .excludedRefs(config.excludedRefs)
+                  .computeRetainedHeapSize(config.computeRetainedHeapSize)
+                  .reachabilityInspectorClasses(config.reachabilityInspectorClasses)
+                  .build()
+              HeapAnalyzers.runAnalysis(this, heapDump)
+            }
+      }
+    } catch (e: IOException) {
+      CanaryLog.d(e, "Could not imported Hprof file")
+    }
+  }
+
   override fun onDestroy() {
     super.onDestroy()
     if (!isChangingConfigurations) {
@@ -53,6 +118,8 @@ internal class LeakActivity : NavigatingActivity() {
   }
 
   companion object {
+    private const val FILE_REQUEST_CODE = 0
+
     fun createPendingIntent(
       context: Context,
       screens: ArrayList<Screen>

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/GroupListScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/GroupListScreen.kt
@@ -1,15 +1,14 @@
 package leakcanary.internal.activity.screen
 
 import android.app.AlertDialog
-import android.graphics.drawable.Drawable
 import android.text.Html
-import android.text.Html.ImageGetter
 import android.text.format.DateUtils
 import android.text.method.LinkMovementMethod
 import android.view.ViewGroup
 import android.widget.ListView
 import android.widget.TextView
 import com.squareup.leakcanary.core.R
+import leakcanary.internal.activity.LeakActivity
 import leakcanary.internal.activity.db
 import leakcanary.internal.activity.db.LeakingInstanceTable
 import leakcanary.internal.activity.ui.SimpleListAdapter
@@ -69,6 +68,13 @@ internal class GroupListScreen : Screen() {
                   .show()
               val messageView = dialog.findViewById<TextView>(android.R.id.message)
               messageView.movementMethod = LinkMovementMethod.getInstance()
+              true
+            }
+
+        // TODO String res
+        menu.add("Import and analyze Hprof file")
+            .setOnMenuItemClickListener {
+              activity<LeakActivity>().requestImportHprof()
               true
             }
       }


### PR DESCRIPTION
Also removed the wait for pending files to be removed. Since we have a threshold now, we won't be dumping the heap as often, and we're still using a serial service for the analysis so things will enqueue nicely. This change allows us to reuse the same mechanism for importing hprof even if an analysis is in progress.

Fixes #1040