### PR TITLE
Fail early on 0 byte length

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -85,7 +85,12 @@ internal class AndroidHeapDumper(
 
     return try {
       Debug.dumpHprofData(heapDumpFile.absolutePath)
-      heapDumpFile
+      if (heapDumpFile.length() == 0L) {
+        CanaryLog.d("Dumped heap file is 0 byte length")
+        null
+      } else {
+        heapDumpFile
+      }
     } catch (e: Exception) {
       CanaryLog.d(e, "Could not dump heap")
       // Abort heap dump

--- a/leakcanary-haha/src/main/java/leakcanary/HprofParser.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/HprofParser.kt
@@ -945,10 +945,14 @@ class HprofParser private constructor(
     )
 
     fun open(heapDump: File): HprofParser {
-      if (heapDump.length() > MAX_HEAP_DUMP_SIZE) {
+      val fileLength = heapDump.length()
+      if (fileLength > MAX_HEAP_DUMP_SIZE) {
         throw IllegalArgumentException(
-            "Heap dump file length is ${heapDump.length()} bytes which is more than the max supported $MAX_HEAP_DUMP_SIZE"
+            "Heap dump file length is $fileLength bytes which is more than the max supported $MAX_HEAP_DUMP_SIZE"
         )
+      }
+      if (fileLength == 0L) {
+        throw IllegalArgumentException("Heap dump file is 0 byte length")
       }
       val inputStream = heapDump.inputStream()
       val channel = inputStream.channel


### PR DESCRIPTION
* Fail heap dumping (and notify) when the file size is 0, and don't move forward with analysis.
* Improved error when file size is 0 (useful for hprof import)

See #1364