### PR TITLE
Thread name based exclusions

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/Exclusion.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/Exclusion.kt
@@ -47,11 +47,14 @@ data class Exclusion(
   sealed class ExclusionType {
     abstract val matching: String
 
-    class ThreadExclusion(
+    /**
+     * Local references held in the stack of frames of a given thread.
+     */
+    class JavaLocalExclusion(
       val threadName: String
     ) : ExclusionType() {
       override val matching: String
-        get() = "any threads named $threadName"
+        get() = "local variable on thread $threadName"
     }
 
     class StaticFieldExclusion(
@@ -62,6 +65,12 @@ data class Exclusion(
         get() = "static field $className#$fieldName"
     }
 
+    /**
+     * Excludes a member field of an instance of a class. [fieldName] can belong to a superclass
+     * and will still match for subclasses. This is to support overriding of rules for specific
+     * cases. If two exclusions for the same field name but different classname match in a class
+     * hierarchy, then the closest class in the hierarchy wins.
+     */
     class InstanceFieldExclusion(
       val className: String,
       val fieldName: String

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
@@ -6,11 +6,9 @@ sealed class LeakNode {
   abstract val visitOrder: Int
 
   class RootNode(
-    override val instance: Long
-  ) : LeakNode() {
-    override val visitOrder
-      get() = 0
-  }
+    override val instance: Long,
+    override val visitOrder: Int
+  ) : LeakNode()
 
   class ChildNode(
     override val instance: Long,

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/LeakTraceRenderer.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/LeakTraceRenderer.kt
@@ -57,7 +57,7 @@ private fun getNextElementString(
   val simpleClassName = element.simpleClassName
   val referenceName = if (element.reference != null) ".${element.reference.displayName}" else ""
   val exclusionString =
-    if (element.exclusion != null) " , matching exclusion ${element.exclusion.matching}" else ""
+    if (element.exclusion != null) ", matching exclusion ${element.exclusion.matching}" else ""
   val requiredSpaces =
     staticString.length + holderString.length + simpleClassName.length + "├─".length
   val leakString = if (maybeLeakCause) {

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/HprofWriterHelper.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/HprofWriterHelper.kt
@@ -1,5 +1,6 @@
 package leakcanary.internal
 
+import leakcanary.GcRoot
 import leakcanary.GcRoot.StickyClass
 import leakcanary.HeapDumpMemoryStore
 import leakcanary.HeapValue
@@ -126,9 +127,14 @@ class HprofWriterHelper constructor(
     )
     classDumps[loadClass.id] = classDump
     writer.write(classDump)
-    val gcRootRecord = GcRootRecord(gcRoot = StickyClass(classDump.id))
-    writer.write(gcRootRecord)
+    val gcRoot = StickyClass(classDump.id)
+    gcRoot(gcRoot)
     return classDump.id
+  }
+
+  fun gcRoot(gcRoot: GcRoot) {
+    val gcRootRecord = GcRootRecord(gcRoot = gcRoot)
+    writer.write(gcRootRecord)
   }
 
   fun arrayClass(className: String): Long {

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/LabelerTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/LabelerTest.kt
@@ -2,7 +2,9 @@ package leakcanary.internal
 
 import leakcanary.HeapAnalysisSuccess
 import leakcanary.HprofParser
+import leakcanary.InstanceDefaultLabeler
 import leakcanary.LeakNode
+import leakcanary.LeakTraceElement.Type.LOCAL
 import leakcanary.LeakingInstance
 import leakcanary.ObjectIdMetadata.STRING
 import org.assertj.core.api.Assertions.assertThat
@@ -12,7 +14,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
-class LabelTest {
+class LabelerTest {
 
   @get:Rule
   var testFolder = TemporaryFolder()
@@ -40,6 +42,17 @@ class LabelTest {
     val leak = analysis.retainedInstances[0] as LeakingInstance
 
     assertThat(leak.leakTrace.elements.last().labels).isEqualTo(listOf("Hello World"))
+  }
+
+  @Test fun threadNameLabel() {
+    hprofFile.writeJavaLocalLeak(threadClass = "MyThread", threadName = "kroutine")
+
+    val analysis =
+      hprofFile.checkForLeaks<HeapAnalysisSuccess>(labelers = listOf(InstanceDefaultLabeler))
+
+    val leak = analysis.retainedInstances[0] as LeakingInstance
+
+    assertThat(leak.leakTrace.elements.first().labels).contains("Thread name: 'kroutine'")
   }
 
 }

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/TestUtil.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/TestUtil.kt
@@ -1,18 +1,15 @@
 package leakcanary.internal
 
 import leakcanary.AnalyzerProgressListener
-import leakcanary.CanaryLog
 import leakcanary.Exclusion
 import leakcanary.Exclusion.ExclusionType.InstanceFieldExclusion
-import leakcanary.Exclusion.ExclusionType.ThreadExclusion
+import leakcanary.Exclusion.ExclusionType.JavaLocalExclusion
 import leakcanary.Exclusion.Status.NEVER_REACHABLE
 import leakcanary.Exclusion.Status.WEAKLY_REACHABLE
 import leakcanary.ExclusionsFactory
 import leakcanary.LeakInspector
 import leakcanary.HeapAnalysis
-import leakcanary.HeapAnalysisFailure
 import leakcanary.HeapAnalyzer
-import leakcanary.HprofParser
 import leakcanary.KeyedWeakReference
 import leakcanary.Labeler
 import java.io.File
@@ -95,11 +92,11 @@ val defaultExclusionsFactory: ExclusionsFactory = {
       ,
 
       Exclusion(
-          type = ThreadExclusion("FinalizerWatchdogDaemon"),
+          type = JavaLocalExclusion("FinalizerWatchdogDaemon"),
           status = NEVER_REACHABLE
       ),
       Exclusion(
-          type = ThreadExclusion("main"),
+          type = JavaLocalExclusion("main"),
           status = NEVER_REACHABLE
       )
   )

--- a/leakcanary-android-core/src/main/java/leakcanary/AndroidExcludedRefs.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/AndroidExcludedRefs.kt
@@ -31,7 +31,7 @@ import android.os.Build.VERSION_CODES.P
 import leakcanary.AndroidExcludedRefs.Companion.exclusionsFactory
 import leakcanary.Exclusion.ExclusionType.InstanceFieldExclusion
 import leakcanary.Exclusion.ExclusionType.StaticFieldExclusion
-import leakcanary.Exclusion.ExclusionType.ThreadExclusion
+import leakcanary.Exclusion.ExclusionType.JavaLocalExclusion
 import leakcanary.Exclusion.Status.NEVER_REACHABLE
 import leakcanary.Exclusion.Status.WEAKLY_REACHABLE
 import leakcanary.internal.HeapDumpTrigger
@@ -1112,7 +1112,7 @@ enum class AndroidExcludedRefs {
       // reference to the object and it was about to be GCed.
       exclusions.add(
           Exclusion(
-              type = ThreadExclusion("FinalizerWatchdogDaemon"),
+              type = JavaLocalExclusion("FinalizerWatchdogDaemon"),
               status = NEVER_REACHABLE
           )
       )
@@ -1129,7 +1129,7 @@ enum class AndroidExcludedRefs {
       // a real leak.
       exclusions.add(
           Exclusion(
-              type = ThreadExclusion("main"),
+              type = JavaLocalExclusion("main"),
               status = NEVER_REACHABLE
           )
       )
@@ -1143,7 +1143,7 @@ enum class AndroidExcludedRefs {
     ) {
       exclusions.add(
           Exclusion(
-              type = ThreadExclusion(HeapDumpTrigger.LEAK_CANARY_THREAD_NAME),
+              type = JavaLocalExclusion(HeapDumpTrigger.LEAK_CANARY_THREAD_NAME),
               status = NEVER_REACHABLE
           )
       )

--- a/leakcanary-haha/src/main/java/leakcanary/Record.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/Record.kt
@@ -15,6 +15,22 @@ sealed class Record {
 
   object HeapDumpEndRecord : Record()
 
+  class StackFrameRecord(
+    val id: Long,
+    val methodNameStringId: Long,
+    val methodSignatureStringId: Long,
+    val sourceFileNameStringId: Long,
+    val classSerialNumber: Int,
+    /**
+     * >0 line number
+     * 0 no line information available
+     * -1 unknown location
+     * -2 compiled method (Not implemented)
+     * -3 native method (Not implemented)
+     */
+    val lineNumber: Int
+  ) : Record()
+
   class StackTraceRecord(
     val stackTraceSerialNumber: Int,
     val threadSerialNumber: Int,


### PR DESCRIPTION
* Readded support for exclusions of local variable based on thread names
* Renamed ThreadExclusion to JavaLocalExclusion
* Fixed bug: KeyedWeakReference was not always ignored because its superclass is has a weakly reachable exclusion.
* Fixed bug: all root nodes had the same visit order as the first non root enqueued item, making it possible for a non root node to be dequeued before we're done with all roots.
* Redded gc root sorting
* Added tests to cover all uncovered bugs
* Added support for parsing StackFrameRecord

Fixes #1339