### PR TITLE
Support for Android Test Orchestrator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
               espresso: 'androidx.test.espresso:espresso-core:3.1.0',
               rules: 'androidx.test:rules:1.1.0',
               runner: 'androidx.test:runner:1.1.0',
+              orchestrator: 'androidx.test:orchestrator:1.1.0',
           ],
       ],
       android_support: 'com.android.support:support-v4:28.0.0',

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -91,10 +91,10 @@ complexity:
     #LeakCanary - increased from 11 to 12
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    thresholdInFiles: 12
-    thresholdInClasses: 12
-    thresholdInInterfaces: 12
-    thresholdInObjects: 12
+    thresholdInFiles: 50
+    thresholdInClasses: 50
+    thresholdInInterfaces: 11
+    thresholdInObjects: 50
     thresholdInEnums: 12
     ignoreDeprecated: false
     ignorePrivate: false

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -139,7 +139,12 @@ android {
     // ...
 
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"
+    testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"	
+
+    // If you're using Android Test Orchestrator
+    testOptions {
+      execution 'ANDROIDX_TEST_ORCHESTRATOR'
+    }
   }
 }
 ```

--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -198,7 +198,6 @@ object LeakCanary {
      * LeakCanary.config = LeakCanary.config.copy(retainedVisibleThreshold = 3)
      * ```
      */
