### PR TITLE
Fix formatting for IRequestFinishCallback leak description

### DIFF
--- a/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -60,10 +60,10 @@ enum class AndroidReferenceMatchers {
                   "anonymous subclass. That anonymous subclass has a reference to the activity. " +
                   "Another process is keeping the android.app.IRequestFinishCallback\$Stub " +
                   "reference alive long after Activity.onDestroyed() has been called, " +
-                  "causing the activity to leak." +
+                  "causing the activity to leak. " +
                   "Fix: You can \"fix\" this leak by overriding Activity.onBackPressed() and calling " +
                   "Activity.finishAfterTransition(); instead of super if the activity is task root and the " +
-                  "fragment stack is empty." +
+                  "fragment stack is empty. " +
                   "Tracked here: https://issuetracker.google.com/issues/139738913"
           ) {
               sdkInt == 29


### PR DESCRIPTION
Without this the text has multiple instances of missing spaces after periods, like 'to leak.Fix:' and 'empty.Tracked here' as shown in the attached screenshot. Fixes #1828.

<details>
<summary>Screenshot</summary>

![screenshot-20200915-131712](https://user-images.githubusercontent.com/13348378/93182242-17b25500-f757-11ea-8a62-60ca8a29bbc7.png)


</details>