### PR TITLE
Fix lateinit crash

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HprofExplorerScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HprofExplorerScreen.kt
@@ -51,7 +51,7 @@ internal class HprofExplorerScreen(
     container.inflate(R.layout.leak_canary_hprof_explorer).apply {
       container.activity.title = resources.getString(R.string.leak_canary_loading_title)
 
-      lateinit var closeable: Closeable
+      var closeable: Closeable? = null
 
       addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
         override fun onViewAttachedToWindow(view: View) {
@@ -59,7 +59,7 @@ internal class HprofExplorerScreen(
 
         override fun onViewDetachedFromWindow(view: View) {
           Io.execute {
-            closeable.close()
+            closeable?.close()
           }
         }
       })


### PR DESCRIPTION
App would crash if the screen was closed before the content of the screen was loaded, due to a lateinit variable not being init yet. Kotlin does not support references to local variable (e.g. to check if it's init) so I'm changing to a nullable ref instead.

Fixes #1769