### PR TITLE
Add group for notifications

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/Notifications.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/Notifications.kt
@@ -49,7 +49,12 @@ internal object Notifications {
     if (!canShowNotification) {
       return
     }
-    val builder = Notification.Builder(context)
+
+    val builder = if (SDK_INT >= O) {
+      Notification.Builder(context, type.name)
+    } else Notification.Builder(context)
+
+    builder
         .setContentText(contentText)
         .setContentTitle(contentTitle)
         .setAutoCancel(true)
@@ -82,6 +87,7 @@ internal object Notifications {
         notificationManager.createNotificationChannel(notificationChannel)
       }
       builder.setChannelId(type.name)
+      builder.setGroup(type.name)
     }
 
     return if (SDK_INT < JELLY_BEAN) {


### PR DESCRIPTION
As the grouping is made by notification channel,
the group name and the corresponding channel ID are the same.

Fixes #1845 