### PR TITLE
Updated Android Gradle Plugin to 3.5.0 and Kotlin to 1.3.50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
       'minSdk'    : 14,
       'compileSdk': 29,
       'errorProne': '2.3.1',
-      'kotlin'    : '1.3.41',
+      'kotlin'    : '1.3.50',
   ]
   ext.deps = [
       assertj_core  : 'org.assertj:assertj-core:3.9.1',

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
       'minSdk'    : 14,
       'compileSdk': 29,
       'errorProne': '2.3.1',
-      'kotlin'    : '1.3.21',
+      'kotlin'    : '1.3.41',
   ]
   ext.deps = [
       assertj_core  : 'org.assertj:assertj-core:3.9.1',
@@ -41,7 +41,7 @@ buildscript {
   }
   dependencies {
     classpath deps.kotlin.gradlePlugin
-    classpath 'com.android.tools.build:gradle:3.4.2'
+    classpath 'com.android.tools.build:gradle:3.5.0'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.16'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.18"

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakViews.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakViews.kt
@@ -50,10 +50,10 @@ internal fun View.shareToStackOverflow(content: String) {
   // AsyncTask was needed here due to setPrimaryClip making a disk write which
   // violated StrictMode if on the main thread
   AsyncTask.execute {
-    clipboard.primaryClip = ClipData.newPlainText(
+    clipboard.setPrimaryClip(ClipData.newPlainText(
         context.getString(R.string.leak_canary_leak_clipdata_label),
         "```\n$content```"
-    )
+    ))
   }
   Toast.makeText(context, R.string.leak_canary_leak_copied, Toast.LENGTH_LONG)
       .show()


### PR DESCRIPTION
Just a version bump to support the latest stable versions of Android Studio and Kotlin. 

Note: local build still fails due to the `val cannot be reassigned` error in `clipboard.primaryClip = ClipData.newPlainText(...)` call. 