### PR TITLE
Fix Android P ViewLocationHolder leak

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakScreen.kt
@@ -77,8 +77,8 @@ internal class LeakScreen(
 
     activity.title = String.format(
         resources.getQuantityText(
-            R.plurals.leak_canary_group_screen_title, leak.leakTraces.size
-        )
+                R.plurals.leak_canary_group_screen_title, leak.leakTraces.size
+            )
             .toString(), leak.leakTraces.size, leak.shortDescription
     )
 
@@ -237,12 +237,13 @@ internal class LeakScreen(
 
 METADATA
 
-${if (analysis.metadata.isNotEmpty())
+${if (analysis.metadata.isNotEmpty()) {
     analysis.metadata
         .map { "${it.key}: ${it.value}" }
         .joinToString("\n")
-  else
+  } else {
     ""
+  }
   }
 Analysis duration: ${analysis.analysisDurationMillis} ms"""
 }

--- a/plumber-android/build.gradle
+++ b/plumber-android/build.gradle
@@ -5,6 +5,8 @@ dependencies {
   api project(':shark-log')
 
   implementation deps.kotlin.stdlib
+  // Optional dependency
+  compileOnly deps.androidx.fragment
 }
 
 android {

--- a/plumber-android/src/main/java/leakcanary/ViewLocationHolderLeakFix.kt
+++ b/plumber-android/src/main/java/leakcanary/ViewLocationHolderLeakFix.kt
@@ -1,0 +1,68 @@
+package leakcanary
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.Application
+import android.os.Build.VERSION
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import leakcanary.AndroidLeakFixes.Companion.checkMainThread
+import leakcanary.internal.onAndroidXFragmentViewDestroyed
+
+/**
+ * @see [AndroidLeakFixes.VIEW_LOCATION_HOLDER].
+ */
+@SuppressLint("NewApi")
+object ViewLocationHolderLeakFix {
+
+  private var groupAndOutChildren: Pair<ViewGroup, ArrayList<View>>? = null
+
+  internal fun applyFix(application: Application) {
+    if (VERSION.SDK_INT != 28) {
+      return
+    }
+    application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks
+    by AndroidLeakFixes.noOpDelegate() {
+
+      override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?
+      ) {
+        activity.onAndroidXFragmentViewDestroyed {
+          uncheckedClearStaticPool(application)
+        }
+      }
+
+      override fun onActivityDestroyed(activity: Activity) {
+        uncheckedClearStaticPool(application)
+      }
+    })
+  }
+
+  /**
+   * Clears the ViewGroup.ViewLocationHolder.sPool static pool.
+   */
+  fun clearStaticPool(application: Application) {
+    checkMainThread()
+    if (VERSION.SDK_INT != 28) {
+      return
+    }
+    uncheckedClearStaticPool(application)
+  }
+
+  private fun uncheckedClearStaticPool(application: Application) {
+    if (groupAndOutChildren == null) {
+      val viewGroup = FrameLayout(application)
+      // ViewLocationHolder.MAX_POOL_SIZE = 32
+      for (i in 0 until 32) {
+        val childView = View(application)
+        viewGroup.addView(childView)
+      }
+      groupAndOutChildren = viewGroup to ArrayList()
+    }
+    val (group, outChildren) = groupAndOutChildren!!
+    group.addChildrenForAccessibility(outChildren)
+  }
+}

--- a/plumber-android/src/main/java/leakcanary/internal/FragmentExtensions.kt
+++ b/plumber-android/src/main/java/leakcanary/internal/FragmentExtensions.kt
@@ -1,0 +1,33 @@
+package leakcanary.internal
+
+import android.app.Activity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+
+private val hasAndroidXFragmentActivity: Boolean by lazy {
+  try {
+    Class.forName("androidx.fragment.app.FragmentActivity")
+    true
+  } catch (ignored: Throwable) {
+    false
+  }
+}
+
+internal fun Activity.onAndroidXFragmentViewDestroyed(block: () -> Unit) {
+  if (!hasAndroidXFragmentActivity) {
+    return
+  }
+  if (this is FragmentActivity) {
+    supportFragmentManager.registerFragmentLifecycleCallbacks(
+        object : FragmentManager.FragmentLifecycleCallbacks() {
+          override fun onFragmentViewDestroyed(
+            fm: FragmentManager,
+            fragment: Fragment
+          ) {
+            block()
+          }
+        }, true
+    )
+  }
+}


### PR DESCRIPTION
Related to #1081

Used the code from @jrodbx ([here](https://github.com/square/leakcanary/issues/1081#issuecomment-453606702)) to log whether the leak is happening, which worked after changing this:

```
adb shell settings put global hidden_api_policy_pre_p_apps  1
adb shell settings put global hidden_api_policy_p_apps 1
```

Then I used the code from @eneim [here](https://github.com/square/leakcanary/issues/1081#issuecomment-551080576) to reproduce the leak. The leak was not happening on the P emulator until I turned on talkback, then it immediately started happening.