### PR TITLE
Fix Docs. Releasing.md: fix code block

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -109,7 +109,7 @@ See [Change Log](https://square.github.io/leakcanary/changelog#version-20-alpha-
 ```
 * Add the CLIP zip from `shark-cli/build/distributions/` to the release.
 * Make a pull request to [brew](https://brew.sh/). Just execute 
-```(bash)
+```bash
 brew bump-formula-pr --url https://github.com/square/leakcanary/releases/download/v{{ leak_canary.next_release }}/shark-cli-{{ leak_canary.next_release }}.zip leakcanary-shark
 ```
 (The url parameter should point at zip from this new release).   


### PR DESCRIPTION
Looks like docs engine doesn't understand code lang meta info. Fixed it via removing meta.
Here's current state in [docs](https://square.github.io/leakcanary/releasing/)

> ![image](https://user-images.githubusercontent.com/2548610/82315624-3cc6cf00-99d4-11ea-9d67-4d9caf20a79f.png)
