### PR TITLE
Update AssistStructure ref matcher to API 28

### DIFF
--- a/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -523,7 +523,7 @@ enum class AndroidReferenceMatchers {
               " on the screen. TextView.ChangeWatcher and android.widget.Editor end up in spans and" +
               " typically hold on to the view hierarchy"
       ) {
-        sdkInt in 24..27
+        sdkInt in 24..28
       }
     }
   },


### PR DESCRIPTION
Fixes #1573 which reports this happens on Android 9 as well.