### PR TITLE
Don't ignore thread locals

### DIFF
--- a/shark/src/test/java/shark/HeapDumps.kt
+++ b/shark/src/test/java/shark/HeapDumps.kt
@@ -1,3 +1,4 @@
+
 package shark
 
 import shark.GcRoot.JavaFrame
@@ -135,27 +136,6 @@ fun File.writeJavaLocalLeak(
 
     val leaking = "Leaking" watchedInstance {}
     gcRoot(JavaFrame(id = leaking.value, threadSerialNumber = 42, frameNumber = 0))
-  }
-}
-
-fun File.writeLollipopJavaLocalLeak(
-  threadClass: String,
-  threadName: String
-) {
-  dump {
-    val threadLocalValues = "java.lang.ThreadLocal\$Values" instance {
-      field["table"] = objectArray("Leaking" watchedInstance {})
-    }
-
-    val threadClassId =
-      clazz(className = "java.lang.Thread", fields = listOf("name" to ReferenceHolder::class, "localValues" to ReferenceHolder::class))
-    val myThreadClassId = clazz(className = threadClass, superclassId = threadClassId)
-    val threadInstance = instance(myThreadClassId, listOf(string(threadName), threadLocalValues))
-    gcRoot(
-        ThreadObject(
-            id = threadInstance.value, threadSerialNumber = 42, stackTraceSerialNumber = 0
-        )
-    )
   }
 }
 

--- a/shark/src/test/java/shark/ReferenceMatcherTest.kt
+++ b/shark/src/test/java/shark/ReferenceMatcherTest.kt
@@ -87,18 +87,6 @@ class ReferenceMatcherTest {
     assertThat(leak.pattern).isEqualTo(matcher.pattern)
   }
 
-  @Test fun excludedLollipopThread() {
-    hprofFile.writeLollipopJavaLocalLeak(threadClass = "MyThread", threadName = "kroutine")
-
-    val matcher = LibraryLeakReferenceMatcher(JavaLocalPattern("kroutine"))
-    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>(
-        referenceMatchers = listOf(matcher)
-    )
-
-    val leak = analysis.libraryLeaks[0]
-    assertThat(leak.pattern).isEqualTo(matcher.pattern)
-  }
-
   @Test fun overrideSuperclassExclusion() {
     hprofFile.dump {
       "GcRoot" clazz {


### PR DESCRIPTION
Since bbf89a09719619685f884535df98707b2877543f any pattern matching java locals would also to thread locals of a matching thread. This was because we found that Lollipop stored java local in a thread local. Unfortunately, that led to ignoring all thread locals for the main thread, when some leaks are actually caused by those (e.g. actions hanging out in ViewRootImpl.RunQueue after the view hierarchy is detached).

Reverts bbf89a09719619685f884535df98707b2877543f for now.

Once we get a hprof on lollipop we should look for other ways to identify java locals, or maybe filter this down to Lollipop only.