### PR TITLE
Backward compatibility with Okio 1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
       mockito       : 'org.mockito:mockito-core:2.7.5',
       mockito_kotlin: 'com.nhaarman:mockito-kotlin-kt1.1:1.5.0',
       okio: 'com.squareup.okio:okio:2.2.2',
+      okio_1x: 'com.squareup.okio:okio:1.0.0',
       robolectric   : 'org.robolectric:robolectric:4.0-alpha-3',
       androidGradlePlugin: "com.android.tools.build:gradle:3.5.2"
   ]

--- a/shark-hprof/build.gradle
+++ b/shark-hprof/build.gradle
@@ -8,7 +8,14 @@ dependencies {
   api project(':shark-log')
 
   implementation deps.kotlin.stdlib
-  implementation deps.okio
+  // compileOnly ensures this dependency is not exposed through this artifact's pom.xml in Maven Central.
+  // Okio is a required dependency, but we're making it required on the "shark" artifact which is the main artifact that
+  // should generally be used. The shark artifact depends on Okio 2.x (ensure compatibility with modern Okio). Depending on 1.x here
+  // enables us to ensure binary compatibility with Okio 1.x and allow us to use the deprecated (error level) Okio APIs to keep that
+  // compatibility.
+  // See https://github.com/square/leakcanary/issues/1624
+  compileOnly deps.okio_1x
+  testImplementation deps.okio_1x
 
   testImplementation deps.assertj_core
   testImplementation deps.junit

--- a/shark-hprof/src/main/java/shark/Hprof.kt
+++ b/shark-hprof/src/main/java/shark/Hprof.kt
@@ -1,8 +1,7 @@
 package shark
 
 import okio.BufferedSource
-import okio.buffer
-import okio.source
+import okio.Okio
 import shark.Hprof.Companion.open
 import java.io.Closeable
 import java.io.File
@@ -40,7 +39,7 @@ class Hprof private constructor(
     if (currentPosition == newPosition) {
       return
     }
-    source.buffer.clear()
+    source.buffer().clear()
     channel.position(newPosition)
     reader.position = newPosition
   }
@@ -71,8 +70,7 @@ class Hprof private constructor(
       }
       val inputStream = hprofFile.inputStream()
       val channel = inputStream.channel
-      val source = inputStream.source()
-          .buffer()
+      val source = Okio.buffer(Okio.source(inputStream))
 
       val endOfVersionString = source.indexOf(0)
       val versionName = source.readUtf8(endOfVersionString)

--- a/shark-hprof/src/main/java/shark/HprofWriter.kt
+++ b/shark-hprof/src/main/java/shark/HprofWriter.kt
@@ -2,8 +2,7 @@ package shark
 
 import okio.Buffer
 import okio.BufferedSink
-import okio.buffer
-import okio.sink
+import okio.Okio
 import shark.GcRoot.Debugger
 import shark.GcRoot.Finalizing
 import shark.GcRoot.InternedString
@@ -389,13 +388,13 @@ class HprofWriter private constructor(
   ) {
     flushHeapBuffer()
     workBuffer.block()
-    writeTagHeader(tag, workBuffer.size)
+    writeTagHeader(tag, workBuffer.size())
     writeAll(workBuffer)
   }
 
   private fun BufferedSink.flushHeapBuffer() {
-    if (workBuffer.size > 0) {
-      writeTagHeader(HprofReader.HEAP_DUMP, workBuffer.size)
+    if (workBuffer.size() > 0) {
+      writeTagHeader(HprofReader.HEAP_DUMP, workBuffer.size())
       writeAll(workBuffer)
       writeTagHeader(HprofReader.HEAP_DUMP_END, 0)
     }
@@ -436,9 +435,7 @@ class HprofWriter private constructor(
       /** Version of the opened hprof, which is tied to the runtime where the heap was dumped. */
       hprofVersion: HprofVersion = HprofVersion.ANDROID
     ): HprofWriter {
-      val sink = hprofFile.outputStream()
-          .sink()
-          .buffer()
+      val sink = Okio.buffer(Okio.sink(hprofFile.outputStream()))
       sink.writeUtf8(hprofVersion.versionString)
       sink.writeByte(0)
       sink.writeInt(identifierByteSize)

--- a/shark/build.gradle
+++ b/shark/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   api project(':shark-graph')
 
   implementation deps.kotlin.stdlib
+  implementation deps.okio
 
   testImplementation deps.assertj_core
   testImplementation deps.junit


### PR DESCRIPTION
LeakCanary was using APIs introduced in Okio 2.x (extension functions), which breaks any consumers that forces Okio to 1.x . This change reverts to using the 1.x APIs. Unfortunately we cannot directly compile against 2.x because the deprecated APIs have an Error deprecation level. So here the module that depends on Okio compiles against 1.x, and then its consumer module depends on 2.x so that the resolution defaults to the higher version. This has the advantage of enforcing that we write code that compiles against two versions of Okio

Fixes #1624

cc @swankjesse @JakeWharton in case you have some thoughts on this.