### PR TITLE
Ability to analyze any hprof

### DIFF
--- a/leakcanary-analyzer/src/main/java/leakcanary/ObjectReporter.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/ObjectReporter.kt
@@ -3,24 +3,43 @@ package leakcanary
 class ObjectReporter(val objectRecord: GraphObjectRecord) {
 
   private val mutableLabels = mutableListOf<String>()
-  private val mutableLeakNodeStatuses = mutableListOf<LeakNodeStatusAndReason>()
+
+  private val mutableLeakingStatuses = mutableListOf<LeakNodeStatusAndReason>()
+  private val mutableLikelyLeakingStatuses = mutableListOf<LeakNodeStatusAndReason>()
+  private val mutableNotLeakingStatuses = mutableListOf<LeakNodeStatusAndReason>()
 
   val labels: List<String>
     get() = mutableLabels
 
   val leakNodeStatuses: List<LeakNodeStatusAndReason>
-    get() = mutableLeakNodeStatuses
+    get() = mutableLeakingStatuses + mutableLikelyLeakingStatuses + mutableNotLeakingStatuses
+
+  val leakingStatuses: List<LeakNodeStatusAndReason>
+    get() = mutableLeakingStatuses
 
   fun addLabel(label: String) {
     mutableLabels += label
   }
 
+
+  /**
+   * The inspector is almost sure this instance is leaking, but not 100%. This information will
+   * be used for decorating leaktraces, but [HeapAnalyzer] will not look for these instances.
+   */
+  fun reportLikelyLeaking(reason: String) {
+    mutableLikelyLeakingStatuses += LeakNodeStatus.leaking(reason)
+  }
+
+  /**
+   * The inspector is 100% sure this instance is leaking. [HeapAnalyzer] will look for these
+   * instances.
+   */
   fun reportLeaking(reason: String) {
-    mutableLeakNodeStatuses += LeakNodeStatus.leaking(reason)
+    mutableLeakingStatuses += LeakNodeStatus.leaking(reason)
   }
 
   fun reportNotLeaking(reason: String) {
-    mutableLeakNodeStatuses += LeakNodeStatus.notLeaking(reason)
+    mutableNotLeakingStatuses += LeakNodeStatus.notLeaking(reason)
   }
 
 }

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/GcRootRecordListener.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/GcRootRecordListener.kt
@@ -1,0 +1,62 @@
+package leakcanary.internal
+
+import leakcanary.GcRoot
+import leakcanary.GcRoot.JavaFrame
+import leakcanary.GcRoot.JniGlobal
+import leakcanary.GcRoot.JniLocal
+import leakcanary.GcRoot.JniMonitor
+import leakcanary.GcRoot.MonitorUsed
+import leakcanary.GcRoot.NativeStack
+import leakcanary.GcRoot.ReferenceCleanup
+import leakcanary.GcRoot.StickyClass
+import leakcanary.GcRoot.ThreadBlock
+import leakcanary.GcRoot.ThreadObject
+import leakcanary.HprofPushRecordsParser.OnRecordListener
+import leakcanary.Record
+import leakcanary.Record.HeapDumpRecord.GcRootRecord
+import kotlin.reflect.KClass
+
+internal class GcRootRecordListener : OnRecordListener {
+
+  val gcRoots = mutableListOf<GcRoot>()
+
+  override fun recordTypes(): Set<KClass<out Record>> = setOf(GcRootRecord::class)
+
+  override fun onTypeSizesAvailable(typeSizes: Map<Int, Int>) {
+  }
+
+  override fun onRecord(
+    position: Long,
+    record: Record
+  ) {
+    when (record) {
+      is GcRootRecord -> {
+        // TODO Ignoring VmInternal because we've got 150K of it, but is this the right thing
+        // to do? What's VmInternal exactly? History does not go further than
+        // https://android.googlesource.com/platform/dalvik2/+/refs/heads/master/hit/src/com/android/hit/HprofParser.java#77
+        // We should log to figure out what objects VmInternal points to.
+        when (record.gcRoot) {
+          // ThreadObject points to threads, which we need to find the thread that a JavaLocalExclusion
+          // belongs to
+          is ThreadObject,
+          is JniGlobal,
+          is JniLocal,
+          is JavaFrame,
+          is NativeStack,
+          is StickyClass,
+          is ThreadBlock,
+          is MonitorUsed,
+            // TODO What is this and why do we care about it as a root?
+          is ReferenceCleanup,
+          is JniMonitor
+          -> {
+            gcRoots.add(record.gcRoot)
+          }
+        }
+      }
+      else -> {
+        throw IllegalArgumentException("Unexpected record $record")
+      }
+    }
+  }
+}

