### PR TITLE
Unit tests for Builders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ buildscript {
       junit: 'junit:junit:4.12',
       kotlin: [
           gradlePlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
-          stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
+          stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
+          reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
       ],
       mockito: 'org.mockito:mockito-core:2.7.5',
       mockito_kotlin: 'com.nhaarman:mockito-kotlin-kt1.1:1.5.0',

--- a/leakcanary-android-core/build.gradle
+++ b/leakcanary-android-core/build.gradle
@@ -9,7 +9,9 @@ dependencies {
 
   implementation deps.kotlin.stdlib
 
+  testImplementation deps.assertj_core
   testImplementation deps.junit
+  testImplementation deps.kotlin.reflect
   testImplementation deps.mockito
   testImplementation deps.mockito_kotlin
   androidTestImplementation deps.androidx.test.espresso

--- a/leakcanary-android-core/src/test/java/leakcanary/LeakCanaryConfigTest.kt
+++ b/leakcanary-android-core/src/test/java/leakcanary/LeakCanaryConfigTest.kt
@@ -5,28 +5,22 @@ import org.junit.Test
 import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.memberProperties
 
-class AppWatcherTest {
-
-  @Test fun appWatcherLoads_notInstalled() {
-    assertThat(AppWatcher.isInstalled)
-        .describedAs("Ensure AppWatcher doesn't crash in JUnit tests")
-        .isFalse()
-  }
+class LeakCanaryConfigTest {
 
   /**
-   * Validates that each field in [AppWatcher.Config] has a matching builder function
-   * in [AppWatcher.Config.Builder]
+   * Validates that each field in [LeakCanary.Config] has a matching builder function
+   * in [LeakCanary.Config.Builder]
    */
-  @Test fun `AppWatcher Config Builder matches AppWatcher Config`() {
+  @Test fun `LeakCanary Config Builder matches LeakCanary Config`() {
     assertThat(configProperties())
         .containsExactlyInAnyOrderElementsOf(configBuilderFunctions())
   }
 
-  private fun configBuilderFunctions() = AppWatcher.Config.Builder::class.memberFunctions
+  private fun configBuilderFunctions() = LeakCanary.Config.Builder::class.memberFunctions
       .map { it.name }
       .subtract(listOf("build", "equals", "hashCode", "toString"))
 
-  private fun configProperties() = AppWatcher.Config::class.memberProperties
+  private fun configProperties() = LeakCanary.Config::class.memberProperties
       .filter { member ->
         // Ignore deprecated fields, we don't need builders for those
         member.annotations.none { it is Deprecated }

--- a/leakcanary-object-watcher-android/build.gradle
+++ b/leakcanary-object-watcher-android/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
   testImplementation deps.assertj_core
   testImplementation deps.junit
+  testImplementation deps.kotlin.reflect
 }
 
 android {


### PR DESCRIPTION
Added unit tests for LeakCanary.Config.Builder and AppWatcher.Config.Builder to make sure their APIs match the data classes.
Tests will fail if one adds a field to `.Config` and forgets to add a matching builder method to `.Config.Builder`