### PR TITLE
Show heapdump status in AboutScreen (#1805)

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpPolicy.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpPolicy.kt
@@ -1,0 +1,28 @@
+package leakcanary.internal
+
+import leakcanary.LeakCanary
+import leakcanary.internal.HeapDumpPolicy.HeapDumpStatus.DISABLED_CONFIG_CHANGED
+import leakcanary.internal.HeapDumpPolicy.HeapDumpStatus.DISABLED_DEBUGGER_ATTACHED
+import leakcanary.internal.HeapDumpPolicy.HeapDumpStatus.ENABLED
+
+object HeapDumpPolicy {
+  enum class HeapDumpStatus {
+    ENABLED,
+    DISABLED_DEBUGGER_ATTACHED,
+    DISABLED_CONFIG_CHANGED
+  }
+
+  fun getHeapDumpStatus(): HeapDumpStatus {
+    val config = LeakCanary.config
+
+    if (!config.dumpHeapWhenDebugging && DebuggerControl.isDebuggerAttached) {
+      return DISABLED_DEBUGGER_ATTACHED
+    }
+
+    if (!config.dumpHeap) {
+      return DISABLED_CONFIG_CHANGED
+    }
+
+    return ENABLED
+  }
+}

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
@@ -1,11 +1,18 @@
 package leakcanary.internal.activity.screen
 
+import android.content.res.Resources
 import android.text.Html
 import android.text.method.LinkMovementMethod
 import android.view.ViewGroup
 import android.widget.TextView
 import com.squareup.leakcanary.core.BuildConfig
 import com.squareup.leakcanary.core.R
+import leakcanary.LeakCanary
+import leakcanary.internal.DebuggerControl
+import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_BY_DEVELOPER
+import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_DEBUGGER_ATTACHED
+import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.DISABLED_RUNNING_TESTS
+import leakcanary.internal.activity.screen.AboutScreen.HeapDumpPolicy.HeapDumpStatus.ENABLED
 import leakcanary.internal.navigation.Screen
 import leakcanary.internal.navigation.activity
 import leakcanary.internal.navigation.inflate
@@ -20,11 +27,64 @@ internal class AboutScreen : Screen() {
       val application = activity.application
       val appName = application.packageManager.getApplicationLabel(application.applicationInfo)
       val appPackageName = context.packageName
+
       aboutTextView.text = Html.fromHtml(
           String.format(
               resources.getString(R.string.leak_canary_about_message), appName, appPackageName
           )
       )
+
+      val heapDumpText = findViewById<TextView>(R.id.leak_canary_about_heap_dump_text)
+      heapDumpText.text = getHeapDumpStatusMessage(resources)
     }
 
+  private fun getHeapDumpStatusMessage(resources: Resources) =
+    when (getHeapDumpStatus(resources)) {
+      ENABLED -> resources.getString(R.string.leak_canary_heap_dump_enabled_text)
+      DISABLED_DEBUGGER_ATTACHED -> String.format(
+          resources.getString(R.string.leak_canary_heap_dump_disabled_text),
+          resources.getString(R.string.leak_canary_heap_dump_disabled_build_non_debuggable)
+      )
+      DISABLED_BY_DEVELOPER -> String.format(
+          resources.getString(R.string.leak_canary_heap_dump_disabled_text),
+          resources.getString(R.string.leak_canary_heap_dump_disabled_by_app)
+      )
+      DISABLED_RUNNING_TESTS -> String.format(
+          resources.getString(R.string.leak_canary_heap_dump_disabled_text),
+          resources.getString(R.string.leak_canary_heap_dump_disabled_running_tests)
+      )
+    }
+
+  private companion object HeapDumpPolicy {
+    enum class HeapDumpStatus {
+      ENABLED,
+      DISABLED_DEBUGGER_ATTACHED,
+      DISABLED_BY_DEVELOPER,
+      DISABLED_RUNNING_TESTS
+    }
+
+    fun getHeapDumpStatus(resources: Resources): HeapDumpStatus {
+      val config = LeakCanary.config
+      if (!config.dumpHeap) {
+        if (isRunningTests(resources)) {
+          return DISABLED_RUNNING_TESTS
+        }
+        return DISABLED_BY_DEVELOPER
+      }
+
+      if (!config.dumpHeapWhenDebugging && DebuggerControl.isDebuggerAttached) {
+        return DISABLED_DEBUGGER_ATTACHED
+      }
+
+      return ENABLED
+    }
+
+    private fun isRunningTests(resources: Resources) =
+      try {
+        Class.forName(resources.getString(R.string.leak_canary_test_class_name))
+        true
+      } catch (e: Exception) {
+        false
+      }
+  }
 }

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_about_screen.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_about_screen.xml
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/leak_canary_about_text"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingLeft="16dp"
-    android:paddingRight="16dp"
-    android:paddingBottom="16dp"
-    />
+    android:layout_height="match_parent"
+    >
+  <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+      android:id="@+id/leak_canary_about_text"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:paddingBottom="16dp"
+      android:paddingLeft="16dp"
+      android:paddingRight="16dp"
+      />
 
+  <TextView
+      android:id="@+id/leak_canary_about_heap_dump_text"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_alignParentBottom="true"
+      android:paddingBottom="16dp"
+      android:paddingLeft="16dp"
+      android:paddingRight="16dp"
+      android:textStyle="italic"
+      />
+
+</RelativeLayout>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -23,8 +23,13 @@
   and open sourced by <a href="https://twitter.com/Piwai">Pierre-Yves Ricau</a> at <a href="https://square.github.io">Square</a>.<br><br>
   You can learn more about memory leaks at <a href="https://squ.re/leaks">https://squ.re/leaks</a>.<br><br>
   We welcome contributions from the community - please do not hesitate to
-  <a href="https://github.com/square/leakcanary/issues">report an issue</a> or open a pull request!<br>
+  <a href="https://github.com/square/leakcanary/issues">report an issue</a> or open a pull request!<br><br>
 ]]></string>
+  <string name="leak_canary_heap_dump_disabled_text">Heap dumping is currently disabled, because <i>%s</i>.</string>
+  <string name="leak_canary_heap_dump_enabled_text">Heap dumping is currently enabled.</string>
+  <string name="leak_canary_heap_dump_disabled_by_app">LeakCanary.Config.dumpHeap is set to false</string>
+  <string name="leak_canary_heap_dump_disabled_running_tests">tests are running</string>
+  <string name="leak_canary_heap_dump_disabled_build_non_debuggable">the debugger is attached and LeakCanary.Config.dumpHeapWhenDebugging is set to false</string>
   <string name="leak_canary_analysis_failed">Heap analysis failed</string>
   <string name="leak_canary_analysis_success_notification">Found %1$d retained objects grouped as %2$d distinct leaks</string>
   <string name="leak_canary_class_has_leaked">%1$s Leaked</string>


### PR DESCRIPTION
This status aims at preventing confusions about
whether LeakCanary is currently working or not (#1803).