### PR TITLE
Save resource ids into heap dump

### DIFF
--- a/shark-android/build.gradle
+++ b/shark-android/build.gradle
@@ -11,7 +11,10 @@ dependencies {
 
   testImplementation deps.assertj_core
   testImplementation deps.junit
+  testImplementation deps.mockito
+  testImplementation deps.mockito_kotlin
   testImplementation deps.okio
+  testImplementation project(':shark-test')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
+++ b/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
@@ -96,8 +96,14 @@ enum class AndroidObjectInspectors : ObjectInspector {
           labels += "View#mAttachInfo is not null (view attached)"
         }
 
-        // TODO Add back support for view id labels, see https://github.com/square/leakcanary/issues/1297
-
+        AndroidResourceIdNames.readFromHeap(instance.graph)?.let { resIds ->
+         val mID = instance["android.view.View", "mID"]!!.value.asInt!!
+          val noViewId = -1
+          if (mID != noViewId) {
+            val resourceName = resIds[mID]
+            labels += "View.mID = R.id.$resourceName"
+          }
+        }
         labels += "View.mWindowAttachCount = $mWindowAttachCount"
       }
     }

--- a/shark-android/src/main/java/shark/AndroidResourceIdNames.kt
+++ b/shark-android/src/main/java/shark/AndroidResourceIdNames.kt
@@ -1,0 +1,99 @@
+package shark
+
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.IntArrayDump
+
+class AndroidResourceIdNames private constructor(
+  private val resourceIds: IntArray,
+  private val names: Array<String>
+) {
+
+  operator fun get(id: Int): String? {
+    val indexOfId = resourceIds.binarySearch(id)
+    return if (indexOfId >= 0) {
+      names[indexOfId]
+    } else {
+      null
+    }
+  }
+
+  companion object {
+
+    internal const val FIRST_APP_RESOURCE_ID = 0x7F010000
+    internal const val RESOURCE_ID_TYPE_ITERATOR = 0x00010000
+
+    @Volatile
+    @JvmStatic
+    private var holderField: AndroidResourceIdNames? = null
+
+    /**
+     * @param getResourceTypeName a function that delegates to Android
+     * Resources.getResourceTypeName but returns null when the name isn't found instead of
+     * throwing an exception.
+     *
+     * @param getResourceEntryName a function that delegates to Android
+     * Resources.getResourceEntryName but returns null when the name isn't found instead of
+     * throwing an exception.
+     */
+    @Synchronized fun saveToMemory(
+      getResourceTypeName: (Int) -> String?,
+      getResourceEntryName: (Int) -> String?
+    ) {
+      if (holderField != null) {
+        return
+      }
+
+      // This is based on https://jebware.com/blog/?p=600 which itself is based on
+      // https://stackoverflow.com/a/6646113/703646
+
+      val idToNamePairs = mutableListOf<Pair<Int, String>>()
+      findIdTypeResourceIdStart(getResourceTypeName)?.let { idTypeResourceIdStart ->
+        var resourceId = idTypeResourceIdStart
+        while (true) {
+          val entry = getResourceEntryName(resourceId) ?: break
+          idToNamePairs += resourceId to entry
+          resourceId++
+        }
+      }
+      val resourceIds = idToNamePairs.map { it.first }
+          .toIntArray()
+      val names = idToNamePairs.map { it.second }
+          .toTypedArray()
+      holderField = AndroidResourceIdNames(resourceIds, names)
+    }
+
+    private fun findIdTypeResourceIdStart(getResourceTypeName: (Int) -> String?): Int? {
+      var resourceTypeId = FIRST_APP_RESOURCE_ID
+      while (true) {
+        when (getResourceTypeName(resourceTypeId)) {
+          null -> return null
+          "id" -> return resourceTypeId
+          else -> resourceTypeId += RESOURCE_ID_TYPE_ITERATOR
+        }
+      }
+    }
+
+    fun readFromHeap(graph: HeapGraph): AndroidResourceIdNames? {
+      return graph.context.getOrPut(AndroidResourceIdNames::class.java.name) {
+        val className = AndroidResourceIdNames::class.java.name
+        val holderClass = graph.findClassByName(className)
+        holderClass?.let {
+          val holderField = holderClass["holderField"]!!
+          holderField.valueAsInstance?.let { instance ->
+            val resourceIds =
+              (instance[className, "resourceIds"]!!.valueAsPrimitiveArray!!.readRecord() as IntArrayDump).array
+            val names = instance[className, "names"]!!.valueAsObjectArray!!.readElements()
+                .map { it.readAsJavaString()!! }
+                .toList()
+                .toTypedArray()
+            AndroidResourceIdNames(resourceIds, names)
+          }
+        }
+      }
+    }
+
+    internal fun resetForTests() {
+      holderField = null
+    }
+  }
+
+}

