### PR TITLE
Pending analysis won't block heap dumps anymore

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -67,18 +67,6 @@ internal class HeapDumpTrigger(
       return
     }
 
-
-    if (leakDirectoryProvider.hasPendingHeapDump()) {
-      CanaryLog.d(
-          "Leak Analysis in progress, will retry in %d ms",
-          WAIT_FOR_PENDING_ANALYSIS_MILLIS
-      )
-      scheduleTick(
-          "had pending heap dump",
-          WAIT_FOR_PENDING_ANALYSIS_MILLIS
-      )
-      return
-    }
     gcTrigger.runGc()
 
     retainedKeys = refWatcher.retainedKeys
@@ -132,7 +120,6 @@ internal class HeapDumpTrigger(
 
   companion object {
     const val LEAK_CANARY_THREAD_NAME = "LeakCanary-Heap-Dump"
-    const val WAIT_FOR_PENDING_ANALYSIS_MILLIS = 20_000L
     const val WAIT_FOR_DEBUG_MILLIS = 20_000L
     const val WAIT_FOR_HEAP_DUMPER_MILLIS = 5_000L
     const val MIN_LEAKS_WHEN_VISIBLE = 5

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
@@ -69,21 +69,6 @@ internal class LeakDirectoryProvider @JvmOverloads constructor(
     return files
   }
 
-  fun hasPendingHeapDump(): Boolean {
-    val pendingHeapDumps =
-      listFiles(FilenameFilter { _, filename ->
-        filename.endsWith(
-            PENDING_HEAPDUMP_SUFFIX
-        )
-      })
-    for (file in pendingHeapDumps) {
-      if (System.currentTimeMillis() - file.lastModified() < ANALYSIS_MAX_DURATION_MS) {
-        return true
-      }
-    }
-    return false
-  }
-
   fun newHeapDumpFile(): File? {
     cleanupOldHeapDumps()
 
@@ -209,8 +194,5 @@ internal class LeakDirectoryProvider @JvmOverloads constructor(
 
     private const val HPROF_SUFFIX = ".hprof"
     private const val PENDING_HEAPDUMP_SUFFIX = "_pending$HPROF_SUFFIX"
-
-    /** 10 minutes  */
-    private const val ANALYSIS_MAX_DURATION_MS = 10 * 60 * 1000
   }
 }


### PR DESCRIPTION
Previously, we looked for a `*_pending.hprof` file younger than 10 minutes on the filesystem to detect if an analysis was in progress, and skip heap dumps to avoid constantly doing heap dumps.

This meant that if the process died (e.g. crash) during an analysis, no heap dumps would happen in the next 10 minutes.

Heap analysis is now fast, it finds many leaks at once, it's serial and in a single process. This means we can remove this behavior and just dump the heap whenever thresholds are met and then enqueue work to the serial service.

If the process is killed during an analysis, it won't resume but it's easy enough to import the hprof again, from the sd card.

Fixes #1312