### PR TITLE
Improve the way LeakCanary Deobfuscation Plugin is applied

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -543,7 +543,6 @@ And then you need to apply and configure the plugin in your app (or library) spe
 
 ```groovy
 apply plugin: 'com.android.application'
-// LeakCanary plugin should be added after android application or android library plugin
 apply plugin: 'com.squareup.leakcanary.deobfuscation'
 
 leakCanary {

--- a/leakcanary-deobfuscation-gradle-plugin/src/test/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPluginTest.kt
+++ b/leakcanary-deobfuscation-gradle-plugin/src/test/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPluginTest.kt
@@ -115,8 +115,8 @@ class LeakCanaryLeakDeobfuscationPluginTest {
     buildFile.writeText(
       """
         plugins {
-          id 'com.android.application'
           id 'com.squareup.leakcanary.deobfuscation'
+          id 'com.android.application'
         }
         
         allprojects {
@@ -162,28 +162,6 @@ class LeakCanaryLeakDeobfuscationPluginTest {
       }
     }
     assertThat(obfuscationMappingEntry == null).isTrue()
-  }
-
-  @Test
-  fun `should throw if android plugin is not applied before deobfuscation plugin`() {
-    buildFile.writeText(
-      """
-        plugins {
-          id 'com.squareup.leakcanary.deobfuscation'
-        }
-      """.trimIndent()
-    )
-
-    val result = GradleRunner.create()
-      .withProjectDir(tempFolder.root)
-      .withPluginClasspath()
-      .buildAndFail()
-
-    assertThat(
-      result.output.contains(
-    "LeakCanary deobfuscation plugin can be used only in Android application or library module."
-      )
-    ).isTrue()
   }
 
   @Test


### PR DESCRIPTION
This change causes that LeakCanary deobfuscation plugin no longer have to be applied after android/library plugin. It now uses `PluginManager.withPlugin` method that ensures that LeakCanary plugin will be applied after android or library plugin has been applied.

It's also a potential fix for #1807 