### PR TITLE
ISSUE_TEMPLATE: Correct link to FAQ page

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-sdk.md
+++ b/.github/ISSUE_TEMPLATE/5-sdk.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Read this first: https://github.com/square/leakcanary#can-a-leak-be-caused-by-the-android-sdk
+Read this first: https://square.github.io/leakcanary/faq/#can-a-leak-be-caused-by-the-android-sdk
 
 ### LeakTrace information
 


### PR DESCRIPTION
Documentation was moved to square.github.io/faq but this link went unnoticed.