### PR TITLE
Fixed crash using `first` in `LeakingInstance.createGroupDescription()`

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakingInstanceTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakingInstanceTable.kt
@@ -270,15 +270,12 @@ internal object LeakingInstanceTable {
     db.delete("leaking_instance", null, null)
   }
 
-  private fun LeakingInstance.createGroupDescription(): String {
-    return if (exclusionStatus == WONT_FIX_LEAK) {
-      leakTrace.firstElementExclusion.matching
-    } else {
-      val element = leakTrace.leakCauses.first()
-      val referenceName = element.reference!!.groupingName
-      val refDescription = element.simpleClassName + "." + referenceName
-      refDescription
+    private fun LeakingInstance.createGroupDescription() = leakTrace.leakCauses.firstOrNull().run {
+        when {
+            exclusionStatus == WONT_FIX_LEAK -> leakTrace.firstElementExclusion.matching
+            this != null -> "$simpleClassName.$referenceName"
+            else -> "UNKNOWN_CLASS_NAME.$referenceName"
+        }
     }
-  }
 
 }


### PR DESCRIPTION
I've noticed intermittent crashes when working with LeakCanary. The underlying cause with a call for `first()` on an occasionally empty list. This pull request tries to address the issue.

The fix uses `firstOrNull()` and tries to handle the null case gracefully by returning a meaningful string.