### PR TITLE
Profiler CPU Sampling hook

### DIFF
--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
@@ -30,7 +30,7 @@ class ProfiledTest {
         .copyTo(FileOutputStream(heapDumpFile))
 
     SharkLog.d { "Waiting, please start profiler" }
-    Thread.sleep(20000)
+    Profiler.waitForSamplingStart()
 
     val analyzer = HeapAnalyzer(object : OnAnalysisProgressListener {
       override fun onAnalysisProgress(step: Step) {
@@ -46,7 +46,7 @@ class ProfiledTest {
     )
     SharkLog.d { result.toString() }
     // Giving time to stop CPU profiler (otherwise trace won't succeed)
-    Thread.sleep(20000)
+    Profiler.waitForSamplingStop()
   }
 
 }

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
@@ -1,14 +1,13 @@
 package leakcanary
 
-import android.util.Log
+import shark.SharkLog
 
 /**
  * Helper class for working with Android Studio's Profiler
  */
 internal object Profiler {
-  private const val SLEEP_TIME = 1000L
+  private const val SLEEP_TIME_MILLIS = 1000L
   private const val SAMPLING_THREAD_NAME = "Sampling Profiler"
-  private const val TAG = "Profiler"
 
   /**
    * Wait until Profiler is attached and CPU Sampling is started.
@@ -17,10 +16,10 @@ internal object Profiler {
    * Note: only works with 'Sample Java Methods' profiling, won't work with 'Trace Java Methods'!
    */
   fun waitForSamplingStart() {
-    Log.d(TAG, "Waiting for sampling to start. Go to Profiler -> CPU -> Record")
+    SharkLog.d { "Waiting for sampling to start. Go to Profiler -> CPU -> Record" }
     sleepUntil { samplingThreadExists() }
-    Thread.sleep(SLEEP_TIME) //Wait a bit more to ensure profiler started sampling
-    Log.d(TAG, "Sampling started! Proceeding...")
+    Thread.sleep(SLEEP_TIME_MILLIS) //Wait a bit more to ensure profiler started sampling
+    SharkLog.d { "Sampling started! Proceeding..." }
   }
 
 
@@ -30,14 +29,14 @@ internal object Profiler {
    * profiler.
    */
   fun waitForSamplingStop() {
-    Log.d(TAG, "Waiting for sampling to stop. Go to Profiler -> CPU -> Stop recording")
+    SharkLog.d { "Waiting for sampling to stop. Go to Profiler -> CPU -> Stop recording" }
     sleepUntil { !samplingThreadExists() }
-    Log.d(TAG, "Sampling stopped! Proceeding...")
+    SharkLog.d { "Sampling stopped! Proceeding..." }
   }
 
   private inline fun sleepUntil(condition: () -> Boolean) {
     while (true) {
-      if (condition()) return else Thread.sleep(SLEEP_TIME)
+      if (condition()) return else Thread.sleep(SLEEP_TIME_MILLIS)
     }
   }
 

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
@@ -1,0 +1,60 @@
+package leakcanary
+
+import android.util.Log
+
+/**
+ * Helper class for working with Android Studio's Profiler
+ */
+internal object Profiler {
+  private const val SLEEP_TIME = 1000L
+  private const val SAMPLING_THREAD_NAME = "Sampling Profiler"
+  private const val TAG = "Profiler"
+
+  /**
+   * Wait until Profiler is attached and CPU Sampling is started.
+   * Calling this on main thread can lead to ANR if you try to interact with UI while it's waiting for
+   * profiler.
+   * Note: only works with 'Sample Java Methods' profiling, won't work with 'Trace Java Methods'!
+   */
+  fun waitForSamplingStart() {
+    Log.d(TAG, "Waiting for sampling to start. Go to Profiler -> CPU -> Record")
+    sleepUntil { samplingThreadExists() }
+    Thread.sleep(SLEEP_TIME) //Wait a bit more to ensure profiler started sampling
+    Log.d(TAG, "Sampling started! Proceeding...")
+  }
+
+
+  /**
+   * Wait until CPU Sampling stops.
+   * Calling this on main thread can lead to ANR if you try to interact with UI while it's waiting for
+   * profiler.
+   */
+  fun waitForSamplingStop() {
+    Log.d(TAG, "Waiting for sampling to stop. Go to Profiler -> CPU -> Stop recording")
+    sleepUntil { !samplingThreadExists() }
+    Log.d(TAG, "Sampling stopped! Proceeding...")
+  }
+
+  private inline fun sleepUntil(condition: () -> Boolean) {
+    while (true) {
+      if (condition()) return else Thread.sleep(SLEEP_TIME)
+    }
+  }
+
+  private fun samplingThreadExists() = findThread(SAMPLING_THREAD_NAME) != null
+
+  /**
+   * Utility to get thread by its name; in case of multiple matches first one will be returned.
+   */
+  private fun findThread(threadName: String): Thread? {
+    // Based on https://stackoverflow.com/a/1323480
+    var rootGroup = Thread.currentThread().threadGroup
+    while (rootGroup.parent != null) rootGroup = rootGroup.parent
+
+    var threads = arrayOfNulls<Thread>(rootGroup.activeCount())
+    while (rootGroup.enumerate(threads, true) == threads.size) {
+      threads = arrayOfNulls(threads.size * 2)
+    }
+    return threads.firstOrNull { it?.name == threadName }
+  }
+}


### PR DESCRIPTION
Added Profiler utility with hooks for CPU sampling. 
Use `Profiler.waitForSamplingStart()` and `Profiler.waitForSamplingStop()`