### PR TITLE
Prioritize system classes

### DIFF
--- a/shark-graph/src/main/java/shark/internal/hppc/LongScatterSet.kt
+++ b/shark-graph/src/main/java/shark/internal/hppc/LongScatterSet.kt
@@ -60,6 +60,29 @@ internal class LongScatterSet(expectedElements: Int = 4) {
     ensureCapacity(expectedElements)
   }
 
+  fun elementSequence(): Sequence<Long> {
+    val max = mask + 1
+    var slot = -1
+    return generateSequence {
+      if (slot < max) {
+        var existing: Long
+        slot++
+        while (slot < max) {
+          existing = keys[slot]
+          if (existing != 0L) {
+            return@generateSequence existing
+          }
+          slot++
+        }
+      }
+      if (slot == max && hasEmptyKey) {
+        slot++
+        return@generateSequence 0L
+      }
+      return@generateSequence null
+    }
+  }
+
   private fun hashKey(key: Long): Int {
     return HPPC.mixPhi(key)
   }

--- a/shark-graph/src/test/java/shark/HprofHeapGraphTest.kt
+++ b/shark-graph/src/test/java/shark/HprofHeapGraphTest.kt
@@ -1,0 +1,100 @@
+package shark
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.StickyClass
+import shark.HprofHeapGraph.Companion.openHeapGraph
+import shark.HprofRecord.HeapDumpRecord.GcRootRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord
+import shark.HprofRecord.LoadClassRecord
+import shark.HprofRecord.StringRecord
+
+class HprofHeapGraphTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  private lateinit var hprofFile: File
+
+  @Before
+  fun setUp() {
+    hprofFile = testFolder.newFile("temp.hprof")
+  }
+
+  @Test
+  fun `non system class can be found`() {
+    val className = "com.example.SimpleClass"
+
+    HprofWriter.openWriterFor(hprofFile).use { writer ->
+      val classNameRecord = StringRecord(1L, className)
+      writer.write(classNameRecord)
+      writer.writeClass(42, classNameRecord, rootClass = false)
+    }
+
+    hprofFile.openHeapGraph().use { graph ->
+      assertThat(graph.findClassByName(className)).isNotNull
+    }
+  }
+
+  @Test
+  fun `system class can be found`() {
+    val className = "com.example.SimpleClass"
+
+    HprofWriter.openWriterFor(hprofFile).use { writer ->
+      val classNameRecord = StringRecord(1L, className)
+      writer.write(classNameRecord)
+      writer.writeClass(42, classNameRecord, rootClass = true)
+    }
+
+    hprofFile.openHeapGraph().use { graph ->
+      assertThat(graph.findClassByName(className)).isNotNull
+    }
+  }
+
+  @Test
+  fun `system class prioritized over non system class`() {
+    val className = "com.example.SimpleClass"
+
+    HprofWriter.openWriterFor(hprofFile).use { writer ->
+      val classNameRecord = StringRecord(1L, className)
+      writer.write(classNameRecord)
+      writer.writeClass(24, classNameRecord, rootClass = false)
+      writer.writeClass(25, classNameRecord, rootClass = false)
+      writer.writeClass(42, classNameRecord, rootClass = true)
+      writer.writeClass(43, classNameRecord, rootClass = false)
+    }
+
+    hprofFile.openHeapGraph().use { graph ->
+      val heapClass = graph.findClassByName(className)!!
+      assertThat(heapClass.objectId).isEqualTo(42)
+    }
+  }
+
+  private fun HprofWriter.writeClass(
+    classId: Long,
+    classNameRecord: StringRecord,
+    rootClass: Boolean
+  ) {
+    val loadClass = LoadClassRecord(1, classId, 1, classNameRecord.id)
+    val classDump = ClassDumpRecord(
+      id = loadClass.id,
+      stackTraceSerialNumber = 1,
+      superclassId = 0,
+      classLoaderId = 0,
+      signersId = 0,
+      protectionDomainId = 0,
+      instanceSize = 0,
+      staticFields = emptyList(),
+      fields = emptyList()
+    )
+    write(loadClass)
+    if (rootClass) {
+      write(GcRootRecord(gcRoot = StickyClass(classId)))
+    }
+    write(classDump)
+  }
+}

--- a/shark-hprof/api/shark-hprof.api
+++ b/shark-hprof/api/shark-hprof.api
@@ -431,6 +431,7 @@ public final class shark/HprofRecordReader {
 	public final fun skipClassDumpRecord ()V
 	public final fun skipClassDumpStaticFields ()V
 	public final fun skipHeapDumpInfoRecord ()V
+	public final fun skipId ()V
 	public final fun skipInstanceDumpRecord ()V
 	public final fun skipObjectArrayDumpRecord ()V
 	public final fun skipPrimitiveArrayDumpRecord ()V

--- a/shark-hprof/src/main/java/shark/HprofDeobfuscator.kt
+++ b/shark-hprof/src/main/java/shark/HprofDeobfuscator.kt
@@ -104,10 +104,7 @@ class HprofDeobfuscator {
       StreamingHprofReader.readerFor(inputHprofFile, hprofHeader).asStreamingRecordReader()
     HprofWriter.openWriterFor(
       outputHprofFile,
-      hprofHeader = HprofHeader(
-        identifierByteSize = hprofHeader.identifierByteSize,
-        version = hprofHeader.version
-      )
+      hprofHeader = hprofHeader
     ).use { writer ->
       reader.readRecords(setOf(HprofRecord::class),
         OnHprofRecordListener { _,

--- a/shark-hprof/src/main/java/shark/HprofPrimitiveArrayStripper.kt
+++ b/shark-hprof/src/main/java/shark/HprofPrimitiveArrayStripper.kt
@@ -55,10 +55,7 @@ class HprofPrimitiveArrayStripper {
       StreamingHprofReader.readerFor(hprofSourceProvider, header).asStreamingRecordReader()
     HprofWriter.openWriterFor(
       hprofSink,
-      hprofHeader = HprofHeader(
-        identifierByteSize = header.identifierByteSize,
-        version = header.version
-      )
+      hprofHeader = header
     )
       .use { writer ->
         reader.readRecords(setOf(HprofRecord::class),

--- a/shark-hprof/src/main/java/shark/HprofRecordReader.kt
+++ b/shark-hprof/src/main/java/shark/HprofRecordReader.kt
@@ -409,6 +409,10 @@ class HprofRecordReader internal constructor(
     return source.skip(byteCount.toLong())
   }
 
+  fun skipId() {
+    skip(identifierByteSize)
+  }
+
   fun skip(byteCount: Long) {
     bytesRead += byteCount
     return source.skip(byteCount)


### PR DESCRIPTION
In Android VMs, AFAIK there is only ever one instance of each class. However, classes can become unloaded and loaded again later, if there are no side effects. That's totally transparent to the runtime, however one of the side effects is that the class will be present twice in the heap dump.

Also, on Android, all loaded classes are held by a sticky class GC Root (i.e. they're system classes). So that's how we find which of the classes are loaded vs not when we get duplicated classes.

This change makes it so we always prioritize system classes when finding classes by name, ensure we find the loaded class.

It's worth noting that standard JVMs behave differently, so we need a different behavior for those. The ideal fix here would be to run a mark and sweep and ignore unreachable classes, however that's time consuming (and harder to do prior to having parsed the heap dump).

Fixes https://github.com/square/leakcanary/issues/1759
Fixes https://github.com/square/leakcanary/issues/2072