### PR TITLE
Introducing proper API for finding leaking objects

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -6,8 +6,11 @@ import leakcanary.internal.InternalLeakCanary
 import shark.AndroidMetadataExtractor
 import shark.AndroidObjectInspectors
 import shark.AndroidReferenceMatchers
+import shark.FilteringLeakingObjectFinder
 import shark.HeapAnalysisSuccess
 import shark.IgnoredReferenceMatcher
+import shark.KeyedWeakReferenceFinder
+import shark.LeakingObjectFinder
 import shark.LibraryLeakReferenceMatcher
 import shark.MetadataExtractor
 import shark.ObjectInspector
@@ -137,13 +140,35 @@ object LeakCanary {
     val requestWriteExternalStoragePermission: Boolean = false,
 
     /**
-     * When true, [objectInspectors] are used to find leaks instead of only checking instances
-     * tracked by [KeyedWeakReference]. This leads to finding more leaks and shorter leak traces.
-     * However this also means the same leaking instances will be found in every heap dump for a
-     * given process life.
+     * Finds the objects that are leaking, for which LeakCanary will compute leak traces.
      *
-     * Defaults to false.
+     * Defaults to [KeyedWeakReferenceFinder] which finds all objects tracked by a
+     * [KeyedWeakReference], ie all objects that were passed to [ObjectWatcher.watch].
+     *
+     * You could instead replace it with a [FilteringLeakingObjectFinder], which scans all objects
+     * in the heap dump and delegates the decision to a list of
+     * [FilteringLeakingObjectFinder.LeakingObjectFilter]. This can lead to finding more leaks
+     * than the default and shorter leak traces. This also means that every analysis during a
+     * given process life will bring up the same leaking objects over and over again, unlike
+     * when using [KeyedWeakReferenceFinder] (because [KeyedWeakReference] instances are cleared
+     * after each heap dump).
+     *
+     * The list of filters can be built from [AndroidObjectInspectors]:
+     *
+     * ```
+     * LeakCanary.config = LeakCanary.config.copy(
+     *     leakingObjectFinder = FilteringLeakingObjectFinder(
+     *         AndroidObjectInspectors.appLeakingObjectFilters
+     *     )
+     * )
+     * ```
      */
+    val leakingObjectFinder: LeakingObjectFinder = KeyedWeakReferenceFinder,
+
+    /**
+     * Deprecated: This is a no-op, set a custom [leakingObjectFinder] instead.
+     */
+    @Deprecated("This is a no-op, set a custom leakingObjectFinder instead")
     val useExperimentalLeakFinders: Boolean = false
   )
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
@@ -26,7 +26,6 @@ import shark.HeapAnalysis
 import shark.HeapAnalysisException
 import shark.HeapAnalysisFailure
 import shark.HeapAnalyzer
-import shark.ObjectInspectors.KEYED_WEAK_REFERENCE
 import shark.OnAnalysisProgressListener
 import shark.OnAnalysisProgressListener.Step.REPORTING_HEAP_ANALYSIS
 import shark.ProguardMappingReader
@@ -77,12 +76,10 @@ internal class HeapAnalyzerService : ForegroundService(
     }
     return heapAnalyzer.analyze(
         heapDumpFile = heapDumpFile,
+        leakingObjectFinder = config.leakingObjectFinder,
         referenceMatchers = config.referenceMatchers,
         computeRetainedHeapSize = config.computeRetainedHeapSize,
         objectInspectors = config.objectInspectors,
-        leakFinders = if (config.useExperimentalLeakFinders) config.objectInspectors else listOf(
-            KEYED_WEAK_REFERENCE
-        ),
         metadataExtractor = config.metatadaExtractor,
         proguardMapping = proguardMappingReader?.readProguardMapping()
     )

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 import shark.AndroidObjectInspectors
 import shark.AndroidReferenceMatchers
 import shark.HeapAnalyzer
