### PR TITLE
Correctly report gc root leak status

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakNode.kt
@@ -6,6 +6,7 @@ sealed class LeakNode {
   abstract val visitOrder: Int
 
   class RootNode(
+    val gcRoot: GcRoot,
     override val instance: Long,
     override val visitOrder: Int
   ) : LeakNode()

--- a/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/LeakTrace.kt
@@ -32,7 +32,7 @@ data class LeakTrace(
       NOT_LEAKING -> if (index < elements.lastIndex) {
         elements[index + 1].leakStatusAndReason.status != NOT_LEAKING
       } else {
-        true
+        false
       }
       else -> false
     }

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/ShortestPathFinder.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/ShortestPathFinder.kt
@@ -261,7 +261,7 @@ internal class ShortestPathFinder {
       when (gcRoot) {
         is ThreadObject -> {
           threadsBySerialNumber[gcRoot.threadSerialNumber] = gcRoot
-          enqueue(graph, RootNode(gcRoot.id, visitOrder++), exclusionPriority = null)
+          enqueue(graph, RootNode(gcRoot, gcRoot.id, visitOrder++), exclusionPriority = null)
         }
         is JavaFrame -> {
           val threadRoot = threadsBySerialNumber.getValue(gcRoot.threadSerialNumber)
@@ -271,7 +271,7 @@ internal class ShortestPathFinder {
 
           if (exclusion == null || exclusion.status != NEVER_REACHABLE) {
             // visitOrder is unused as this root node isn't enqueued.
-            val rootNode = RootNode(threadRoot.id, visitOrder = 0)
+            val rootNode = RootNode(gcRoot, threadRoot.id, visitOrder = 0)
             // TODO #1352 Instead of <Java Local>, it should be <local variable in Foo.bar()>
             // We should also add the full stacktrace as a label of thread objects
             val leakReference = LeakReference(LOCAL, "")
@@ -282,7 +282,7 @@ internal class ShortestPathFinder {
             )
           }
         }
-        else -> enqueue(graph, RootNode(gcRoot.id, visitOrder++), exclusionPriority = null)
+        else -> enqueue(graph, RootNode(gcRoot, gcRoot.id, visitOrder++), exclusionPriority = null)
       }
     }
     gcRoots.clear()

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/LeakStatusTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/LeakStatusTest.kt
@@ -183,7 +183,7 @@ class LeakStatusTest {
 
     val leak = analysis.retainedInstances[0] as LeakingInstance
     assertThat(leak.leakTrace.elements[0].leakStatusAndReason.status).isEqualTo(NOT_LEAKING)
-    assertThat(leak.leakTrace.elements[0].leakStatusAndReason.reason).isEqualTo("it's a GC root")
+    assertThat(leak.leakTrace.elements[0].leakStatusAndReason.reason).isEqualTo("Class1↓ is not leaking and a system class never leaks")
     assertThat(leak.leakTrace.elements[1].leakStatusAndReason.status).isEqualTo(NOT_LEAKING)
     assertThat(leak.leakTrace.elements[1].leakStatusAndReason.reason).isEqualTo(
         "Class2↓ is not leaking. Conflicts with Class1 is leaking"
@@ -234,7 +234,7 @@ class LeakStatusTest {
 
     assertThat(leak.leakTrace.elements.first().leakStatusAndReason.status).isEqualTo(NOT_LEAKING)
     assertThat(leak.leakTrace.elements.first().leakStatusAndReason.reason).isEqualTo(
-        "it's a GC root. Conflicts with GcRoot is leaking"
+        "a system class never leaks. Conflicts with GcRoot is leaking"
     )
   }
 
@@ -250,7 +250,7 @@ class LeakStatusTest {
 
     assertThat(leak.leakTrace.elements.first().leakStatusAndReason.status).isEqualTo(NOT_LEAKING)
     assertThat(leak.leakTrace.elements.first().leakStatusAndReason.reason).isEqualTo(
-        "it's a GC root and GcRoot is not leaking"
+        "GcRoot is not leaking and a system class never leaks"
     )
   }
 
@@ -262,9 +262,9 @@ class LeakStatusTest {
       )
 
     val leak = analysis.retainedInstances[0] as LeakingInstance
-    assertThat(leak.leakTrace.elements.last().leakStatusAndReason.status).isEqualTo(LEAKING)
+    assertThat(leak.leakTrace.elements.last().leakStatusAndReason.status).isEqualTo(NOT_LEAKING)
     assertThat(leak.leakTrace.elements.last().leakStatusAndReason.reason).isEqualTo(
-        "RefWatcher was watching this. Conflicts with Leaking is not leaking"
+        "Leaking is not leaking. Conflicts with RefWatcher was watching this"
     )
   }
 
@@ -278,7 +278,7 @@ class LeakStatusTest {
     val leak = analysis.retainedInstances[0] as LeakingInstance
     assertThat(leak.leakTrace.elements.last().leakStatusAndReason.status).isEqualTo(LEAKING)
     assertThat(leak.leakTrace.elements.last().leakStatusAndReason.reason).isEqualTo(
-        "RefWatcher was watching this and Leaking is leaking"
+        "Leaking is leaking and RefWatcher was watching this"
     )
   }
 

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/LeakTraceRendererTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/LeakTraceRendererTest.kt
@@ -38,7 +38,8 @@ class LeakTraceRendererTest {
     analysis renders """
     ┬
     ├─ GcRoot
-    │    Leaking: NO (it's a GC root)
+    │    Leaking: NO (a system class never leaks)
+    │    GC Root: System class
     │    ↓ static GcRoot.leak
     │                    ~~~~
     ╰→ Leaking
@@ -74,7 +75,8 @@ class LeakTraceRendererTest {
     analysis renders """
     ┬
     ├─ GcRoot
-    │    Leaking: NO (it's a GC root)
+    │    Leaking: NO (a system class never leaks)
+    │    GC Root: System class
     │    ↓ static GcRoot.instanceA
     │                    ~~~~~~~~~
     ├─ ClassA
@@ -85,7 +87,7 @@ class LeakTraceRendererTest {
     │    Leaking: YES (because reasons)
     │    ↓ ClassB.leak
     ╰→ Leaking
-    ​     Leaking: YES (RefWatcher was watching this)
+    ​     Leaking: YES (ClassB↑ is leaking and RefWatcher was watching this)
     """
   }
 
@@ -113,8 +115,9 @@ class LeakTraceRendererTest {
     analysis renders """
     ┬
     ├─ GcRoot
-    │    Leaking: NO (it's a GC root)
+    │    Leaking: NO (a system class never leaks)
     │    ¯\_(ツ)_/¯
+    │    GC Root: System class
     │    ↓ static GcRoot.leak
     │                    ~~~~
     ╰→ Leaking
@@ -140,7 +143,8 @@ class LeakTraceRendererTest {
     analysis renders """
     ┬
     ├─ GcRoot
-    │    Leaking: NO (it's a GC root)
+    │    Leaking: NO (a system class never leaks)
+    │    GC Root: System class
     │    ↓ static GcRoot.instanceA
     │                    ~~~~~~~~~
     ├─ ClassA
@@ -166,7 +170,8 @@ class LeakTraceRendererTest {
     analysis renders """
     ┬
     ├─ GcRoot
-    │    Leaking: NO (it's a GC root)
+    │    Leaking: NO (a system class never leaks)
+    │    GC Root: System class
     │    ↓ static GcRoot.array
     │                    ~~~~~
     ├─ java.lang.Object[]
@@ -187,7 +192,8 @@ class LeakTraceRendererTest {
     analysis renders """
     ┬
     ├─ MyThread
-    │    Leaking: NO (it's a GC root)
+    │    Leaking: UNKNOWN
+    │    GC Root: Java local variable
     │    ↓ thread MyThread.<Java Local>
     │                      ~~~~~~~~~~~~
     ╰→ Leaking


### PR DESCRIPTION
We were incorrectly deciding that all GC Roots are "not leaking". That's only true for system classes.

Also, the GC root type wasn't reported, which made it hard to pin point why the reference was held.

Fixes #1447