### PR TITLE
Stop renaming heap dumps

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
@@ -25,7 +25,6 @@ import leakcanary.CanaryLog
 import leakcanary.HeapAnalyzer
 import leakcanary.LeakCanary
 import java.io.File
-import java.lang.IllegalStateException
 
 /**
  * This service runs in a main app process.
@@ -61,15 +60,7 @@ internal class HeapAnalyzerService : ForegroundService(
           config.leakInspectors, config.labelers
       )
 
-    try {
-      config.analysisResultListener(application, heapAnalysis)
-    } finally {
-      val path = heapAnalysis.heapDumpFile.absolutePath
-      val deleted = heapAnalysis.heapDumpFile.delete()
-      if (deleted) {
-        LeakDirectoryProvider.filesDeletedEndOfHeapAnalyzer += path
-      }
-    }
+    config.analysisResultListener(application, heapAnalysis)
   }
 
   override fun onProgressUpdate(step: AnalyzerProgressListener.Step) {


### PR DESCRIPTION
Rather than having a default behavior of deleting the pending heap dump with a default listener that renames it so that it's not deleted unless you don't use the default.. we just keep it around, with the right name from the get go. Simplifies logic quite a bit and allows for listener delegation and reporting of the heap dump location.

Fixes #1416