### PR TITLE
Add test coverage for heap analysis

### DIFF
--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/ExclusionTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/ExclusionTest.kt
@@ -1,0 +1,75 @@
+package leakcanary.internal
+
+import leakcanary.Exclusion
+import leakcanary.Exclusion.ExclusionType.InstanceFieldExclusion
+import leakcanary.Exclusion.ExclusionType.StaticFieldExclusion
+import leakcanary.Exclusion.Status.NEVER_REACHABLE
+import leakcanary.HeapAnalysisSuccess
+import leakcanary.LeakingInstance
+import leakcanary.NoPathToInstance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ExclusionTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+  private lateinit var hprofFile: File
+
+  @Before
+  fun setUp() {
+    hprofFile = testFolder.newFile("temp.hprof")
+  }
+
+  @Test fun shortestPathExcluded() {
+    hprofFile.writeTwoPathsToInstance()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess> {
+      listOf(Exclusion(StaticFieldExclusion("GcRoot", "shortestPath")))
+    }
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.elements).hasSize(3)
+    assertThat(leak.leakTrace.elements[0].className).isEqualTo("GcRoot")
+    assertThat(leak.leakTrace.elements[0].reference!!.name).isEqualTo("longestPath")
+    assertThat(leak.leakTrace.elements[1].className).isEqualTo("HasLeaking")
+    assertThat(leak.leakTrace.elements[1].reference!!.name).isEqualTo("leaking")
+    assertThat(leak.leakTrace.elements[2].className).isEqualTo("Leaking")
+  }
+
+  @Test fun allPathsExcluded_ShortestWins() {
+    hprofFile.writeTwoPathsToInstance()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess> {
+      listOf(
+          Exclusion(StaticFieldExclusion("GcRoot", "shortestPath")),
+          Exclusion(InstanceFieldExclusion("HasLeaking", "leaking"))
+      )
+    }
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.exclusionStatus).isEqualTo(Exclusion.Status.WONT_FIX_LEAK)
+    assertThat(leak.leakTrace.elements).hasSize(2)
+    assertThat(leak.leakTrace.elements[0].className).isEqualTo("GcRoot")
+    assertThat(leak.leakTrace.elements[0].reference!!.name).isEqualTo("shortestPath")
+    assertThat(leak.leakTrace.elements[1].className).isEqualTo("Leaking")
+  }
+
+  @Test fun noPathToInstanceNeverReachable() {
+    hprofFile.writeTwoPathsToInstance()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess> {
+      listOf(
+          Exclusion(StaticFieldExclusion("GcRoot", "shortestPath"), status = NEVER_REACHABLE),
+          Exclusion(InstanceFieldExclusion("HasLeaking", "leaking"), status = NEVER_REACHABLE)
+      )
+    }
+
+    assertThat(analysis.retainedInstances[0]).isInstanceOf(NoPathToInstance::class.java)
+  }
+
+}

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/HeapAnalyzerTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/HeapAnalyzerTest.kt
@@ -1,33 +1,100 @@
 package leakcanary.internal
 
-import leakcanary.AnalyzerProgressListener
+import leakcanary.HeapAnalysis
+import leakcanary.HeapAnalysisFailure
 import leakcanary.HeapAnalysisSuccess
-import leakcanary.HeapAnalyzer
 import leakcanary.LeakingInstance
