### PR TITLE
Add Razer TextKeyListener.mContext leak

### DIFF
--- a/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -1141,6 +1141,23 @@ enum class AndroidReferenceMatchers {
     }
   },
 
+  RAZER_TEXT_KEY_LISTENER__MCONTEXT {
+    override fun add(
+      references: MutableList<ReferenceMatcher>
+    ) {
+      references += instanceFieldLeak(
+          "android.text.method.TextKeyListener", "mContext",
+          description =
+          """
+            In AOSP, TextKeyListener instances are held in a TextKeyListener.sInstances static
+            array. The Razer implementation added a mContext field, creating activity leaks.
+          """.trimIndent()
+      ) {
+        manufacturer == RAZER && sdkInt == 28
+      }
+    }
+  },
+
   // ######## Ignored references (not leaks) ########
 
   REFERENCES {
@@ -1235,6 +1252,7 @@ enum class AndroidReferenceMatchers {
     const val ONE_PLUS = "OnePlus"
     const val HUAWEI = "HUAWEI"
     const val VIVO = "vivo"
+    const val RAZER = "Razer"
     const val SHARP = "SHARP"
 
     /**


### PR DESCRIPTION
Leak Trace:

```
┬───
│ GC Root: System class
│
├─ android.text.method.TextKeyListener class
│    Leaking: NO (a class is never leaking)
│    ↓ static TextKeyListener.sInstance
│                             ~~~~~~~~~
├─ android.text.method.TextKeyListener[] array
│    Leaking: UNKNOWN
│    ↓ TextKeyListener[].[0]
│                        ~~~
├─ android.text.method.TextKeyListener instance
│    Leaking: UNKNOWN
│    ↓ TextKeyListener.mContext
│                      ~~~~~~~~
├─ flow.path.FlowPathContextWrapper instance
│    Leaking: YES (FlowPathContextWrapper wraps an Activity with Activity.mDestroyed true)
│    ↓ FlowPathContextWrapper.inflater
├─ com.android.internal.policy.PhoneLayoutInflater instance
│    Leaking: YES (FlowPathContextWrapper↑ is leaking)
│    ↓ PhoneLayoutInflater.mPrivateFactory
╰→ com.squareup.ui.loggedout.LoggedOutActivity instance
​     Leaking: YES (ObjectWatcher was watching this because com.squareup.ui.loggedout.LoggedOutActivity received Activity#onDestroy() callback and Activity#mDestroyed is true)
```