### PR TITLE
Add component name to leak description

### DIFF
--- a/leakcanary-object-watcher-android-androidx/src/main/java/leakcanary/internal/AndroidXFragmentDestroyWatcher.kt
+++ b/leakcanary-object-watcher-android-androidx/src/main/java/leakcanary/internal/AndroidXFragmentDestroyWatcher.kt
@@ -36,8 +36,8 @@ internal class AndroidXFragmentDestroyWatcher(
       val view = fragment.view
       if (view != null && configProvider().watchFragmentViews) {
         objectWatcher.watch(
-            view, "Fragment received Fragment#onDestroyView() callback " +
-            "(references to its view should be cleared to prevent leaks)"
+            view, "${fragment::class.java.name} received Fragment#onDestroyView() callback " +
+            "(references to its views should be cleared to prevent leaks)"
         )
       }
     }
@@ -47,7 +47,9 @@ internal class AndroidXFragmentDestroyWatcher(
       fragment: Fragment
     ) {
       if (configProvider().watchFragments) {
-        objectWatcher.watch(fragment, "Fragment received Fragment#onDestroy() callback")
+        objectWatcher.watch(
+            fragment, "${fragment::class.java.name} received Fragment#onDestroy() callback"
+        )
       }
     }
   }

--- a/leakcanary-object-watcher-android-support-fragments/src/main/java/leakcanary/internal/AndroidSupportFragmentDestroyWatcher.kt
+++ b/leakcanary-object-watcher-android-support-fragments/src/main/java/leakcanary/internal/AndroidSupportFragmentDestroyWatcher.kt
@@ -36,8 +36,8 @@ internal class AndroidSupportFragmentDestroyWatcher(
       val view = fragment.view
       if (view != null && configProvider().watchFragmentViews) {
         objectWatcher.watch(
-            view, "Fragment received Fragment#onDestroyView() callback " +
-            "(references to its view should be cleared to prevent leaks)"
+            view, "${fragment::class.java.name} received Fragment#onDestroyView() callback " +
+            "(references to its views should be cleared to prevent leaks)"
         )
       }
     }
@@ -47,7 +47,9 @@ internal class AndroidSupportFragmentDestroyWatcher(
       fragment: Fragment
     ) {
       if (configProvider().watchFragments) {
-        objectWatcher.watch(fragment, "Fragment received Fragment#onDestroy() callback")
+        objectWatcher.watch(
+            fragment, "${fragment::class.java.name} received Fragment#onDestroy() callback"
+        )
       }
     }
   }

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/ActivityDestroyWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/ActivityDestroyWatcher.kt
@@ -30,7 +30,9 @@ internal class ActivityDestroyWatcher private constructor(
     object : Application.ActivityLifecycleCallbacks by noOpDelegate() {
       override fun onActivityDestroyed(activity: Activity) {
         if (configProvider().watchActivities) {
-          objectWatcher.watch(activity, "Activity received Activity#onDestroy() callback")
+          objectWatcher.watch(
+              activity, "${activity::class.java.name} received Activity#onDestroy() callback"
+          )
         }
       }
     }

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/AndroidOFragmentDestroyWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/AndroidOFragmentDestroyWatcher.kt
@@ -38,8 +38,8 @@ internal class AndroidOFragmentDestroyWatcher(
       val view = fragment.view
       if (view != null && configProvider().watchFragmentViews) {
         objectWatcher.watch(
-            view, "Fragment received Fragment#onDestroyView() callback " +
-            "(references to its view should be cleared to prevent leaks)"
+            view, "${fragment::class.java.name} received Fragment#onDestroyView() callback " +
+            "(references to its views should be cleared to prevent leaks)"
         )
       }
     }
@@ -49,7 +49,9 @@ internal class AndroidOFragmentDestroyWatcher(
       fragment: Fragment
     ) {
       if (configProvider().watchFragments) {
-        objectWatcher.watch(fragment, "Fragment received Fragment#onDestroy() callback")
+        objectWatcher.watch(
+            fragment, "${fragment::class.java.name} received Fragment#onDestroy() callback"
+        )
       }
     }
   }


### PR DESCRIPTION
This is most interesting when tracking leaks post Fragment.onDestroyView(). Sometimes it's unclear which fragment the view belongs to, especially when the fragment isn't part of the leak trace.