### PR TITLE
Log instrumentation test name

### DIFF
--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -177,9 +177,6 @@ class InstrumentationLeakDetector {
         computeRetainedHeapSize = config.computeRetainedHeapSize,
         objectInspectors = config.objectInspectors
     )
-
-    SharkLog.d { "Heap Analysis:\n$heapAnalysis" }
-
     return AnalysisPerformed(heapAnalysis)
   }
 


### PR DESCRIPTION
Example log:

```
helperTextHasExpectedContent(leakcanary.tests.TuPeuxPasTest) failed because application memory leaks were detected:
====================================
HEAP ANALYSIS RESULT
====================================
1 APPLICATION LEAKS

References underlined with "~~~" are likely causes.
Learn more at https://squ.re/leaks.

93205 bytes retained by leaking objects
Signature: 1b4eb109ab722d19564495a9b3ed511b4969686
┬───
│ GC Root: System class
│
├─ leakcanary.internal.InternalAppWatcher class
│    Leaking: NO (ExampleApplication↓ is not leaking and a class is never leaking)
│    ↓ static InternalAppWatcher.application
├─ com.example.leakcanary.ExampleApplication instance
│    Leaking: NO (Application is a singleton)
│    ↓ ExampleApplication.leakedViews
│                         ~~~~~~~~~~~
├─ java.util.ArrayList instance
│    Leaking: UNKNOWN
│    ↓ ArrayList.elementData
│                ~~~~~~~~~~~
├─ java.lang.Object[] array
│    Leaking: UNKNOWN
│    ↓ Object[].[0]
│               ~~~
├─ android.widget.TextView instance
│    Leaking: YES (View.mContext references a destroyed activity)
│    mContext instance of com.example.leakcanary.MainActivity with mDestroyed = true
│    View#mParent is set
│    View#mAttachInfo is null (view detached)
│    View.mWindowAttachCount = 1
│    ↓ TextView.mContext
╰→ com.example.leakcanary.MainActivity instance
​     Leaking: YES (ObjectWatcher was watching this because com.example.leakcanary.MainActivity received Activity#onDestroy() callback and Activity#mDestroyed is true)
​     key = 1d2117b7-8ed8-436b-8bf2-d7e4bc97d695
​     watchDurationMillis = 5154
​     retainedDurationMillis = 150
====================================
0 LIBRARY LEAKS

A Library Leak is a leak caused by a known bug in 3rd party code that you do not have control over.
See https://square.github.io/leakcanary/fundamentals-how-leakcanary-works/#4-categorizing-leaks
====================================
METADATA

Please include this in bug reports and Stack Overflow questions.

Analysis duration: 2239 ms
Heap dump file path: /data/user/0/com.example.leakcanary/files/instrumentation_tests_heapdump.hprof
Heap dump timestamp: 1593530808850
====================================
```

Fixes #1883