### PR TITLE
Add ability to customize class used to detect tests

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -44,9 +44,13 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
   var applicationVisible = false
     private set
 
-  private val isJunitAvailable by lazy {
+  private val testClassName by lazy {
+    application.getString(R.string.leak_canary_test_class_name)
+  }
+
+  private val isRunningTests by lazy {
     try {
-      Class.forName("org.junit.Test")
+      Class.forName(testClassName)
       true
     } catch (e: Exception) {
       false
@@ -104,8 +108,8 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
     // This is called before Application.onCreate(), so if the class is loaded through a secondary
     // dex it might not be available yet.
     Handler().post {
-      if (isJunitAvailable) {
-        SharkLog.d { "JUnit detected in classpath, app is running tests => disabling heap dumping & analysis " }
+      if (isRunningTests) {
+        SharkLog.d { "$testClassName detected in classpath, app is running tests => disabling heap dumping & analysis" }
         LeakCanary.config = LeakCanary.config.copy(dumpHeap = false)
       }
     }

--- a/leakcanary-android-core/src/main/res/values/leak_canary_public.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_public.xml
@@ -16,10 +16,10 @@
   -->
 <resources>
 
+  <public name="leak_canary_add_dynamic_shortcut" type="bool"/>
+  <public name="leak_canary_add_launcher_icon" type="bool"/>
   <public name="leak_canary_display_activity_label" type="string"/>
   <public name="leak_canary_heap_dump_toast" type="layout"/>
   <public name="leak_canary_icon" type="mipmap"/>
-  <public name="leak_canary_add_dynamic_shortcut" type="bool"/>
-  <public name="leak_canary_add_launcher_icon" type="bool"/>
-
+  <public name="leak_canary_test_class_name" type="string"/>
 </resources>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -84,4 +84,5 @@
   <string name="leak_canary_import_hprof_file">Import Heap Dump</string>
   <string name="leak_canary_options_menu_render_heap_dump">Render Heap Dump</string>
   <string name="leak_canary_help_title">Tap here to learn more</string>
+  <string name="leak_canary_test_class_name" translatable="false">org.junit.Test</string>
 </resources>


### PR DESCRIPTION
Developers should not ship JUnit in their app, even in debug. However, some debug libraries unfortunately ship with JUnit as a dependency (e.g. see https://github.com/square/okhttp/issues/4667).

Developers can change the default to target a different class (e.g assertj) to help LeakCanary detect unit tests, by overriding a public string:

```
  <string name="leak_canary_test_class_name">org.assertj.core.api.Assertions</string>
```

Fixes #1649