### PR TITLE
Gradle Build Improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,8 @@ POM_DEVELOPER_ID=square
 POM_DEVELOPER_NAME=Square, Inc.
 
 android.useAndroidX=true
+
+#Gradle properties: https://docs.gradle.org/current/userguide/build_environment.html
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I was running [Gradle Build Scan](https://scans.gradle.com/) and noticed various possible improvements.

- **Updated Gradle to 5.6.1** - minor fixes, last update to 5.x

- Enabled the following settings:
  - **Build cache** - allows reusing previous build artifacts. Can speed up builds a lot, very useful when switching branches.  
  - **Parallel execution** - makes building subprojects in parallel more efficient. Clean `gradlew build` execution time went down from 3 minutes to 2. See [BEFORE](https://gradle.com/s/dhge4eq22k4lq) and [AFTER](https://scans.gradle.com/s/mzyft37gmynuo/)
  - **Configuration on demand** - prevents configuring unrelated subprojects. E.g. running `detekt` on `shark-graph` will no longer trigger configuring `leakcanary-xxx` modules.

Overall, builds should become faster, especially incremental changes and builds when switching branches, since now the artifacts will be reused.
I still want to play around with JVM configuration for Gradlew Daemon: mine was killed due to low memory, so, perhaps, the default setting is not enough

Another thing that requires investigation is Travis configuration. Normally, CI might benefit from NOT using Gradle Daemon, as it will get disposed when build finishes. Same for using local build cache - it might be better to disable it. Does Travis use 'single-use' containers, like Docker on something, or is it same environment between multiple builds?