### PR TITLE
Prevent Jetifier from changing classname strings

### DIFF
--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/FragmentDestroyWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/FragmentDestroyWatcher.kt
@@ -33,7 +33,11 @@ internal object FragmentDestroyWatcher {
   private const val ANDROIDX_FRAGMENT_DESTROY_WATCHER_CLASS_NAME =
     "leakcanary.internal.AndroidXFragmentDestroyWatcher"
 
-  private const val ANDROID_SUPPORT_FRAGMENT_CLASS_NAME = "android.support.v4.app.Fragment"
+  // Using a string builder to prevent Jetifier from changing this string to Android X Fragment
+  @Suppress("VariableNaming", "PropertyName")
+  private val ANDROID_SUPPORT_FRAGMENT_CLASS_NAME =
+    StringBuilder("android.").append("support.v4.app.Fragment")
+        .toString()
   private const val ANDROID_SUPPORT_FRAGMENT_DESTROY_WATCHER_CLASS_NAME =
     "leakcanary.internal.AndroidSupportFragmentDestroyWatcher"
 

--- a/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
+++ b/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
@@ -269,21 +269,21 @@ enum class AndroidObjectInspectors : ObjectInspector {
 
     override val leakingObjectFilter = { heapObject: HeapObject ->
       heapObject is HeapInstance &&
-          heapObject instanceOf "android.support.v4.app.Fragment" &&
-          heapObject["android.support.v4.app.Fragment", "mFragmentManager"]!!.value.isNullReference
+          heapObject instanceOf ANDROID_SUPPORT_FRAGMENT_CLASS_NAME &&
+          heapObject[ANDROID_SUPPORT_FRAGMENT_CLASS_NAME, "mFragmentManager"]!!.value.isNullReference
     }
 
     override fun inspect(
       reporter: ObjectReporter
     ) {
-      reporter.whenInstanceOf("android.support.v4.app.Fragment") { instance ->
-        val fragmentManager = instance["android.support.v4.app.Fragment", "mFragmentManager"]!!
+      reporter.whenInstanceOf(ANDROID_SUPPORT_FRAGMENT_CLASS_NAME) { instance ->
+        val fragmentManager = instance[ANDROID_SUPPORT_FRAGMENT_CLASS_NAME, "mFragmentManager"]!!
         if (fragmentManager.value.isNullReference) {
           leakingReasons += fragmentManager describedWithValue "null"
         } else {
           notLeakingReasons += fragmentManager describedWithValue "not null"
         }
-        val mTag = instance["android.support.v4.app.Fragment", "mTag"]?.value?.readAsJavaString()
+        val mTag = instance[ANDROID_SUPPORT_FRAGMENT_CLASS_NAME, "mTag"]?.value?.readAsJavaString()
         if (!mTag.isNullOrEmpty()) {
           labels += "Fragment.mTag=$mTag"
         }
@@ -515,6 +515,12 @@ enum class AndroidObjectInspectors : ObjectInspector {
             }
           }
   }
+
+  // Using a string builder to prevent Jetifier from changing this string to Android X Fragment
+  @Suppress("VariableNaming", "PropertyName")
+  internal val ANDROID_SUPPORT_FRAGMENT_CLASS_NAME =
+    StringBuilder("android.").append("support.v4.app.Fragment")
+        .toString()
 }
 
 private infix fun HeapField.describedWithValue(valueDescription: String): String {


### PR DESCRIPTION
LeakCanary supports both Android X and the support library. We've caught Jetifier changing string content (ie support fragment class name to android x fragment class name) and we don't want it to do that, so we're playing string tricks to mess with Jetifier.