### PR TITLE
Stops Android Monkey from interfering with LeakCanary during Monkey testing

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -1,11 +1,13 @@
 package leakcanary.internal.activity
 
+import android.app.ActivityManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.AsyncTask
 import android.os.Bundle
+import android.util.Log
 import com.squareup.leakcanary.core.R
 import leakcanary.internal.HeapAnalyzerService
 import leakcanary.internal.InternalLeakCanary
@@ -21,6 +23,15 @@ internal class LeakActivity : NavigatingActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+
+    if (ActivityManager.isUserAMonkey())
+    {
+        Log.d("LeakCanaryMonkey", "it was the monkey")
+        finish()
+    } else {
+        Log.d("LeakCanaryMonkey", "it was an user")
+    }
+
     setContentView(R.layout.leak_canary_leak_activity)
 
     installNavigation(savedInstanceState, findViewById(R.id.main_container))


### PR DESCRIPTION


Without this change, when running Android Monkey it's likely to interact with
the automatically created Leaks app (which has the same root jave packagename)
as the app being tested. 

Note: The topic was discussed in https://github.com/square/leakcanary/issues/719 I don't know whether you want to add this feature, it'd certainly help me with testing other apps I'm involved in and I'd prefer this functionality to be in the main LeakCanary than having to mess about with other approaches. With the current LeakCanary (2.0 beta-3-SNAPSHOT), for me, the package for the Leaks app's activity matches that of the app's.

How to test: run the following commands before and after trying this pull request:
```
./gradlew leakcanary-android-sample:installDebug -Pminify

adb shell monkey -p com.example.leakcanary 500
```

You can check that the method correctly detects the Leaks app was started by Android Monkey (or by a user) with
```
adb logcat -d | grep -i canary | grep -i monkey
```
Here's an extract of running a more verbose and detailed example with Monkey where we can see the internal activity's package name: `com.example.leakcanary/leakcanary.internal.activity.LeakLauncherActivity `

```
julianharty$ adb shell monkey -p com.example.leakcanary   --monitor-native-crashes  -c android.intent.category.LAUNCHER -c android.intent.category.MONKEY  -v 339 -s 1
:Monkey: seed=1566633827291 count=339
:AllowPackage: com.example.leakcanary
:IncludeCategory: android.intent.category.LAUNCHER
:IncludeCategory: android.intent.category.MONKEY
// Event percentages:
//   0: 15.0%
//   1: 10.0%
//   2: 2.0%
//   3: 15.0%
//   4: -0.0%
//   5: 25.0%
//   6: 15.0%
//   7: 2.0%
//   8: 2.0%
//   9: 1.0%
//   10: 13.0%
:Switch: #Intent;action=android.intent.action.MAIN;category=android.intent.category.LAUNCHER;launchFlags=0x10200000;component=com.example.leakcanary/leakcanary.internal.activity.LeakLauncherActivity;end
    // Allowing start of Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10200000 cmp=com.example.leakcanary/leakcanary.internal.activity.LeakLauncherActivity } in package com.example.leakcanary
```