### PR TITLE
Require declaring class when reading field

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalyzer.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/HeapAnalyzer.kt
@@ -425,7 +425,7 @@ class HeapAnalyzer constructor(
 
     leakTraceInspectors.forEach { it.inspect(graph, leakReporters) }
 
-    val leakStatuses = computeLeakStatuses(graph, leakReporters)
+    val leakStatuses = computeLeakStatuses(leakReporters)
 
     node = leafNode
     while (node is ChildNode) {
@@ -439,7 +439,6 @@ class HeapAnalyzer constructor(
   }
 
   private fun computeLeakStatuses(
-    graph: HprofGraph,
     leakReporters: List<LeakTraceElementReporter>
   ): List<LeakNodeStatusAndReason> {
     var lastNotLeakingElementIndex = 0

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTraceElement.kt
@@ -28,7 +28,7 @@ data class LeakTraceElement(
   /**
    * Returns {@link #className} without the package.
    */
-  val simpleClassName: String get() = className.lastSegment('.')
+  val classSimpleName: String get() = className.lastSegment('.')
 
   enum class Type {
     INSTANCE_FIELD,

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/KeyedWeakReferenceMirror.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/KeyedWeakReferenceMirror.kt
@@ -30,23 +30,24 @@ internal class KeyedWeakReferenceMirror(
       heapDumpUptimeMillis: Long?
     ): KeyedWeakReferenceMirror {
 
+      val keyWeakRefClassName = weakRef.className
       val watchDurationMillis = if (heapDumpUptimeMillis != null)
-        heapDumpUptimeMillis - weakRef["watchUptimeMillis"]!!.value.asLong!!
+        heapDumpUptimeMillis - weakRef[keyWeakRefClassName, "watchUptimeMillis"]!!.value.asLong!!
       else 0L
 
       val retainedDurationMillis = if (heapDumpUptimeMillis != null) {
-        val retainedUptimeMillis = weakRef["retainedUptimeMillis"]!!.value.asLong!!
+        val retainedUptimeMillis = weakRef[keyWeakRefClassName, "retainedUptimeMillis"]!!.value.asLong!!
         if (retainedUptimeMillis == -1L) -1L else heapDumpUptimeMillis - retainedUptimeMillis
       } else null
 
-      val keyString = weakRef["key"]!!.value.readAsJavaString()!!
+      val keyString = weakRef[keyWeakRefClassName, "key"]!!.value.readAsJavaString()!!
 
-      val name = weakRef["name"]?.value?.readAsJavaString() ?: UNKNOWN_LEGACY
-      val className = weakRef["className"]?.value?.readAsJavaString() ?: UNKNOWN_LEGACY
+      val name = weakRef[keyWeakRefClassName, "name"]?.value?.readAsJavaString() ?: UNKNOWN_LEGACY
+      val className = weakRef[keyWeakRefClassName, "className"]?.value?.readAsJavaString() ?: UNKNOWN_LEGACY
       return KeyedWeakReferenceMirror(
           watchDurationMillis = watchDurationMillis,
           retainedDurationMillis = retainedDurationMillis,
-          referent = weakRef["referent"]!!.value.actual as ObjectReference,
+          referent = weakRef["java.lang.ref.Reference", "referent"]!!.value.actual as ObjectReference,
           key = keyString,
           name = name,
           className = className

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/LeakTraceRenderer.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/LeakTraceRenderer.kt
@@ -69,7 +69,7 @@ private fun getNextElementString(
     if (element.holder == ARRAY || element.holder == THREAD) {
       "${element.holder.name.toLowerCase(Locale.US)} "
     } else ""
-  val simpleClassName = element.simpleClassName
+  val simpleClassName = element.classSimpleName
   val referenceName = if (element.reference != null) ".${element.reference.displayName}" else ""
   val requiredSpaces =
     staticString.length + holderString.length + simpleClassName.length + "├─".length

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/ShortestPathFinder.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/ShortestPathFinder.kt
@@ -248,7 +248,7 @@ internal class ShortestPathFinder {
         is JavaFrame -> {
           val threadRoot = threadsBySerialNumber.getValue(gcRoot.threadSerialNumber)
           val threadInstance = graph.readGraphObjectRecord(threadRoot.id).asInstance!!
-          val threadName = threadInstance["name"]?.value?.readAsJavaString()
+          val threadName = threadInstance[Thread::class, "name"]?.value?.readAsJavaString()
           val exclusion = threadNameExclusions[threadName]
 
           if (exclusion == null || exclusion.status != NEVER_REACHABLE) {
@@ -449,7 +449,7 @@ internal class ShortestPathFinder {
       STRING -> {
         updateDominator(parentObjectId, objectId, true)
         val stringInstance = graph.readGraphObjectRecord(objectId).asInstance!!
-        val valueId = stringInstance["value"]?.value?.asNonNullObjectIdReference
+        val valueId = stringInstance["java.lang.String", "value"]?.value?.asNonNullObjectIdReference
         if (valueId != null) {
           updateDominator(parentObjectId, valueId, true)
         }
@@ -544,7 +544,7 @@ internal class ShortestPathFinder {
         undominate(objectId, true)
         val stringRecord = graph.readGraphObjectRecord(objectId)
         val stringInstance = stringRecord.asInstance!!
-        val valueId = stringInstance["value"]?.value?.asObjectIdReference
+        val valueId = stringInstance["java.lang.String", "value"]?.value?.asObjectIdReference
         if (valueId != null) {
           undominate(valueId, true)
         }

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/HprofWriterHelper.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/HprofWriterHelper.kt
@@ -60,11 +60,17 @@ class HprofWriterHelper constructor(
       "count" to IntValue::class
   )
   )
-  private val weakReferenceClassId = clazz(
-      className = "java.lang.ref.WeakReference",
+
+  private val referenceClassId  = clazz(
+      className = "java.lang.ref.Reference",
       fields = listOf(
           "referent" to ObjectReference::class
       )
+  )
+
+  private val weakReferenceClassId = clazz(
+      className = "java.lang.ref.WeakReference",
+      superClassId = referenceClassId
   )
   private val keyedWeakReferenceClassId = clazz(
       superClassId = weakReferenceClassId,

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
@@ -211,7 +211,7 @@ internal class DisplayLeakAdapter private constructor(
   ): Spanned {
 
     val packageEnd = element.className.lastIndexOf('.')
-    var simpleName = element.simpleClassName
+    var simpleName = element.classSimpleName
     simpleName = simpleName.replace("[]", "[ ]")
     val styledClassName = "<font color='$classNameColorHexString'>$simpleName</font>"
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakingInstanceTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakingInstanceTable.kt
@@ -282,7 +282,7 @@ internal object LeakingInstanceTable {
       } else {
         val element = leakCauses.first()
         val referenceName = element.reference!!.groupingName
-        val refDescription = element.simpleClassName + "." + referenceName
+        val refDescription = element.classSimpleName + "." + referenceName
         refDescription
       }
     }

--- a/leakcanary-haha/src/test/java/leakcanary/HprofWriterTest.kt
+++ b/leakcanary-haha/src/test/java/leakcanary/HprofWriterTest.kt
@@ -35,7 +35,7 @@ class HprofWriterTest {
       val baguetteInstance =
         treasureChestClass[CONTENT_FIELD_NAME]!!.value.readObjectRecord()!!.asInstance!!
 
-      assertThat(baguetteInstance[ANSWER_FIELD_NAME]!!.value.asInt!!).isEqualTo(42)
+      assertThat(baguetteInstance[BAGUETTE_CLASS_NAME, ANSWER_FIELD_NAME]!!.value.asInt!!).isEqualTo(42)
     }
   }
 


### PR DESCRIPTION
This avoids issues with subclasses redefining fields named identically.

Thanks for @swankjesse for suggesting these changes!