### PR TITLE
Behavior change & bugfixes for retained count notification

### DIFF
--- a/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
@@ -20,5 +20,5 @@
   <item type="id" name="leak_canary_notification_dumping_heap" />
   <item type="id" name="leak_canary_notification_analyzing_heap" />
   <item type="id" name="leak_canary_notification_retained_instances" />
-  <item type="id" name="leak_canary_notification_no_retained_instance" />
+  <item type="id" name="leak_canary_notification_no_retained_instance_on_tap" />
 </resources>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -32,8 +32,8 @@
   <string name="leak_canary_notification_dumping">Dumping Heap</string>
   <string name="leak_canary_notification_foreground_text">LeakCanary is working.</string>
   <string name="leak_canary_notification_message">Click for more details</string>
-  <string name="leak_canary_notification_no_retained_instance_title">No retained instances</string>
-  <string name="leak_canary_notification_no_retained_instance_content">All instances cleared after LeakCanary ran GC</string>
+  <string name="leak_canary_notification_no_retained_instance_title">All retained instances were garbage collected</string>
+  <string name="leak_canary_notification_no_retained_instance_content">Tap to dismiss</string>
   <string name="leak_canary_notification_retained_debugger_attached">Waiting for debugger to detach</string>
   <string name="leak_canary_notification_retained_dump_failed">Failed to dump heap</string>
   <string name="leak_canary_notification_retained_title">%d retained instances, tap to dump heap</string>


### PR DESCRIPTION
* Bugfix: when tapping the "dump heap" notification, if the GC found no retained instance we didn't use a distinct notification id to communicate that, and then soon after we'd dismiss the notification that let's the user know there is no retained instances on tap.
* Bugfix: we weren't running the GC when checking for retained instances and the count was under the threshold
* Change: we now update the notification and keep it around for 30 seconds when the count goes to 0
* Change: the "no retained instance" notification that shows on tap is identical and also auto dismisses after 30 seconds.
* Change: we're checking for retained references (and running the GC) every 2 seconds instead of 5.

Fixes #1427

![Screenshot_1562183815](https://user-images.githubusercontent.com/557033/60621536-c9ec3f80-9d92-11e9-8747-4a0e4f13168f.png)

cc @pforhan @afollestad