### PR TITLE
Ref patterns for native global variables

### DIFF
--- a/shark/src/main/java/shark/HeapAnalyzer.kt
+++ b/shark/src/main/java/shark/HeapAnalyzer.kt
@@ -48,7 +48,7 @@ import shark.internal.PathFinder
 import shark.internal.PathFinder.PathFindingResults
 import shark.internal.ReferencePathNode
 import shark.internal.ReferencePathNode.ChildNode
-import shark.internal.ReferencePathNode.ChildNode.LibraryLeakNode
+import shark.internal.ReferencePathNode.LibraryLeakNode
 import shark.internal.ReferencePathNode.RootNode
 import shark.internal.lastSegment
 import java.io.File
@@ -353,7 +353,7 @@ class HeapAnalyzer constructor(
       val className =
         recordClassName(graph.findObjectById(pathNode.objectId))
 
-      val firstLibraryLeakNode =
+      val firstLibraryLeakNode = if (rootNode is LibraryLeakNode) rootNode else
         shortestChildPath.firstOrNull { it is LibraryLeakNode } as LibraryLeakNode?
 
       if (firstLibraryLeakNode != null) {

--- a/shark/src/main/java/shark/ReferencePattern.kt
+++ b/shark/src/main/java/shark/ReferencePattern.kt
@@ -46,4 +46,10 @@ sealed class ReferencePattern : Serializable {
       return "instance field $className#$fieldName"
     }
   }
+
+  data class NativeGlobalVariablePattern(val className: String) : ReferencePattern() {
+    override fun toString(): String {
+      return "native global variable referencing $className"
+    }
+  }
 }

--- a/shark/src/main/java/shark/internal/ReferencePathNode.kt
+++ b/shark/src/main/java/shark/internal/ReferencePathNode.kt
@@ -7,10 +7,25 @@ import shark.LibraryLeakReferenceMatcher
 internal sealed class ReferencePathNode {
   abstract val objectId: Long
 
-  class RootNode(
-    val gcRoot: GcRoot,
-    override val objectId: Long
-  ) : ReferencePathNode()
+  interface LibraryLeakNode {
+    val matcher: LibraryLeakReferenceMatcher
+  }
+
+  sealed class RootNode : ReferencePathNode() {
+    abstract val gcRoot: GcRoot
+
+    class LibraryLeakRootNode(
+      override val objectId: Long,
+      override val gcRoot: GcRoot,
+      override val matcher: LibraryLeakReferenceMatcher
+    ) : RootNode(), LibraryLeakNode
+
+    class NormalRootNode(
+      override val objectId: Long,
+      override val gcRoot: GcRoot
+    ) : RootNode()
+
+  }
 
   sealed class ChildNode : ReferencePathNode() {
 
@@ -21,12 +36,12 @@ internal sealed class ReferencePathNode {
      */
     abstract val referenceFromParent: LeakReference
 
-    class LibraryLeakNode(
+    class LibraryLeakChildNode(
       override val objectId: Long,
       override val parent: ReferencePathNode,
       override val referenceFromParent: LeakReference,
-      val matcher: LibraryLeakReferenceMatcher
-    ) : ChildNode()
+      override val matcher: LibraryLeakReferenceMatcher
+    ) : ChildNode(), LibraryLeakNode
 
     class NormalNode(
       override val objectId: Long,


### PR DESCRIPTION
Leaks are often caused by native global variables holding references to live objects. On Android this is super common due to the IPC mechanism holding on to instances until the stub in the other process is garbage collected.

Fixes #1562