### PR TITLE
Fixes the primitive array dump record skipping

### DIFF
--- a/shark-hprof/src/main/java/shark/HprofReader.kt
+++ b/shark-hprof/src/main/java/shark/HprofReader.kt
@@ -947,7 +947,7 @@ class HprofReader constructor(
     skip(identifierByteSize + INT_SIZE)
     val arrayLength = readInt()
     val type = readUnsignedByte()
-    skip(identifierByteSize + arrayLength * typeSize(type))
+    skip(arrayLength * typeSize(type))
   }
 
   private fun readHeapDumpInfoRecord(): HeapDumpInfoRecord {

--- a/shark-hprof/src/main/java/shark/HprofReader.kt
+++ b/shark-hprof/src/main/java/shark/HprofReader.kt
@@ -213,7 +213,9 @@ class HprofReader constructor(
         HEAP_DUMP, HEAP_DUMP_SEGMENT -> {
           val heapDumpStart = position
           var previousTag = 0
+          var previousTagPosition = 0L
           while (position - heapDumpStart < length) {
+            val heapDumpTagPosition = position
             val heapDumpTag = readUnsignedByte()
 
             when (heapDumpTag) {
@@ -491,10 +493,11 @@ class HprofReader constructor(
                 }
               }
               else -> throw IllegalStateException(
-                  "Unknown tag $heapDumpTag after $previousTag"
+                  "Unknown tag ${"0x%02x".format(heapDumpTag)} at $heapDumpTagPosition after ${"0x%02x".format(previousTag)} at $previousTagPosition"
               )
             }
             previousTag = heapDumpTag
+            previousTagPosition = heapDumpTagPosition
           }
         }
         HEAP_DUMP_END -> {

--- a/shark-hprof/src/test/java/HeapDumpRule.kt
+++ b/shark-hprof/src/test/java/HeapDumpRule.kt
@@ -1,0 +1,33 @@
+import com.sun.management.HotSpotDiagnosticMXBean
+import org.junit.rules.ExternalResource
+import org.junit.rules.TemporaryFolder
+
+import java.io.File
+import java.io.IOException
+import java.lang.management.ManagementFactory
+import java.util.UUID
+
+class HeapDumpRule : ExternalResource() {
+    private val temporaryFolder = TemporaryFolder()
+
+    @Throws(Throwable::class)
+    override fun before() {
+        temporaryFolder.create()
+    }
+
+    override fun after() {
+        temporaryFolder.delete()
+    }
+
+    @Throws(IOException::class)
+    fun dumpHeap(): File {
+        val hotSpotDiag = ManagementFactory.newPlatformMXBeanProxy(
+                ManagementFactory.getPlatformMBeanServer(),
+                "com.sun.management:type=HotSpotDiagnostic",
+                HotSpotDiagnosticMXBean::class.java
+        )
+        val hprof = File(temporaryFolder.root, "heapDump" + UUID.randomUUID() + ".hprof")
+        hotSpotDiag.dumpHeap(hprof.absolutePath, true)
+        return hprof
+    }
+}

--- a/shark-hprof/src/test/java/HprofReaderPrimitiveArrayTest.kt
+++ b/shark-hprof/src/test/java/HprofReaderPrimitiveArrayTest.kt
@@ -1,0 +1,45 @@
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import shark.Hprof
+import shark.HprofRecord
+import shark.OnHprofRecordListener
+import kotlin.text.Charsets.UTF_8
+
+class HprofReaderPrimitiveArrayTest {
+
+    @get:Rule
+    var heapDumpRule = HeapDumpRule()
+
+    @Test
+    fun skips_primitive_arrays_correctly() {
+        val heapDump = heapDumpRule.dumpHeap()
+
+        Hprof.open(heapDump).use { hprof ->
+            hprof.reader.readHprofRecords(
+                    emptySet(), // skip everything including primitive arrays
+                    OnHprofRecordListener { _, _ -> })
+        }
+    }
+
+    @Test
+    fun reads_primitive_arrays_correctly() {
+        val byteArray = "mybytes".toByteArray(UTF_8)
+
+        val heapDump = heapDumpRule.dumpHeap()
+
+        var myByteArrayIsInHeapDump = false
+        Hprof.open(heapDump).use { hprof ->
+            hprof.reader.readHprofRecords(
+                    setOf(HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord::class),
+                    OnHprofRecordListener { _, record ->
+                        if (record is HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ByteArrayDump) {
+                            if (byteArray.contentEquals(record.array)) {
+                                myByteArrayIsInHeapDump = true
+                            }
+                        }
+                    })
+        }
+        assertThat(myByteArrayIsInHeapDump).isTrue()
+    }
+}


### PR DESCRIPTION
The skip method inadvertently adds an identifier size, which is not possible with a primitive array. This had the effect to advance too much in the hprof file, and as such make the parsing fail for the next heap dump tag.

This code introduces tests that verify the change work. And improves a bit the error reporting in case on unknown tag is found.