-    @Suppress("TooManyFunctions")
     class Builder internal constructor(config: Config) {
       private var dumpHeap = config.dumpHeap
       private var dumpHeapWhenDebugging = config.dumpHeapWhenDebugging

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
@@ -45,7 +45,7 @@ import shark.LeakTraceObject.LeakingStatus.NOT_LEAKING
 import shark.LeakTraceObject.LeakingStatus.UNKNOWN
 import shark.LeakTraceReference.ReferenceType.STATIC_FIELD
 
-@Suppress("DEPRECATION", "TooManyFunctions")
+@Suppress("DEPRECATION")
 internal class DisplayLeakAdapter constructor(
   context: Context,
   private val leakTrace: LeakTrace,

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -24,7 +24,6 @@ import leakcanary.internal.RetainInstanceEvent.NoMoreObjects
 import shark.AndroidResourceIdNames
 import shark.SharkLog
 
-@Suppress("TooManyFunctions")
 internal class HeapDumpTrigger(
   private val application: Application,
   private val backgroundHandler: Handler,

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/NavigatingActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/navigation/NavigatingActivity.kt
@@ -14,7 +14,6 @@ import com.squareup.leakcanary.core.R
 /**
  * A simple backstack navigating activity
  */
-@Suppress("TooManyFunctions")
 internal abstract class NavigatingActivity : Activity() {
 
   private lateinit var backstack: ArrayList<BackstackFrame>

--- a/leakcanary-android-instrumentation/src/main/java/androidx/test/orchestrator/instrumentationlistener/OrchestratedInstrumentationListenerSpy.kt
+++ b/leakcanary-android-instrumentation/src/main/java/androidx/test/orchestrator/instrumentationlistener/OrchestratedInstrumentationListenerSpy.kt
@@ -1,0 +1,20 @@
+package androidx.test.orchestrator.instrumentationlistener
+
+import android.os.Bundle
+import androidx.test.orchestrator.callback.OrchestratorCallback
+
+internal fun OrchestratedInstrumentationListener.delegateSendTestNotification(
+  onSendTestNotification: (Bundle, (Bundle) -> Unit) -> Unit
+) {
+  val realCallback = odoCallback
+
+  val sendTestNotificationCallback: (Bundle) -> Unit = { bundle ->
+    realCallback.sendTestNotification(bundle)
+  }
+
+  odoCallback = object : OrchestratorCallback by realCallback {
+    override fun sendTestNotification(bundle: Bundle) {
+      onSendTestNotification(bundle, sendTestNotificationCallback)
+    }
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/InstrumentationTestResultPublisher.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/InstrumentationTestResultPublisher.kt
@@ -1,0 +1,30 @@
+package leakcanary.internal
+
+import android.app.Instrumentation.REPORT_KEY_IDENTIFIER
+import android.os.Bundle
+import androidx.test.internal.runner.listener.InstrumentationResultPrinter.REPORT_KEY_NAME_CLASS
+import androidx.test.internal.runner.listener.InstrumentationResultPrinter.REPORT_KEY_NAME_TEST
+import androidx.test.internal.runner.listener.InstrumentationResultPrinter.REPORT_KEY_STACK
+import androidx.test.internal.runner.listener.InstrumentationResultPrinter.REPORT_VALUE_RESULT_FAILURE
+import androidx.test.platform.app.InstrumentationRegistry
+import leakcanary.FailTestOnLeakRunListener
+import org.junit.runner.Description
+
+internal class InstrumentationTestResultPublisher : TestResultPublisher {
+  override fun publishTestFinished() {
+  }
+
+  override fun publishTestFailure(
+    description: Description,
+    trace: String
+  ) {
+    val bundle = Bundle()
+    bundle.putString(REPORT_KEY_IDENTIFIER, FailTestOnLeakRunListener::class.java.name)
+    bundle.putString(REPORT_KEY_NAME_CLASS, description.className)
+    bundle.putString(REPORT_KEY_NAME_TEST, description.methodName)
+    bundle.putString(REPORT_KEY_STACK, trace)
+
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    instrumentation.sendStatus(REPORT_VALUE_RESULT_FAILURE, bundle)
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/OrchestratorTestResultPublisher.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/OrchestratorTestResultPublisher.kt
@@ -1,0 +1,75 @@
+package leakcanary.internal
+
+import android.os.Bundle
+import androidx.test.orchestrator.instrumentationlistener.OrchestratedInstrumentationListener
+import androidx.test.orchestrator.instrumentationlistener.delegateSendTestNotification
+import androidx.test.orchestrator.junit.ParcelableDescription
+import androidx.test.orchestrator.junit.ParcelableFailure
+import androidx.test.orchestrator.junit.ParcelableResult
+import androidx.test.orchestrator.listeners.OrchestrationListenerManager.KEY_TEST_EVENT
+import androidx.test.orchestrator.listeners.OrchestrationListenerManager.TestEvent.TEST_FAILURE
+import androidx.test.orchestrator.listeners.OrchestrationListenerManager.TestEvent.TEST_FINISHED
+import androidx.test.orchestrator.listeners.OrchestrationListenerManager.TestEvent.TEST_RUN_FINISHED
+import org.junit.runner.Description
+
+internal class OrchestratorTestResultPublisher(listener: OrchestratedInstrumentationListener) :
+    TestResultPublisher {
+
+  private var sendTestFinished: (() -> Unit)? = null
+
+  private var failureBundle: Bundle? = null
+
+  private var receivedTestFinished: Boolean = false
+
+  init {
+    val failures = mutableListOf<ParcelableFailure>()
+    listener.delegateSendTestNotification { testEventBundle, sendTestNotification ->
+
+      when (testEventBundle.getString(KEY_TEST_EVENT)) {
+        TEST_FINISHED.toString() -> {
+          sendTestFinished = {
+            failureBundle?.let { failureBundle ->
+              failures += failureBundle.get("failure") as ParcelableFailure
+              sendTestNotification(failureBundle)
+            }
+            sendTestNotification(testEventBundle)
+            // reset for next test if any.
+            sendTestFinished = null
+            failureBundle = null
+            receivedTestFinished = false
+          }
+          if (receivedTestFinished) {
+            sendTestFinished!!.invoke()
+          }
+        }
+        TEST_RUN_FINISHED.toString() -> {
+          if (failures.isNotEmpty()) {
+            val result = testEventBundle.get("result") as ParcelableResult
+            result.failures += failures
+          }
+          sendTestNotification(testEventBundle)
+        }
+        else -> sendTestNotification(testEventBundle)
+      }
+    }
+  }
+
+  override fun publishTestFinished() {
+    receivedTestFinished = true
+    sendTestFinished?.invoke()
+  }
+
+  override fun publishTestFailure(
+    description: Description,
+    trace: String
+  ) {
+    val result = Bundle()
+    val failure = ParcelableFailure(
+        ParcelableDescription(description),
+        RuntimeException(trace)
+    )
+    result.putParcelable("failure", failure)
+    result.putString(KEY_TEST_EVENT, TEST_FAILURE.toString())
+    this.failureBundle = result
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/TestResultPublisher.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/TestResultPublisher.kt
@@ -1,0 +1,37 @@
+package leakcanary.internal
+
+import androidx.test.orchestrator.instrumentationlistener.OrchestratedInstrumentationListener
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnitRunner
+import org.junit.runner.Description
+import shark.SharkLog
+
+internal interface TestResultPublisher {
+
+  fun publishTestFinished()
+
+  fun publishTestFailure(
+    description: Description,
+    trace: String
+  )
+
+  companion object {
+    fun install(): TestResultPublisher {
+      val instrumentation = InstrumentationRegistry.getInstrumentation()
+      val orchestratorListener = if (instrumentation is AndroidJUnitRunner) {
+        AndroidJUnitRunner::class.java.getDeclaredField("orchestratorListener")
+            .run {
+              isAccessible = true
+              get(instrumentation) as OrchestratedInstrumentationListener?
+            }
+      } else null
+      return if (orchestratorListener != null) {
+        SharkLog.d { "Android Test Orchestrator detected, failures will be sent via binder callback" }
+        OrchestratorTestResultPublisher(orchestratorListener)
+      } else {
+        SharkLog.d { "Failures will be sent via Instrumentation.sendStatus()" }
+        InstrumentationTestResultPublisher()
+      }
+    }
+  }
+}

--- a/leakcanary-android-sample/build.gradle
+++ b/leakcanary-android-sample/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   androidTestImplementation deps.androidx.test.espresso
   androidTestImplementation deps.androidx.test.rules
   androidTestImplementation deps.androidx.test.runner
+  androidTestUtil deps.androidx.test.orchestrator
 }
 
 android {
@@ -44,8 +45,14 @@ android {
     versionName "1.0"
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArgument "listener",
-        "leakcanary.FailTestOnLeakRunListener"
+    testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"
+
+    // Run ./gradlew leakcanary-android-sample:connectedCheck -Porchestrator
+    if (project.hasProperty('orchestrator')) {
+      testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+      }
+    }
   }
 
   buildTypes {

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcher.kt
@@ -92,7 +92,6 @@ object AppWatcher {
      * AppWatcher.config = AppWatcher.config.copy(watchFragmentViews = false)
      * ```
      */
-    @Suppress("TooManyFunctions")
     class Builder internal constructor(config: Config) {
       private var watchActivities = config.watchActivities
       private var watchFragments = config.watchFragments

--- a/shark-cli/src/main/java/shark/InteractiveCommand.kt
+++ b/shark-cli/src/main/java/shark/InteractiveCommand.kt
@@ -42,7 +42,6 @@ import shark.ValueHolder.ShortHolder
 import java.io.File
 import java.util.Locale
 
-@Suppress("TooManyFunctions")
 class InteractiveCommand : CliktCommand(
     name = "interactive",
     help = "Explore a heap dump."

--- a/shark-graph/src/main/java/shark/HprofHeapGraph.kt
+++ b/shark-graph/src/main/java/shark/HprofHeapGraph.kt
@@ -42,7 +42,6 @@ import kotlin.reflect.KClass
 /**
  * A [HeapGraph] that reads from an indexed [Hprof]. Create a new instance with [indexHprof].
  */
-@Suppress("TooManyFunctions")
 class HprofHeapGraph internal constructor(
   private val hprof: Hprof,
   private val index: HprofInMemoryIndex

--- a/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -25,7 +25,6 @@ import kotlin.reflect.KClass
 /**
  * This class is not thread safe, should be used from a single thread.
  */
-@Suppress("TooManyFunctions")
 internal class HprofInMemoryIndex private constructor(
   private val positionSize: Int,
   private val hprofStringCache: LongObjectScatterMap<String>,

--- a/shark-graph/src/main/java/shark/internal/hppc/LongLongScatterMap.kt
+++ b/shark-graph/src/main/java/shark/internal/hppc/LongLongScatterMap.kt
@@ -23,7 +23,6 @@ import java.util.Locale
  *
  * See https://github.com/carrotsearch/hppc .
  */
-@Suppress("TooManyFunctions")
 class LongLongScatterMap constructor(expectedElements: Int = 4) {
 
   interface ForEachCallback {

--- a/shark-graph/src/main/java/shark/internal/hppc/LongObjectScatterMap.kt
+++ b/shark-graph/src/main/java/shark/internal/hppc/LongObjectScatterMap.kt
@@ -23,7 +23,6 @@ import java.util.Locale
  *
  * See https://github.com/carrotsearch/hppc .
  */
-@Suppress("TooManyFunctions")
 internal class LongObjectScatterMap<T> {
   /**
    * The array holding keys.

--- a/shark-hprof-test/src/main/kotlin/shark/HprofWriterHelper.kt
+++ b/shark-hprof-test/src/main/kotlin/shark/HprofWriterHelper.kt
@@ -33,7 +33,6 @@ import java.util.UUID
 import kotlin.random.Random
 import kotlin.reflect.KClass
 
-@Suppress("TooManyFunctions")
 class HprofWriterHelper constructor(
   private val writer: HprofWriter
 ) : Closeable {

--- a/shark-hprof/src/main/java/shark/HprofReader.kt
+++ b/shark-hprof/src/main/java/shark/HprofReader.kt
@@ -74,7 +74,7 @@ import kotlin.reflect.KClass
  * The Android Hprof format differs in some ways from that reference. This parser implementation
  * is largely adapted from https://android.googlesource.com/platform/tools/base/+/studio-master-dev/perflib/src/main/java/com/android/tools/perflib
  */
-@Suppress("LargeClass", "TooManyFunctions")
+@Suppress("LargeClass")
 class HprofReader constructor(
   private var source: BufferedSource,
   /**

--- a/shark-hprof/src/main/java/shark/HprofWriter.kt
+++ b/shark-hprof/src/main/java/shark/HprofWriter.kt
@@ -64,7 +64,6 @@ import java.io.File
  *
  * Call [open] to create an instance, [write] to add instances and [close] when you're done.
  */
-@Suppress("TooManyFunctions")
 class HprofWriter private constructor(
   private val sink: BufferedSink,
   val identifierByteSize: Int,

--- a/shark/src/main/java/shark/HeapAnalyzer.kt
+++ b/shark/src/main/java/shark/HeapAnalyzer.kt
@@ -52,7 +52,6 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 /**
  * Analyzes heap dumps to look for leaks.
  */
-@Suppress("TooManyFunctions")
 class HeapAnalyzer constructor(
   private val listener: OnAnalysisProgressListener
 ) {

--- a/shark/src/main/java/shark/internal/PathFinder.kt
+++ b/shark/src/main/java/shark/internal/PathFinder.kt
@@ -60,7 +60,6 @@ import java.util.LinkedHashMap
  * identified as "to visit last" and then visiting them as needed if no path is
  * found.
  */
-@Suppress("TooManyFunctions")
 internal class PathFinder(
   private val graph: HeapGraph,
   private val listener: OnAnalysisProgressListener,


### PR DESCRIPTION
With this change, FailTestOnLeakRunListener now hooks into AndroidJUnitRunner when a test run starts to detect if the tests are run by Android Test Orchestrator, in which case we take over the binder callback to send optionally send an extra failure when a leak is detected in test.

This works whether newRunListenerMode is false or true (ie whether OrchestratedInstrumentationListener runs before or after FailTestOnLeakRunListener).

When a test finishes without any failure, we intercept any "test finished" message, check for memory leaks, optionally send a "test failure" message then send the "test finished message". This intercepting is done assuming a single thread calls both listeners (see `org.junit.runner.notification.RunNotifier#wrapIfNotThreadSafe`).

As before with `Instrumentation.sendStatus()`, the current approach is tied to the test runner implementation details and might have to change to adapt to new `androidx.test:runner` versions.

Other change: FailTestOnLeakRunListener will wait up to 2 seconds for all activities to be destroyed before running leak detection, and otherwise proceed.

Fixes #1046