### PR TITLE
Inflate leak toast from application context

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -115,7 +115,8 @@ internal class AndroidHeapDumper(
       )
       toast.setGravity(Gravity.CENTER_VERTICAL, 0, -iconSize)
       toast.duration = Toast.LENGTH_LONG
-      val inflater = LayoutInflater.from(resumedActivity)
+      // Inflating with application context: https://github.com/square/leakcanary/issues/1385
+      val inflater = LayoutInflater.from(resumedActivity.application)
       toast.view = inflater.inflate(R.layout.leak_canary_heap_dump_toast, null)
       toast.show()
 


### PR DESCRIPTION
According to #1385 some apps load within other host apps, and the layout inflater won't find the toast resource in the Resources class of a hosted activity.

So instead we're using the application context. I have no idea if this will work, but it doesn't hurt.