### PR TITLE
Fix TuPeuxPasTest documentation

### DIFF
--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -74,7 +74,7 @@ import java.io.File
  *  - Heap dumps freeze the VM, and the leak analysis is IO and CPU heavy. This can slow down
  * the test and introduce flakiness
  *  - The leak analysis is asynchronous by default. This means the tests could finish and the
- *  process die before the analysis is finished.
+ *  process dies before the analysis is finished.
  *
  * The approach taken here is to collect all objects to watch as you run the test, but not
  * do any heap dump during the test. Then, at the end, if any of the watched objects is still in

--- a/leakcanary-android-sample/src/androidTest/java/leakcanary/tests/TuPeuxPasTest.kt
+++ b/leakcanary-android-sample/src/androidTest/java/leakcanary/tests/TuPeuxPasTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
  * ./gradlew leakcanary-sample:connectedCheck
  *
  * To set this up, we installed a special ObjectWatcher dedicated to detecting leaks in
- * instrumentation tests in [InstrumentationExampleApplication], and then added the FailTestOnLeakRunListener
+ * instrumentation tests in InstrumentationLeakDetector, and then added the FailTestOnLeakRunListener
  * to the config of our build.gradle:
  *
  * testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"


### PR DESCRIPTION
There was a reference to InstrumentationExampleApplication which
does not exist anymore in the project.