### PR TITLE
Fix duplicate dependency build.gradle

### DIFF
--- a/leakcanary-android-core/build.gradle
+++ b/leakcanary-android-core/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-android'
 dependencies {
   api project(':leakcanary-analyzer')
   api project(':leakcanary-leaksentry')
-  api project(':leakcanary-analyzer')
 
   implementation deps.androidx.annotation
   implementation deps.androidx.core


### PR DESCRIPTION
duplicates `api project(':leakcanary-analyzer')`.