+import leakcanary.NoPathToInstance
+import leakcanary.WeakReferenceCleared
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.io.File
 
 class HeapAnalyzerTest {
 
   @get:Rule
   var testFolder = TemporaryFolder()
+  private lateinit var hprofFile: File
+
+  @Before
+  fun setUp() {
+    hprofFile = testFolder.newFile("temp.hprof")
+  }
+
+  @Test fun singlePathToInstance() {
+    hprofFile.writeSinglePathToInstance()
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    assertThat(analysis.retainedInstances[0]).isInstanceOf(LeakingInstance::class.java)
+  }
+
+  @Test fun pathToString() {
+    hprofFile.writeSinglePathToString()
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+
+    assertThat(leak.instanceClassName).isEqualTo("java.lang.String")
+  }
+
+  @Test fun pathToCharArray() {
+    hprofFile.writeSinglePathsToCharArrays(listOf("Hello".toCharArray()))
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.instanceClassName).isEqualTo("char[]")
+  }
+
+  // Two char arrays to ensure we keep going after finding the first one
+  @Test fun pathToTwoCharArrays() {
+    hprofFile.writeSinglePathsToCharArrays(listOf("Hello".toCharArray(), "World".toCharArray()))
+    val analysis = hprofFile.checkForLeaks<HeapAnalysis>()
+    assertThat(analysis).isInstanceOf(HeapAnalysisSuccess::class.java)
+  }
+
+  @Test fun shortestPath() {
+    hprofFile.writeTwoPathsToInstance()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.elements).hasSize(2)
+    assertThat(leak.leakTrace.elements[0].className).isEqualTo("GcRoot")
+    assertThat(leak.leakTrace.elements[0].reference!!.name).isEqualTo("shortestPath")
+    assertThat(leak.leakTrace.elements[1].className).isEqualTo("Leaking")
+  }
+
+  @Test fun noPathToInstance() {
+    hprofFile.writeNoPathToInstance()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    assertThat(analysis.retainedInstances[0]).isInstanceOf(NoPathToInstance::class.java)
+  }
+
+  @Test fun weakRefCleared() {
+    hprofFile.writeWeakReferenceCleared()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    assertThat(analysis.retainedInstances[0]).isInstanceOf(WeakReferenceCleared::class.java)
+  }
+
+  @Test fun failsNoRetainedKeys() {
+    hprofFile.writeMultipleActivityLeaks(0)
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysis>()
+
+    assertThat(analysis).isInstanceOf(HeapAnalysisFailure::class.java)
+  }
 
   @Test
   fun findMultipleLeaks() {
-    val hprofFile = testFolder.newFile("temp.hprof")
+    hprofFile.writeMultipleActivityLeaks(5)
 
-    hprofFile.dumpMultipleActivityLeaks(5)
-
-    val heapAnalyzer = HeapAnalyzer(AnalyzerProgressListener.NONE)
-
-    val leaks =
-      heapAnalyzer.checkForLeaks(
-          hprofFile, defaultExclusionFactory, false, emptyList(), emptyList()
-      )
-    assertThat(leaks).isInstanceOf(HeapAnalysisSuccess::class.java)
-    leaks as HeapAnalysisSuccess
+    val leaks = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
 
     assertThat(leaks.retainedInstances).hasSize(5)
         .hasOnlyElementsOfType(LeakingInstance::class.java)

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/HeapDumps.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/HeapDumps.kt
@@ -1,0 +1,143 @@
+package leakcanary.internal
+
+import leakcanary.HeapValue.BooleanValue
+import leakcanary.HeapValue.ObjectReference
+import leakcanary.HprofWriter
+import java.io.File
+
+fun File.writeWeakReferenceCleared() {
+  HprofWriter.open(this)
+      .helper {
+        keyedWeakReference("Leaking", 0)
+      }
+}
+
+fun File.writeNoPathToInstance() {
+  HprofWriter.open(this)
+      .helper {
+        keyedWeakReference("Leaking", instance(clazz("Leaking")))
+      }
+}
+
+fun File.writeSinglePathToInstance() {
+  HprofWriter.open(this)
+      .helper {
+        val leaking = instance(
+            clazz("Leaking")
+        )
+        keyedWeakReference("Leaking", leaking)
+        clazz(
+            "GcRoot", staticFields = listOf(
+            "shortestPath" to ObjectReference(leaking)
+        )
+        )
+      }
+}
+
+fun File.writeSinglePathToString(value: String = "Hi") {
+  HprofWriter.open(this)
+      .helper {
+        val leaking = string(value)
+        keyedWeakReference("java.lang.String", leaking)
+        clazz(
+            "GcRoot", staticFields = listOf(
+            "shortestPath" to ObjectReference(leaking)
+        )
+        )
+      }
+}
+
+fun File.writeSinglePathsToCharArrays(values: List<CharArray>) {
+  HprofWriter.open(this)
+      .helper {
+        val arrays = mutableListOf<Long>()
+        values.forEach {
+          val leaking = array(it)
+          keyedWeakReference("char[]", leaking)
+          arrays.add(leaking)
+        }
+        clazz(
+            className = "GcRoot",
+            staticFields = listOf(
+                "arrays" to ObjectReference(
+                    objectArray(clazz("char[][]"), arrays.toLongArray())
+                )
+            )
+        )
+
+      }
+}
+
+fun File.writeCustomPathToInstance(path: List<Pair<String, String>>) {
+  HprofWriter.open(this)
+      .helper {
+        val leaking = instance(
+            clazz("Leaking")
+        )
+        keyedWeakReference("Leaking", leaking)
+        var previousInstance = leaking
+        for (index in path.lastIndex downTo 1) {
+          val (className, fieldName) = path[index]
+          previousInstance = instance(
+              clazz(className, fields = listOf(fieldName to ObjectReference::class)),
+              fields = listOf(ObjectReference(previousInstance))
+          )
+        }
+        val root = path.first()
+        clazz(
+            root.first, staticFields = listOf(
+            root.second to ObjectReference(previousInstance)
+        )
+        )
+      }
+}
+
+fun File.writeTwoPathsToInstance() {
+  HprofWriter.open(this)
+      .helper {
+        val leaking = instance(clazz("Leaking"))
+        keyedWeakReference("Leaking", leaking)
+        val hasLeaking = instance(
+            clazz("HasLeaking", fields = listOf("leaking" to ObjectReference::class)),
+            fields = listOf(ObjectReference(leaking))
+        )
+        clazz(
+            "GcRoot", staticFields = listOf(
+            "shortestPath" to ObjectReference(leaking),
+            "longestPath" to ObjectReference(hasLeaking)
+        )
+        )
+      }
+}
+
+fun File.writeMultipleActivityLeaks(leakCount: Int) {
+  HprofWriter.open(this)
+      .helper {
+        val activityClassId = clazz(
+            className = "android.app.Activity",
+            fields = listOf("mDestroyed" to BooleanValue::class)
+        )
+        val exampleActivityClassId = clazz(
+            superClassId = activityClassId,
+            className = "com.example.ExampleActivity"
+        )
+        val activityArrayClassId = arrayClass("com.example.ExampleActivity")
+
+        val destroyedActivities = mutableListOf<Long>()
+        for (i in 1..leakCount) {
+          destroyedActivities.add(instance(exampleActivityClassId, listOf(BooleanValue(true))))
+        }
+
+        clazz(
+            className = "com.example.ActivityHolder",
+            staticFields = listOf(
+                "activities" to ObjectReference(
+                    objectArray(activityArrayClassId, destroyedActivities.toLongArray())
+                )
+            )
+        )
+        destroyedActivities.forEach { instanceId ->
+          keyedWeakReference("com.example.ExampleActivity", instanceId)
+        }
+      }
+}

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/HprofWriterHelper.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/HprofWriterHelper.kt
@@ -63,8 +63,8 @@ class HprofWriterHelper constructor(
   )
 
   fun clazz(
-    superClassId: Long = -1L, // -1 defaults to java.lang.Object
     className: String,
+    superClassId: Long = -1L, // -1 defaults to java.lang.Object
     staticFields: List<Pair<String, HeapValue>> = emptyList(),
     fields: List<Pair<String, KClass<out HeapValue>>> = emptyList()
   ): Long {

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/LabelTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/LabelTest.kt
@@ -1,0 +1,48 @@
+package leakcanary.internal
+
+import leakcanary.HeapAnalysisSuccess
+import leakcanary.HprofParser
+import leakcanary.Labeler
+import leakcanary.LeakNode
+import leakcanary.LeakingInstance
+import leakcanary.ObjectIdMetadata.STRING
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class LabelTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+  private lateinit var hprofFile: File
+
+  @Before
+  fun setUp() {
+    hprofFile = testFolder.newFile("temp.hprof")
+  }
+
+
+  @Test fun stringContentAsLabel() {
+    hprofFile.writeSinglePathToString("World")
+
+    val labeler = object : Labeler {
+      override fun computeLabels(
+        parser: HprofParser,
+        node: LeakNode
+      ) = if (parser.objectIdMetadata(node.instance) == STRING) {
+        listOf("Hello ${parser.retrieveStringById(node.instance)}")
+      } else emptyList()
+
+    }
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>(labelers = listOf(labeler))
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+
+    assertThat(leak.leakTrace.elements.last().labels).isEqualTo(listOf("Hello World"))
+  }
+
+}

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/ReachabilityTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/ReachabilityTest.kt
@@ -1,0 +1,331 @@
+package leakcanary.internal
+
+import leakcanary.HeapAnalysisSuccess
+import leakcanary.HprofParser
+import leakcanary.LeakNode
+import leakcanary.LeakingInstance
+import leakcanary.Reachability
+import leakcanary.Reachability.Inspector
+import leakcanary.Reachability.Status.REACHABLE
+import leakcanary.Reachability.Status.UNKNOWN
+import leakcanary.Reachability.Status.UNREACHABLE
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.InstanceDumpRecord
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ReachabilityTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+  private lateinit var hprofFile: File
+
+  @Before
+  fun setUp() {
+    hprofFile = testFolder.newFile("temp.hprof")
+  }
+
+  @Test fun gcRootsReachable() {
+    hprofFile.writeSinglePathToInstance()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+
+    assertThat(leak.leakTrace.expectedReachability.first().status).isEqualTo(REACHABLE)
+  }
+
+  @Test fun leakingInstanceUnreachable() {
+    hprofFile.writeSinglePathToInstance()
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+
+    assertThat(leak.leakTrace.expectedReachability.last().status).isEqualTo(UNREACHABLE)
+  }
+
+  @Test fun defaultsToUnknown() {
+    hprofFile.writeCustomPathToInstance(listOf("GcRoot" to "staticField1", "Class1" to "field1"))
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+
+    assertThat(leak.leakTrace.expectedReachability[1].status).isEqualTo(UNKNOWN)
+  }
+
+  @Test fun inspectorReachable() {
+    hprofFile.writeCustomPathToInstance(listOf("GcRoot" to "staticField1", "Class1" to "field1"))
+
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+        reachabilityInspectors = listOf(reachableInstance("Class1"))
+    )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.expectedReachability[1].status).isEqualTo(REACHABLE)
+  }
+
+  @Test fun inspectorUnreachable() {
+    hprofFile.writeCustomPathToInstance(listOf("GcRoot" to "staticField1", "Class1" to "field1"))
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(unreachableInstance("Class1"))
+      )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.expectedReachability[1].status).isEqualTo(UNREACHABLE)
+  }
+
+  @Test fun unreachableWinsUnknown() {
+    hprofFile.writeCustomPathToInstance(listOf("GcRoot" to "staticField1", "Class1" to "field1"))
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(unreachableInstance("Class1"), unknownInstance())
+      )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.expectedReachability[1].status).isEqualTo(UNREACHABLE)
+  }
+
+  @Test fun reachableWhenNextIsReachable() {
+    hprofFile.writeCustomPathToInstance(
+        listOf(
+            "GcRoot" to "staticField1",
+            "Class1" to "field1",
+            "Class2" to "field2",
+            "Class3" to "field3"
+        )
+    )
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(reachableInstance("Class3"))
+      )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.expectedReachability[1].status).isEqualTo(REACHABLE)
+  }
+
+  @Test fun unreachableWhenPreviousIsUnreachable() {
+    hprofFile.writeCustomPathToInstance(
+        listOf(
+            "GcRoot" to "staticField1",
+            "Class1" to "field1",
+            "Class2" to "field2",
+            "Class3" to "field3"
+        )
+    )
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(unreachableInstance("Class1"))
+      )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.expectedReachability[3].status).isEqualTo(UNREACHABLE)
+  }
+
+  @Test fun reachableWinsConflicts() {
+    hprofFile.writeCustomPathToInstance(
+        listOf(
+            "GcRoot" to "staticField1",
+            "Class1" to "field1",
+            "Class2" to "field2",
+            "Class3" to "field3"
+        )
+    )
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(
+              reachableInstance("Class3"), unreachableInstance("Class1")
+          )
+      )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.expectedReachability[0].status).isEqualTo(REACHABLE)
+    assertThat(leak.leakTrace.expectedReachability[1].status).isEqualTo(REACHABLE)
+    assertThat(leak.leakTrace.expectedReachability[2].status).isEqualTo(REACHABLE)
+    assertThat(leak.leakTrace.expectedReachability[3].status).isEqualTo(REACHABLE)
+  }
+
+  @Test fun middleUnknown() {
+    hprofFile.writeCustomPathToInstance(
+        listOf(
+            "GcRoot" to "staticField1",
+            "Class1" to "field1",
+            "Class2" to "field2",
+            "Class3" to "field3"
+        )
+    )
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(
+              reachableInstance("Class1"), unreachableInstance("Class3")
+          )
+      )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.expectedReachability[2].status).isEqualTo(UNKNOWN)
+  }
+
+  @Test fun leakCausesAreLastReachableAndUnknown() {
+    hprofFile.writeCustomPathToInstance(
+        listOf(
+            "GcRoot" to "staticField1",
+            "Class1" to "field1",
+            "Class2" to "field2",
+            "Class3" to "field3"
+        )
+    )
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(
+              reachableInstance("Class1"), unreachableInstance("Class3")
+          )
+      )
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(leak.leakTrace.elementMayBeLeakCause(0)).isFalse()
+    assertThat(leak.leakTrace.elementMayBeLeakCause(1)).isTrue()
+    assertThat(leak.leakTrace.elementMayBeLeakCause(2)).isTrue()
+    assertThat(leak.leakTrace.elementMayBeLeakCause(3)).isFalse()
+  }
+
+  @Test fun sameLeakTraceSameGroup() {
+    assertThat(
+        computeGroupHash(
+            path = listOf(
+                "GcRoot" to "staticField1",
+                "Class1" to "field1",
+                "Class2" to "field2",
+                "Class3" to "field3"
+            ), reachable = "Class1", unreachable = "Class3"
+        )
+    ).isEqualTo(
+        computeGroupHash(
+            path = listOf(
+                "GcRoot" to "staticField1",
+                "Class1" to "field1",
+                "Class2" to "field2",
+                "Class3" to "field3"
+            ), reachable = "Class1", unreachable = "Class3"
+        )
+    )
+  }
+
+  @Test fun differentLeakTraceDifferentGroup() {
+    assertThat(
+        computeGroupHash(
+            path = listOf(
+                "GcRoot" to "staticField1",
+                "Class1" to "field1a",
+                "Class2" to "field2",
+                "Class3" to "field3"
+            ), reachable = "Class1", unreachable = "Class3"
+        )
+    ).isNotEqualTo(
+        computeGroupHash(
+            path = listOf(
+                "GcRoot" to "staticField1",
+                "Class1" to "field1b",
+                "Class2" to "field2",
+                "Class3" to "field3"
+            ), reachable = "Class1", unreachable = "Class3"
+        )
+    )
+  }
+
+  @Test fun sameCausesSameGroup() {
+    assertThat(
+        computeGroupHash(
+            path = listOf(
+                "GcRoot" to "staticField1",
+                "Class1" to "field1",
+                "Class2" to "field2",
+                "Class3" to "field3a"
+            ), reachable = "Class1", unreachable = "Class3"
+        )
+    ).isEqualTo(
+        computeGroupHash(
+            path = listOf(
+                "GcRoot" to "staticField1",
+                "Class1" to "field1",
+                "Class2" to "field2",
+                "Class3" to "field3b"
+            ), reachable = "Class1", unreachable = "Class3"
+        )
+    )
+  }
+
+  private fun unknownInstance(): Inspector {
+    return object : Inspector {
+      override fun expectedReachability(
+        parser: HprofParser,
+        node: LeakNode
+      ): Reachability {
+        return Reachability.unknown()
+      }
+    }
+  }
+
+  private fun reachableInstance(className: String): Inspector {
+    return object : Inspector {
+      override fun expectedReachability(
+        parser: HprofParser,
+        node: LeakNode
+      ): Reachability = with(parser) {
+        val record = node.instance.objectRecord
+        if (record is InstanceDumpRecord) {
+          if (className(record.classId) == className) {
+            return Reachability.reachable("because reasons")
+          }
+        }
+        return Reachability.unknown()
+      }
+    }
+  }
+
+  private fun unreachableInstance(className: String): Inspector {
+    return object : Inspector {
+      override fun expectedReachability(
+        parser: HprofParser,
+        node: LeakNode
+      ): Reachability = with(parser) {
+        val record = node.instance.objectRecord
+        if (record is InstanceDumpRecord) {
+          if (className(record.classId) == className) {
+            return Reachability.unreachable("because reasons")
+          }
+        }
+        return Reachability.unknown()
+      }
+    }
+  }
+
+  private fun computeGroupHash(
+    path: List<Pair<String, String>>,
+    reachable: String,
+    unreachable: String
+  ): String {
+    hprofFile.writeCustomPathToInstance(path)
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          reachabilityInspectors = listOf(
+              reachableInstance(reachable), unreachableInstance(unreachable)
+          )
+      )
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+    return leak.groupHash
+  }
+
+}

