### PR TITLE
Introducing exclusion priority

### DIFF
--- a/leakcanary-analyzer-perflib/src/test/java/leakcanary/internal/HeapAnalyzerPerflibHeapDumpTest.kt
+++ b/leakcanary-analyzer-perflib/src/test/java/leakcanary/internal/HeapAnalyzerPerflibHeapDumpTest.kt
@@ -19,7 +19,7 @@ class HeapAnalyzerPerflibHeapDumpTest {
     val retainedInstance = findLeak(ASYNC_TASK_P)!!
     assertThat(retainedInstance).isInstanceOf(LeakingInstance::class.java)
     val leak = retainedInstance as LeakingInstance
-    assertThat(leak.excludedLeak).isFalse()
+    assertThat(leak.exclusionStatus).isNull()
     assertThat(leak.instanceClassName).isEqualTo("com.example.leakcanary.MainActivity")
   }
 

--- a/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalysis.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalysis.kt
@@ -1,5 +1,6 @@
 package leakcanary
 
+import leakcanary.Exclusion.Status.WONT_FIX_LEAK
 import leakcanary.internal.createSHA1Hash
 import java.io.File
 import java.io.Serializable
@@ -75,7 +76,7 @@ data class LeakingInstance(
    * True if the only path to the leaking reference is through excluded references. Usually, that
    * means you can safely ignore this report.
    */
-  val excludedLeak: Boolean,
+  val exclusionStatus: Exclusion.Status?,
   /**
    * Shortest path to GC roots for the leaking instance.
    */
@@ -91,7 +92,7 @@ data class LeakingInstance(
   val groupHash = createGroupHash()
 
   private fun createGroupHash(): String {
-    val uniqueString = if (excludedLeak) {
+    val uniqueString = if (exclusionStatus == WONT_FIX_LEAK) {
       leakTrace.firstElementExclusion.matching
     } else {
       leakTrace.leakCauses
@@ -114,4 +115,4 @@ fun HeapAnalysis.leakingInstances(): List<LeakingInstance> {
 }
 
 fun HeapAnalysis.applicationLeaks(): List<LeakingInstance> =
-  leakingInstances().filter { !it.excludedLeak }
+  leakingInstances().filter { it.exclusionStatus == null }

--- a/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalyzer.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalyzer.kt
@@ -285,7 +285,7 @@ class HeapAnalyzer constructor(
           key,
           parser.retrieveString(weakReference.name),
           parser.retrieveString(weakReference.className),
-          weakReference.watchDurationMillis, pathResult.excludingKnownLeaks, leakTrace, retainedSize
+          weakReference.watchDurationMillis, pathResult.exclusionStatus, leakTrace, retainedSize
       )
       analysisResults[key] = leakDetected
     }

--- a/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalyzer.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalyzer.kt
@@ -315,7 +315,7 @@ class HeapAnalyzer constructor(
     // We iterate from the leak to the GC root
     val ignored = leakingNode.instance
 
-    val leafNode = ChildNode(ignored, null, leakingNode, null)
+    val leafNode = ChildNode(ignored, Int.MAX_VALUE, null, leakingNode, null)
     var node: LeakNode = leafNode
     val nodes = mutableListOf<LeakNode>()
     while (node is ChildNode) {

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
@@ -2,13 +2,19 @@ package leakcanary
 
 sealed class LeakNode {
   abstract val instance: Long
+  /** Used by the shortest path finder to create a segmented FIFO queue using a priority queue. */
+  abstract val visitOrder: Int
 
   class RootNode(
     override val instance: Long
-  ) : LeakNode()
+  ) : LeakNode() {
+    override val visitOrder
+      get() = 0
+  }
 
   class ChildNode(
     override val instance: Long,
+    override val visitOrder: Int,
     val exclusion: ExclusionDescription?,
     val parent: LeakNode,
     /**

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/TestUtil.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/TestUtil.kt
@@ -1,9 +1,12 @@
 package leakcanary.internal
 
 import leakcanary.Exclusion
-import leakcanary.Exclusion.ExclusionType.ClassExclusion
+import leakcanary.Exclusion.ExclusionType.InstanceFieldExclusion
 import leakcanary.Exclusion.ExclusionType.ThreadExclusion
+import leakcanary.Exclusion.Status.NEVER_REACHABLE
+import leakcanary.Exclusion.Status.WEAKLY_REACHABLE
 import leakcanary.HprofParser
+import leakcanary.KeyedWeakReference
 import java.io.File
 import java.lang.ref.PhantomReference
 import java.lang.ref.SoftReference
@@ -25,32 +28,71 @@ internal fun fileFromName(filename: String): File {
 val defaultExclusionFactory: (HprofParser) -> List<Exclusion> = {
   listOf(
       Exclusion(
-          type = ClassExclusion(WeakReference::class.java.name),
-          alwaysExclude = true
-      ),
+          type = InstanceFieldExclusion(WeakReference::class.java.name, "referent"),
+          status = WEAKLY_REACHABLE
+      )
+      ,
       Exclusion(
-          type = ClassExclusion(SoftReference::class.java.name),
-          alwaysExclude = true
-      ),
+          type = InstanceFieldExclusion(KeyedWeakReference::class.java.name, "referent"),
+          status = NEVER_REACHABLE
+      )
+      ,
       Exclusion(
-          type = ClassExclusion(PhantomReference::class.java.name),
-          alwaysExclude = true
-      ),
+          type = InstanceFieldExclusion(SoftReference::class.java.name, "referent"),
+          status = NEVER_REACHABLE
+      )
+      ,
       Exclusion(
-          type = ClassExclusion("java.lang.ref.Finalizer"),
-          alwaysExclude = true
-      ),
+          type = InstanceFieldExclusion(PhantomReference::class.java.name, "referent"),
+          status = NEVER_REACHABLE
+      )
+      ,
       Exclusion(
-          type = ClassExclusion("java.lang.ref.FinalizerReference"),
-          alwaysExclude = true
-      ),
+          type = InstanceFieldExclusion("java.lang.ref.Finalizer", "prev"),
+          status = NEVER_REACHABLE
+      )
+      ,
+      Exclusion(
+          type = InstanceFieldExclusion("java.lang.ref.Finalizer", "element"),
+          status = NEVER_REACHABLE
+      )
+      ,
+      Exclusion(
+          type = InstanceFieldExclusion("java.lang.ref.Finalizer", "next"),
+          status = NEVER_REACHABLE
+      )
+      ,
+      Exclusion(
+          type = InstanceFieldExclusion("java.lang.ref.FinalizerReference", "prev"),
+          status = NEVER_REACHABLE
+      )
+      ,
+      Exclusion(
+          type = InstanceFieldExclusion("java.lang.ref.FinalizerReference", "element"),
+          status = NEVER_REACHABLE
+      )
+      ,
+      Exclusion(
+          type = InstanceFieldExclusion("java.lang.ref.FinalizerReference", "next"),
+          status = NEVER_REACHABLE
+      )
+      ,
+      Exclusion(
+          type = InstanceFieldExclusion("sun.misc.Cleaner", "prev"), status = NEVER_REACHABLE
+      )
+      ,
+      Exclusion(
+          type = InstanceFieldExclusion("sun.misc.Cleaner", "next"), status = NEVER_REACHABLE
+      )
+      ,
+
       Exclusion(
           type = ThreadExclusion("FinalizerWatchdogDaemon"),
-          alwaysExclude = true
+          status = NEVER_REACHABLE
       ),
       Exclusion(
           type = ThreadExclusion("main"),
-          alwaysExclude = true
+          status = NEVER_REACHABLE
       )
   )
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
@@ -26,8 +26,6 @@ import android.widget.BaseAdapter
 import android.widget.TextView
 import androidx.annotation.ColorRes
 import com.squareup.leakcanary.core.R
-import com.squareup.leakcanary.core.R.id
-import com.squareup.leakcanary.core.R.string
 import leakcanary.LeakTrace
 import leakcanary.LeakTraceElement
 import leakcanary.LeakTraceElement.Type.STATIC_FIELD
@@ -115,7 +113,7 @@ internal class DisplayLeakAdapter private constructor(
   }
 
   private fun bindTopRow(view: View) {
-    val textView = view.findViewById<TextView>(id.leak_canary_row_text)
+    val textView = view.findViewById<TextView>(R.id.leak_canary_row_text)
     textView.text = view.context.packageName
   }
 
@@ -158,13 +156,13 @@ internal class DisplayLeakAdapter private constructor(
         Html.fromHtml(
             """
               <font color='$helpColorHexString'>
-                <b>${resources.getString(string.leak_canary_help_title)}</b>
+                <b>${resources.getString(R.string.leak_canary_help_title)}</b>
               </font>
             """
         )
       }
       val detailText = Html.fromHtml(
-          resources.getString(string.leak_canary_help_detail)
+          resources.getString(R.string.leak_canary_help_detail)
       ) as SpannableStringBuilder
       SquigglySpan.replaceUnderlineSpans(detailText, resources)
       detailView.text = detailText
@@ -194,13 +192,13 @@ internal class DisplayLeakAdapter private constructor(
     view: View,
     position: Int
   ) {
-    val titleView = view.findViewById<TextView>(id.leak_canary_row_text)
-    val timeView = view.findViewById<TextView>(id.leak_canary_row_time)
+    val titleView = view.findViewById<TextView>(R.id.leak_canary_row_text)
+    val timeView = view.findViewById<TextView>(R.id.leak_canary_row_time)
 
     val projection = instanceProjections[position - TOP_ROW_COUNT - leakTrace.elements.size]
 
     titleView.text =
-      view.resources.getString(string.leak_canary_class_has_leaked, projection.classSimpleName)
+      view.resources.getString(R.string.leak_canary_class_has_leaked, projection.classSimpleName)
 
     timeView.text = DateUtils.formatDateTime(
         view.context, projection.createdAtTimeMillis,
@@ -298,31 +296,31 @@ internal class DisplayLeakAdapter private constructor(
         return START_LAST_REACHABLE
       }
       val nextReachability = leakTrace.expectedReachability[elementIndex(position + 1)]
-      return if (nextReachability.status != Reachability.Status.REACHABLE) {
+      return if (nextReachability.status != REACHABLE) {
         START_LAST_REACHABLE
       } else START
     } else {
       val isLeakingInstance = position == count - 1
       if (isLeakingInstance) {
         val previousReachability = leakTrace.expectedReachability[elementIndex(position - 1)]
-        return if (previousReachability.status != Reachability.Status.UNREACHABLE) {
+        return if (previousReachability.status != UNREACHABLE) {
           END_FIRST_UNREACHABLE
         } else END
       } else {
         val reachability = leakTrace.expectedReachability[elementIndex(position)]
         when (reachability.status) {
           Reachability.Status.UNKNOWN -> return NODE_UNKNOWN
-          Reachability.Status.REACHABLE -> {
+          REACHABLE -> {
             val nextReachability = leakTrace.expectedReachability[elementIndex(position + 1)]
-            return if (nextReachability.status != Reachability.Status.REACHABLE) {
+            return if (nextReachability.status != REACHABLE) {
               NODE_LAST_REACHABLE
             } else {
               NODE_REACHABLE
             }
           }
-          Reachability.Status.UNREACHABLE -> {
+          UNREACHABLE -> {
             val previousReachability = leakTrace.expectedReachability[elementIndex(position - 1)]
-            return if (previousReachability.status != Reachability.Status.UNREACHABLE) {
+            return if (previousReachability.status != UNREACHABLE) {
               NODE_FIRST_UNREACHABLE
             } else {
               NODE_UNREACHABLE

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
@@ -26,6 +26,6 @@ internal class LeaksDbHelper(context: Context) : SQLiteOpenHelper(
 
   companion object {
     // Last updated for 2.0-alpha-2
-    private const val VERSION = 3
+    private const val VERSION = 4
   }
 }

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/HeapAnalyzerComparisonTest.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/HeapAnalyzerComparisonTest.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.Executor
  * Instrumentation test that runs the two heap analyzer implementations on the same heap
  * dump and logs how they perform. This isn't meant to run as part of the test suite.
  */
-@Ignore
+//@Ignore
 class HeapAnalyzerComparisonTest {
 
   @Volatile

--- a/leakcanary-haha/src/main/java/leakcanary/HprofParser.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/HprofParser.kt
@@ -810,6 +810,16 @@ class HprofParser private constructor(
 
   val Long.objectRecord: ObjectRecord get() = retrieveRecordById(this)
 
+  val ObjectRecord.hydratedInstance: HydratedInstance
+    get() = hydrateInstance(
+        this as InstanceDumpRecord
+    )
+
+  val Long.hydratedInstance: HydratedInstance
+    get() = hydrateInstance(
+        retrieveRecordById(this) as InstanceDumpRecord
+    )
+
   val Long?.stringOrNull: String?
     get() = if (this == null) {
       null


### PR DESCRIPTION
* "excludedLeak" is now known as "won't fix leak", which matches its reality better. It's a leak that is known and real yet we're not fixing.
* Exclusion.alwaysExclude is replaced with Exclusion.status, with 3 possible values: NEVER_REACHABLE, WONT_FIX_LEAK, WEAKLY_REACHABLE.
* The shortest path finder will now follow weak references after all other paths have been exhausted.
* Removed class exclusion, was confusing, replaced with less lazy approach of listing fields to exclude
* VIEWLOCATIONHOLDER_ROOT should not have been always excluded, fixed.

Fixes #1173 ... well kinda. Instead of "non leaking retained instances", LeakCanary will report weakly reachable traces. Not sure if that'll help but it's a foundation we can build on.