### PR TITLE
Make SharkLog use Kotlin Templates and inline lambda

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/DefaultOnHeapAnalyzedListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/DefaultOnHeapAnalyzedListener.kt
@@ -26,7 +26,7 @@ class DefaultOnHeapAnalyzedListener(private val application: Application) : OnHe
 
   override fun onHeapAnalyzed(heapAnalysis: HeapAnalysis) {
     // TODO better log that include leakcanary version, exclusions, etc.
-    SharkLog.d("%s", heapAnalysis)
+    SharkLog.d { "$heapAnalysis" }
 
     val (id, groupProjections) = LeaksDbHelper(application)
         .writableDatabase.use { db ->

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -68,7 +68,7 @@ internal class AndroidHeapDumper(
     showToast(waitingForToast)
 
     if (!waitingForToast.wait(5, SECONDS)) {
-      SharkLog.d("Did not dump heap, too much time waiting for Toast.")
+      SharkLog.d { "Did not dump heap, too much time waiting for Toast." }
       return null
     }
 
@@ -87,13 +87,13 @@ internal class AndroidHeapDumper(
     return try {
       Debug.dumpHprofData(heapDumpFile.absolutePath)
       if (heapDumpFile.length() == 0L) {
-        SharkLog.d("Dumped heap file is 0 byte length")
+        SharkLog.d { "Dumped heap file is 0 byte length" }
         null
       } else {
         heapDumpFile
       }
     } catch (e: Exception) {
-      SharkLog.d(e, "Could not dump heap")
+      SharkLog.e(e) { "Could not dump heap" }
       // Abort heap dump
       null
     } finally {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -93,7 +93,7 @@ internal class AndroidHeapDumper(
         heapDumpFile
       }
     } catch (e: Exception) {
-      SharkLog.e(e) { "Could not dump heap" }
+      SharkLog.d(e) { "Could not dump heap" }
       // Abort heap dump
       null
     } finally {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
@@ -38,7 +38,7 @@ internal class HeapAnalyzerService : ForegroundService(
 
   override fun onHandleIntentInForeground(intent: Intent?) {
     if (intent == null) {
-      SharkLog.d("HeapAnalyzerService received a null intent, ignoring.")
+      SharkLog.d { "HeapAnalyzerService received a null intent, ignoring." }
       return
     }
     // Since we're running in the main process we should be careful not to impact it.
@@ -70,7 +70,7 @@ internal class HeapAnalyzerService : ForegroundService(
 
   override fun onAnalysisProgress(step: OnAnalysisProgressListener.Step) {
     val percent = (100f * step.ordinal / shark.OnAnalysisProgressListener.Step.values().size).toInt()
-    SharkLog.d("Analysis in progress, working on: %s", step.name)
+    SharkLog.d { "Analysis in progress, working on: ${step.name}" }
     val lowercase = step.name.replace("_", " ")
         .toLowerCase()
     val message = lowercase.substring(0, 1).toUpperCase() + lowercase.substring(1)

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -78,10 +78,10 @@ internal class HeapDumpTrigger(
     val config = configProvider()
     // A tick will be rescheduled when this is turned back on.
     if (!config.dumpHeap) {
-      SharkLog.d("No checking for retained object: LeakCanary.Config.dumpHeap is false")
+      SharkLog.d { "No checking for retained object: LeakCanary.Config.dumpHeap is false" }
       return
     }
-    SharkLog.d("Checking retained object because %s", reason)
+    SharkLog.d { "Checking retained object because $reason" }
 
     var retainedReferenceCount = objectWatcher.retainedObjectCount
 
@@ -95,20 +95,19 @@ internal class HeapDumpTrigger(
     if (!config.dumpHeapWhenDebugging && DebuggerControl.isDebuggerAttached) {
       showRetainedCountWithDebuggerAttached(retainedReferenceCount)
       scheduleRetainedObjectCheck("debugger was attached", WAIT_FOR_DEBUG_MILLIS)
-      SharkLog.d(
-          "Not checking for leaks while the debugger is attached, will retry in %d ms",
-          WAIT_FOR_DEBUG_MILLIS
-      )
+      SharkLog.d {
+          "Not checking for leaks while the debugger is attached, will retry in $WAIT_FOR_DEBUG_MILLIS ms"
+      }
       return
     }
 
-    SharkLog.d("Found %d retained references, dumping the heap", retainedReferenceCount)
+    SharkLog.d { "Found $retainedReferenceCount retained references, dumping the heap" }
     val heapDumpUptimeMillis = SystemClock.uptimeMillis()
     KeyedWeakReference.heapDumpUptimeMillis = heapDumpUptimeMillis
     dismissRetainedCountNotification()
     val heapDumpFile = heapDumper.dumpHeap()
     if (heapDumpFile == null) {
-      SharkLog.d("Failed to dump heap, will retry in %d ms", WAIT_AFTER_DUMP_FAILED_MILLIS)
+      SharkLog.d { "Failed to dump heap, will retry in $WAIT_AFTER_DUMP_FAILED_MILLIS ms" }
       scheduleRetainedObjectCheck("failed to dump heap", WAIT_AFTER_DUMP_FAILED_MILLIS)
       showRetainedCountWithHeapDumpFailed(retainedReferenceCount)
       return
@@ -125,7 +124,7 @@ internal class HeapDumpTrigger(
       gcTrigger.runGc()
       val retainedReferenceCount = objectWatcher.retainedObjectCount
       if (retainedReferenceCount == 0) {
-        SharkLog.d("No retained objects after GC")
+        SharkLog.d { "No retained objects after GC" }
         @Suppress("DEPRECATION")
         val builder = Notification.Builder(application)
             .setContentTitle(
@@ -153,11 +152,11 @@ internal class HeapDumpTrigger(
 
       val heapDumpUptimeMillis = SystemClock.uptimeMillis()
       KeyedWeakReference.heapDumpUptimeMillis = heapDumpUptimeMillis
-      SharkLog.d("Dumping the heap because user tapped notification")
+      SharkLog.d { "Dumping the heap because user tapped notification" }
 
       val heapDumpFile = heapDumper.dumpHeap()
       if (heapDumpFile == null) {
-        SharkLog.d("Failed to dump heap")
+        SharkLog.d { "Failed to dump heap" }
         showRetainedCountWithHeapDumpFailed(retainedReferenceCount)
         return@post
       }
@@ -174,7 +173,7 @@ internal class HeapDumpTrigger(
     val countChanged = lastDisplayedRetainedObjectCount != retainedKeysCount
     lastDisplayedRetainedObjectCount = retainedKeysCount
     if (retainedKeysCount == 0) {
-      SharkLog.d("No retained objects")
+      SharkLog.d { "No retained objects" }
       if (countChanged) {
         showNoMoreRetainedObjectNotification()
       }
@@ -183,11 +182,9 @@ internal class HeapDumpTrigger(
 
     if (retainedKeysCount < retainedVisibleThreshold) {
       if (applicationVisible || applicationInvisibleLessThanWatchPeriod) {
-        SharkLog.d(
-            "Found %d retained objects, which is less than the visible threshold of %d",
-            retainedKeysCount,
-            retainedVisibleThreshold
-        )
+        SharkLog.d {
+            "Found $retainedKeysCount retained objects, which is less than the visible threshold of $retainedVisibleThreshold"
+        }
         showRetainedCountBelowThresholdNotification(retainedKeysCount, retainedVisibleThreshold)
         scheduleRetainedObjectCheck(
             "Showing retained objects notification", WAIT_FOR_OBJECT_THRESHOLD_MILLIS
@@ -200,7 +197,7 @@ internal class HeapDumpTrigger(
 
   private fun scheduleRetainedObjectCheck(reason: String) {
     if (checkScheduled) {
-      SharkLog.d("Already scheduled retained check, ignoring ($reason)")
+      SharkLog.d { "Already scheduled retained check, ignoring ($reason)" }
       return
     }
     checkScheduled = true
@@ -215,7 +212,7 @@ internal class HeapDumpTrigger(
     delayMillis: Long
   ) {
     if (checkScheduled) {
-      SharkLog.d("Already scheduled retained check, ignoring ($reason)")
+      SharkLog.d { "Already scheduled retained check, ignoring ($reason)" }
       return
     }
     checkScheduled = true

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -210,7 +210,7 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
     try {
       shortcutManager.addDynamicShortcuts(listOf(shortcut))
     } catch (ignored: Throwable) {
-      SharkLog.e(ignored) {
+      SharkLog.d(ignored) {
         "Could not add dynamic shortcut. " +
             "shortcutCount=$shortcutCount, " +
             "maxShortcutCountPerActivity=${shortcutManager.maxShortcutCountPerActivity}"

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -107,7 +107,7 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
       }
 
       if (runningInInstrumentationTests) {
-        SharkLog.d("Instrumentation test detected, setting LeakCanary.Config.dumpHeap to false")
+        SharkLog.d { "Instrumentation test detected, setting LeakCanary.Config.dumpHeap to false" }
         LeakCanary.config = LeakCanary.config.copy(dumpHeap = false)
       }
     }
@@ -210,12 +210,11 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
     try {
       shortcutManager.addDynamicShortcuts(listOf(shortcut))
     } catch (ignored: Throwable) {
-      SharkLog.d(
-          ignored,
-          "Could not add dynamic shortcut. " +
-              "shortcutCount=$shortcutCount, " +
-              "maxShortcutCountPerActivity=${shortcutManager.maxShortcutCountPerActivity}"
-      )
+      SharkLog.e(ignored) {
+        "Could not add dynamic shortcut. " +
+            "shortcutCount=$shortcutCount, " +
+            "maxShortcutCountPerActivity=${shortcutManager.maxShortcutCountPerActivity}"
+      }
     }
   }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
@@ -73,29 +73,27 @@ internal class LeakDirectoryProvider constructor(
     if (!directoryWritableAfterMkdirs(storageDirectory)) {
       if (!hasStoragePermission()) {
         if (requestExternalStoragePermission()) {
-          SharkLog.d("WRITE_EXTERNAL_STORAGE permission not granted, requesting")
+          SharkLog.d { "WRITE_EXTERNAL_STORAGE permission not granted, requesting" }
           requestWritePermissionNotification()
         } else {
-          SharkLog.d("WRITE_EXTERNAL_STORAGE permission not granted, ignoring")
+          SharkLog.d { "WRITE_EXTERNAL_STORAGE permission not granted, ignoring" }
         }
       } else {
         val state = Environment.getExternalStorageState()
         if (Environment.MEDIA_MOUNTED != state) {
-          SharkLog.d("External storage not mounted, state: %s", state)
+          SharkLog.d { "External storage not mounted, state: $state" }
         } else {
-          SharkLog.d(
-              "Could not create heap dump directory in external storage: [%s]",
-              storageDirectory.absolutePath
-          )
+          SharkLog.d {
+              "Could not create heap dump directory in external storage: [${storageDirectory.absolutePath}]"
+          }
         }
       }
       // Fallback to app storage.
       storageDirectory = appStorageDirectory()
       if (!directoryWritableAfterMkdirs(storageDirectory)) {
-        SharkLog.d(
-            "Could not create heap dump directory in app storage: [%s]",
-            storageDirectory.absolutePath
-        )
+        SharkLog.d {
+            "Could not create heap dump directory in app storage: [${storageDirectory.absolutePath}]"
+        }
         return null
       }
     }
@@ -116,7 +114,7 @@ internal class LeakDirectoryProvider constructor(
         filesDeletedClearDirectory += path
       }
       if (!deleted) {
-        SharkLog.d("Could not delete file %s", file.path)
+        SharkLog.d { "Could not delete file ${file.path}" }
       }
     }
   }
@@ -183,7 +181,7 @@ internal class LeakDirectoryProvider constructor(
 
     val filesToRemove = hprofFiles.size - maxStoredHeapDumps
     if (filesToRemove > 0) {
-      SharkLog.d("Removing %d heap dumps", filesToRemove)
+      SharkLog.d { "Removing $filesToRemove heap dumps" }
       // Sort with oldest modified first.
       hprofFiles.sortWith(Comparator { lhs, rhs ->
         java.lang.Long.valueOf(lhs.lastModified())
@@ -195,7 +193,7 @@ internal class LeakDirectoryProvider constructor(
         if (deleted) {
           filesDeletedTooOld += path
         } else {
-          SharkLog.d("Could not delete old hprof file %s", hprofFiles[i].path)
+          SharkLog.d { "Could not delete old hprof file ${hprofFiles[i].path}" }
         }
       }
     }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
@@ -27,7 +27,7 @@ internal class NotificationReceiver : BroadcastReceiver() {
         // Do nothing, the notification has auto cancel true.
       }
       else -> {
-        SharkLog.d("NotificationReceiver received unknown intent action for $intent")
+        SharkLog.d { "NotificationReceiver received unknown intent action for $intent" }
       }
     }
   }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -77,7 +77,7 @@ internal class LeakActivity : NavigatingActivity() {
             }
       }
     } catch (e: IOException) {
-      SharkLog.e(e) { "Could not imported Hprof file" }
+      SharkLog.d(e) { "Could not imported Hprof file" }
     }
   }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -47,9 +47,9 @@ internal class LeakActivity : NavigatingActivity() {
     resultCode: Int,
     returnIntent: Intent?
   ) {
-    SharkLog.d(
+    SharkLog.d {
         "Got activity result with requestCode=$requestCode resultCode=$resultCode returnIntent=$returnIntent"
-    )
+    }
     if (requestCode == FILE_REQUEST_CODE && resultCode == RESULT_OK && returnIntent != null) {
       returnIntent.data?.let { fileUri ->
         AsyncTask.THREAD_POOL_EXECUTOR.execute {
@@ -77,7 +77,7 @@ internal class LeakActivity : NavigatingActivity() {
             }
       }
     } catch (e: IOException) {
-      SharkLog.d(e, "Could not imported Hprof file")
+      SharkLog.e(e) { "Could not imported Hprof file" }
     }
   }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -127,7 +127,7 @@ internal object HeapAnalysisTable {
         if (heapDumpDeleted) {
           LeakDirectoryProvider.filesDeletedRemoveLeak += path
         } else {
-          SharkLog.d("Could not delete heap dump file %s", heapDumpFile.path)
+          SharkLog.d { "Could not delete heap dump file ${heapDumpFile.path}" }
         }
       }
     }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
@@ -91,7 +91,7 @@ internal class RenderHeapDumpScreen(
                   val imageFile = File(storageDir, "${heapDumpFile.name}.png")
                   val saved = savePng(imageFile, bitmap)
                   if (saved) {
-                    SharkLog.d("Png saved at $imageFile")
+                    SharkLog.d { "Png saved at $imageFile" }
                     imageFile.setReadable(true, false)
                     val imageUri = LeakCanaryFileProvider.getUriForFile(
                         activity,

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/IndexingTest.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/IndexingTest.kt
@@ -19,11 +19,11 @@ class IndexingTest {
     context.assets.open("large-dump.hprof").copyTo(FileOutputStream(heapDumpFile))
 
     Hprof.open(heapDumpFile).use { hprof ->
-      SharkLog.d("Start indexing")
+      SharkLog.d { "Start indexing" }
       val before = SystemClock.uptimeMillis()
       HprofHeapGraph.indexHprof(hprof)
       val durationMs = (SystemClock.uptimeMillis() - before)
-      SharkLog.d("Indexing took $durationMs ms")
+      SharkLog.d { "Indexing took $durationMs ms" }
     }
   }
 }

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeakRunListener.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeakRunListener.kt
@@ -96,7 +96,7 @@ open class FailTestOnLeakRunListener : RunListener() {
 
   private fun detectLeaks() {
     if (skipLeakDetectionReason != null) {
-      SharkLog.d("Skipping leak detection because the test %s", skipLeakDetectionReason)
+      SharkLog.d { "Skipping leak detection because the test $skipLeakDetectionReason" }
       skipLeakDetectionReason = null
       return
     }

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -152,7 +152,7 @@ class InstrumentationLeakDetector {
     try {
       Debug.dumpHprofData(heapDumpFile.absolutePath)
     } catch (exception: Exception) {
-      SharkLog.e(exception) { "Could not dump heap" }
+      SharkLog.d(exception) { "Could not dump heap" }
       return AnalysisPerformed(
           HeapAnalysisFailure(
               heapDumpFile, analysisDurationMillis = 0,

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -152,7 +152,7 @@ class InstrumentationLeakDetector {
     try {
       Debug.dumpHprofData(heapDumpFile.absolutePath)
     } catch (exception: Exception) {
-      SharkLog.d(exception, "Could not dump heap")
+      SharkLog.e(exception) { "Could not dump heap" }
       return AnalysisPerformed(
           HeapAnalysisFailure(
               heapDumpFile, analysisDurationMillis = 0,
@@ -176,7 +176,7 @@ class InstrumentationLeakDetector {
         )
     )
 
-    SharkLog.d("Heap Analysis:\n%s", heapAnalysis)
+    SharkLog.d { "Heap Analysis:\n$heapAnalysis" }
 
     return AnalysisPerformed(heapAnalysis)
   }

--- a/leakcanary-android-process/src/main/java/leakcanary/LeakCanaryProcess.kt
+++ b/leakcanary-android-process/src/main/java/leakcanary/LeakCanaryProcess.kt
@@ -54,7 +54,7 @@ object LeakCanaryProcess {
     try {
       packageInfo = packageManager.getPackageInfo(context.packageName, PackageManager.GET_SERVICES)
     } catch (e: Exception) {
-      SharkLog.e(e) { "Could not get package info for ${context.packageName}" }
+      SharkLog.d(e) { "Could not get package info for ${context.packageName}" }
       return false
     }
 

--- a/leakcanary-android-process/src/main/java/leakcanary/LeakCanaryProcess.kt
+++ b/leakcanary-android-process/src/main/java/leakcanary/LeakCanaryProcess.kt
@@ -54,7 +54,7 @@ object LeakCanaryProcess {
     try {
       packageInfo = packageManager.getPackageInfo(context.packageName, PackageManager.GET_SERVICES)
     } catch (e: Exception) {
-      SharkLog.d(e, "Could not get package info for %s", context.packageName)
+      SharkLog.e(e) { "Could not get package info for ${context.packageName}" }
       return false
     }
 
@@ -71,12 +71,10 @@ object LeakCanaryProcess {
     }
 
     if (serviceInfo.processName == null) {
-      SharkLog.d("Did not expect service %s to have a null process name", serviceClass)
+      SharkLog.d { "Did not expect service $serviceClass to have a null process name" }
       return false
     } else if (serviceInfo.processName == mainProcess) {
-      SharkLog.d(
-          "Did not expect service %s to run in main process %s", serviceClass, mainProcess
-      )
+      SharkLog.d { "Did not expect service $serviceClass to run in main process $mainProcess" }
       // Technically we are in the service process, but we're not in the service dedicated process.
       return false
     }
@@ -89,7 +87,7 @@ object LeakCanaryProcess {
       runningProcesses = activityManager.runningAppProcesses
     } catch (exception: SecurityException) {
       // https://github.com/square/leakcanary/issues/948
-      SharkLog.d("Could not get running app processes %d", exception)
+      SharkLog.d { "Could not get running app processes $exception" }
       return false
     }
 
@@ -102,7 +100,7 @@ object LeakCanaryProcess {
       }
     }
     if (myProcess == null) {
-      SharkLog.d("Could not find running process for %d", myPid)
+      SharkLog.d { "Could not find running process for $myPid" }
       return false
     }
 

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/DefaultCanaryLog.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/DefaultCanaryLog.kt
@@ -15,7 +15,7 @@ internal class DefaultCanaryLog : Logger {
     }
   }
 
-  override fun e(throwable: Throwable, message: String) {
+  override fun d(throwable: Throwable, message: String) {
     d("$message\n${Log.getStackTraceString(throwable)}")
   }
 

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/DefaultCanaryLog.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/DefaultCanaryLog.kt
@@ -5,31 +5,18 @@ import shark.SharkLog.Logger
 
 internal class DefaultCanaryLog : Logger {
 
-  override fun d(
-    message: String,
-    vararg args: Any?
-  ) {
-    val formatted = if (args.isNotEmpty()) String.format(message, *args) else message
-
-    if (formatted.length < 4000) {
-      Log.d("LeakCanary", formatted)
+  override fun d(message: String) {
+    if (message.length < 4000) {
+      Log.d("LeakCanary", message)
     } else {
-      formatted.split(NEW_LINE_REGEX).forEach {line ->
+      message.split(NEW_LINE_REGEX).forEach {line ->
         Log.d("LeakCanary", line)
       }
     }
   }
 
-  override fun d(
-    throwable: Throwable,
-    message: String,
-    vararg args: Any?
-  ) {
-    d(
-        String.format(message, *args) + '\n'.toString() + Log.getStackTraceString(
-            throwable
-        )
-    )
+  override fun e(throwable: Throwable, message: String) {
+    d("$message\n${Log.getStackTraceString(throwable)}")
   }
 
   companion object {

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/InternalAppWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/InternalAppWatcher.kt
@@ -57,7 +57,7 @@ internal object InternalAppWatcher {
   )
 
   fun install(application: Application) {
-    SharkLog.d("Installing AppWatcher")
+    SharkLog.d { "Installing AppWatcher" }
     checkMainThread()
     if (this::application.isInitialized) {
       return

--- a/leakcanary-object-watcher/src/main/java/leakcanary/ObjectWatcher.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/ObjectWatcher.kt
@@ -134,12 +134,12 @@ class ObjectWatcher constructor(
     val watchUptimeMillis = clock.uptimeMillis()
     val reference =
       KeyedWeakReference(watchedObject, key, name, watchUptimeMillis, queue)
-    SharkLog.d(
-        "Watching %s with key %s",
-        ((if (watchedObject is Class<*>) watchedObject.toString() else "instance of ${watchedObject.javaClass.name}") +
-            if (name.isNotEmpty()) " named $name" else ""),
-        key
-    )
+    SharkLog.d {
+        "Watching " +
+            (if (watchedObject is Class<*>) watchedObject.toString() else "instance of ${watchedObject.javaClass.name}") +
+            (if (name.isNotEmpty()) " named $name" else "") +
+            " with key $key"
+    }
 
     watchedObjects[key] = reference
     checkRetainedExecutor.execute {

--- a/shark-cli/src/main/java/shark/CLILogger.kt
+++ b/shark-cli/src/main/java/shark/CLILogger.kt
@@ -6,24 +6,12 @@ import java.io.StringWriter
 
 class CLILogger : Logger {
 
-  override fun d(
-    message: String,
-    vararg args: Any?
-  ) {
-    val formatted = if (args.isNotEmpty()) {
-      String.format(message, *args)
-    } else {
-      message
-    }
-    println(formatted)
+  override fun d(message: String) {
+    println(message)
   }
 
-  override fun d(
-    throwable: Throwable,
-    message: String,
-    vararg args: Any?
-  ) {
-    d(String.format(message, *args) + '\n' + getStackTraceString(throwable))
+  override fun e(throwable: Throwable, message: String) {
+    d("$message\n${getStackTraceString(throwable)}")
   }
 
   private fun getStackTraceString(throwable: Throwable): String {

--- a/shark-cli/src/main/java/shark/CLILogger.kt
+++ b/shark-cli/src/main/java/shark/CLILogger.kt
@@ -10,7 +10,7 @@ class CLILogger : Logger {
     println(message)
   }
 
-  override fun e(throwable: Throwable, message: String) {
+  override fun d(throwable: Throwable, message: String) {
     d("$message\n${getStackTraceString(throwable)}")
   }
 

--- a/shark-cli/src/main/java/shark/Main.kt
+++ b/shark-cli/src/main/java/shark/Main.kt
@@ -24,7 +24,7 @@ fun printHelp() {
   val workingDirectory = File(System.getProperty("user.dir"))
 
   // ASCII art is a remix of a shark from -David "TAZ" Baltazar- and chick from jgs.
-  SharkLog.d(
+  SharkLog.d {
       """
     Shark CLI, running in directory $workingDirectory
 
@@ -54,7 +54,7 @@ fun printHelp() {
     strip-hprof: Replaces all primitive arrays from the provided hprof file with arrays of zeroes and generates a new "-stripped" hprof file.
       USAGE: strip-hprof HPROF_FILE_PATH
   """.trimIndent()
-  )
+  }
 }
 
 private fun dumpHeap(packageName: String): File {
@@ -72,7 +72,7 @@ private fun dumpHeap(packageName: String): File {
   val (processName, processId) = if (matchingProcesses.size == 1) {
     matchingProcesses[0]
   } else if (matchingProcesses.isEmpty()) {
-    SharkLog.d("No process matching \"$packageName\"")
+    SharkLog.d { "No process matching \"$packageName\"" }
     System.exit(1)
     throw RuntimeException("System exiting with error")
   } else {
@@ -80,9 +80,9 @@ private fun dumpHeap(packageName: String): File {
     if (matchingExactly != null) {
       matchingExactly
     } else {
-      SharkLog.d(
+      SharkLog.d {
           "More than one process matches \"$packageName\" but none matches exactly: ${matchingProcesses.map { it.first }}"
-      )
+      }
       System.exit(1)
       throw RuntimeException("System exiting with error")
     }
@@ -95,9 +95,9 @@ private fun dumpHeap(packageName: String): File {
 
   val heapDumpDevicePath = "/data/local/tmp/$heapDumpFileName"
 
-  SharkLog.d(
+  SharkLog.d {
       "Dumping heap for process \"$processName\" with pid $processId to $heapDumpDevicePath"
-  )
+  }
 
   runCommand(
       workingDirectory, "adb", "shell", "am", "dumpheap", processId, heapDumpDevicePath
@@ -106,16 +106,16 @@ private fun dumpHeap(packageName: String): File {
   // Dump heap takes time but adb returns immediately.
   Thread.sleep(5000)
 
-  SharkLog.d("Pulling $heapDumpDevicePath")
+  SharkLog.d { "Pulling $heapDumpDevicePath" }
 
   val pullResult = runCommand(workingDirectory, "adb", "pull", heapDumpDevicePath)
-  SharkLog.d(pullResult)
-  SharkLog.d("Removing $heapDumpDevicePath")
+  SharkLog.d { pullResult }
+  SharkLog.d { "Removing $heapDumpDevicePath" }
 
   runCommand(workingDirectory, "adb", "shell", "rm", heapDumpDevicePath)
 
   val heapDumpFile = File(workingDirectory, heapDumpFileName)
-  SharkLog.d("Pulled heap dump to $heapDumpFile")
+  SharkLog.d { "Pulled heap dump to $heapDumpFile" }
 
   return heapDumpFile
 }
@@ -138,23 +138,23 @@ private fun runCommand(
 
 private fun analyze(heapDumpFile: File) {
   val listener = OnAnalysisProgressListener { step ->
-    SharkLog.d(step.name)
+    SharkLog.d { step.name }
   }
 
   val heapAnalyzer = HeapAnalyzer(listener)
-  SharkLog.d("Analyzing heap dump $heapDumpFile")
+  SharkLog.d { "Analyzing heap dump $heapDumpFile" }
   val heapAnalysis = heapAnalyzer.analyze(
       heapDumpFile, AndroidReferenceMatchers.appDefaults, true,
       AndroidObjectInspectors.appDefaults
   )
 
-  SharkLog.d(heapAnalysis.toString())
+  SharkLog.d { heapAnalysis.toString() }
 }
 
 private fun stripHprof(heapDumpFile: File) {
-  SharkLog.d("Stripping primitive arrays in heap dump $heapDumpFile")
+  SharkLog.d { "Stripping primitive arrays in heap dump $heapDumpFile" }
   val stripper = HprofPrimitiveArrayStripper()
   val outputFile = stripper.stripPrimitiveArrays(heapDumpFile)
-  SharkLog.d("Stripped primitive arrays to $outputFile")
+  SharkLog.d { "Stripped primitive arrays to $outputFile" }
 }
 

--- a/shark-log/build.gradle
+++ b/shark-log/build.gradle
@@ -6,6 +6,9 @@ targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
   implementation deps.kotlin.stdlib
+
+  testImplementation deps.assertj_core
+  testImplementation deps.junit
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/shark-log/src/main/java/shark/SharkLog.kt
+++ b/shark-log/src/main/java/shark/SharkLog.kt
@@ -13,19 +13,12 @@ object SharkLog {
     /**
      * Logs a debug message formatted with the passed in arguments.
      */
-    fun d(
-      message: String,
-      vararg args: Any?
-    )
+    fun d(message: String)
 
     /**
      * Logs a [Throwable] and debug message formatted with the passed in arguments.
      */
-    fun d(
-      throwable: Throwable,
-      message: String,
-      vararg args: Any?
-    )
+    fun e(throwable: Throwable, message: String)
   }
 
   @Volatile var logger: Logger? = null
@@ -33,25 +26,18 @@ object SharkLog {
   /**
    * @see Logger.d
    */
-  fun d(
-    message: String,
-    vararg args: Any?
-  ) {
+  inline fun d(message: () -> String) {
     // Local variable to prevent the ref from becoming null after the null check.
     val logger = logger ?: return
-    logger.d(message, *args)
+    logger.d(message.invoke())
   }
 
   /**
-   * @see Logger.d
+   * @see Logger.e
    */
-  fun d(
-    throwable: Throwable,
-    message: String,
-    vararg args: Any?
-  ) {
+  inline fun e(throwable: Throwable, message: () -> String) {
     // Local variable to prevent the ref from becoming null after the null check.
     val logger = logger ?: return
-    logger.d(throwable, message, *args)
+    logger.e(throwable, message.invoke())
   }
 }

--- a/shark-log/src/main/java/shark/SharkLog.kt
+++ b/shark-log/src/main/java/shark/SharkLog.kt
@@ -18,7 +18,7 @@ object SharkLog {
     /**
      * Logs a [Throwable] and debug message formatted with the passed in arguments.
      */
-    fun e(throwable: Throwable, message: String)
+    fun d(throwable: Throwable, message: String)
   }
 
   @Volatile var logger: Logger? = null
@@ -33,11 +33,11 @@ object SharkLog {
   }
 
   /**
-   * @see Logger.e
+   * @see Logger.d
    */
-  inline fun e(throwable: Throwable, message: () -> String) {
+  inline fun d(throwable: Throwable, message: () -> String) {
     // Local variable to prevent the ref from becoming null after the null check.
     val logger = logger ?: return
-    logger.e(throwable, message.invoke())
+    logger.d(throwable, message.invoke())
   }
 }

--- a/shark-log/src/test/java/shark/SharkLogTest.kt
+++ b/shark-log/src/test/java/shark/SharkLogTest.kt
@@ -1,0 +1,42 @@
+package shark
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.SharkLog.Logger
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class SharkLogTest {
+
+  @Test fun `logging works when logger is set`() {
+
+    val outputStream = ByteArrayOutputStream()
+    val printStream = PrintStream(outputStream)
+
+    SharkLog.logger = object : Logger {
+      override fun d(message: String) = printStream.print(message)
+      override fun e(throwable: Throwable, message: String) = printStream.print("$message+${throwable.message}")
+    }
+
+    //Test debug logging
+    SharkLog.d { "Test debug" }
+    assertThat(outputStream.toString()).isEqualTo("Test debug")
+
+    outputStream.reset()
+
+    //Test error logging
+    SharkLog.e(Exception("Test exception")) { "Test error" }
+    assertThat(outputStream.toString()).isEqualTo("Test error+Test exception")
+  }
+
+  @Test fun `logging is no-op without logger and string is ignored`() {
+
+    SharkLog.logger = null
+
+    //Logging message will throw an exception when attempting to use it
+    //But since it's in lambda string will not be accessed
+    SharkLog.d { "".substring(1) }
+
+    SharkLog.e(Exception("Test exception")) { "".substring(1) }
+  }
+}

--- a/shark-log/src/test/java/shark/SharkLogTest.kt
+++ b/shark-log/src/test/java/shark/SharkLogTest.kt
@@ -8,35 +8,38 @@ import java.io.PrintStream
 
 class SharkLogTest {
 
+  private class StreamLogger(private val stream: PrintStream) : Logger {
+    override fun d(message: String) = stream.print(message)
+    override fun d(throwable: Throwable, message: String) = stream.print("$message ${throwable.message}")
+  }
+
   @Test fun `logging works when logger is set`() {
-
     val outputStream = ByteArrayOutputStream()
-    val printStream = PrintStream(outputStream)
 
-    SharkLog.logger = object : Logger {
-      override fun d(message: String) = printStream.print(message)
-      override fun e(throwable: Throwable, message: String) = printStream.print("$message+${throwable.message}")
-    }
+    SharkLog.logger = StreamLogger(PrintStream(outputStream))
 
-    //Test debug logging
+    // Test debug logging
     SharkLog.d { "Test debug" }
     assertThat(outputStream.toString()).isEqualTo("Test debug")
+  }
 
-    outputStream.reset()
+  @Test fun `logging with exception works when logger is set`() {
+    val outputStream = ByteArrayOutputStream()
 
-    //Test error logging
-    SharkLog.e(Exception("Test exception")) { "Test error" }
-    assertThat(outputStream.toString()).isEqualTo("Test error+Test exception")
+    SharkLog.logger = StreamLogger(PrintStream(outputStream))
+
+    // Test error logging
+    SharkLog.d(Exception("Test exception")) { "Test error" }
+    assertThat(outputStream.toString()).isEqualTo("Test error Test exception")
   }
 
   @Test fun `logging is no-op without logger and string is ignored`() {
-
     SharkLog.logger = null
 
-    //Logging message will throw an exception when attempting to use it
-    //But since it's in lambda string will not be accessed
+    // Logging message will throw an exception when attempting to use it
+    // But since it's in lambda string will not be accessed
     SharkLog.d { "".substring(1) }
 
-    SharkLog.e(Exception("Test exception")) { "".substring(1) }
+    SharkLog.d(Exception("Test exception")) { "".substring(1) }
   }
 }

--- a/shark/src/main/java/shark/ObjectInspectors.kt
+++ b/shark/src/main/java/shark/ObjectInspectors.kt
@@ -40,10 +40,10 @@ enum class ObjectInspectors : ObjectInspector {
           }
 
           if (heapDumpUptimeMillis == null) {
-            SharkLog.d(
+            SharkLog.d {
                 "leakcanary.KeyedWeakReference.heapDumpUptimeMillis field not found, " +
                     "this must be a heap dump from an older version of LeakCanary."
-            )
+            }
           }
 
           val addedToContext: List<KeyedWeakReferenceMirror> = graph.instances

--- a/shark/src/main/java/shark/internal/PathFinder.kt
+++ b/shark/src/main/java/shark/internal/PathFinder.kt
@@ -306,10 +306,9 @@ internal class PathFinder(
           // See https://github.com/square/leakcanary/issues/1516
           val objectExists = graph.objectExists(gcRoot.id)
           if (!objectExists) {
-            SharkLog.d(
-                "%s gc root ignored because it's pointing to unknown object @%s",
-                gcRoot::class.java.simpleName, gcRoot.id
-            )
+            SharkLog.d {
+                "${gcRoot::class.java.simpleName} gc root ignored because it's pointing to unknown object @${gcRoot.id}"
+            }
           }
           objectExists
         }
@@ -429,7 +428,7 @@ internal class PathFinder(
         if (!this) {
           // dalvik.system.PathClassLoader.runtimeInternalObjects references objects which don't
           // otherwise exist in the heap dump.
-          SharkLog.d("Invalid Hprof? Found unknown object id $objectId")
+          SharkLog.d { "Invalid Hprof? Found unknown object id $objectId" }
         }
       }
     }


### PR DESCRIPTION
Resolves #1548 

- Replaced `SharkLog.d()` method with one with lambda parameter. 
- Replaced `SharkLog.d(exception)` with `SharkLog.e(exception)`
- Replaced usage of args with Kotlin's String Template
- Added simple test for `SharkLog` 