### PR TITLE
Add reference to java.lang.Object to decrease number of binary searches

### DIFF
--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Benchmark.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/Benchmark.kt
@@ -32,15 +32,22 @@ object Benchmark {
   fun <T> benchmarkCode(times: Int = 10, block:() -> T): T {
     // Warm-up run, no benchmarking
     val result = block()
-    var total = 0L
+    val measurements = mutableListOf<Long>()
     repeat(times) {
       val start = SystemClock.uptimeMillis()
       block()
       val end = SystemClock.uptimeMillis()
       SharkLog.d { "BenchmarkCode, iteration ${it + 1}/$times, duration ${end-start}" }
-      total += (end-start)
+      measurements.add(end - start)
     }
-    SharkLog.d { "BenchmarkCode complete. Iterations: $times, average duration ${total/times} ms" }
+    measurements.sort()
+    val median: Double = if (times % 2 == 0) {
+      (measurements[times / 2] + measurements[times / 2 - 1]).toDouble() / 2
+    } else {
+      measurements[times / 2].toDouble()
+    }
+    SharkLog.d { "BenchmarkCode complete, $times iterations. Durations (ms): median $median, " +
+        "min ${measurements.first()}, max ${measurements.last()}" }
     return result
   }
 }

--- a/shark-graph/src/main/java/shark/HprofHeapGraph.kt
+++ b/shark-graph/src/main/java/shark/HprofHeapGraph.kt
@@ -103,14 +103,9 @@ class HprofHeapGraph internal constructor(
   // Pixel 2 XL API 28. Hit count was ~120K, miss count ~290K
   private val objectCache = LruCache<Long, ObjectRecord>(3000)
 
-  // java.lang.Object is the most accessed class in Heap, so we want to memorize a reference to it
-  private val javaLangObject: HeapClass
+  // java.lang.Object is the most accessed class in Heap, so we want to memoize a reference to it
+  private val javaLangObjectClass: HeapClass? = findClassByName("java.lang.Object")
 
-  init {
-    val classId = index.classId("java.lang.Object")!!
-    val indexedObject = index.indexedObjectOrNull(classId)!!
-    javaLangObject = wrapIndexedObject(indexedObject, classId) as HeapClass
-  }
   override fun findObjectById(objectId: Long): HeapObject {
     return findObjectByIdOrNull(objectId) ?: throw IllegalArgumentException(
         "Object id $objectId not found in heap dump."
@@ -118,7 +113,7 @@ class HprofHeapGraph internal constructor(
   }
 
   override fun findObjectByIdOrNull(objectId: Long): HeapObject? {
-    if (objectId == javaLangObject.objectId) return javaLangObject
+    if (objectId == javaLangObjectClass?.objectId) return javaLangObjectClass
 
     val indexedObject = index.indexedObjectOrNull(objectId) ?: return null
     return wrapIndexedObject(indexedObject, objectId)


### PR DESCRIPTION
In Profiled test we noticed that `java.lang.Object` class is being accessed quite often. `271957` times to be precise - and every time it's by doing a binary search over a `SortedBytesMap`

In order to eliminate these unnecessary calls we keep a fixed reference to `java.lang.Object`.

Benchmarks (with `Benchmark` class) on Google Pixel 3:
```
With optimization
20 iterations. Durations (ms): median 11721.0, min 11608, max 11780

Without
20 iterations. Durations (ms): median 12049.5, min 11903, max 12260
```

Total - stunning 2.4% speedup! 😃 

This PR also updates `Benchmark` to use median instead of average