### PR TITLE
Don't look for activity in application

### DIFF
--- a/shark-android/src/test/java/shark/LegacyHprofTest.kt
+++ b/shark-android/src/test/java/shark/LegacyHprofTest.kt
@@ -60,8 +60,8 @@ class LegacyHprofTest {
         .use { hprof ->
           val graph = HprofHeapGraph.indexHprof(hprof)
           graph.findClassByName("java.lang.Thread")!!.instances.map { instance ->
-            instance["java.lang.Thread", "name"]!!.value.readAsJavaString()!!
-          }
+                instance["java.lang.Thread", "name"]!!.value.readAsJavaString()!!
+              }
               .toList()
         }
     return threadNames
@@ -85,7 +85,12 @@ class LegacyHprofTest {
     val contextWrapperStatuses = Hprof.open(fileFromResources("leak_asynctask_o.hprof"))
         .use { hprof ->
           val graph = HprofHeapGraph.indexHprof(hprof)
-          graph.instances.filter { it instanceOf "android.content.ContextWrapper" && !(it instanceOf "android.app.Activity") }
+          graph.instances.filter {
+                it instanceOf "android.content.ContextWrapper"
+                    && !(it instanceOf "android.app.Activity")
+                    && !(it instanceOf "android.app.Application")
+                    && !(it instanceOf "android.app.Service")
+              }
               .map { instance ->
                 val reporter = ObjectReporter(instance)
                 AndroidObjectInspectors.CONTEXT_WRAPPER.inspect(reporter)
@@ -105,7 +110,7 @@ class LegacyHprofTest {
         }
     assertThat(contextWrapperStatuses.filter { it == DESTROYED }).hasSize(12)
     assertThat(contextWrapperStatuses.filter { it == NOT_DESTROYED }).hasSize(6)
-    assertThat(contextWrapperStatuses.filter { it == NOT_ACTIVITY }).hasSize(1)
+    assertThat(contextWrapperStatuses.filter { it == NOT_ACTIVITY }).hasSize(0)
   }
 
   @Test fun gcRootInNonPrimaryHeap() {


### PR DESCRIPTION
In this [StackOverflow question](https://stackoverflow.com/questions/62213443/finding-cause-in-leakcanary-leak-trace) I noticed this bit:

```
D LeakCanary: ├─ <>.application.HomeApplication
D LeakCanary: │    Leaking: NO (Application is a singleton)
D LeakCanary: │    HomeApplication does not wrap an activity context
```

The comment `HomeApplication does not wrap an activity context` doesn't make sense for an application, it's meant for ContextWrapper instances that may wrap an activity context.

This fixes that, and optimizes things a bit so that we don't keep looking up the full class hierarchy.