### PR TITLE
Wait for heap to be done dumping

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -86,7 +86,15 @@ internal class AndroidHeapDumper(
 
     return try {
       Debug.dumpHprofData(heapDumpFile.absolutePath)
-      if (heapDumpFile.length() == 0L) {
+      var previousFileLength: Long
+      var fileLength = heapDumpFile.length()
+      do {
+        SharkLog.d { "Waiting 200ms for heap to be done dumping" }
+        Thread.sleep(200)
+        previousFileLength = fileLength
+        fileLength = heapDumpFile.length()
+      } while (previousFileLength != fileLength)
+      if (fileLength == 0L) {
         SharkLog.d { "Dumped heap file is 0 byte length" }
         null
       } else {

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -161,6 +161,15 @@ class InstrumentationLeakDetector {
       )
     }
 
+    var previousFileLength: Long
+    var fileLength = heapDumpFile.length()
+    do {
+      SharkLog.d { "Waiting 200ms for heap to be done dumping" }
+      Thread.sleep(200)
+      previousFileLength = fileLength
+      fileLength = heapDumpFile.length()
+    } while (previousFileLength != fileLength)
+
     refWatcher.clearObjectsWatchedBefore(heapDumpUptimeMillis)
 
     val listener = shark.OnAnalysisProgressListener.NO_OP


### PR DESCRIPTION
We've seen several cases where analyzing the heap right after the heap dump fails (missing objects) but retrying soon after succeeds, which would indicate that the heap dump file isn't done being written to disk. This is an attempt at fixing that by sleeping while the file is appended to.