### PR TITLE
Don't crash when LeakSentry is not installed

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -50,7 +50,7 @@ object LeakCanary {
   )
 
   @Volatile
-  var config: Config = Config()
+  var config: Config = if (LeakSentry.isInstalled) Config() else InternalLeakCanary.noInstallConfig
 
   /** [Intent] that can be used to programmatically launch the leak display activity. */
   val leakDisplayActivityIntent

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -14,6 +14,7 @@ import com.squareup.leakcanary.core.R
 import leakcanary.CanaryLog
 import leakcanary.GcTrigger
 import leakcanary.LeakCanary
+import leakcanary.LeakCanary.Config
 import leakcanary.LeakSentry
 import leakcanary.internal.activity.LeakActivity
 
@@ -34,6 +35,12 @@ internal object InternalLeakCanary : LeakSentryListener {
 
   val leakDisplayActivityIntent: Intent
     get() = LeakActivity.createIntent(application)
+
+  val noInstallConfig: Config
+    get() = Config(
+        dumpHeap = false, exclusionsFactory = { emptyList() }, leakInspectors = emptyList(),
+        labelers = emptyList()
+    )
 
   override fun onLeakSentryInstalled(application: Application) {
     this.application = application

--- a/leakcanary-leaksentry/src/main/java/leakcanary/LeakSentry.kt
+++ b/leakcanary-leaksentry/src/main/java/leakcanary/LeakSentry.kt
@@ -15,16 +15,21 @@ object LeakSentry {
   )
 
   @Volatile
-  var config: Config = Config()
+  var config: Config = if (isInstalled) Config() else Config(enabled = false)
 
   val refWatcher
     get() = InternalLeakSentry.refWatcher
 
+  /** @see [manualInstall] */
+  val isInstalled
+    get() = InternalLeakSentry.isInstalled
+
   /**
-   * [LeakSentry] is automatically installed on process start by
-   * [leaksentry.internal.LeakSentryInstaller] which is registered in the AndroidManifest.xml of
-   * your app. If you disabled [leaksentry.internal.LeakSentryInstaller] then you can call this
-   * method to install [LeakSentry].
+   * [LeakSentry] is automatically installed on main process start by
+   * [leakcanary.internal.LeakSentryInstaller] which is registered in the AndroidManifest.xml of
+   * your app. If you disabled [leakcanary.internal.LeakSentryInstaller] or you need LeakSentry
+   * or LeakCanary to run outside of the main process then you can call this method to install
+   * [LeakSentry].
    */
   fun manualInstall(application: Application) = InternalLeakSentry.install(application)
 

--- a/leakcanary-leaksentry/src/main/java/leakcanary/internal/InternalLeakSentry.kt
+++ b/leakcanary-leaksentry/src/main/java/leakcanary/internal/InternalLeakSentry.kt
@@ -13,6 +13,9 @@ import java.util.concurrent.Executor
 
 internal object InternalLeakSentry {
 
+  val isInstalled
+    get() = ::application.isInitialized
+
   private val listener: LeakSentryListener
 
   val isDebuggableBuild by lazy {


### PR DESCRIPTION
LeakSentry may not always be installed, e.g. if there's another process that's not the main process. Default behavior should be a no-op rather than crashing.

Fixes #1345