### PR TITLE
Reachability inspectors use parser

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
@@ -11,6 +11,9 @@ sealed class LeakNode {
     override val instance: Long,
     val exclusion: Exclusion?,
     val parent: LeakNode,
+    /**
+     * The reference from the parent to this node
+     */
     val leakReference: LeakReference?
   ) : LeakNode()
 }

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
@@ -12,18 +12,10 @@ data class LeakTraceElement(
 
   val holder: Holder,
 
-  /**
-   * Class hierarchy for that object. The first element is [.className]. [Object]
-   * is excluded. There is always at least one element.
-   */
-  val classHierarchy: List<String>,
+  val className: String,
 
   /** If not null, there was no path that could exclude this element.  */
   val exclusion: Exclusion?,
-
-  /** List of all fields (member and static) for that object.  */
-  @Deprecated("This field will be replaced with the parser itself")
-  val fieldReferences: List<LeakReference>,
 
   /**
    * Ordered labels that were computed during analysis. A label provides
@@ -32,8 +24,10 @@ data class LeakTraceElement(
   val labels: List<String>
 ) : Serializable {
 
-  val className: String
-    get() = classHierarchy[0]
+  /**
+   * Returns {@link #className} without the package.
+   */
+  val simpleClassName: String get() = className.lastSegment('.')
 
   enum class Type {
     INSTANCE_FIELD,
@@ -48,33 +42,4 @@ data class LeakTraceElement(
     THREAD,
     ARRAY
   }
-
-  /**
-   * Returns the string value of the first field reference that has the provided referenceName, or
-   * null if no field reference with that name was found.
-   */
-  fun getFieldReferenceValue(referenceName: String): String? {
-    return fieldReferences.find { fieldReference -> fieldReference.name == referenceName }
-        ?.value
-  }
-
-  /** @see [isInstanceOf][] */
-  fun isInstanceOf(expectedClass: Class<out Any>): Boolean {
-    return isInstanceOf(expectedClass.name)
-  }
-
-  /**
-   * Returns true if this element is an instance of the provided class name, false otherwise.
-   */
-  fun isInstanceOf(expectedClassName: String): Boolean {
-    return classHierarchy.contains(expectedClassName)
-  }
-
-  /**
-   * Returns {@link #className} without the package.
-   */
-  fun getSimpleClassName(): String {
-    return className.lastSegment('.')
-  }
-
 }

--- a/leakcanary-analyzer/src/main/java/leakcanary/Reachability.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/Reachability.kt
@@ -41,7 +41,10 @@ class Reachability private constructor(
    */
   interface Inspector {
 
-    fun expectedReachability(element: LeakTraceElement): Reachability
+    fun expectedReachability(
+      parser: HprofParser,
+      node: LeakNode
+    ): Reachability
   }
 
   companion object {

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/LeakTraceRenderer.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/LeakTraceRenderer.kt
@@ -54,7 +54,7 @@ private fun getNextElementString(
     if (element.holder == ARRAY || element.holder == THREAD) {
       "${element.holder.name.toLowerCase(Locale.US)} "
     } else ""
-  val simpleClassName = element.getSimpleClassName()
+  val simpleClassName = element.simpleClassName
   val referenceName = if (element.reference != null) ".${element.reference.displayName}" else ""
   val exclusionString =
     if (element.exclusion != null) " , matching exclusion ${element.exclusion.matching}" else ""

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
@@ -216,7 +216,7 @@ internal class DisplayLeakAdapter private constructor(
   ): Spanned {
 
     val packageEnd = element.className.lastIndexOf('.')
-    var simpleName = element.getSimpleClassName()
+    var simpleName = element.simpleClassName
     simpleName = simpleName.replace("[]", "[ ]")
     val styledClassName = "<font color='$classNameColorHexString'>$simpleName</font>"
 
@@ -255,7 +255,7 @@ internal class DisplayLeakAdapter private constructor(
         referenceName = "<i>$referenceName</i>"
       }
 
-      htmlString +=  "$indentation$styledClassName.${if (maybeLeakCause) "<b>$referenceName</b>" else referenceName}"
+      htmlString += "$indentation$styledClassName.${if (maybeLeakCause) "<b>$referenceName</b>" else referenceName}"
     }
 
     val exclusion = element.exclusion

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -28,6 +28,9 @@ internal object HeapAnalysisTable {
         object BLOB
         )"""
 
+  @Language("RoomSql")
+  const val drop = "DROP TABLE IF EXISTS heap_analysis"
+
   fun insert(
     db: SQLiteDatabase,
     heapAnalysis: HeapAnalysis

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakingInstanceTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakingInstanceTable.kt
@@ -33,6 +33,9 @@ internal object LeakingInstanceTable {
         on leaking_instance (group_hash)
     """
 
+  @Language("RoomSql")
+  const val drop = "DROP TABLE IF EXISTS leaking_instance"
+
   fun insert(
     db: SQLiteDatabase,
     heapAnalysisId: Long,
@@ -261,7 +264,7 @@ internal object LeakingInstanceTable {
     } else {
       val element = leakTrace.leakCauses.first()
       val referenceName = element.reference!!.groupingName
-      element.getSimpleClassName() + "." + referenceName
+      element.simpleClassName + "." + referenceName
     }
   }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
@@ -5,7 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 
 internal class LeaksDbHelper(context: Context) : SQLiteOpenHelper(
-    context, "leaks.db", null, 1
+    context, "leaks.db", null, VERSION
 ) {
 
   override fun onCreate(db: SQLiteDatabase) {
@@ -19,6 +19,13 @@ internal class LeaksDbHelper(context: Context) : SQLiteOpenHelper(
     oldVersion: Int,
     newVersion: Int
   ) {
-    TODO("Upgrade not needed yet")
+    db.execSQL(HeapAnalysisTable.drop)
+    db.execSQL(LeakingInstanceTable.drop)
+    onCreate(db)
+  }
+
+  companion object {
+    // Last updated for 2.0-alpha-2
+    private const val VERSION = 2
   }
 }

--- a/leakcanary-haha/src/main/java/leakcanary/HeapValue.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/HeapValue.kt
@@ -1,5 +1,15 @@
 package leakcanary
 
+import leakcanary.HeapValue.BooleanValue
+import leakcanary.HeapValue.ByteValue
+import leakcanary.HeapValue.CharValue
+import leakcanary.HeapValue.DoubleValue
+import leakcanary.HeapValue.FloatValue
+import leakcanary.HeapValue.IntValue
+import leakcanary.HeapValue.LongValue
+import leakcanary.HeapValue.ObjectReference
+import leakcanary.HeapValue.ShortValue
+
 sealed class HeapValue {
   data class ObjectReference(val value: Long) : HeapValue() {
     val isNull
@@ -15,3 +25,60 @@ sealed class HeapValue {
   data class IntValue(val value: Int) : HeapValue()
   data class LongValue(val value: Long) : HeapValue()
 }
+
+val HeapValue?.isNullReference
+  get() = this is ObjectReference && isNull
+
+val HeapValue?.reference
+  get() = if (this is ObjectReference && !isNull) {
+    this.value
+  } else
+    null
+
+val HeapValue?.boolean
+  get() = if (this is BooleanValue) {
+    this.value
+  } else
+    null
+
+val HeapValue?.char
+  get() = if (this is CharValue) {
+    this.value
+  } else
+    null
+
+val HeapValue?.float
+  get() = if (this is FloatValue) {
+    this.value
+  } else
+    null
+
+val HeapValue?.double
+  get() = if (this is DoubleValue) {
+    this.value
+  } else
+    null
+
+val HeapValue?.byte
+  get() = if (this is ByteValue) {
+    this.value
+  } else
+    null
+
+val HeapValue?.short
+  get() = if (this is ShortValue) {
+    this.value
+  } else
+    null
+
+val HeapValue?.int
+  get() = if (this is IntValue) {
+    this.value
+  } else
+    null
+
+val HeapValue?.long
+  get() = if (this is LongValue) {
+    this.value
+  } else
+    null

--- a/leakcanary-haha/src/main/java/leakcanary/HydratedClass.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/HydratedClass.kt
@@ -43,4 +43,14 @@ class HydratedClass(
     }
     return false
   }
+
+  val simpleClassName: String
+    get() {
+      val separator = className.lastIndexOf('.')
+      return if (separator == -1) {
+        className
+      } else {
+        className.substring(separator + 1)
+      }
+    }
 }

--- a/leakcanary-haha/src/main/java/leakcanary/HydratedInstance.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/HydratedInstance.kt
@@ -21,14 +21,16 @@ class HydratedInstance(
       hydratedClass.fieldNames.forEachIndexed { fieldIndex, fieldName ->
         if (fieldName == name) {
           val fieldValue = fieldValues[classIndex][fieldIndex]
-          if (fieldValue is T) {
-            return fieldValue
-          } else return null
+          return if (fieldValue is T) {
+            fieldValue
+          } else null
         }
       }
     }
     return null
   }
+
+  operator fun get(name: String): HeapValue? = fieldValueOrNull(name)
 
   fun hasField(name: String): Boolean {
     classHierarchy.forEach { hydratedClass ->


### PR DESCRIPTION
* Updated Reachability inspectors to work like labelers and use the heap dump parser directly
* Removed `LeakTraceElement.references` which was used by inspectors and was causing LeakCanary to store really large blobs in the db, causing #1293

Fixes #1293