### PR TITLE
SemAppIconSolution leak happens on API 29

### DIFF
--- a/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -831,7 +831,7 @@ enum class AndroidReferenceMatchers {
       references += instanceFieldLeak(
           "android.app.SemAppIconSolution", "mContext"
       ) {
-        manufacturer == SAMSUNG && sdkInt == 28
+        manufacturer == SAMSUNG && sdkInt in 28..29
       }
     }
   },


### PR DESCRIPTION
```
┬───
│ GC Root: System class
│
├─ android.app.SemAppIconSolution class
│    Leaking: NO (a class is never leaking)
│    ↓ static SemAppIconSolution.uniqueInstance
│                                ~~~~~~~~~~~~~~
├─ android.app.SemAppIconSolution instance
│    Leaking: UNKNOWN
│    ↓ SemAppIconSolution.mContext
│                         ~~~~~~~~
├─ android.app.ContextImpl instance
│    Leaking: UNKNOWN
│    ↓ ContextImpl.mAutofillClient
│                  ~~~~~~~~~~~~~~~
╰→ com.squareup.ui.main.MainActivity instance
```