### PR TITLE
Fix broken link in faq that should lead to instrumentation test section

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ D/LeakCanary: Installing AppWatcher
 
 If you do not see `Installing AppWatcher` in the logs, check your dependencies (`./gradlew app:dependencies`) and make sure LeakCanary is there.
 
-Note that LeakCanary is automatically disabled in tests (see [Running LeakCanary in instrumentation tests](recipes.md/#running-leakcanary-in-instrumentation-tests)):
+Note that LeakCanary is automatically disabled in tests (see [Running LeakCanary in instrumentation tests](recipes.md#running-leakcanary-in-instrumentation-tests)):
 
 ```
 $ adb logcat | grep LeakCanary


### PR DESCRIPTION
Currently, [a broken link](https://square.github.io/leakcanary/faq/recipes.md/#running-leakcanary-in-instrumentation-tests) is generated, change it so it generats [a working one](https://square.github.io/leakcanary/recipes/#running-leakcanary-in-instrumentation-tests).