### PR TITLE
Fix crash when going back while already going back

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/Db.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/Db.kt
@@ -32,9 +32,7 @@ internal object Db {
       block(dbBlock)
       val updateUi = dbBlock.updateUi
       if (updateUi != null) {
-        updateUi {
-          updateUi()
-        }
+        updateUi(updateUi)
       }
     }
   }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/Io.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/Io.kt
@@ -5,6 +5,8 @@ import android.os.Looper
 import android.view.View
 import android.view.View.OnAttachStateChangeListener
 import leakcanary.internal.activity.db.Io.OnIo
+import leakcanary.internal.navigation.activity
+import leakcanary.internal.navigation.onScreenExiting
 import java.util.concurrent.Executors
 
 internal object Io {
@@ -34,14 +36,9 @@ internal object Io {
   ) {
     checkMainThread()
     val viewWrapper: VolatileObjectRef<View> = VolatileObjectRef(view)
-    view.addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
-      override fun onViewAttachedToWindow(v: View?) {
-      }
-
-      override fun onViewDetachedFromWindow(v: View?) {
-        viewWrapper.element = null
-      }
-    })
+    view.onScreenExiting {
+      viewWrapper.element = null
+    }
     serialExecutor.execute backgroundExecute@{
       if (viewWrapper.element == null) {
         return@backgroundExecute

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/NavigatingActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/NavigatingActivity.kt
@@ -92,6 +92,7 @@ internal abstract class NavigatingActivity : Activity() {
 
     currentView.startAnimation(loadAnimation(this, R.anim.leak_canary_exit_alpha))
     container.removeView(currentView)
+    currentView.notifyScreenExiting()
 
     backstack.clear()
 
@@ -108,6 +109,7 @@ internal abstract class NavigatingActivity : Activity() {
 
     currentView.startAnimation(loadAnimation(this, R.anim.leak_canary_exit_forward))
     container.removeView(currentView)
+    currentView.notifyScreenExiting()
     val backstackFrame = BackstackFrame(currentScreen, currentView)
     backstack.add(backstackFrame)
 
@@ -124,6 +126,7 @@ internal abstract class NavigatingActivity : Activity() {
 
     currentView.startAnimation(loadAnimation(this, R.anim.leak_canary_exit_backward))
     container.removeView(currentView)
+    currentView.notifyScreenExiting()
 
     val latest = backstack.removeAt(backstack.size - 1)
     currentScreen = latest.screen

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/Views.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/Views.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
+import com.squareup.leakcanary.core.R
 
 internal fun ViewGroup.inflate(layoutResId: Int) = LayoutInflater.from(context)
     .inflate(layoutResId, this, false)!!
@@ -36,4 +37,21 @@ internal fun Context.getColorCompat(id: Int): Int {
   } else {
     resources.getColor(id)
   }
+}
+
+internal fun View.onScreenExiting(block: () -> Unit) {
+  @Suppress("UNCHECKED_CAST")
+  var callbacks = getTag(R.id.leak_canary_notification_on_screen_exit) as MutableList<() -> Unit>?
+  if (callbacks == null) {
+    callbacks = mutableListOf<() -> Unit>()
+    setTag(R.id.leak_canary_notification_on_screen_exit, callbacks)
+  }
+  callbacks.add(block)
+}
+
+internal fun View.notifyScreenExiting() {
+  @Suppress("UNCHECKED_CAST")
+  val callbacks = getTag(R.id.leak_canary_notification_on_screen_exit)
+      as MutableList<() -> Unit>?
+  callbacks?.forEach { it.invoke() }
 }

--- a/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
@@ -21,4 +21,5 @@
   <item type="id" name="leak_canary_notification_analyzing_heap" />
   <item type="id" name="leak_canary_notification_retained_objects" />
   <item type="id" name="leak_canary_notification_no_retained_object_on_tap" />
+  <item type="id" name="leak_canary_notification_on_screen_exit" />
 </resources>


### PR DESCRIPTION
The navigation utilities we have in place normally take care of canceling scheduled work (IO and back on main thread as well) when we leave a screen. Unfortunately we were previously waiting for the view animation to be done (view detached). Instead we now cancel the work as soon as we decide to move.

Fixes #1768