-import shark.ObjectInspectors.KEYED_WEAK_REFERENCE
+import shark.KeyedWeakReferenceFinder
 import shark.OnAnalysisProgressListener
 import shark.OnAnalysisProgressListener.Step
 import shark.SharkLog
@@ -39,10 +39,10 @@ class ProfiledTest {
     })
     val result = analyzer.analyze(
         heapDumpFile = heapDumpFile,
+        leakingObjectFinder = KeyedWeakReferenceFinder,
         referenceMatchers = AndroidReferenceMatchers.appDefaults,
         objectInspectors = AndroidObjectInspectors.appDefaults,
-        computeRetainedHeapSize = true,
-        leakFinders = listOf(KEYED_WEAK_REFERENCE)
+        computeRetainedHeapSize = true
     )
     SharkLog.d { result.toString() }
     // Giving time to stop CPU profiler (otherwise trace won't succeed)

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -27,7 +27,6 @@ import shark.HeapAnalysis
 import shark.HeapAnalysisException
 import shark.HeapAnalysisFailure
 import shark.HeapAnalyzer
-import shark.ObjectInspectors
 import shark.SharkLog
 import java.io.File
 
@@ -172,12 +171,11 @@ class InstrumentationLeakDetector {
 
     val heapAnalyzer = HeapAnalyzer(listener)
     val heapAnalysis = heapAnalyzer.analyze(
-        heapDumpFile, config.referenceMatchers,
-        config.computeRetainedHeapSize,
-        config.objectInspectors,
-        if (config.useExperimentalLeakFinders) config.objectInspectors else listOf(
-            ObjectInspectors.KEYED_WEAK_REFERENCE
-        )
+        heapDumpFile = heapDumpFile,
+        leakingObjectFinder = config.leakingObjectFinder,
+        referenceMatchers = config.referenceMatchers,
+        computeRetainedHeapSize = config.computeRetainedHeapSize,
+        objectInspectors = config.objectInspectors
     )
 
     SharkLog.d { "Heap Analysis:\n$heapAnalysis" }

--- a/shark-android/src/test/java/shark/LegacyHprofTest.kt
+++ b/shark-android/src/test/java/shark/LegacyHprofTest.kt
@@ -2,6 +2,7 @@ package shark
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import shark.FilteringLeakingObjectFinder.LeakingObjectFilter
 import shark.LegacyHprofTest.WRAPS_ACTIVITY.DESTROYED
 import shark.LegacyHprofTest.WRAPS_ACTIVITY.NOT_ACTIVITY
 import shark.LegacyHprofTest.WRAPS_ACTIVITY.NOT_DESTROYED
@@ -143,6 +144,9 @@ class LegacyHprofTest {
     val heapAnalyzer = HeapAnalyzer(OnAnalysisProgressListener.NO_OP)
     val analysis = heapAnalyzer.analyze(
         heapDumpFile = hprofFile,
+        leakingObjectFinder = FilteringLeakingObjectFinder(
+            AndroidObjectInspectors.appLeakingObjectFilters
+        ),
         referenceMatchers = AndroidReferenceMatchers.appDefaults,
         computeRetainedHeapSize = false,
         objectInspectors = AndroidObjectInspectors.appDefaults,

--- a/shark-cli/src/main/java/shark/Main.kt
+++ b/shark-cli/src/main/java/shark/Main.kt
@@ -197,7 +197,7 @@ private fun dumpHeap(
 
   SharkLog.d { "Pulling $heapDumpDevicePath" }
 
-  val pullResult = runCommand(workingDirectory, "adb",  "-s", deviceId, "pull", heapDumpDevicePath)
+  val pullResult = runCommand(workingDirectory, "adb", "-s", deviceId, "pull", heapDumpDevicePath)
   SharkLog.d { pullResult }
   SharkLog.d { "Removing $heapDumpDevicePath" }
 
@@ -244,8 +244,13 @@ private fun analyze(
   val heapAnalyzer = HeapAnalyzer(listener)
   SharkLog.d { "Analyzing heap dump $heapDumpFile" }
   val heapAnalysis = heapAnalyzer.analyze(
-      heapDumpFile, AndroidReferenceMatchers.appDefaults, true,
-      AndroidObjectInspectors.appDefaults,
+      heapDumpFile = heapDumpFile,
+      leakingObjectFinder = FilteringLeakingObjectFinder(
+          AndroidObjectInspectors.appLeakingObjectFilters
+      ),
+      referenceMatchers = AndroidReferenceMatchers.appDefaults,
+      computeRetainedHeapSize = true,
+      objectInspectors = AndroidObjectInspectors.appDefaults,
       proguardMapping = proguardMapping
   )
 

--- a/shark/src/main/java/shark/FilteringLeakingObjectFinder.kt
+++ b/shark/src/main/java/shark/FilteringLeakingObjectFinder.kt
@@ -1,0 +1,31 @@
+package shark
+
+/**
+ * Finds the objects that are leaking by scanning all objects in the heap dump
+ * and delegating the decision to a list of [FilteringLeakingObjectFinder.LeakingObjectFilter]
+ */
+class FilteringLeakingObjectFinder(private val filters: List<LeakingObjectFilter>) :
+    LeakingObjectFinder {
+
+  /**
+   * Filter to be passed to the [FilteringLeakingObjectFinder] constructor.
+   */
+  interface LeakingObjectFilter {
+    /**
+     * Returns whether the passed in [heapObject] is leaking. This should only return true
+     * when we're 100% sure the passed in [heapObject] should not be in memory anymore.
+     */
+    fun isLeakingObject(heapObject: HeapObject): Boolean
+  }
+
+  override fun findLeakingObjectIds(graph: HeapGraph): Set<Long> {
+    return graph.objects
+        .filter { heapObject ->
+          filters.any { filter ->
+            filter.isLeakingObject(heapObject)
+          }
+        }
+        .map { it.objectId }
+        .toSet()
+  }
+}

--- a/shark/src/main/java/shark/KeyedWeakReferenceFinder.kt
+++ b/shark/src/main/java/shark/KeyedWeakReferenceFinder.kt
@@ -1,0 +1,48 @@
+package shark
+
+import shark.ObjectInspectors.KEYED_WEAK_REFERENCE
+import shark.internal.KeyedWeakReferenceMirror
+
+/**
+ * Finds all objects tracked by a KeyedWeakReference, ie all objects that were passed to
+ * ObjectWatcher.watch.
+ */
+object KeyedWeakReferenceFinder : LeakingObjectFinder {
+
+  override fun findLeakingObjectIds(graph: HeapGraph): Set<Long> =
+    findKeyedWeakReferences(graph).map { it.referent.value }.toSet()
+
+  internal fun findKeyedWeakReferences(graph: HeapGraph): List<KeyedWeakReferenceMirror> {
+    return graph.context.getOrPut(KEYED_WEAK_REFERENCE.name) {
+      val keyedWeakReferenceClass = graph.findClassByName("leakcanary.KeyedWeakReference")
+
+      val heapDumpUptimeMillis = if (keyedWeakReferenceClass == null) {
+        null
+      } else {
+        keyedWeakReferenceClass["heapDumpUptimeMillis"]?.value?.asLong
+      }
+
+      if (heapDumpUptimeMillis == null) {
+        SharkLog.d {
+          "leakcanary.KeyedWeakReference.heapDumpUptimeMillis field not found, " +
+              "this must be a heap dump from an older version of LeakCanary."
+        }
+      }
+
+      val addedToContext: List<KeyedWeakReferenceMirror> = graph.instances
+          .filter { instance ->
+            val className = instance.instanceClassName
+            className == "leakcanary.KeyedWeakReference" || className == "com.squareup.leakcanary.KeyedWeakReference"
+          }
+          .map {
+            KeyedWeakReferenceMirror.fromInstance(
+                it, heapDumpUptimeMillis
+            )
+          }
+          .filter { it.hasReferent }
+          .toList()
+      graph.context[KEYED_WEAK_REFERENCE.name] = addedToContext
+      addedToContext
+    }
+  }
+}

--- a/shark/src/main/java/shark/LeakingObjectFinder.kt
+++ b/shark/src/main/java/shark/LeakingObjectFinder.kt
@@ -1,0 +1,14 @@
+package shark
+
+/**
+ * Finds the objects that are leaking, for which Shark will compute
+ * leak traces.
+ */
+interface LeakingObjectFinder {
+
+  /**
+   * For a given heap graph, returns a set of object ids for the objects that are leaking.
+   */
+  fun findLeakingObjectIds(graph: HeapGraph): Set<Long>
+
+}

--- a/shark/src/main/java/shark/ObjectReporter.kt
+++ b/shark/src/main/java/shark/ObjectReporter.kt
@@ -19,17 +19,20 @@ class ObjectReporter constructor(val heapObject: HeapObject) {
 
   /**
    * Reasons for which this object is expected to be unreachable (ie it's leaking).
-   *
-   * Only add reasons to this if you're 100% sure this object is leaking, otherwise add reasons to
-   * [likelyLeakingReasons]. The difference is that objects that are "likely leaking" are not
-   * considered to be leaking objects on which LeakCanary should compute the leak trace.
    */
   val leakingReasons = mutableSetOf<String>()
 
   /**
-   * @see leakingReasons
+   * Deprecated, use leakingReasons instead.
    */
-  val likelyLeakingReasons = mutableSetOf<String>()
+  @Deprecated(
+      "Replace likelyLeakingReasons with leakingReasons",
+      replaceWith = ReplaceWith(
+          "leakingReasons"
+      )
+  )
+  val likelyLeakingReasons
+    get() = leakingReasons
 
   /**
    * Reasons for which this object is expected to be reachable (ie it's not leaking).

--- a/shark/src/test/java/shark/LeakStatusTest.kt
+++ b/shark/src/test/java/shark/LeakStatusTest.kt
@@ -5,6 +5,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import shark.FilteringLeakingObjectFinder.LeakingObjectFilter
 import shark.HeapObject.HeapClass
 import shark.HeapObject.HeapInstance
 import shark.LeakNodeStatus.LEAKING
@@ -151,6 +152,10 @@ class LeakStatusTest {
 
     val analysis =
       hprofFile.checkForLeaks<HeapAnalysisSuccess>(
+          leakFilters = listOf(object : LeakingObjectFilter {
+            override fun isLeakingObject(heapObject: HeapObject) =
+              heapObject is HeapInstance && heapObject instanceOf "Class1"
+          }),
           objectInspectors = listOf(leakingInstance("Class1"))
       )
 

--- a/shark/src/test/java/shark/LeakTraceStringRenderingTest.kt
+++ b/shark/src/test/java/shark/LeakTraceStringRenderingTest.kt
@@ -5,6 +5,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import shark.FilteringLeakingObjectFinder.LeakingObjectFilter
+import shark.HeapObject.HeapInstance
 import shark.ReferencePattern.InstanceFieldPattern
 import java.io.File
 
@@ -98,6 +100,10 @@ class LeakTraceStringRenderingTest {
               }
             }
           })
+          , leakFilters = listOf(object : LeakingObjectFilter {
+        override fun isLeakingObject(heapObject: HeapObject) =
+          heapObject is HeapInstance && heapObject instanceOf "ClassB"
+      })
       )
 
     analysis renders """


### PR DESCRIPTION
Prior implementation was relying on calling ObjectInspector implementations, which were doing way too much work. That also forced the introduction of "likelyLeaking", which wasn't great.

Fixes #1693