--- a/leakcanary-analyzer/src/main/java/leakcanary/internal/KeyedWeakReferenceMirror.kt
+++ b/leakcanary-analyzer/src/main/java/leakcanary/internal/KeyedWeakReferenceMirror.kt
@@ -8,10 +8,8 @@ internal class KeyedWeakReferenceMirror(
   val key: String,
     // The name field does not exist in pre 1.0 heap dumps.
   val name: String,
-  // 0 in pre 2.0 alpha 3 heap dumps
-  val watchDurationMillis: Long,
-    // The className field does not exist in pre 2.0 heap dumps.
-  val className: String,
+  // null in pre 2.0 alpha 3 heap dumps
+  val watchDurationMillis: Long?,
     // null in pre 2.0 alpha 3 heap dumps, -1 if the instance is not retained.
   val retainedDurationMillis: Long?
 ) {
@@ -33,7 +31,7 @@ internal class KeyedWeakReferenceMirror(
       val keyWeakRefClassName = weakRef.className
       val watchDurationMillis = if (heapDumpUptimeMillis != null)
         heapDumpUptimeMillis - weakRef[keyWeakRefClassName, "watchUptimeMillis"]!!.value.asLong!!
-      else 0L
+      else null
 
       val retainedDurationMillis = if (heapDumpUptimeMillis != null) {
         val retainedUptimeMillis = weakRef[keyWeakRefClassName, "retainedUptimeMillis"]!!.value.asLong!!
@@ -43,14 +41,12 @@ internal class KeyedWeakReferenceMirror(
       val keyString = weakRef[keyWeakRefClassName, "key"]!!.value.readAsJavaString()!!
 
       val name = weakRef[keyWeakRefClassName, "name"]?.value?.readAsJavaString() ?: UNKNOWN_LEGACY
-      val className = weakRef[keyWeakRefClassName, "className"]?.value?.readAsJavaString() ?: UNKNOWN_LEGACY
       return KeyedWeakReferenceMirror(
           watchDurationMillis = watchDurationMillis,
           retainedDurationMillis = retainedDurationMillis,
           referent = weakRef["java.lang.ref.Reference", "referent"]!!.value.actual as ObjectReference,
           key = keyString,
-          name = name,
-          className = className
+          name = name
       )
     }
   }

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/HeapDumps.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/HeapDumps.kt
@@ -10,14 +10,14 @@ import java.io.File
 fun File.writeWeakReferenceCleared() {
   HprofWriter.open(this)
       .helper {
-        keyedWeakReference("Leaking", ObjectReference(0))
+        keyedWeakReference(ObjectReference(0))
       }
 }
 
 fun File.writeNoPathToInstance() {
   HprofWriter.open(this)
       .helper {
-        keyedWeakReference("Leaking", instance(clazz("Leaking")))
+        keyedWeakReference(instance(clazz("Leaking")))
       }
 }
 
@@ -25,7 +25,7 @@ fun File.writeSinglePathToInstance() {
   HprofWriter.open(this)
       .helper {
         val leaking = instance(clazz("Leaking"))
-        keyedWeakReference("Leaking", leaking)
+        keyedWeakReference(leaking)
         clazz(
             "GcRoot", staticFields = listOf(
             "shortestPath" to leaking
@@ -38,7 +38,7 @@ fun File.writeSinglePathToString(value: String = "Hi") {
   HprofWriter.open(this)
       .helper {
         val leaking = string(value)
-        keyedWeakReference("java.lang.String", leaking)
+        keyedWeakReference(leaking)
         clazz(
             "GcRoot", staticFields = listOf(
             "shortestPath" to leaking
@@ -53,7 +53,7 @@ fun File.writeSinglePathsToCharArrays(values: List<String>) {
         val arrays = mutableListOf<Long>()
         values.forEach {
           val leaking = it.charArrayDump
-          keyedWeakReference("char[]", leaking)
+          keyedWeakReference(leaking)
           arrays.add(leaking.value)
         }
         clazz(
@@ -72,7 +72,7 @@ fun File.writeTwoPathsToInstance() {
   HprofWriter.open(this)
       .helper {
         val leaking = instance(clazz("Leaking"))
-        keyedWeakReference("Leaking", leaking)
+        keyedWeakReference(leaking)
         val hasLeaking = instance(
             clazz("HasLeaking", fields = listOf("leaking" to ObjectReference::class)),
             fields = listOf(leaking)
@@ -114,7 +114,7 @@ fun File.writeMultipleActivityLeaks(leakCount: Int) {
             )
         )
         destroyedActivities.forEach { instanceId ->
-          keyedWeakReference("com.example.ExampleActivity", instanceId)
+          keyedWeakReference(instanceId)
         }
       }
 }

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/LabelerTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/LabelerTest.kt
@@ -3,10 +3,9 @@ package leakcanary.internal
 import leakcanary.AndroidObjectInspectors
 import leakcanary.HeapAnalysisSuccess
 import leakcanary.HprofGraph
-import leakcanary.LeakingInstance
 import leakcanary.ObjectInspector
 import leakcanary.ObjectReporter
-import leakcanary.asInstance
+import leakcanary.whenInstanceOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -33,7 +32,7 @@ class LabelerTest {
         graph: HprofGraph,
         reporter: ObjectReporter
       ) {
-        reporter.asInstance("java.lang.String")  { instance ->
+        reporter.whenInstanceOf("java.lang.String")  { instance ->
           addLabel("Hello ${instance.readAsJavaString()}")
         }
       }
@@ -41,9 +40,9 @@ class LabelerTest {
 
     val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>(objectInspectors = listOf(labeler))
 
-    val leak = analysis.retainedInstances[0] as LeakingInstance
+    val leak = analysis.leakingInstances[0]
 
-    assertThat(leak.leakTrace.elements.last().labels).isEqualTo(listOf("Hello World"))
+    assertThat(leak.leakTrace.elements.last().labels).contains("Hello World")
   }
 
   @Test fun threadNameLabel() {
@@ -52,7 +51,7 @@ class LabelerTest {
     val analysis =
       hprofFile.checkForLeaks<HeapAnalysisSuccess>(objectInspectors = listOf(AndroidObjectInspectors.THREAD))
 
-    val leak = analysis.retainedInstances[0] as LeakingInstance
+    val leak = analysis.leakingInstances[0]
 
     assertThat(leak.leakTrace.elements.first().labels).contains("Thread name: 'kroutine'")
   }

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/LegacyHprofTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/LegacyHprofTest.kt
@@ -5,7 +5,6 @@ import leakcanary.AndroidObjectInspectors
 import leakcanary.HeapAnalysis
 import leakcanary.HeapAnalysisFailure
 import leakcanary.HeapAnalysisSuccess
-import leakcanary.LeakingInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.File
@@ -15,9 +14,9 @@ class LegacyHprofTest {
   @Test fun preM() {
     val analysis = analyzeHprof("leak_asynctask_pre_m.hprof")
 
-    assertThat(analysis.retainedInstances).hasSize(2)
-    val leak1 = analysis.retainedInstances[0] as LeakingInstance
-    val leak2 = analysis.retainedInstances[1] as LeakingInstance
+    assertThat(analysis.leakingInstances).hasSize(2)
+    val leak1 = analysis.leakingInstances[0]
+    val leak2 = analysis.leakingInstances[1]
     assertThat(leak1.instanceClassName).isEqualTo("com.example.leakcanary.MainActivity")
     assertThat(leak2.instanceClassName).isEqualTo("android.graphics.Bitmap")
   }
@@ -25,24 +24,24 @@ class LegacyHprofTest {
   @Test fun androidM() {
     val analysis = analyzeHprof("leak_asynctask_m.hprof")
 
-    assertThat(analysis.retainedInstances).hasSize(1)
-    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(analysis.leakingInstances).hasSize(1)
+    val leak = analysis.leakingInstances[0]
     assertThat(leak.instanceClassName).isEqualTo("com.example.leakcanary.MainActivity")
   }
 
   @Test fun androidO() {
     val analysis = analyzeHprof("leak_asynctask_o.hprof")
 
-    assertThat(analysis.retainedInstances).hasSize(1)
-    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(analysis.leakingInstances).hasSize(1)
+    val leak = analysis.leakingInstances[0]
     assertThat(leak.instanceClassName).isEqualTo("com.example.leakcanary.MainActivity")
   }
 
   @Test fun gcRootInNonPrimaryHeap() {
     val analysis = analyzeHprof("gc_root_in_non_primary_heap.hprof")
 
-    assertThat(analysis.retainedInstances).hasSize(1)
-    val leak = analysis.retainedInstances[0] as LeakingInstance
+    assertThat(analysis.leakingInstances).hasSize(1)
+    val leak = analysis.leakingInstances[0]
     assertThat(leak.instanceClassName).isEqualTo("com.example.leakcanary.MainActivity")
   }
 
@@ -56,9 +55,7 @@ class LegacyHprofTest {
         objectInspectors = AndroidObjectInspectors.defaultInspectors(),
         exclusions = AndroidKnownReference.mapToExclusions(AndroidKnownReference.appDefaults)
     )
-    if (analysis is HeapAnalysisFailure) {
-      print(analysis)
-    }
+    print(analysis)
     return analysis as HeapAnalysisSuccess
   }
 

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/RetainedSizeTest.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/RetainedSizeTest.kt
@@ -230,20 +230,13 @@ class RetainedSizeTest {
     }
 
     val retainedInstances = retainedInstances()
-    require(retainedInstances.size == 3)
+    require(retainedInstances.size == 1)
 
-    retainedInstances.forEach { instance ->
-      when (instance.instanceClassName) {
-        "GrandParentLeaking" -> {
-          // 4 bytes per ref * 2 + short + int + long
-          assertThat(instance.retainedHeapSize).isEqualTo(22)
-        }
-        "ParentLeaking", "ChildLeaking" -> {
-          assertThat(instance.retainedHeapSize).isEqualTo(0)
-        }
-        else -> throw IllegalStateException("Unexpected ${instance.instanceClassName}")
-      }
-    }
+    val instance = retainedInstances[0]
+
+    assertThat(instance.instanceClassName).isEqualTo("GrandParentLeaking")
+    // 4 bytes per ref * 2 + short + int + long
+    assertThat(instance.retainedHeapSize).isEqualTo(22)
   }
 
   @Test fun crossDominatedIsNotDominated() {
@@ -315,7 +308,7 @@ class RetainedSizeTest {
     val analysis = hprofFile.checkForLeaks<HeapAnalysis>(computeRetainedHeapSize = true)
     println(analysis.toString())
     analysis as HeapAnalysisSuccess
-    return analysis.retainedInstances.map { it as LeakingInstance }
+    return analysis.leakingInstances.map { it }
   }
 
   private fun firstRetainedSize(): Int {

--- a/leakcanary-analyzer/src/test/java/leakcanary/internal/TestUtil.kt
+++ b/leakcanary-analyzer/src/test/java/leakcanary/internal/TestUtil.kt
@@ -1,6 +1,7 @@
 package leakcanary.internal
 
 import leakcanary.AnalyzerProgressListener
+import leakcanary.AndroidObjectInspectors
 import leakcanary.Exclusion
 import leakcanary.Exclusion.ExclusionType.InstanceFieldExclusion
 import leakcanary.Exclusion.ExclusionType.JavaLocalExclusion
@@ -22,9 +23,14 @@ fun <T : HeapAnalysis> File.checkForLeaks(
   computeRetainedHeapSize: Boolean = false,
   exclusions: List<Exclusion> = defaultExclusionsFactory
 ): T {
+  val inspectors = if (AndroidObjectInspectors.KEYED_WEAK_REFERENCE !in objectInspectors) {
+    objectInspectors + AndroidObjectInspectors.KEYED_WEAK_REFERENCE
+  } else {
+    objectInspectors
+  }
   val heapAnalyzer = HeapAnalyzer(AnalyzerProgressListener.NONE)
   val result = heapAnalyzer.checkForLeaks(
-      this, exclusions, computeRetainedHeapSize, objectInspectors
+      this, exclusions, computeRetainedHeapSize, inspectors
   )
   if (result is HeapAnalysisFailure) {
     println(result)

--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -60,8 +60,15 @@ object LeakCanary {
      * WRITE_EXTERNAL_STORAGE permission is not granted and [requestWriteExternalStoragePermission]
      * is true, then LeakCanary will display a notification to ask for that permission.
      */
-    val requestWriteExternalStoragePermission: Boolean = false
+    val requestWriteExternalStoragePermission: Boolean = false,
 
+    /**
+     * When true, [objectInspectors] are used to find leaks instead of only checking instances
+     * tracked by [KeyedWeakReference]. This leads to finding more leaks and shorter leak traces.
+     * However this also means the same leaking instances will be found in every heap dump for a
+     * given process life.
+     */
+    val useExperimentalLeakFinders: Boolean = false
   )
 
   @Volatile

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
@@ -51,10 +51,9 @@ import leakcanary.internal.MoreDetailsView.Details.OPENED
 import leakcanary.internal.activity.db.LeakingInstanceTable.InstanceProjection
 import leakcanary.internal.navigation.inflate
 
-internal class DisplayLeakAdapter private constructor(
+internal class DisplayLeakAdapter constructor(
   context: Context,
   private val leakTrace: LeakTrace,
-  private val referenceName: String,
   private val instanceProjections: List<InstanceProjection>
 ) : BaseAdapter() {
 
@@ -62,15 +61,8 @@ internal class DisplayLeakAdapter private constructor(
 
   constructor(
     context: Context,
-    leakTrace: LeakTrace,
-    referenceName: String
-  ) : this(context, leakTrace, referenceName, emptyList())
-
-  constructor(
-    context: Context,
-    leakTrace: LeakTrace,
-    instanceProjections: List<InstanceProjection>
-  ) : this(context, leakTrace, "", instanceProjections)
+    leakTrace: LeakTrace
+  ) : this(context, leakTrace, emptyList())
 
   private val opened = BooleanArray(TOP_ROW_COUNT + leakTrace.elements.size)
 
@@ -279,10 +271,6 @@ internal class DisplayLeakAdapter private constructor(
         htmlString += " because <font color='#f3cf83'>" + exclusion.reason + "</font>"
       }
     }
-    if (isLeakingInstance && referenceName != "") {
-      htmlString += " <font color='$extraColorHexString'>$referenceName</font>"
-    }
-
     return HtmlCompat.fromHtml(htmlString, HtmlCompat.FROM_HTML_MODE_LEGACY)
   }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import com.squareup.leakcanary.core.R
 import leakcanary.AnalyzerProgressListener
 import leakcanary.AndroidKnownReference
+import leakcanary.AndroidObjectInspectors
 import leakcanary.CanaryLog
 import leakcanary.HeapAnalyzer
 import leakcanary.LeakCanary
@@ -60,7 +61,10 @@ internal class HeapAnalyzerService : ForegroundService(
 
     val heapAnalysis =
       heapAnalyzer.checkForLeaks(
-          heapDumpFile, exclusions, config.computeRetainedHeapSize, config.objectInspectors
+          heapDumpFile, exclusions, config.computeRetainedHeapSize, config.objectInspectors,
+          if (config.useExperimentalLeakFinders) config.objectInspectors else listOf(
+              AndroidObjectInspectors.KEYED_WEAK_REFERENCE
+          )
       )
 
     config.analysisResultListener(application, heapAnalysis)

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -113,7 +113,7 @@ internal class HeapDumpTrigger(
       return
     }
     lastDisplayedRetainedInstanceCount = 0
-    refWatcher.removeInstancesRetainedBeforeHeapDump(heapDumpUptimeMillis)
+    refWatcher.removeInstancesWatchedBeforeHeapDump(heapDumpUptimeMillis)
 
     HeapAnalyzerService.runAnalysis(application, heapDumpFile)
   }
@@ -160,7 +160,7 @@ internal class HeapDumpTrigger(
         return@post
       }
       lastDisplayedRetainedInstanceCount = 0
-      refWatcher.removeInstancesRetainedBeforeHeapDump(heapDumpUptimeMillis)
+      refWatcher.removeInstancesWatchedBeforeHeapDump(heapDumpUptimeMillis)
       HeapAnalyzerService.runAnalysis(application, heapDumpFile)
     }
   }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -40,7 +40,7 @@ internal object HeapAnalysisTable {
     values.put("object", heapAnalysis.toByteArray())
     when (heapAnalysis) {
       is HeapAnalysisSuccess -> {
-        values.put("retained_instance_count", heapAnalysis.retainedInstances.size)
+        values.put("retained_instance_count", heapAnalysis.leakingInstances.size)
       }
       is HeapAnalysisFailure -> {
         val cause = heapAnalysis.exception.cause!!

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
@@ -26,6 +26,6 @@ internal class LeaksDbHelper(context: Context) : SQLiteOpenHelper(
 
   companion object {
     // Last updated for next after 2.0-alpha-3
-    private const val VERSION = 11
+    private const val VERSION = 12
   }
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HprofExplorerScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HprofExplorerScreen.kt
@@ -303,16 +303,7 @@ internal class HprofExplorerScreen(
             is GraphObjectArrayRecord -> {
               objectRecord.arrayClassName
             }
-            is GraphPrimitiveArrayRecord -> when (objectRecord.primitiveType) {
-              BOOLEAN -> "boolean[]"
-              CHAR -> "char[]"
-              FLOAT -> "float[]"
-              DOUBLE -> "double[]"
-              BYTE -> "byte[]"
-              SHORT -> "short[]"
-              INT -> "int[]"
-              LONG -> "long[]"
-            }
+            is GraphPrimitiveArrayRecord -> objectRecord.arrayClassName
           }
         }
       }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakingInstanceScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakingInstanceScreen.kt
@@ -70,8 +70,7 @@ internal class LeakingInstanceScreen private constructor(
 
     val listView = findViewById<ListView>(R.id.leak_canary_list)
 
-    val adapter =
-      DisplayLeakAdapter(context, leakingInstance.leakTrace, leakingInstance.referenceName)
+    val adapter = DisplayLeakAdapter(context, leakingInstance.leakTrace)
     listView.adapter = adapter
 
     listView.setOnItemClickListener { _, _, position, _ ->

--- a/leakcanary-android-core/src/main/res/values-de/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values-de/leak_canary_strings.xml
@@ -70,6 +70,5 @@
   <string name="leak_canary_options_menu_import_hprof_file">Hprof Datei importieren &amp; analysieren</string>
   <string name="leak_canary_options_menu_see_analysis_list">Siehe Analyse-Liste</string>
   <string name="leak_canary_options_menu_render_heap_dump">Heap Dump rendern</string>
-  <string name="leak_canary_heap_analysis_success_screen_no_path_to_instance_count">%d erhaltene Instanzen ohne Leaks</string>
   <string name="leak_canary_help_title">Tippe hier, um mehr zu erfahren</string>
 </resources>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -85,6 +85,5 @@
   <string name="leak_canary_options_menu_see_analysis_list">See Analysis List</string>
   <string name="leak_canary_options_menu_render_heap_dump">Render Heap Dump</string>
   <string name="leak_canary_options_menu_explore_heap_dump">Explore Heap Dump</string>
-  <string name="leak_canary_heap_analysis_success_screen_no_path_to_instance_count">%d non leaking retained instances</string>
   <string name="leak_canary_help_title">Tap here to learn more</string>
 </resources>

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -168,14 +168,18 @@ class InstrumentationLeakDetector {
       )
     }
 
-    refWatcher.removeInstancesRetainedBeforeHeapDump(heapDumpUptimeMillis)
+    refWatcher.removeInstancesWatchedBeforeHeapDump(heapDumpUptimeMillis)
 
     val listener = AnalyzerProgressListener.NONE
 
     val heapAnalyzer = HeapAnalyzer(listener)
     val heapAnalysis = heapAnalyzer.checkForLeaks(
-        heapDumpFile, AndroidKnownReference.mapToExclusions(config.knownReferences), config.computeRetainedHeapSize,
-        config.objectInspectors
+        heapDumpFile, AndroidKnownReference.mapToExclusions(config.knownReferences),
+        config.computeRetainedHeapSize,
+        config.objectInspectors,
+        if (config.useExperimentalLeakFinders) config.objectInspectors else listOf(
+            AndroidObjectInspectors.KEYED_WEAK_REFERENCE
+        )
     )
 
     CanaryLog.d("Heap Analysis:\n%s", heapAnalysis)

--- a/leakcanary-haha/src/main/java/leakcanary/GraphContext.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/GraphContext.kt
@@ -1,0 +1,25 @@
+package leakcanary
+
+class GraphContext {
+  private val store = mutableMapOf<String, Any>()
+  operator fun <T> get(key: String): T? {
+    @Suppress("UNCHECKED_CAST")
+    return store[key] as T?
+  }
+
+  operator fun <T> set(
+    key: String,
+    value: T
+  ) {
+    store[key] = (value as Any)
+  }
+
+  operator fun contains(key: String): Boolean {
+    return key in store
+  }
+
+  operator fun minusAssign(key: String) {
+    @Suppress("UNCHECKED_CAST")
+    store -= key
+  }
+}

--- a/leakcanary-haha/src/main/java/leakcanary/GraphObjectRecord.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/GraphObjectRecord.kt
@@ -1,6 +1,14 @@
 package leakcanary
 
 import leakcanary.HeapValue.ObjectReference
+import leakcanary.PrimitiveType.BOOLEAN
+import leakcanary.PrimitiveType.BYTE
+import leakcanary.PrimitiveType.CHAR
+import leakcanary.PrimitiveType.DOUBLE
+import leakcanary.PrimitiveType.FLOAT
+import leakcanary.PrimitiveType.INT
+import leakcanary.PrimitiveType.LONG
+import leakcanary.PrimitiveType.SHORT
 import leakcanary.Record.HeapDumpRecord.ObjectRecord
 import leakcanary.Record.HeapDumpRecord.ObjectRecord.ClassDumpRecord
 import leakcanary.Record.HeapDumpRecord.ObjectRecord.InstanceDumpRecord
@@ -89,6 +97,10 @@ sealed class GraphObjectRecord {
         }
       }
       return null
+    }
+
+    override fun toString(): String {
+      return "record of class $name"
     }
   }
 
@@ -201,6 +213,10 @@ sealed class GraphObjectRecord {
         )
       }
     }
+
+    override fun toString(): String {
+      return "instance @$objectId of $className"
+    }
   }
 
   class GraphObjectArrayRecord internal constructor(
@@ -221,6 +237,10 @@ sealed class GraphObjectRecord {
       return readRecord().elementIds.asSequence()
           .map { GraphHeapValue(graph, ObjectReference(it)) }
     }
+
+    override fun toString(): String {
+      return "object array @$objectId of $arrayClassName"
+    }
   }
 
   class GraphPrimitiveArrayRecord internal constructor(
@@ -231,8 +251,24 @@ sealed class GraphObjectRecord {
     val primitiveType: PrimitiveType
       get() = indexedObject.primitiveType
 
+    val arrayClassName: String
+      get() = when (primitiveType) {
+        BOOLEAN -> "boolean[]"
+        CHAR -> "char[]"
+        FLOAT -> "float[]"
+        DOUBLE -> "double[]"
+        BYTE -> "byte[]"
+        SHORT -> "short[]"
+        INT -> "int[]"
+        LONG -> "long[]"
+      }
+
     override fun readRecord(): PrimitiveArrayDumpRecord {
       return graph.readPrimitiveArrayDumpRecord(objectId, indexedObject)
+    }
+
+    override fun toString(): String {
+      return "primitive array @$objectId of $arrayClassName"
     }
   }
 

--- a/leakcanary-haha/src/main/java/leakcanary/HprofPushRecordsParser.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/HprofPushRecordsParser.kt
@@ -579,7 +579,6 @@ class HprofPushRecordsParser {
                   skipHeapDumpInfoRecord()
                 }
               }
-
               else -> throw IllegalStateException(
                   "Unknown tag $heapDumpTag after $previousTag"
               )

--- a/leakcanary-haha/src/main/java/leakcanary/internal/HprofInMemoryIndex.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/internal/HprofInMemoryIndex.kt
@@ -1,9 +1,11 @@
 package leakcanary.internal
 
+import leakcanary.GcRoot.JniGlobal
 import leakcanary.HprofPushRecordsParser.OnRecordListener
 import leakcanary.HprofReader
 import leakcanary.PrimitiveType
 import leakcanary.Record
+import leakcanary.Record.HeapDumpRecord.GcRootRecord
 import leakcanary.Record.HeapDumpRecord.ObjectRecord.ClassDumpRecord
 import leakcanary.Record.HeapDumpRecord.ObjectRecord.InstanceDumpRecord
 import leakcanary.Record.HeapDumpRecord.ObjectRecord.ObjectArrayDumpRecord
@@ -17,6 +19,8 @@ import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.In
 import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.LongArrayDump
 import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ShortArrayDump
 import leakcanary.Record.LoadClassRecord
+import leakcanary.Record.StackFrameRecord
+import leakcanary.Record.StackTraceRecord
 import leakcanary.Record.StringRecord
 import leakcanary.internal.IndexedObject.IndexedClass
 import leakcanary.internal.IndexedObject.IndexedInstance
@@ -66,8 +70,16 @@ internal class HprofInMemoryIndex private constructor(
         .map { it.first to it.second as IndexedInstance }
   }
 
+  fun indexedObjectSequence(): Sequence<Pair<Long, IndexedObject>> {
+    return objectIndex.entrySequence()
+  }
+
   fun indexedObject(objectId: Long): IndexedObject {
-    return objectIndex[objectId]
+    return objectIndex[objectId]!!
+  }
+
+  fun objectIdIsIndexed(objectId: Long): Boolean {
+    return objectIndex[objectId] != null
   }
 
   class Builder : OnRecordListener {

--- a/leakcanary-haha/src/main/java/leakcanary/internal/LongToObjectSparseArray.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/internal/LongToObjectSparseArray.kt
@@ -23,11 +23,11 @@ internal class LongToObjectSparseArray<T>(initialCapacity: Int) : Cloneable {
     size = 0
   }
 
-  operator fun get(key: Long): T {
+  operator fun get(key: Long): T? {
     val i = binarySearch(keys, size, key)
 
     return if (i < 0 || values[i] == null) {
-      throw NullPointerException("Key $key not set")
+      null
     } else {
       values[i]!!
     }

--- a/leakcanary-watcher/src/main/java/leakcanary/KeyedWeakReference.kt
+++ b/leakcanary-watcher/src/main/java/leakcanary/KeyedWeakReference.kt
@@ -28,8 +28,6 @@ class KeyedWeakReference(
 ) : WeakReference<Any>(
     referent, referenceQueue
 ) {
-  val className: String = referent.javaClass.name
-
   /**
    * Compared against [heapDumpUptimeMillis] so that the Hprof Parser knows only to look at
    * instances that were moved to retained, then used to remove weak references post heap dump.


### PR DESCRIPTION
Large internal changes to support this.
* KeyedWeakReference isn't the only way to find leaks any more. It's one inspector amongst many. Its fields are now provided as labels.
* The View inspector unfortunately isn't able to provide 100% accurate information, because a lot of libraries cache views, so introduce a new isLikelyLeaking API