### PR TITLE
Profiling and benchmarking tools

### DIFF
--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Benchmark.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Benchmark.kt
@@ -1,0 +1,46 @@
+package leakcanary
+
+import android.os.SystemClock
+import leakcanary.Profiler.runWithMethodTracing
+import shark.SharkLog
+
+/**
+ * Set of tools for benchmarking and tracing blocks of code
+ */
+object Benchmark {
+
+  /**
+   * Executes the given function [block] twice (without and with method tracing to SD card) and
+   * returns the result of the function execution.
+   * First execution of [block] is done to warm up code and load any necessary libs. Second
+   * execution is measured with [runWithMethodTracing]
+   */
+  fun <T> benchmarkWithMethodTracing(block:() -> T): T {
+    SharkLog.d { "Dry run to warm up the code." }
+    block()
+    SharkLog.d { "Run with sampling" }
+    return runWithMethodTracing(block)
+  }
+
+  /**
+   * Executes the given function [block] multiple times measuring the average execution time and
+   * returns the result of the function execution.
+   * Number of executions is [times] + 1, where 1 execution is done for code warm up and other
+   * [times] executions are measured. Results of measurement will be outputted to LogCat at each
+   * iteration and in the end of measurement.
+   */
+  fun <T> benchmarkCode(times: Int = 10, block:() -> T): T {
+    // Warm-up run, no benchmarking
+    val result = block()
+    var total = 0L
+    repeat(times) {
+      val start = SystemClock.uptimeMillis()
+      block()
+      val end = SystemClock.uptimeMillis()
+      SharkLog.d { "BenchmarkCode, iteration ${it + 1}/$times, duration ${end-start}" }
+      total += (end-start)
+    }
+    SharkLog.d { "BenchmarkCode complete. Iterations:$times, avg duration ${total/times}" }
+    return result
+  }
+}

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Benchmark.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Benchmark.kt
@@ -40,7 +40,7 @@ object Benchmark {
       SharkLog.d { "BenchmarkCode, iteration ${it + 1}/$times, duration ${end-start}" }
       total += (end-start)
     }
-    SharkLog.d { "BenchmarkCode complete. Iterations:$times, avg duration ${total/times}" }
+    SharkLog.d { "BenchmarkCode complete. Iterations: $times, average duration ${total/times} ms" }
     return result
   }
 }

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
@@ -3,6 +3,7 @@ package leakcanary
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
 import leakcanary.Profiler.runWithProfilerSampling
+import org.junit.Ignore
 import org.junit.Test
 import shark.AndroidObjectInspectors
 import shark.AndroidReferenceMatchers
