### PR TITLE
Fix analysis crash by excluding AndroidResourceIdNames from obfuscation

### DIFF
--- a/shark-android/src/main/resources/META-INF/proguard/shark.pro
+++ b/shark-android/src/main/resources/META-INF/proguard/shark.pro
@@ -1,0 +1,2 @@
+# Used during heap analysis to find resource id names
+-keep class shark.AndroidResourceIdNames { *; }


### PR DESCRIPTION
Fixes https://github.com/square/leakcanary/issues/1696