### PR TITLE
Don't crash on missing hprof file during analysis

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/LeakDirectoryProvider.kt
@@ -210,10 +210,10 @@ internal class LeakDirectoryProvider constructor(
     fun hprofDeleteReason(file: File): String {
       val path = file.absolutePath
       return when {
-        filesDeletedTooOld.contains(path) -> "Older than all other hprof files"
-        filesDeletedClearDirectory.contains(path) -> "Hprof directory cleared"
-        filesDeletedRemoveLeak.contains(path) -> "Leak manually removed"
-        else -> "Unknown"
+        filesDeletedTooOld.contains(path) -> "older than all other hprof files"
+        filesDeletedClearDirectory.contains(path) -> "hprof directory cleared"
+        filesDeletedRemoveLeak.contains(path) -> "leak manually removed"
+        else -> "unknown"
       }
     }
   }

--- a/shark/src/main/java/shark/HeapAnalyzer.kt
+++ b/shark/src/main/java/shark/HeapAnalyzer.kt
@@ -44,7 +44,6 @@ import shark.OnAnalysisProgressListener.Step.COMPUTING_RETAINED_SIZE
 import shark.OnAnalysisProgressListener.Step.EXTRACTING_METADATA
 import shark.OnAnalysisProgressListener.Step.FINDING_RETAINED_OBJECTS
 import shark.OnAnalysisProgressListener.Step.PARSING_HEAP_DUMP
-import shark.OnAnalysisProgressListener.Step.REPORTING_HEAP_ANALYSIS
 import shark.internal.PathFinder
 import shark.internal.PathFinder.PathFindingResults
 import shark.internal.ReferencePathNode
@@ -90,7 +89,6 @@ class HeapAnalyzer constructor(
 
     if (!heapDumpFile.exists()) {
       val exception = IllegalArgumentException("File does not exist: $heapDumpFile")
-      listener.onAnalysisProgress(REPORTING_HEAP_ANALYSIS)
       return HeapAnalysisFailure(
           heapDumpFile, System.currentTimeMillis(), since(analysisStartNanoTime),
           HeapAnalysisException(exception)
@@ -110,14 +108,12 @@ class HeapAnalyzer constructor(
                 graph, leakFinders, referenceMatchers, computeRetainedHeapSize, objectInspectors
             )
             val (applicationLeaks, libraryLeaks) = findLeakInput.findLeaks()
-            listener.onAnalysisProgress(REPORTING_HEAP_ANALYSIS)
             return HeapAnalysisSuccess(
                 heapDumpFile, System.currentTimeMillis(), since(analysisStartNanoTime), metadata,
                 applicationLeaks, libraryLeaks
             )
           }
     } catch (exception: Throwable) {
-      listener.onAnalysisProgress(REPORTING_HEAP_ANALYSIS)
       return HeapAnalysisFailure(
           heapDumpFile, System.currentTimeMillis(), since(analysisStartNanoTime),
           HeapAnalysisException(exception)


### PR DESCRIPTION
If the hprof file is missing, return a HeapAnalysisFailure result instead of crashing.

With #1670 we saw this could happen when a lot of leaks are detected and more than 7 heap dumps are enqueued to be processed. 3cf9c8d9dbec80c4f500e91a68b4dfdbf854299b introduced a max of 1 heap dumps per minute, so this edge case should happen less often now.

Fixes #1670