### PR TITLE
Disabled dynamic shortcuts for Instant Apps

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -121,6 +121,10 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
     if (!application.resources.getBoolean(R.bool.leak_canary_add_dynamic_shortcut)) {
       return
     }
+    if (VERSION.SDK_INT >= VERSION_CODES.O && application.packageManager.isInstantApp) {
+      // Instant Apps don't have access to ShortcutManager
+      return
+    }
 
     val shortcutManager = application.getSystemService(ShortcutManager::class.java)!!
     val dynamicShortcuts = shortcutManager.dynamicShortcuts


### PR DESCRIPTION
Fixes #1612 
Instant Apps don't have access to the Shortcut Manager service (there are no app icons at all), so we need to disable those.

Ref:
`Context.getSystemService()`
https://developer.android.com/reference/android/content/Context#getSystemService(java.lang.String)

> Note: Instant apps, for which PackageManager#isInstantApp() returns true, don't have access to the following system services: DEVICE_POLICY_SERVICE, FINGERPRINT_SERVICE, KEYGUARD_SERVICE, SHORTCUT_SERVICE, USB_SERVICE, WALLPAPER_SERVICE, WIFI_P2P_SERVICE, WIFI_SERVICE, WIFI_AWARE_SERVICE. For these services this method will return null. Generally, if you are running as an instant app you should always check whether the result of this method is null.