--- a/leakcanary-watcher/src/main/java/leakcanary/RefWatcher.kt
+++ b/leakcanary-watcher/src/main/java/leakcanary/RefWatcher.kt
@@ -67,7 +67,7 @@ class RefWatcher constructor(
   }
 
   /**
-   * Watches the provided references and notifies registered [NewRefListener]s.
+   * Watches the provided references.
    *
    * @param referenceName An logical identifier for the watched object.
    */
@@ -75,7 +75,6 @@ class RefWatcher constructor(
     watchedReference: Any,
     referenceName: String
   ) {
-    checkWatchedObjectType(watchedReference)
     removeWeaklyReachableReferences()
     val key = UUID.randomUUID()
         .toString()
@@ -96,14 +95,6 @@ class RefWatcher constructor(
     watchedReferences[key] = reference
     checkRetainedExecutor.execute {
       moveToRetained(key)
-    }
-  }
-
-  private fun checkWatchedObjectType(watchedReference: Any) {
-    if (watchedReference is String) {
-      throw IllegalArgumentException(
-          "watchedReference $watchedReference has a type that the LeakCanary shortest path finder will skip"
-      )
     }
   }
 


### PR DESCRIPTION
* Fixed bug when reachability inspectors conflicts (reachable should win and erase unreachable)
* Added back support for leaking instances being empty objects, strings, primitive arrays or any object that we otherwise don't follow to find shortest paths.