@@ -16,6 +17,7 @@ import java.io.FileOutputStream
 
 class ProfiledTest {
 
+  @Ignore
   @Test fun analyzeLargeDump() {
     profileAnalysis("large-dump.hprof")
   }

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
@@ -2,8 +2,7 @@ package leakcanary
 
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
-import leakcanary.Profiler.runWithSampling
-import org.junit.Ignore
+import leakcanary.Profiler.runWithProfilerSampling
 import org.junit.Test
 import shark.AndroidObjectInspectors
 import shark.AndroidReferenceMatchers
@@ -17,7 +16,6 @@ import java.io.FileOutputStream
 
 class ProfiledTest {
 
-  @Ignore
   @Test fun analyzeLargeDump() {
     profileAnalysis("large-dump.hprof")
   }
@@ -30,7 +28,7 @@ class ProfiledTest {
     context.assets.open(fileName)
         .copyTo(FileOutputStream(heapDumpFile))
 
-    runWithSampling {
+    runWithProfilerSampling {
       val analyzer = HeapAnalyzer(object : OnAnalysisProgressListener {
         override fun onAnalysisProgress(step: Step) {
           Log.d("LeakCanary", step.name)

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/ProfiledTest.kt
@@ -2,6 +2,7 @@ package leakcanary
 
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
+import leakcanary.Profiler.runWithSampling
 import org.junit.Ignore
 import org.junit.Test
 import shark.AndroidObjectInspectors
@@ -29,25 +30,21 @@ class ProfiledTest {
     context.assets.open(fileName)
         .copyTo(FileOutputStream(heapDumpFile))
 
-    SharkLog.d { "Waiting, please start profiler" }
-    Profiler.waitForSamplingStart()
-
-    val analyzer = HeapAnalyzer(object : OnAnalysisProgressListener {
-      override fun onAnalysisProgress(step: Step) {
-        Log.d("LeakCanary", step.name)
-      }
-    })
-    val result = analyzer.analyze(
-        heapDumpFile = heapDumpFile,
-        leakingObjectFinder = KeyedWeakReferenceFinder,
-        referenceMatchers = AndroidReferenceMatchers.appDefaults,
-        objectInspectors = AndroidObjectInspectors.appDefaults,
-        computeRetainedHeapSize = true
-    )
-    SharkLog.d { result.toString() }
-    // Giving time to stop CPU profiler (otherwise trace won't succeed)
-    Profiler.waitForSamplingStop()
+    runWithSampling {
+      val analyzer = HeapAnalyzer(object : OnAnalysisProgressListener {
+        override fun onAnalysisProgress(step: Step) {
+          Log.d("LeakCanary", step.name)
+        }
+      })
+      val result = analyzer.analyze(
+          heapDumpFile = heapDumpFile,
+          leakingObjectFinder = KeyedWeakReferenceFinder,
+          referenceMatchers = AndroidReferenceMatchers.appDefaults,
+          objectInspectors = AndroidObjectInspectors.appDefaults,
+          computeRetainedHeapSize = true
+      )
+      SharkLog.d { result.toString() }
+    }
   }
-
 }
 

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
@@ -79,19 +79,6 @@ internal object Profiler {
     return result
   }
 
-  /**
-   * Executes the given function [block] twice (without and with method tracing to SD card) and
-   * returns the result of the function execution.
-   * First execution of [block] is done to warm up code and load any necessary libs. Second
-   * execution is measured with [runWithMethodTracing]
-   */
-  fun <T> benchmarkWithMethodTracing(block:() -> T): T {
-    SharkLog.d { "Dry run to warm up the code." }
-    block()
-    SharkLog.d { "Run with sampling" }
-    return runWithMethodTracing(block)
-  }
-
   private inline fun sleepUntil(condition: () -> Boolean) {
     while (true) {
       if (condition()) return else Thread.sleep(SLEEP_TIME_MILLIS)

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
@@ -34,6 +34,20 @@ internal object Profiler {
     SharkLog.d { "Sampling stopped! Proceeding..." }
   }
 
+  /**
+   * Executes the given function [block] with CPU sampling via Profiler and returns the result of
+   * the function execution.
+   * First, it awaits for Profiler to be attached at start of sampling, then executes [block]
+   * and finally waits for sampling to stop. See [waitForSamplingStart] and [waitForSamplingStop]
+   * for more details.
+   */
+  fun <T> runWithSampling(block:() -> T): T {
+    waitForSamplingStart()
+    val result = block()
+    waitForSamplingStop()
+    return result
+  }
+
   private inline fun sleepUntil(condition: () -> Boolean) {
     while (true) {
       if (condition()) return else Thread.sleep(SLEEP_TIME_MILLIS)

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
@@ -1,6 +1,10 @@
 package leakcanary
 
+import android.os.Debug
 import shark.SharkLog
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * Helper class for working with Android Studio's Profiler
@@ -22,7 +26,6 @@ internal object Profiler {
     SharkLog.d { "Sampling started! Proceeding..." }
   }
 
-
   /**
    * Wait until CPU Sampling stops.
    * Calling this on main thread can lead to ANR if you try to interact with UI while it's waiting for
@@ -41,11 +44,52 @@ internal object Profiler {
    * and finally waits for sampling to stop. See [waitForSamplingStart] and [waitForSamplingStop]
    * for more details.
    */
-  fun <T> runWithSampling(block:() -> T): T {
+  fun <T> runWithProfilerSampling(block: () -> T): T {
     waitForSamplingStart()
     val result = block()
     waitForSamplingStop()
     return result
+  }
+
+  private const val TRACES_FOLDER = "/sdcard/traces/"
+  private const val TRACE_NAME_PATTERN = "yyyy-MM-dd_HH-mm-ss_SSS'.trace'"
+  private const val BUFFER_SIZE = 50 * 1024 * 1024
+  private const val TRACE_INTERVAL_US = 1000
+
+  /**
+   * Executes the given function [block] with method tracing to SD card and returns the result of
+   * the function execution.
+   * Tracing is performed with [Debug.startMethodTracingSampling] which uses sampling with
+   * [TRACE_INTERVAL_US] microseconds interval.
+   * Trace file will be stored in [TRACES_FOLDER] and can be pulled via `adb pull` command.
+   * See Logcat output for an exact command to retrieve trace file
+   */
+  fun <T> runWithMethodTracing(block: () -> T): T {
+    java.io.File(TRACES_FOLDER).mkdirs()
+    val fileName = SimpleDateFormat(TRACE_NAME_PATTERN, Locale.US).format(Date())
+    Debug.startMethodTracingSampling(
+        "$TRACES_FOLDER$fileName",
+        BUFFER_SIZE,
+        TRACE_INTERVAL_US
+    )
+    val result = block()
+    Debug.stopMethodTracing()
+    SharkLog.d { "Method tracing complete! Run following command to retrieve your trace:" }
+    SharkLog.d { "adb pull $TRACES_FOLDER$fileName ~/Downloads/ " }
+    return result
+  }
+
+  /**
+   * Executes the given function [block] twice (without and with method tracing to SD card) and
+   * returns the result of the function execution.
+   * First execution of [block] is done to warm up code and load any necessary libs. Second
+   * execution is measured with [runWithMethodTracing]
+   */
+  fun <T> benchmarkWithMethodTracing(block:() -> T): T {
+    SharkLog.d { "Dry run to warm up the code." }
+    block()
+    SharkLog.d { "Run with sampling" }
+    return runWithMethodTracing(block)
   }
 
   private inline fun sleepUntil(condition: () -> Boolean) {

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Profiler.kt
@@ -74,7 +74,7 @@ internal object Profiler {
     )
     val result = block()
     Debug.stopMethodTracing()
-    SharkLog.d { "Method tracing complete! Run following command to retrieve your trace:" }
+    SharkLog.d { "Method tracing complete! Run the following command to retrieve the trace:" }
     SharkLog.d { "adb pull $TRACES_FOLDER$fileName ~/Downloads/ " }
     return result
   }


### PR DESCRIPTION
Improved tools to measure code performance:

- `runWithProfilerSampling` - waits for Profiler to be attached and CPU sampling to start/stop
- `runWithMethodTracing` - runs with CPU Sampling saved to SD card 
- `Benchmark.benchmarkWithMethodTracing()` - same as `runWithMethodTracing` but adds another function invocation to warm up code before doing the measurements
- `Benchmark.benchmarkCode()` - similar to Androidx Benchmark, runs code `n` + 1 times (first execution for code warm up), measures each execution and average time and prints everything to LogCat. Good for running leak analysis multiple times. Defaults to 11 executions.