### PR TITLE
At most 1 heap dump a minute

### DIFF
--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -45,6 +45,7 @@
   <string name="leak_canary_notification_no_retained_object_content">Tap to dismiss</string>
   <string name="leak_canary_notification_retained_debugger_attached">Waiting for debugger to detach</string>
   <string name="leak_canary_notification_retained_dump_failed">Failed to dump heap</string>
+  <string name="leak_canary_notification_retained_dump_wait">"Last heap dump was less than a minute ago"</string>
   <string name="leak_canary_notification_retained_title">%d retained objects, tap to dump heap</string>
   <string name="leak_canary_notification_retained_visible">App visible, waiting until %d retained objects</string>
   <string name="leak_canary_share_with">Share with…</string>

--- a/shark/src/main/java/shark/HeapAnalysis.kt
+++ b/shark/src/main/java/shark/HeapAnalysis.kt
@@ -98,7 +98,7 @@ ${if (applicationLeaks.isNotEmpty()) "\n" + applicationLeaks.joinToString(
     ) + "\n" else ""}====================================
 ${libraryLeaks.size} LIBRARY LEAKS
 
-Leaks coming from the Android Framework or Google libraries.
+Library Leaks are leaks coming from the Android Framework or Google libraries.
 ${if (libraryLeaks.isNotEmpty()) "\n" + libraryLeaks.joinToString(
         "\n\n"
     ) + "\n" else ""}====================================

--- a/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
+++ b/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
@@ -64,7 +64,7 @@ class HeapAnalysisStringRenderingTest {
       |====================================
       |0 LIBRARY LEAKS
       |
-      |Leaks coming from the Android Framework or Google libraries.
+      |Library Leaks are leaks coming from the Android Framework or Google libraries.
       |====================================
       |METADATA
       |
@@ -101,7 +101,7 @@ class HeapAnalysisStringRenderingTest {
       |====================================
       |0 LIBRARY LEAKS
       |
-      |Leaks coming from the Android Framework or Google libraries.
+      |Library Leaks are leaks coming from the Android Framework or Google libraries.
       |====================================
       |METADATA
       |


### PR DESCRIPTION
* Automatic heap dumps are now rate limited to one per minute. Heap dumps can still be triggered manually by tapping the retained object notification. This should alleviate #1670 (though it won't fully make it go away)
* Also updated various pieces of the logging to provide more details about what's going on, while also logging less.