### PR TITLE
Support enable/disable heap dump at runtime in AboutScreen.

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
@@ -39,6 +39,10 @@ internal class AboutScreen : Screen() {
 
           val heapDumpText = findViewById<TextView>(R.id.leak_canary_about_heap_dump_text)
           heapDumpText.text = getHeapDumpStatusMessage(resources)
+          heapDumpText.setOnClickListener {
+            LeakCanary.config = LeakCanary.config.copy(dumpHeap = !LeakCanary.config.dumpHeap)
+            heapDumpText.text = getHeapDumpStatusMessage(resources)
+          }
         }
 
   private fun getHeapDumpStatusMessage(resources: Resources) =

--- a/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_ids.xml
@@ -22,4 +22,5 @@
   <item type="id" name="leak_canary_notification_retained_objects" />
   <item type="id" name="leak_canary_notification_no_retained_object_on_tap" />
   <item type="id" name="leak_canary_notification_on_screen_exit" />
+  <item type="id" name="leak_canary_notification_heap_dump_disabled" />
 </resources>

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -54,6 +54,7 @@
   <string name="leak_canary_notification_retained_dump_wait">Last heap dump was less than a minute ago</string>
   <string name="leak_canary_notification_retained_title">%d retained objects, tap to dump heap</string>
   <string name="leak_canary_notification_retained_visible">App visible, waiting until %d retained objects</string>
+  <string name="leak_canary_notification_heap_dump_disabled">Heap dumping is disabled from About screen.</string>
   <string name="leak_canary_share_with">Share with…</string>
   <string name="leak_canary_display_activity_label">Leaks</string>
   <string name="leak_canary_storage_permission_activity_label">Storage permission</string>


### PR DESCRIPTION
Added ability to toggle heap dump at runtime by clicking the text "Heap dumping is currently enabled" in AboutScreen.

Fixes: #1886

It can be a useful feature in case you are outside and your device is in low-battery state.
For example, you are going on a vacation but forgot to install your app with LeakCanary disabled, it can consume your battery and disturb you with notifications.