### PR TITLE
ConfigBuilder for LeakCanary.Config for Java callers.

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -48,7 +48,7 @@ To customize the heap dumping & analysis, update [LeakCanary.config](/leakcanary
 LeakCanary.config = LeakCanary.config.copy(retainedVisibleThreshold = 3)
 ```
 
-Java callers can use [ConfigBuilder](/leakcanary/api/leakcanary-android-core/leakcanary/-config-builder/) instead:
+In Java, you can use [ConfigBuilder](/leakcanary/api/leakcanary-android-core/leakcanary/-config-builder/) instead:
 ```
 LeakCanary.Config config = LeakCanary.getConfig().newBuilder()
    .computeRetainedHeapSize(false);

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -48,6 +48,13 @@ To customize the heap dumping & analysis, update [LeakCanary.config](/leakcanary
 LeakCanary.config = LeakCanary.config.copy(retainedVisibleThreshold = 3)
 ```
 
+Java callers can use [ConfigBuilder](/leakcanary/api/leakcanary-android-core/leakcanary/-config-builder/) instead:
+```
+LeakCanary.Config config = LeakCanary.getConfig().newBuilder()
+   .computeRetainedHeapSize(false);
+LeakCanary.setConfig(config);
+```
+
 The LeakCanary UI can be configured by overriding the following resources:
 
 * `mipmap/leak_canary_icon` see [Icon and label](#icon-and-label)

--- a/leakcanary-android-core/src/main/java/leakcanary/ConfigBuilder.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/ConfigBuilder.kt
@@ -6,7 +6,7 @@ import shark.ObjectInspector
 import shark.ReferenceMatcher
 
 /**
- * Builder for [LeakCanary.Config] intended to use only by Java callers.
+ * Builder for [LeakCanary.Config] intended to be used only from Java code.
  *
  * Usage:
  * ```
@@ -18,7 +18,7 @@ import shark.ReferenceMatcher
  * LeakCanary.setConfig(config);
  * ```
  *
- * Kotlin callers should be using `copy()` method instead:
+ * For idiomatic Kotlin use `copy()` method instead:
  * ```
  * LeakCanary.config = LeakCanary.config.copy(dumpHeap = false)
  * ```
@@ -39,39 +39,48 @@ class ConfigBuilder(config: LeakCanary.Config) {
   private var leakingObjectFinder: LeakingObjectFinder = config.leakingObjectFinder
 
   /** @see [LeakCanary.Config.dumpHeap] */
-  fun dumpHeap(value: Boolean) = apply { dumpHeap = value }
+  fun dumpHeap(dumpHeap: Boolean) =
+    apply { this.dumpHeap = dumpHeap }
 
   /** @see [LeakCanary.Config.dumpHeapWhenDebugging] */
-  fun dumpHeapWhenDebugging(value: Boolean) = apply { dumpHeapWhenDebugging = value }
+  fun dumpHeapWhenDebugging(dumpHeapWhenDebugging: Boolean) =
+    apply { this.dumpHeapWhenDebugging = dumpHeapWhenDebugging }
 
   /** @see [LeakCanary.Config.retainedVisibleThreshold] */
-  fun retainedVisibleThreshold(value: Int) = apply { retainedVisibleThreshold = value }
+  fun retainedVisibleThreshold(retainedVisibleThreshold: Int) =
+    apply { this.retainedVisibleThreshold = retainedVisibleThreshold }
 
   /** @see [LeakCanary.Config.referenceMatchers] */
-  fun referenceMatchers(value: List<ReferenceMatcher>) = apply { referenceMatchers = value }
+  fun referenceMatchers(referenceMatchers: List<ReferenceMatcher>) =
+    apply { this.referenceMatchers = referenceMatchers }
 
   /** @see [LeakCanary.Config.objectInspectors] */
-  fun objectInspectors(value: List<ObjectInspector>) = apply { objectInspectors = value }
+  fun objectInspectors(objectInspectors: List<ObjectInspector>) =
+    apply { this.objectInspectors = objectInspectors }
 
   /** @see [LeakCanary.Config.onHeapAnalyzedListener] */
-  fun onHeapAnalyzedListener(value: OnHeapAnalyzedListener) =
-    apply { onHeapAnalyzedListener = value }
+  fun onHeapAnalyzedListener(onHeapAnalyzedListener: OnHeapAnalyzedListener) =
+    apply { this.onHeapAnalyzedListener = onHeapAnalyzedListener }
 
   /** @see [LeakCanary.Config.metadataExtractor] */
-  fun metadataExtractor(value: MetadataExtractor) = apply { metadataExtractor = value }
+  fun metadataExtractor(metadataExtractor: MetadataExtractor) =
+    apply { this.metadataExtractor = metadataExtractor }
 
   /** @see [LeakCanary.Config.computeRetainedHeapSize] */
-  fun computeRetainedHeapSize(value: Boolean) = apply { computeRetainedHeapSize = value }
+  fun computeRetainedHeapSize(computeRetainedHeapSize: Boolean) =
+    apply { this.computeRetainedHeapSize = computeRetainedHeapSize }
 
   /** @see [LeakCanary.Config.maxStoredHeapDumps] */
-  fun maxStoredHeapDumps(value: Int) = apply { maxStoredHeapDumps = value }
+  fun maxStoredHeapDumps(maxStoredHeapDumps: Int) =
+    apply { this.maxStoredHeapDumps = maxStoredHeapDumps }
 
   /** @see [LeakCanary.Config.requestWriteExternalStoragePermission] */
-  fun requestWriteExternalStoragePermission(value: Boolean) =
-    apply { requestWriteExternalStoragePermission = value }
+  fun requestWriteExternalStoragePermission(requestWriteExternalStoragePermission: Boolean) =
+    apply { this.requestWriteExternalStoragePermission = requestWriteExternalStoragePermission }
 
   /** @see [LeakCanary.Config.leakingObjectFinder] */
-  fun leakingObjectFinder(value: LeakingObjectFinder) = apply { leakingObjectFinder = value }
+  fun leakingObjectFinder(leakingObjectFinder: LeakingObjectFinder) =
+    apply { this.leakingObjectFinder = leakingObjectFinder }
 
   fun build(): LeakCanary.Config =
     LeakCanary.config.copy(

--- a/leakcanary-android-core/src/main/java/leakcanary/ConfigBuilder.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/ConfigBuilder.kt
@@ -1,0 +1,90 @@
+package leakcanary
+
+import shark.LeakingObjectFinder
+import shark.MetadataExtractor
+import shark.ObjectInspector
+import shark.ReferenceMatcher
+
+/**
+ * Builder for [LeakCanary.Config] intended to use only by Java callers.
+ *
+ * Usage:
+ * ```
+ * LeakCanary.Config config = LeakCanary.getConfig().newBuilder()
+ *    .dumpHeap(false)
+ *    .retainedVisibleThreshold(3)
+ *    .maxStoredHeapDumps(10)
+ *    .build();
+ * LeakCanary.setConfig(config);
+ * ```
+ *
+ * Kotlin callers should be using `copy()` method instead:
+ * ```
+ * LeakCanary.config = LeakCanary.config.copy(dumpHeap = false)
+ * ```
+ */
+@Suppress("TooManyFunctions")
+class ConfigBuilder(config: LeakCanary.Config) {
+  private var dumpHeap: Boolean = config.dumpHeap
+  private var dumpHeapWhenDebugging: Boolean = config.dumpHeapWhenDebugging
+  private var retainedVisibleThreshold: Int = config.retainedVisibleThreshold
+  private var referenceMatchers: List<ReferenceMatcher> = config.referenceMatchers
+  private var objectInspectors: List<ObjectInspector> = config.objectInspectors
+  private var onHeapAnalyzedListener: OnHeapAnalyzedListener = config.onHeapAnalyzedListener
+  private var metadataExtractor: MetadataExtractor = config.metadataExtractor
+  private var computeRetainedHeapSize: Boolean = config.computeRetainedHeapSize
+  private var maxStoredHeapDumps: Int = config.maxStoredHeapDumps
+  private var requestWriteExternalStoragePermission: Boolean =
+    config.requestWriteExternalStoragePermission
+  private var leakingObjectFinder: LeakingObjectFinder = config.leakingObjectFinder
+
+  /** @see [LeakCanary.Config.dumpHeap] */
+  fun dumpHeap(value: Boolean) = apply { dumpHeap = value }
+
+  /** @see [LeakCanary.Config.dumpHeapWhenDebugging] */
+  fun dumpHeapWhenDebugging(value: Boolean) = apply { dumpHeapWhenDebugging = value }
+
+  /** @see [LeakCanary.Config.retainedVisibleThreshold] */
+  fun retainedVisibleThreshold(value: Int) = apply { retainedVisibleThreshold = value }
+
+  /** @see [LeakCanary.Config.referenceMatchers] */
+  fun referenceMatchers(value: List<ReferenceMatcher>) = apply { referenceMatchers = value }
+
+  /** @see [LeakCanary.Config.objectInspectors] */
+  fun objectInspectors(value: List<ObjectInspector>) = apply { objectInspectors = value }
+
+  /** @see [LeakCanary.Config.onHeapAnalyzedListener] */
+  fun onHeapAnalyzedListener(value: OnHeapAnalyzedListener) =
+    apply { onHeapAnalyzedListener = value }
+
+  /** @see [LeakCanary.Config.metadataExtractor] */
+  fun metadataExtractor(value: MetadataExtractor) = apply { metadataExtractor = value }
+
+  /** @see [LeakCanary.Config.computeRetainedHeapSize] */
+  fun computeRetainedHeapSize(value: Boolean) = apply { computeRetainedHeapSize = value }
+
+  /** @see [LeakCanary.Config.maxStoredHeapDumps] */
+  fun maxStoredHeapDumps(value: Int) = apply { maxStoredHeapDumps = value }
+
+  /** @see [LeakCanary.Config.requestWriteExternalStoragePermission] */
+  fun requestWriteExternalStoragePermission(value: Boolean) =
+    apply { requestWriteExternalStoragePermission = value }
+
+  /** @see [LeakCanary.Config.leakingObjectFinder] */
+  fun leakingObjectFinder(value: LeakingObjectFinder) = apply { leakingObjectFinder = value }
+
+  fun build(): LeakCanary.Config =
+    LeakCanary.config.copy(
+        dumpHeap = this.dumpHeap,
+        dumpHeapWhenDebugging = this.dumpHeapWhenDebugging,
+        retainedVisibleThreshold = this.retainedVisibleThreshold,
+        referenceMatchers = this.referenceMatchers,
+        objectInspectors = this.objectInspectors,
+        onHeapAnalyzedListener = this.onHeapAnalyzedListener,
+        metadataExtractor = this.metadataExtractor,
+        computeRetainedHeapSize = this.computeRetainedHeapSize,
+        maxStoredHeapDumps = this.maxStoredHeapDumps,
+        requestWriteExternalStoragePermission = this.requestWriteExternalStoragePermission,
+        leakingObjectFinder = this.leakingObjectFinder
+    )
+}

--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -175,9 +175,11 @@ object LeakCanary {
   ) {
 
     /**
-     * Construct a new Config via [ConfigBuilder]
+     * Construct a new Config via [ConfigBuilder].
+     * Note: this method is intended to be used from Java code only. For idiomatic Kotlin use
+     * `copy()` to modify [LeakCanary.config].
      */
-    @SinceKotlin("999.9") // Hide from Kotlin code, this is needed only for Java callers
+    @SinceKotlin("999.9") // Hide from Kotlin code, this method is only for Java code
     fun newBuilder() = ConfigBuilder(this)
   }
 
@@ -189,7 +191,7 @@ object LeakCanary {
    * LeakCanary.config = LeakCanary.config.copy(computeRetainedHeapSize = true)
    * ```
    *
-   * Java callers can use [ConfigBuilder] instead:
+   * In Java, you can use [ConfigBuilder] instead:
    * ```
    * LeakCanary.Config config = LeakCanary.getConfig().newBuilder()
    *    .computeRetainedHeapSize(false);

--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+
 package leakcanary
 
 import android.content.Intent
@@ -170,7 +172,14 @@ object LeakCanary {
      */
     @Deprecated("This is a no-op, set a custom leakingObjectFinder instead")
     val useExperimentalLeakFinders: Boolean = false
-  )
+  ) {
+
+    /**
+     * Construct a new Config via [ConfigBuilder]
+     */
+    @SinceKotlin("999.9") // Hide from Kotlin code, this is needed only for Java callers
+    fun newBuilder() = ConfigBuilder(this)
+  }
 
   /**
    * The current LeakCanary configuration. Can be updated at any time, usually by replacing it with
@@ -179,8 +188,15 @@ object LeakCanary {
    * ```
    * LeakCanary.config = LeakCanary.config.copy(computeRetainedHeapSize = true)
    * ```
+   *
+   * Java callers can use [ConfigBuilder] instead:
+   * ```
+   * LeakCanary.Config config = LeakCanary.getConfig().newBuilder()
+   *    .computeRetainedHeapSize(false);
+   * LeakCanary.setConfig(config);
+   * ```
    */
-  @Volatile
+  @JvmStatic @Volatile
   var config: Config = if (AppWatcher.isInstalled) Config() else InternalLeakCanary.noInstallConfig
     set(newConfig) {
       val previousConfig = field


### PR DESCRIPTION
Adresses #1714 
Java users should have a convenient API to replace LeakCanary's Config. This proof of concept shows one such approach