--- a/shark-android/src/test/java/shark/AndroidResourceIdNamesTest.kt
+++ b/shark-android/src/test/java/shark/AndroidResourceIdNamesTest.kt
@@ -1,0 +1,148 @@
+package shark
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.AndroidResourceIdNames.Companion.FIRST_APP_RESOURCE_ID
+import shark.AndroidResourceIdNames.Companion.RESOURCE_ID_TYPE_ITERATOR
+import java.io.File
+
+class AndroidResourceIdNamesTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Before fun setUp() {
+    AndroidResourceIdNames.resetForTests()
+  }
+
+  @After fun tearDown() {
+    AndroidResourceIdNames.resetForTests()
+  }
+
+  @Test fun `saveToMemory call is cached`() {
+    val getResourceTypeName: (Int) -> String? = mock()
+
+    for (i in 0..2) {
+      AndroidResourceIdNames.saveToMemory(
+          getResourceTypeName = getResourceTypeName,
+          getResourceEntryName = { null }
+      )
+    }
+
+    verify(getResourceTypeName).invoke(any())
+  }
+
+  @Test fun `AndroidResourceIdNames available in heap dump when saveToMemory is called`() {
+    AndroidResourceIdNames.saveToMemory(
+        getResourceTypeName = { null }, getResourceEntryName = { null })
+
+    dumpAndReadHeap { resIdNames ->
+      assertThat(resIdNames).isNotNull
+    }
+  }
+
+  @Test fun `AndroidResourceIdNames not available in heap dump when saveToMemory is not called`() {
+    dumpAndReadHeap { resIdNames ->
+      assertThat(resIdNames).isNull()
+    }
+  }
+
+
+  @Test fun `saveToMemory stores and retrieves resource id`() {
+    val firstIdResourceId = FIRST_APP_RESOURCE_ID
+
+    val getResourceTypeName =
+      createGetResourceTypeName(mapOf(firstIdResourceId to "id"))
+
+    val getResourceEntryName =
+      createGetResourceEntryName(mapOf(FIRST_APP_RESOURCE_ID to "view_container"))
+
+    AndroidResourceIdNames.saveToMemory(getResourceTypeName, getResourceEntryName)
+
+    dumpAndReadHeap { resIdNames ->
+      assertThat(resIdNames!![firstIdResourceId]).isEqualTo("view_container")
+    }
+  }
+
+  @Test fun `id type starts after layout`() {
+    val layoutResourceId = FIRST_APP_RESOURCE_ID
+    val firstIdResourceId = layoutResourceId + RESOURCE_ID_TYPE_ITERATOR
+
+    val getResourceTypeName =
+      createGetResourceTypeName(
+          mapOf(
+              layoutResourceId to "layout",
+              firstIdResourceId to "id"
+          )
+      )
+    val getResourceEntryName =
+      createGetResourceEntryName(mapOf(firstIdResourceId to "view_container"))
+
+    AndroidResourceIdNames.saveToMemory(getResourceTypeName, getResourceEntryName)
+
+    dumpAndReadHeap { resIdNames ->
+      assertThat(resIdNames!![firstIdResourceId]).isEqualTo("view_container")
+    }
+  }
+
+  @Test fun `two consecutive id resource ids`() {
+    val firstIdResourceId = FIRST_APP_RESOURCE_ID
+    val secondIdResourceId = FIRST_APP_RESOURCE_ID + 1
+
+    val getResourceTypeName =
+      createGetResourceTypeName(
+          mapOf(
+              firstIdResourceId to "id"
+          )
+      )
+    val getResourceEntryName = createGetResourceEntryName(
+        mapOf(
+            firstIdResourceId to "view_container",
+            secondIdResourceId to "menu_button"
+        )
+    )
+
+    AndroidResourceIdNames.saveToMemory(getResourceTypeName, getResourceEntryName)
+
+    dumpAndReadHeap { resIdNames ->
+      assertThat(resIdNames!![secondIdResourceId]).isEqualTo("menu_button")
+    }
+  }
+
+  private fun createGetResourceEntryName(resourceIdMap: Map<Int, String>): (Int) -> String? {
+    val getResourceEntryName: (Int) -> String? = mock()
+    resourceIdMap.forEach { (resourceId, resourceName) ->
+      whenever(getResourceEntryName.invoke(resourceId)).thenReturn(resourceName)
+    }
+    return getResourceEntryName
+  }
+
+  private fun createGetResourceTypeName(resourceIdMap: Map<Int, String>): (Int) -> String? {
+    val getResourceTypeName: (Int) -> String? = mock()
+    resourceIdMap.forEach { (resourceId, resourceName) ->
+      whenever(getResourceTypeName.invoke(resourceId)).thenReturn(resourceName)
+    }
+    return getResourceTypeName
+  }
+
+  fun dumpAndReadHeap(block: (AndroidResourceIdNames?) -> Unit) {
+    val hprofFolder = testFolder.newFolder()
+    val hprofFile = File(hprofFolder, "heapdump.hprof")
+    JvmTestHeapDumper.dumpHeap(hprofFile.absolutePath)
+    Hprof.open(hprofFile)
+        .use { hprof ->
+          val graph = HprofHeapGraph.indexHprof(hprof)
+          val idNames = AndroidResourceIdNames.readFromHeap(graph)
+          block(idNames)
+        }
+  }
+
+}

--- a/shark-graph/src/main/java/shark/GraphContext.kt
+++ b/shark-graph/src/main/java/shark/GraphContext.kt
@@ -5,7 +5,7 @@ package shark
  * This is a simple [MutableMap] of [String] to [Any], but with unsafe generics access.
  */
 class GraphContext {
-  private val store = mutableMapOf<String, Any>()
+  private val store = mutableMapOf<String, Any?>()
   operator fun <T> get(key: String): T? {
     @Suppress("UNCHECKED_CAST")
     return store[key] as T?
@@ -20,7 +20,7 @@ class GraphContext {
   ): T {
     @Suppress("UNCHECKED_CAST")
     return store.getOrPut(key, {
-      defaultValue() as Any
+      defaultValue()
     }) as T
   }
 
@@ -31,7 +31,7 @@ class GraphContext {
     key: String,
     value: T
   ) {
-    store[key] = (value as Any)
+    store[key] = (value as Any?)
   }
 
   /**


### PR DESCRIPTION
Save resource ids into heap dump

This enables us to know the view id names when displaying a leak trace

Implementation based on a [blog article](https://jebware.com/blog/?p=600) from @jebstuart which itself is based on a [Stack Overflow answer](https://stackoverflow.com/a/6646113/703646).

Fixes #1297