### PR TITLE
Shark CLI: Add version option

### DIFF
--- a/shark-cli/build.gradle
+++ b/shark-cli/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'application'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+compileKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
 
 dependencies {
   api project(':shark-android')
@@ -18,3 +19,23 @@ application {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+
+def generatedVersionDir = "${buildDir}/generated-version"
+
+sourceSets {
+  main {
+    output.dir(generatedVersionDir, builtBy: 'generateVersionProperties')
+  }
+}
+
+task generateVersionProperties {
+  doLast {
+    def propertiesFile = file "$generatedVersionDir/version.properties"
+    propertiesFile.parentFile.mkdirs()
+    def properties = new Properties()
+    properties.setProperty("version_name", rootProject.VERSION_NAME.toString())
+    propertiesFile.withWriter { properties.store(it, null) }
+  }
+}
+processResources.dependsOn generateVersionProperties

--- a/shark-cli/src/main/java/shark/SharkCliCommand.kt
+++ b/shark-cli/src/main/java/shark/SharkCliCommand.kt
@@ -10,6 +10,7 @@ import com.github.ajalt.clikt.parameters.groups.cooccurring
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.parameters.types.file
 import shark.DumpProcessCommand.Companion.dumpHeap
 import shark.SharkCliCommand.HeapDumpSource.HprofFileSource
@@ -18,12 +19,15 @@ import shark.SharkLog.Logger
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.util.*
 import java.util.concurrent.TimeUnit.SECONDS
 
 class SharkCliCommand : CliktCommand(
     name = "shark-cli",
     // This ASCII art is a remix of a shark from -David "TAZ" Baltazar- and chick from jgs.
     help = """
+    |Version: $versionName
+    |
     |```
     |$S                ^`.                 .=""=.
     |$S^_              \  \               / _  _ \
@@ -66,6 +70,10 @@ class SharkCliCommand : CliktCommand(
       folderOkay = false,
       readable = true
   )
+
+  init {
+    versionOption(versionName)
+  }
 
   class CommandParams(
     val source: HeapDumpSource,
@@ -191,6 +199,13 @@ class SharkCliCommand : CliktCommand(
       }
       return output
     }
+
+    private val versionName = run {
+      val properties = Properties()
+      properties.load(SharkCliCommand::class.java.getResourceAsStream("/version.properties"))
+      properties.getProperty("version_name", "no version")
+    }
+
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/square/leakcanary/issues/1826

- Pass version_name to jar build. [I used this StackOverflow recipe](https://stackoverflow.com/questions/50117966/get-version-in-kotlin-java-code-in-gradle-project)

- New option `--version` [according to clikt docs options](https://ajalt.github.io/clikt/options/#eager-options)
Looks like this:
```
➜  shark-cli --version
shark-cli version 2.3-SNAPSHOT
```

- Add version info into `help` part of default output
Looks like this. A little shifted. But it's limitation of clikt (or I don't know how to unshift)
```
➜  shark-cli
Usage: shark-cli [OPTIONS] COMMAND [ARGS]...

  Version: 2.3-SNAPSHOT

  ​                ^`.                 .=""=.
  ​^_              \  \               / _  _ \
  ​\ \             {   \             |  d  b  |
  ​{  \           /     `~~~--__     \   /\   /
  ​{   \___----~~'              `~~-_/'-=\/=-'\,
  ​ \                         /// a  `~.      \ \
  ​ / /~~~~-, ,__.    ,      ///  __,,,,)      \ |
  ​ \/      \/    `~~~;   ,---~~-_`/ \        / \/
  ​                  /   /            '.    .'
  ​                 '._.'             _|`~~`|_
  ​                                   /|\  /|\

Options:
  -p, --process TEXT              Full or partial name of a process, e.g.
                                  "example" would match "com.example.app"
  -d, --device ID                 device/emulator id
  -m, --obfuscation-mapping PATH  path to obfuscation mapping file
  --verbose / --no-verbose        provide additional details as to what
                                  shark-cli is doing
  -h, --hprof FILE                path to a .hprof file
  --version                       Show the version and exit
  --help                          Show this message and exit

Commands:
  interactive   Explore a heap dump.
  analyze       Analyze a heap dump.
  dump-process  Dump the heap and pull the hprof file.
  strip-hprof   Replace all primitive arrays from the provided heap dump with
                arrays of zeroes and generate a new "-stripped.hprof" file.
```

