### PR TITLE
Strip heap dumps from primitive arrays

### DIFF
--- a/leakcanary-cli/src/main/java/leakcanary/Main.kt
+++ b/leakcanary-cli/src/main/java/leakcanary/Main.kt
@@ -15,7 +15,8 @@ fun main(args: Array<String>) {
       analyze(heapDumpFile)
     }
     args.size == 2 && args[0] == "dump-process" -> dumpHeap(args[1])
-    args.size == 2 && args[0] == "analyze-file" -> analyze(File(args[1]))
+    args.size == 2 && args[0] == "analyze-hprof" -> analyze(File(args[1]))
+    args.size == 2 && args[0] == "strip-hprof" -> stripHprof(File(args[1]))
     else -> printHelp()
   }
 }
@@ -28,7 +29,7 @@ fun printHelp() {
     LeakCanary CLI
     Running in directory $workingDirectory
 
-    Commands: [analyze-process, dump-process, analyze-file]
+    Commands: [analyze-process, dump-process, analyze-hprof, strip-hprof]
 
     analyze-process: Dumps the heap for the provided process name, pulls the hprof file and analyzes it.
       USAGE: analyze-process PROCESS_PACKAGE_NAME
@@ -36,8 +37,11 @@ fun printHelp() {
     dump-process: Dumps the heap for the provided process name and pulls the hprof file.
       USAGE: dump-process PROCESS_PACKAGE_NAME
 
-    analyze-file: Analyzes the provided hprof file.
-      USAGE: analyze-file HPROF_FILE_PATH
+    analyze-hprof: Analyzes the provided hprof file.
+      USAGE: analyze-hprof HPROF_FILE_PATH
+
+    strip-hprof: Removes all primitive arrays from the provided hprof file and generates a new "-stripped" hprof file.
+      USAGE: strip-hprof HPROF_FILE_PATH
   """.trimIndent()
   )
 }
@@ -135,3 +139,11 @@ private fun analyze(heapDumpFile: File) {
 
   CanaryLog.d(heapAnalysis.toString())
 }
+
+private fun stripHprof(heapDumpFile: File) {
+  CanaryLog.d("Stripping primitive arrays in heap dump $heapDumpFile")
+  val stripper = HprofPrimitiveArrayStripper()
+  val outputFile = stripper.stripPrimitiveArrays(heapDumpFile)
+  CanaryLog.d("Stripped primitive arrays to $outputFile")
+}
+

--- a/leakcanary-haha/src/main/java/leakcanary/GraphObjectRecord.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/GraphObjectRecord.kt
@@ -201,7 +201,12 @@ sealed class GraphObjectRecord {
           // https://android-review.googlesource.com/#/c/83611/
           val offset = this["java.lang.String", "offset"]?.value?.asInt ?: 0
 
-          val chars = valueRecord.array.copyOfRange(offset, offset + count)
+          // Handle heap dumps where all primitive arrays have been replaced with empty arrays,
+          // e.g. with HprofPrimitiveArrayStripper
+          val toIndex = if (offset + count > valueRecord.array.size) {
+            valueRecord.array.size
+          } else offset + count
+          val chars = valueRecord.array.copyOfRange(offset, toIndex)
           return String(chars)
         }
         is ByteArrayDump -> {

--- a/leakcanary-haha/src/main/java/leakcanary/HprofPrimitiveArrayStripper.kt
+++ b/leakcanary-haha/src/main/java/leakcanary/HprofPrimitiveArrayStripper.kt
@@ -1,0 +1,85 @@
+package leakcanary
+
+import leakcanary.HprofPushRecordsParser.OnRecordListener
+import leakcanary.Record.HeapDumpEndRecord
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.BooleanArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ByteArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.CharArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.DoubleArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.FloatArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.IntArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.LongArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ShortArrayDump
+import java.io.File
+import kotlin.reflect.KClass
+
+class HprofPrimitiveArrayStripper {
+
+  fun stripPrimitiveArrays(
+    inputHprofFile: File,
+    outputHprofFile: File = File(
+        inputHprofFile.parent, inputHprofFile.name.replace(
+        ".hprof", "-stripped.hprof"
+    ).let { if (it != inputHprofFile.name) it else inputHprofFile.name + "-stripped" })
+  ): File {
+    val parser = HprofPushRecordsParser()
+
+    lateinit var writer: HprofWriter
+
+    parser.readHprofRecords(inputHprofFile, setOf(object : OnRecordListener {
+
+      override fun recordTypes(): Set<KClass<out Record>> = setOf(Record::class)
+
+      override fun onTypeSizesAvailable(typeSizes: Map<Int, Int>) {
+        writer =
+          HprofWriter.open(outputHprofFile, idSize = typeSizes.getValue(HprofReader.OBJECT_TYPE))
+      }
+
+      override fun onRecord(
+        position: Long,
+        record: Record
+      ) {
+
+        // HprofWriter automatically emits HeapDumpEndRecord, because it flushes
+        // all continuous heap dump sub records as one heap dump record.
+        if (record is HeapDumpEndRecord) {
+          return
+        }
+        writer.write(
+            when (record) {
+              is BooleanArrayDump -> BooleanArrayDump(
+                  record.id, record.stackTraceSerialNumber, booleanArrayOf()
+              )
+              is CharArrayDump -> CharArrayDump(
+                  record.id, record.stackTraceSerialNumber, charArrayOf()
+              )
+              is FloatArrayDump -> FloatArrayDump(
+                  record.id, record.stackTraceSerialNumber, floatArrayOf()
+              )
+              is DoubleArrayDump -> DoubleArrayDump(
+                  record.id, record.stackTraceSerialNumber, doubleArrayOf()
+              )
+              is ByteArrayDump -> ByteArrayDump(
+                  record.id, record.stackTraceSerialNumber, byteArrayOf()
+              )
+              is ShortArrayDump -> ShortArrayDump(
+                  record.id, record.stackTraceSerialNumber, shortArrayOf()
+              )
+              is IntArrayDump -> IntArrayDump(
+                  record.id, record.stackTraceSerialNumber, intArrayOf()
+              )
+              is LongArrayDump -> LongArrayDump(
+                  record.id, record.stackTraceSerialNumber, longArrayOf()
+              )
+              else -> {
+                record
+              }
+            }
+        )
+      }
+    }))
+    writer.close()
+    return outputHprofFile
+  }
+
+}

--- a/leakcanary-haha/src/test/java/leakcanary/HprofPrimitiveArrayStripperTest.kt
+++ b/leakcanary-haha/src/test/java/leakcanary/HprofPrimitiveArrayStripperTest.kt
@@ -1,0 +1,72 @@
+package leakcanary
+
+import leakcanary.GraphObjectRecord.GraphPrimitiveArrayRecord
+import leakcanary.PrimitiveType.BOOLEAN
+import leakcanary.PrimitiveType.CHAR
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.BooleanArrayDump
+import leakcanary.Record.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.CharArrayDump
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class HprofPrimitiveArrayStripperTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  private var lastId = 0L
+  private val id: Long
+    get() = ++lastId
+
+  @Test
+  fun stripHprof() {
+    val hprofFile = testFolder.newFile("temp.hprof")
+
+    val booleanArray = BooleanArrayDump(id, 1, booleanArrayOf(true, false, true, true))
+    val charArray = CharArrayDump(id, 1, "Hello World!".toCharArray())
+    hprofFile.writeRecords(listOf(booleanArray, charArray))
+
+    val stripper = HprofPrimitiveArrayStripper()
+
+    val strippedFile = stripper.stripPrimitiveArrays(hprofFile)
+
+    strippedFile.readHprof { graph ->
+      val booleanArrays = graph.objectSequence()
+          .filter { it is GraphPrimitiveArrayRecord && it.primitiveType == BOOLEAN }
+          .map { it.readRecord() as BooleanArrayDump }
+          .toList()
+      assertThat(booleanArrays).hasSize(1)
+      assertThat(booleanArrays[0].id).isEqualTo(booleanArray.id)
+      assertThat(booleanArrays[0].array).isEmpty()
+
+      val charArrays = graph.objectSequence()
+          .filter { it is GraphPrimitiveArrayRecord && it.primitiveType == CHAR }
+          .map { it.readRecord() as CharArrayDump }
+          .toList()
+      assertThat(charArrays).hasSize(1)
+      assertThat(charArrays[0].id).isEqualTo(charArray.id)
+      assertThat(charArrays[0].array).isEmpty()
+    }
+  }
+
+  private fun File.writeRecords(
+    records: List<Record>
+  ) {
+    HprofWriter.open(this)
+        .use { writer ->
+          records.forEach { record ->
+            writer.write(record)
+          }
+        }
+  }
+
+  fun File.readHprof(block: (HprofGraph) -> Unit) {
+    val (graph, closeable) = HprofGraph.readHprof(this)
+    closeable.use {
+      block(graph)
+    }
+  }
+
+}


### PR DESCRIPTION
* New HprofPrimitiveArrayStripper that can replace all primitive arrays in an hprof file with empty arrays.
* This can be useful to strip an Hprof of any PII before sharing it.
* New CLI command: `./bin/leakcanary-cli strip-hprof /path/to/heapdump.hprof`
* Also renamed CLI command from analyze-file to analyze-hprof