### PR TITLE
Log posting failures

### DIFF
--- a/plumber-android/src/main/java/leakcanary/AndroidLeakFixes.kt
+++ b/plumber-android/src/main/java/leakcanary/AndroidLeakFixes.kt
@@ -165,15 +165,19 @@ enum class AndroidLeakFixes {
                   // When the Handler thread becomes idle, we post a message to force it to move.
                   // Source: https://developer.squareup.com/blog/a-small-leak-will-sink-a-great-ship/
                   try {
-                    flushHandler.postDelayed({
+                    val posted = flushHandler.postDelayed({
                       // Right after this postDelayed executes, the idle handler will likely be called
                       // again (if the queue is otherwise empty), so we'll need to schedule a flush
                       // again.
                       scheduleFlush = true
                     }, 1000)
+                    if (!posted) {
+                      SharkLog.d { "Failed to post to ${handlerThread.name}" }
+                    }
                   } catch (ignored: RuntimeException) {
-                    // If the thread is quitting, posting to it will throw. There is no safe and atomic way
+                    // If the thread is quitting, posting to it may throw. There is no safe and atomic way
                     // to check if a thread is quitting first then post it it.
+                    SharkLog.d(ignored) { "Failed to post to ${handlerThread.name}" }
                   }
                 }
               }


### PR DESCRIPTION
I noticed this in Logcat and wish I had the thread name:

```
    java.lang.IllegalStateException: Handler (android.os.Handler) {50f9508} sending message to a Handler on a dead thread
        at android.os.MessageQueue.enqueueMessage(MessageQueue.java:543)
        at android.os.Handler.enqueueMessage(Handler.java:643)
        at android.os.Handler.sendMessageAtTime(Handler.java:612)
        at android.os.Handler.sendMessageDelayed(Handler.java:582)
        at android.os.Handler.postDelayed(Handler.java:410)
        at leakcanary.AndroidLeakFixes$FLUSH_HANDLER_THREADS$apply$1$3$2.invoke(AndroidLeakFixes.kt:164)
        at leakcanary.AndroidLeakFixes$FLUSH_HANDLER_THREADS$apply$1$3$2.invoke(AndroidLeakFixes.kt:137)
        at leakcanary.AndroidLeakFixes$Companion$onEachIdle$1$1.queueIdle(AndroidLeakFixes.kt:416)
        at android.os.MessageQueue.next(MessageQueue.java:392)
        at android.os.Looper.loop(Looper.java:136)
        at android.os.HandlerThread.run(HandlerThread.java:61)
```