### PR TITLE
Improve hprof storage

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/DefaultAnalysisResultListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/DefaultAnalysisResultListener.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.squareup.leakcanary.core.R
 import leakcanary.Exclusion.Status.WEAKLY_REACHABLE
 import leakcanary.Exclusion.Status.WONT_FIX_LEAK
+import leakcanary.internal.LeakDirectoryProvider
 import leakcanary.internal.Notifications
 import leakcanary.internal.NotificationType.LEAKCANARY_RESULT
 import leakcanary.internal.activity.LeakActivity
@@ -85,9 +86,12 @@ object DefaultAnalysisResultListener : AnalysisResultListener {
   private fun renameHeapdump(heapDumpFile: File): File {
     val fileName = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss_SSS'.hprof'", Locale.US).format(Date())
 
+    val path = heapDumpFile.absolutePath
     val newFile = File(heapDumpFile.parent, fileName)
     val renamed = heapDumpFile.renameTo(newFile)
-    if (!renamed) {
+    if (renamed) {
+     LeakDirectoryProvider.filesRenamedEndOfHeapAnalyzer += path
+    } else {
       CanaryLog.d(
           "Could not rename heap dump file %s to %s", heapDumpFile.path, newFile.path
       )

--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -50,7 +50,22 @@ object LeakCanary {
      * (e.g. bitmaps).
      * Computing the retained heap size can slow down the leak analysis and is off by default.
      */
-    val computeRetainedHeapSize: Boolean = false
+    val computeRetainedHeapSize: Boolean = false,
+
+    /**
+     * How many heap dumps are kept locally. When this threshold is reached LeakCanary starts
+     * deleting the older heap dumps. As several heap dumps may be enqueued you should avoid
+     * going down to 1 or 2.
+     */
+    val maxStoredHeapDumps: Int = 7,
+
+    /**
+     * LeakCanary always attempts to store heap dumps on the external storage first. If the
+     * WRITE_EXTERNAL_STORAGE permission is not granted and [requestWriteExternalStoragePermission]
+     * is true, then LeakCanary will display a notification to ask for that permission.
+     */
+    val requestWriteExternalStoragePermission: Boolean = false
+
   )
 
   @Volatile

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -30,7 +30,11 @@ internal object InternalLeakCanary : LeakSentryListener {
     private set
 
   val leakDirectoryProvider: LeakDirectoryProvider by lazy {
-    LeakDirectoryProvider(application)
+    LeakDirectoryProvider(application, {
+      LeakCanary.config.maxStoredHeapDumps
+    }, {
+      LeakCanary.config.requestWriteExternalStoragePermission
+    })
   }
 
   val leakDisplayActivityIntent: Intent

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -10,6 +10,7 @@ import leakcanary.HeapAnalysisFailure
 import leakcanary.HeapAnalysisSuccess
 import leakcanary.Serializables
 import leakcanary.internal.InternalLeakCanary
+import leakcanary.internal.LeakDirectoryProvider
 import leakcanary.leakingInstances
 import leakcanary.toByteArray
 import org.intellij.lang.annotations.Language
@@ -120,8 +121,11 @@ internal object HeapAnalysisTable {
   ) {
     if (heapDumpFile != null) {
       AsyncTask.SERIAL_EXECUTOR.execute {
+        val path = heapDumpFile.absolutePath
         val heapDumpDeleted = heapDumpFile.delete()
-        if (!heapDumpDeleted) {
+        if (heapDumpDeleted) {
+          LeakDirectoryProvider.filesDeletedRemoveLeak += path
+        } else {
           CanaryLog.d("Could not delete heap dump file %s", heapDumpFile.path)
         }
       }


### PR DESCRIPTION
* Added LeakCanary.Config.maxStoredHeapDumps (default 7) to enabling configuring how many hprof files are retained.
* Added LeakCanary.Config.requestWriteExternalStoragePermission (default false) to stop having those pesky double LeakCanary notifications on first leak for most users.
* Added tracking of why files were removed in case #1417 happens again.