### PR TITLE
[bugfix]AppWatcher manualInstall function not works bugfix

### DIFF
--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcherManualInstaller.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcherManualInstaller.kt
@@ -1,0 +1,9 @@
+package leakcanary
+
+import android.app.Application
+import leakcanary.internal.InternalAppWatcher
+
+object AppWatcherManualInstaller {
+    @JvmStatic
+    fun manualInstall(application: Application) = InternalAppWatcher.install(application)
+}


### PR DESCRIPTION
### **[reproduce bug]**
- Disable ContentProvider `leakcanary.internal.AppWatcherInstaller$MainProcess`

- Use `fun manualInstall` in `AppWatcher `

 Leakcanary will not work by manualInstall in this situation.

### **[bug reason]**

In [AppWacther.kt](https://github.com/square/leakcanary/blob/master/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcher.kt)
```@Volatile
  var config: Config = if (isInstalled) Config() else Config(enabled = false)
    set(newConfig) {
      SharkLog.d { "AppWatcher setConfig" }
      val previousConfig = field
      field = newConfig
      logConfigChange(previousConfig, newConfig)
    }
```

Decompiled it to AppWatcher.java

```
   static {
      AppWatcher var0 = new AppWatcher();
      INSTANCE = var0;
      config = var0.isInstalled() ? new AppWatcher.Config(false, false, false, false, 0L, 31, (DefaultConstructorMarker)null) : new AppWatcher.Config(false, false, false, false, 0L, 30, (DefaultConstructorMarker)null);
   }
```

More source code,`isInstalled` related source code:

```
/** @see [manualInstall] */
  val isInstalled
    get() = InternalAppWatcher.isInstalled
```

```
internal object InternalAppWatcher {

  val isInstalled
    get() = ::application.isInitialized
```

We can see the fact that `config` is in the static block code in the class which runs before static method, and it's related `isInstalled` need to be correct. 

So the reason is when calling` AppWatcher.munalInstall`,  the static block code is excuted, but application is not set to InternalAppWatcher already, so `isInstalled` is not ready and config is not enabled.

### **[Solution]**
Add another [`AppWactherManualInstaller`](https://github.com/square/leakcanary/pull/1726/commits/ec63aa514e68863b8a0db3c574dff6f653a19e5d#diff-8fa07fcdf653e2efeabdefd69f12830f) to meet manual install need.

When need to manual install leakcanary in runtime, call `manualInstall` in this manual installer, application is already correctly set to the `InternalAppWatcher`, and then AppWatcher config will work correctly.