### PR TITLE
Updating Deprecated Calls & Lint Fixes

### DIFF
--- a/leakcanary-analyzer-perflib/src/main/java/leakcanary/internal/perflib/ShortestPathFinder.kt
+++ b/leakcanary-analyzer-perflib/src/main/java/leakcanary/internal/perflib/ShortestPathFinder.kt
@@ -163,7 +163,7 @@ internal class ShortestPathFinder(
         node.instance is ClassObj -> visitClassObj(node)
         node.instance is ClassInstance -> visitClassInstance(node)
         node.instance is ArrayInstance -> visitArrayInstance(node)
-        else -> throw IllegalStateException("Unexpected type for " + node.instance!!)
+        else -> throw IllegalStateException("Unexpected type for " + node.instance)
       }
     }
     return OldResult(
@@ -229,7 +229,7 @@ internal class ShortestPathFinder(
   }
 
   private fun checkSeen(node: LeakNode): Boolean {
-    return !visitedSet.add(node.instance!!)
+    return !visitedSet.add(node.instance)
   }
 
   private fun visitRootObj(node: LeakNode) {

--- a/leakcanary-analyzer/src/main/java/leakcanary/Serializables.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/Serializables.kt
@@ -38,6 +38,7 @@ fun Serializable.toByteArray(): ByteArray {
 
 object Serializables {
 
+  @Suppress("UNCHECKED_CAST")
   fun <T> fromByteArray(byteArray: ByteArray): T? {
     val inputStream = ByteArrayInputStream(byteArray)
     return try {
@@ -47,6 +48,7 @@ object Serializables {
     }
   }
 
+  @Suppress("UNCHECKED_CAST")
   fun <T> load(file: File): T? {
 
     val fileInputStream = try {

--- a/leakcanary-android-core/src/main/java/leakcanary/AndroidReachabilityInspectors.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/AndroidReachabilityInspectors.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package leakcanary
 
 import android.app.Activity

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -84,15 +84,15 @@ internal class AndroidHeapDumper(
 
     val toast = waitingForToast.get()
 
-    try {
-      Debug.dumpHprofData(heapDumpFile!!.absolutePath)
+    return try {
+      Debug.dumpHprofData(heapDumpFile.absolutePath)
       cancelToast(toast)
       notificationManager.cancel(notificationId)
-      return heapDumpFile
+      heapDumpFile
     } catch (e: Exception) {
       CanaryLog.d(e, "Could not dump heap")
       // Abort heap dump
-      return null
+      null
     }
 
   }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakConnectorView.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakConnectorView.kt
@@ -26,6 +26,7 @@ import android.graphics.PorterDuff.Mode.CLEAR
 import android.graphics.PorterDuffXfermode
 import android.util.AttributeSet
 import android.view.View
+import androidx.core.content.ContextCompat
 import com.squareup.leakcanary.core.R
 import leakcanary.internal.DisplayLeakConnectorView.Type.END
 import leakcanary.internal.DisplayLeakConnectorView.Type.END_FIRST_UNREACHABLE
@@ -80,18 +81,18 @@ internal class DisplayLeakConnectorView(
         .toFloat()
 
     classNamePaint = Paint(Paint.ANTI_ALIAS_FLAG)
-    classNamePaint.color = resources.getColor(R.color.leak_canary_class_name)
+    classNamePaint.color = ContextCompat.getColor(context, R.color.leak_canary_class_name)
     classNamePaint.strokeWidth = strokeSize
 
     leakGroupRootPaint = Paint(Paint.ANTI_ALIAS_FLAG)
-    leakGroupRootPaint.color = resources.getColor(R.color.leak_canary_class_name)
+    leakGroupRootPaint.color = ContextCompat.getColor(context, R.color.leak_canary_class_name)
     leakGroupRootPaint.strokeWidth = strokeSize
     val pathLines = resources.getDimensionPixelSize(R.dimen.leak_canary_connector_leak_dash_line)
         .toFloat()
     leakGroupRootPaint.pathEffect = DashPathEffect(floatArrayOf(pathLines, pathLines), 0f)
 
     leakPaint = Paint(Paint.ANTI_ALIAS_FLAG)
-    leakPaint.color = resources.getColor(R.color.leak_canary_leak)
+    leakPaint.color = ContextCompat.getColor(context, R.color.leak_canary_leak)
     leakPaint.style = Paint.Style.STROKE
     leakPaint.strokeWidth = strokeSize
 
@@ -104,7 +105,7 @@ internal class DisplayLeakConnectorView(
     clearPaint.xfermode = CLEAR_XFER_MODE
 
     referencePaint = Paint(Paint.ANTI_ALIAS_FLAG)
-    referencePaint.color = resources.getColor(R.color.leak_canary_reference)
+    referencePaint.color = ContextCompat.getColor(context, R.color.leak_canary_reference)
     referencePaint.strokeWidth = strokeSize
   }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/SquigglySpan.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/SquigglySpan.kt
@@ -15,6 +15,7 @@
  */
 package leakcanary.internal
 
+import android.content.Context
 import android.content.res.Resources
 import android.graphics.Canvas
 import android.graphics.Paint
@@ -22,13 +23,14 @@ import android.graphics.Path
 import android.text.SpannableStringBuilder
 import android.text.style.ReplacementSpan
 import android.text.style.UnderlineSpan
+import androidx.core.content.ContextCompat
 import com.squareup.leakcanary.core.R
 
 /**
  * Inspired from https://github.com/flavienlaurent/spans and
  * https://github.com/andyxialm/WavyLineView
  */
-internal class SquigglySpan(resources: Resources) : ReplacementSpan() {
+internal class SquigglySpan(context: Context, resources: Resources) : ReplacementSpan() {
 
   private val squigglyPaint: Paint = Paint(Paint.ANTI_ALIAS_FLAG)
   private val path: Path
@@ -42,7 +44,7 @@ internal class SquigglySpan(resources: Resources) : ReplacementSpan() {
 
   init {
     squigglyPaint.style = Paint.Style.STROKE
-    squigglyPaint.color = resources.getColor(R.color.leak_canary_leak)
+    squigglyPaint.color = ContextCompat.getColor(context, R.color.leak_canary_leak)
     val strokeWidth =
       resources.getDimensionPixelSize(R.dimen.leak_canary_squiggly_span_stroke_width)
           .toFloat()
@@ -57,7 +59,7 @@ internal class SquigglySpan(resources: Resources) : ReplacementSpan() {
     path = Path()
     val waveHeight = 2 * amplitude + strokeWidth
     halfWaveHeight = waveHeight / 2
-    referenceColor = resources.getColor(R.color.leak_canary_reference)
+    referenceColor = ContextCompat.getColor(context, R.color.leak_canary_reference)
   }
 
   override fun getSize(
@@ -100,6 +102,7 @@ internal class SquigglySpan(resources: Resources) : ReplacementSpan() {
 
     fun replaceUnderlineSpans(
       builder: SpannableStringBuilder,
+      context: Context,
       resources: Resources
     ) {
       val underlineSpans = builder.getSpans(0, builder.length, UnderlineSpan::class.java)
@@ -107,7 +110,7 @@ internal class SquigglySpan(resources: Resources) : ReplacementSpan() {
         val start = builder.getSpanStart(span)
         val end = builder.getSpanEnd(span)
         builder.removeSpan(span)
-        builder.setSpan(SquigglySpan(resources), start, end, 0)
+        builder.setSpan(SquigglySpan(context, resources), start, end, 0)
       }
     }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/GroupScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/GroupScreen.kt
@@ -46,7 +46,7 @@ internal class GroupScreen(private val groupHash: String) : Screen() {
 
     val listView = findViewById<ListView>(R.id.leak_canary_list)
 
-    val adapter = DisplayLeakAdapter(resources, leakTrace, projections)
+    val adapter = DisplayLeakAdapter(context, leakTrace, projections)
     listView.adapter = adapter
 
     listView.setOnItemClickListener { _, _, position, _ ->

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
@@ -1,5 +1,6 @@
 package leakcanary.internal.activity.screen
 
+import android.content.Context
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Bitmap.Config.ARGB_8888
@@ -9,6 +10,7 @@ import android.graphics.Paint
 import android.graphics.Paint.Style.FILL
 import android.graphics.Paint.Style.STROKE
 import android.graphics.Rect
+import androidx.core.content.ContextCompat
 import com.squareup.leakcanary.core.R
 import leakcanary.HprofParser
 import leakcanary.HprofParser.RecordCallbacks
@@ -45,6 +47,7 @@ object HeapDumpRenderer {
   }
 
   fun render(
+    context: Context,
     resources: Resources,
     heapDumpFile: File,
     sourceWidth: Int,
@@ -59,21 +62,21 @@ object HeapDumpRenderer {
     val recordPositions = mutableListOf<Pair<Int, Long>>()
     var currentRecord: Record? = null
 
-    val otherColor = resources.getColor(R.color.leak_canary_heap_other)
-    val stackTraceColor = resources.getColor(R.color.leak_canary_heap_stack_trace)
-    val hprofStringColor = resources.getColor(R.color.leak_canary_heap_hprof_string)
-    val loadClassColor = resources.getColor(R.color.leak_canary_heap_load_class)
-    val classDumpColor = resources.getColor(R.color.leak_canary_heap_class_dump)
-    val instanceColor = resources.getColor(R.color.leak_canary_heap_instance)
-    val objectArrayColor = resources.getColor(R.color.leak_canary_heap_object_array)
-    val booleanArrayColor = resources.getColor(R.color.leak_canary_heap_boolean_array)
-    val charArrayColor = resources.getColor(R.color.leak_canary_heap_char_array)
-    val floatArrayColor = resources.getColor(R.color.leak_canary_heap_float_array)
-    val doubleArrayColor = resources.getColor(R.color.leak_canary_heap_double_array)
-    val byteArrayColor = resources.getColor(R.color.leak_canary_heap_byte_array)
-    val shortArrayColor = resources.getColor(R.color.leak_canary_heap_short_array)
-    val intArrayColor = resources.getColor(R.color.leak_canary_heap_int_array)
-    val longArrayColor = resources.getColor(R.color.leak_canary_heap_long_array)
+    val otherColor = ContextCompat.getColor(context, R.color.leak_canary_heap_other)
+    val stackTraceColor = ContextCompat.getColor(context, R.color.leak_canary_heap_stack_trace)
+    val hprofStringColor = ContextCompat.getColor(context, R.color.leak_canary_heap_hprof_string)
+    val loadClassColor = ContextCompat.getColor(context, R.color.leak_canary_heap_load_class)
+    val classDumpColor = ContextCompat.getColor(context, R.color.leak_canary_heap_class_dump)
+    val instanceColor = ContextCompat.getColor(context, R.color.leak_canary_heap_instance)
+    val objectArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_object_array)
+    val booleanArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_boolean_array)
+    val charArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_char_array)
+    val floatArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_float_array)
+    val doubleArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_double_array)
+    val byteArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_byte_array)
+    val shortArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_short_array)
+    val intArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_int_array)
+    val longArrayColor = ContextCompat.getColor(context, R.color.leak_canary_heap_long_array)
     val colors = mapOf(
         StringRecord::class to hprofStringColor,
         LoadClassRecord::class to loadClassColor,
@@ -92,10 +95,10 @@ object HeapDumpRenderer {
         HeapDumpEndRecord::class to otherColor
     )
 
-    val appHeapColor = resources.getColor(R.color.leak_canary_heap_app)
-    val imageHeapColor = resources.getColor(R.color.leak_canary_heap_image)
-    val zygoteHeapColor = resources.getColor(R.color.leak_canary_heap_zygote)
-    val stringColor = resources.getColor(R.color.leak_canary_heap_instance_string)
+    val appHeapColor = ContextCompat.getColor(context, R.color.leak_canary_heap_app)
+    val imageHeapColor = ContextCompat.getColor(context, R.color.leak_canary_heap_image)
+    val zygoteHeapColor = ContextCompat.getColor(context, R.color.leak_canary_heap_zygote)
+    val stringColor = ContextCompat.getColor(context, R.color.leak_canary_heap_instance_string)
 
     val updatePosition: (Record) -> Unit =
       { newRecord ->

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakingInstanceScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakingInstanceScreen.kt
@@ -70,7 +70,7 @@ internal class LeakingInstanceScreen private constructor(
     val listView = findViewById<ListView>(R.id.leak_canary_list)
 
     val adapter =
-      DisplayLeakAdapter(resources, leakingInstance.leakTrace, leakingInstance.referenceName)
+      DisplayLeakAdapter(context, leakingInstance.leakTrace, leakingInstance.referenceName)
     listView.adapter = adapter
 
     listView.setOnItemClickListener { _, _, position, _ ->

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
@@ -2,6 +2,8 @@ package leakcanary.internal.activity.screen
 
 import android.content.Intent
 import android.graphics.Bitmap
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Environment
 import android.os.Environment.DIRECTORY_DOWNLOADS
 import android.view.View
@@ -46,8 +48,7 @@ internal class RenderHeapDumpScreen(
 
           executeOnIo {
             val bitmap = HeapDumpRenderer.render(
-                resources,
-                heapDumpFile, measuredWidth, measuredHeight, 0
+                context, resources, heapDumpFile, measuredWidth, measuredHeight, 0
             )
             updateUi {
               imageView.setImageBitmap(bitmap)
@@ -55,7 +56,11 @@ internal class RenderHeapDumpScreen(
               imageView.visibility = View.VISIBLE
             }
           }
-          viewTreeObserver.removeGlobalOnLayoutListener(this)
+          if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
+            viewTreeObserver.removeOnGlobalLayoutListener(this)
+          } else {
+            viewTreeObserver.removeGlobalOnLayoutListener(this)
+          }
         }
       })
 
@@ -79,10 +84,7 @@ internal class RenderHeapDumpScreen(
                 )
                     .show()
                 executeOnIo {
-                  val bitmap = HeapDumpRenderer.render(
-                      resources,
-                      heapDumpFile, 2048, 0, 4
-                  )
+                  val bitmap = HeapDumpRenderer.render(context, resources, heapDumpFile, 2048, 0, 4)
                   val storageDir =
                     Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS)
 


### PR DESCRIPTION
Html -> HtmlCompat.
Context -> ContextCompat.
Suppressed a few lint warnings we're unable to resolve.

Cuts out a lot of deprecation warnings. Lint output is much thiner now; screenshot below. Remaining issues mostly revolve around the new Notification API but that will involve more work due to having to adhere to the new notification channels philosophy.

![image](https://user-images.githubusercontent.com/1205783/57034793-52b8f480-6c05-11e9-8833-0bdf03cc7d7b.png)

@pyricau let me know if anything looks suspicious; corrected a few Kotlin conversion nullability lint warnings that I'm not 💯 due to context.