### PR TITLE
Fix crash occurs when no browser is installed

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakViews.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakViews.kt
@@ -67,7 +67,8 @@ internal fun View.shareToStackOverflow(content: String) {
   try {
     activity.startActivity(browserIntent)
   } catch (e: ActivityNotFoundException) {
-    Toast.makeText(context, e.toString(), Toast.LENGTH_LONG).show();
+    Toast.makeText(context, R.string.leak_canary_leak_missing_browser_error, Toast.LENGTH_LONG)
+            .show();
   }
 }
 
@@ -98,7 +99,8 @@ internal fun View.shareToGitHubIssue(failure: HeapAnalysisFailure) {
   try {
     activity.startActivity(browserIntent)
   } catch (e: ActivityNotFoundException) {
-    Toast.makeText(context, e.toString(), Toast.LENGTH_LONG).show();
+    Toast.makeText(context, R.string.leak_canary_leak_missing_browser_error, Toast.LENGTH_LONG)
+            .show();
   }
 }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakViews.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakViews.kt
@@ -1,6 +1,7 @@
 package leakcanary.internal.activity
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -63,7 +64,11 @@ internal fun View.shareToStackOverflow(content: String) {
   Toast.makeText(context, R.string.leak_canary_leak_copied, Toast.LENGTH_LONG)
       .show()
   val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(STACKOVERFLOW_QUESTION_URL))
-  activity.startActivity(browserIntent)
+  try {
+    activity.startActivity(browserIntent)
+  } catch (e: ActivityNotFoundException) {
+    Toast.makeText(context, e.toString(), Toast.LENGTH_LONG).show();
+  }
 }
 
 internal fun View.shareToGitHubIssue(failure: HeapAnalysisFailure) {
@@ -90,7 +95,11 @@ internal fun View.shareToGitHubIssue(failure: HeapAnalysisFailure) {
   Toast.makeText(context, R.string.leak_canary_failure_copied, Toast.LENGTH_LONG)
       .show()
   val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(NEW_ISSUE_URL))
-  activity.startActivity(browserIntent)
+  try {
+    activity.startActivity(browserIntent)
+  } catch (e: ActivityNotFoundException) {
+    Toast.makeText(context, e.toString(), Toast.LENGTH_LONG).show();
+  }
 }
 
 private const val STACKOVERFLOW_QUESTION_URL =

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -95,4 +95,5 @@
   <string name="leak_canary_tv_analysis_success">Heap Analysis performed: %1$d application leaks, %2$d library leaks. See details in Logcat</string>
   <string name="leak_canary_tv_analysis_failure">Heap Analysis failed, see details in Logcat</string>
   <string name="leak_canary_tv_toast_retained_objects">%1$d retained objects. Heap dump threshold is %2$d.\nBackground the app to trigger heap dump immediately</string>
+  <string name="leak_canary_leak_missing_browser_error">Missing browser</string>
 </resources>


### PR DESCRIPTION
E/AndroidRuntime(12780): FATAL EXCEPTION: main
E/AndroidRuntime(12780): Process: com.*, PID: 12780
E/AndroidRuntime(12780): android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=http://stackoverflow.com/... }
E/AndroidRuntime(12780): at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:1969)
E/AndroidRuntime(12780): at android.app.Instrumentation.execStartActivity(Instrumentation.java:1648)
E/AndroidRuntime(12780): at android.app.Activity.startActivityForResult(Activity.java:4502)
E/AndroidRuntime(12780): at android.app.Activity.startActivityForResult(Activity.java:4460)
E/AndroidRuntime(12780): at android.app.Activity.startActivity(Activity.java:4821)
E/AndroidRuntime(12780): at android.app.Activity.startActivity(Activity.java:4789)
E/AndroidRuntime(12780): at leakcanary.internal.activity.LeakViewsKt.shareToStackOverflow(LeakViews.kt:66)
E/AndroidRuntime(12780): at leakcanary.internal.activity.screen.LeakScreen$onLeakTraceSelected$1$2.invoke(LeakScreen.kt:212)
E/AndroidRuntime(12780): at leakcanary.internal.activity.screen.LeakScreen$onLeakTraceSelected$1$2.invoke(LeakScreen.kt:35)
E/AndroidRuntime(12780): at leakcanary.internal.activity.ui.UiUtils$replaceUrlSpanWithAction$newSpan$1.onClick(UiUtils.kt:24)
E/AndroidRuntime(12780): at android.text.method.LinkMovementMethod.onTouchEvent(LinkMovementMethod.java:216)
E/AndroidRuntime(12780): at android.widget.TextView.onTouchEvent(TextView.java:9692)
E/AndroidRuntime(12780): at android.view.View.dispatchTouchEvent(View.java:11820)