### PR TITLE
Propagate heap analysis updates to the UI

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakTraceTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakTraceTable.kt
@@ -41,8 +41,4 @@ internal object LeakTraceTable {
   ) {
     db.delete("leak_trace", "heap_analysis_id=$heapAnalysisId", null)
   }
-
-  fun deleteAll(db: SQLiteDatabase) {
-    db.delete("leak_trace", null, null)
-  }
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpsScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpsScreen.kt
@@ -13,15 +13,24 @@ import leakcanary.internal.activity.db.HeapAnalysisTable.Projection
 import leakcanary.internal.activity.db.executeOnDb
 import leakcanary.internal.activity.ui.SimpleListAdapter
 import leakcanary.internal.activity.ui.TimeFormatter
+import leakcanary.internal.navigation.NavigatingActivity
 import leakcanary.internal.navigation.Screen
 import leakcanary.internal.navigation.activity
 import leakcanary.internal.navigation.goTo
 import leakcanary.internal.navigation.inflate
 import leakcanary.internal.navigation.onCreateOptionsMenu
+import leakcanary.internal.navigation.onScreenExiting
 
 internal class HeapDumpsScreen : Screen() {
   override fun createView(container: ViewGroup) =
     container.inflate(R.layout.leak_canary_heap_dumps_screen).apply {
+
+      val unsubscribeRefresh = HeapAnalysisTable.onUpdate {
+        activity<NavigatingActivity>().refreshCurrentScreen()
+      }
+
+      onScreenExiting { unsubscribeRefresh() }
+
       onCreateOptionsMenu { menu ->
         menu.add(R.string.leak_canary_delete_all)
             .setOnMenuItemClickListener {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeaksScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeaksScreen.kt
@@ -7,19 +7,29 @@ import android.view.ViewGroup
 import android.widget.ListView
 import android.widget.TextView
 import com.squareup.leakcanary.core.R
+import leakcanary.internal.activity.db.HeapAnalysisTable
 import leakcanary.internal.activity.db.LeakTable
 import leakcanary.internal.activity.db.LeakTable.AllLeaksProjection
 import leakcanary.internal.activity.db.executeOnDb
 import leakcanary.internal.activity.ui.SimpleListAdapter
 import leakcanary.internal.activity.ui.TimeFormatter
+import leakcanary.internal.navigation.NavigatingActivity
 import leakcanary.internal.navigation.Screen
 import leakcanary.internal.navigation.activity
 import leakcanary.internal.navigation.goTo
 import leakcanary.internal.navigation.inflate
+import leakcanary.internal.navigation.onScreenExiting
 
 internal class LeaksScreen : Screen() {
   override fun createView(container: ViewGroup) =
     container.inflate(R.layout.leak_canary_list).apply {
+
+      val unsubscribeRefresh = HeapAnalysisTable.onUpdate {
+        activity<NavigatingActivity>().refreshCurrentScreen()
+      }
+
+      onScreenExiting { unsubscribeRefresh() }
+
       executeOnDb {
         val projections = LeakTable.retrieveAllLeaks(db)
         updateUi { onGroupsRetrieved(projections) }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/NavigatingActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/NavigatingActivity.kt
@@ -121,6 +121,16 @@ internal abstract class NavigatingActivity : Activity() {
     screenUpdated()
   }
 
+  fun refreshCurrentScreen() {
+    onCreateOptionsMenu = NO_MENU
+    container.removeView(currentView)
+    currentView.notifyScreenExiting()
+    currentView = currentScreen.createView(container)
+    container.addView(currentView)
+
+    screenUpdated()
+  }
+
   fun goBack() {
     onCreateOptionsMenu = NO_MENU
 


### PR DESCRIPTION
The list of leaks and the list of heap dumps were previously not updating when a heap dump analysis was added or remove. This makes them update immediately by reloading those screens.

Fixes #1742