### PR TITLE
Add heapDumpDurationMillis to HeapAnalysis

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -156,8 +156,8 @@ internal class HeapDumpTrigger(
     saveResourceIdNamesToMemory()
     val heapDumpUptimeMillis = SystemClock.uptimeMillis()
     KeyedWeakReference.heapDumpUptimeMillis = heapDumpUptimeMillis
-    val heapDumpFile = heapDumper.dumpHeap()
-    if (heapDumpFile == null) {
+    val heapDumpResult = heapDumper.dumpHeap()
+    if (heapDumpResult == null) {
       if (retry) {
         SharkLog.d { "Failed to dump heap, will retry in $WAIT_AFTER_DUMP_FAILED_MILLIS ms" }
         scheduleRetainedObjectCheck(
@@ -177,7 +177,11 @@ internal class HeapDumpTrigger(
     lastDisplayedRetainedObjectCount = 0
     lastHeapDumpUptimeMillis = SystemClock.uptimeMillis()
     objectWatcher.clearObjectsWatchedBefore(heapDumpUptimeMillis)
-    HeapAnalyzerService.runAnalysis(application, heapDumpFile)
+    HeapAnalyzerService.runAnalysis(
+        context = application,
+        heapDumpFile = heapDumpResult.file,
+        heapDumpDurationMills = heapDumpResult.durationMillis
+    )
   }
 
   private fun saveResourceIdNamesToMemory() {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumper.kt
@@ -24,12 +24,13 @@ internal interface HeapDumper {
    * @return a [File] referencing the dumped heap, or [.RETRY_LATER] if the heap could
    * not be dumped.
    */
-  fun dumpHeap(): DumpHeapResult?
+  fun dumpHeap(): DumpHeapResult
 
 }
 
 /** Dump heap result holding the file and the dump heap duration */
-data class DumpHeapResult(
-    val file: File,
-    val durationMillis: Long
-)
+internal sealed class DumpHeapResult
+
+internal data class HeapDump(val file: File, val durationMillis: Long): DumpHeapResult()
+internal object NoHeapDump: DumpHeapResult()
+

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumper.kt
@@ -24,6 +24,12 @@ internal interface HeapDumper {
    * @return a [File] referencing the dumped heap, or [.RETRY_LATER] if the heap could
    * not be dumped.
    */
-  fun dumpHeap(): File?
+  fun dumpHeap(): DumpHeapResult?
 
 }
+
+/** Dump heap result holding the file and the dump heap duration */
+data class DumpHeapResult(
+    val file: File,
+    val durationMillis: Long
+)

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -26,6 +26,7 @@ internal object HeapAnalysisTable {
         (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         created_at_time_millis INTEGER,
+        dump_duration_millis INTEGER DEFAULT -1,
         leak_count INTEGER DEFAULT 0,
         exception_summary TEXT DEFAULT NULL,
         object BLOB
@@ -47,6 +48,7 @@ internal object HeapAnalysisTable {
   ): Long {
     val values = ContentValues()
     values.put("created_at_time_millis", heapAnalysis.createdAtTimeMillis)
+    values.put("dump_duration_millis", heapAnalysis.dumpDurationMillis)
     values.put("object", heapAnalysis.toByteArray())
     when (heapAnalysis) {
       is HeapAnalysisSuccess -> {
@@ -92,8 +94,7 @@ internal object HeapAnalysisTable {
     db.inTransaction {
       return db.rawQuery(
           """
-              SELECT
-              object
+              SELECT object
               FROM heap_analysis
               WHERE id=$id
               """, null

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -94,7 +94,8 @@ internal object HeapAnalysisTable {
     db.inTransaction {
       return db.rawQuery(
           """
-              SELECT object
+              SELECT
+              object
               FROM heap_analysis
               WHERE id=$id
               """, null

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeaksDbHelper.kt
@@ -36,13 +36,11 @@ internal class LeaksDbHelper(context: Context) : SQLiteOpenHelper(
               } else {
                 null
               }
-            }
-                .map {
-                  if (it is HeapAnalysisSuccess) {
-                    HeapAnalysisSuccess.upgradeFrom20Deserialized(it)
-                  } else it
-                }
-                .toList()
+            }.map {
+              if (it is HeapAnalysisSuccess) {
+                HeapAnalysisSuccess.upgradeFrom20Deserialized(it)
+              } else it
+            }.toList()
           }
       recreateDb(db)
       db.inTransaction {
@@ -51,6 +49,8 @@ internal class LeaksDbHelper(context: Context) : SQLiteOpenHelper(
           put("is_read", 1)
         }, null, null)
       }
+    } else if (oldVersion == 23) {
+      db.execSQL("ALTER TABLE heap_analysis ADD COLUMN dump_duration_millis INTEGER DEFAULT -1")
     } else {
       throw IllegalStateException("Database migration from $oldVersion not supported")
     }
@@ -72,7 +72,7 @@ internal class LeaksDbHelper(context: Context) : SQLiteOpenHelper(
   }
 
   companion object {
-    internal const val VERSION = 23
+    internal const val VERSION = 24
     internal const val DATABASE_NAME = "leaks.db"
   }
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpScreen.kt
@@ -24,6 +24,7 @@ import leakcanary.internal.navigation.goBack
 import leakcanary.internal.navigation.goTo
 import leakcanary.internal.navigation.inflate
 import leakcanary.internal.navigation.onCreateOptionsMenu
+import shark.HeapAnalysis
 import shark.HeapAnalysisSuccess
 import shark.LibraryLeak
 
@@ -101,11 +102,12 @@ internal class HeapDumpScreen(
           val shareFile =
             if (heapDumpFileExist) """Share <a href="share_hprof">Heap Dump file</a><br><br>""" else ""
 
-          val dumpDurationMillis = if (heapAnalysis.dumpDurationMillis > -1) {
-            "${heapAnalysis.dumpDurationMillis} ms"
-          } else {
-            "UNKNOWN"
-          }
+          val dumpDurationMillis =
+            if (heapAnalysis.dumpDurationMillis != HeapAnalysis.DUMP_DURATION_UNKNOWN) {
+              "${heapAnalysis.dumpDurationMillis} ms"
+            } else {
+              "Unknown"
+            }
           val titleText = explore + shareAnalysis + shareFile +
               (heapAnalysis.metadata + mapOf(
                   "Analysis duration" to "${heapAnalysis.analysisDurationMillis} ms",

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpScreen.kt
@@ -101,11 +101,17 @@ internal class HeapDumpScreen(
           val shareFile =
             if (heapDumpFileExist) """Share <a href="share_hprof">Heap Dump file</a><br><br>""" else ""
 
+          val dumpDurationMillis = if (heapAnalysis.dumpDurationMillis > -1) {
+            "${heapAnalysis.dumpDurationMillis} ms"
+          } else {
+            "UNKNOWN"
+          }
           val titleText = explore + shareAnalysis + shareFile +
               (heapAnalysis.metadata + mapOf(
-                  "Analysis duration" to "${heapAnalysis.analysisDurationMillis} ms"
-                  , "Heap dump file path" to heapAnalysis.heapDumpFile.absolutePath
-                  , "Heap dump timestamp" to "${heapAnalysis.createdAtTimeMillis}"
+                  "Analysis duration" to "${heapAnalysis.analysisDurationMillis} ms",
+                  "Heap dump file path" to heapAnalysis.heapDumpFile.absolutePath,
+                  "Heap dump timestamp" to "${heapAnalysis.createdAtTimeMillis}",
+                  "Heap dump duration" to dumpDurationMillis
               ))
                   .map { "<b>${it.key}:</b> ${it.value}" }
                   .joinToString("<br>")

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/utils/Timing.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/utils/Timing.kt
@@ -1,0 +1,12 @@
+package leakcanary.internal.utils
+
+import android.os.SystemClock
+
+/**
+ * Executes the given [block] and returns elapsed time in milliseconds using [SystemClock.uptimeMillis]
+ */
+inline fun measureDurationMillis(block: () -> Unit): Long {
+    val start = SystemClock.uptimeMillis()
+    block()
+    return SystemClock.uptimeMillis() - start
+}

--- a/shark/src/main/java/shark/HeapAnalysis.kt
+++ b/shark/src/main/java/shark/HeapAnalysis.kt
@@ -21,6 +21,11 @@ sealed class HeapAnalysis : Serializable {
   abstract val createdAtTimeMillis: Long
 
   /**
+   * Total time spent dumping the heap.
+   */
+  abstract val dumpDurationMillis: Long
+
+  /**
    * Total time spent analyzing the heap.
    */
   abstract val analysisDurationMillis: Long
@@ -34,13 +39,14 @@ sealed class HeapAnalysis : Serializable {
  * The analysis performed by [HeapAnalyzer] did not complete successfully.
  */
 data class HeapAnalysisFailure(
-  override val heapDumpFile: File,
-  override val createdAtTimeMillis: Long,
-  override val analysisDurationMillis: Long,
-  /**
-   * An exception wrapping the actual exception that was thrown.
-   */
-  val exception: HeapAnalysisException
+    override val heapDumpFile: File,
+    override val createdAtTimeMillis: Long,
+    override val dumpDurationMillis: Long,
+    override val analysisDurationMillis: Long,
+    /**
+     * An exception wrapping the actual exception that was thrown.
+     */
+    val exception: HeapAnalysisException
 ) : HeapAnalysis() {
 
   override fun toString(): String {
@@ -73,15 +79,16 @@ Heap dump timestamp: $createdAtTimeMillis
  * The result of a successful heap analysis performed by [HeapAnalyzer].
  */
 data class HeapAnalysisSuccess(
-  override val heapDumpFile: File,
-  override val createdAtTimeMillis: Long,
-  override val analysisDurationMillis: Long,
-  val metadata: Map<String, String>,
-  /**
+    override val heapDumpFile: File,
+    override val createdAtTimeMillis: Long,
+    override val dumpDurationMillis: Long,
+    override val analysisDurationMillis: Long,
+    val metadata: Map<String, String>,
+    /**
    * The list of [ApplicationLeak] found in the heap dump by [HeapAnalyzer].
    */
   val applicationLeaks: List<ApplicationLeak>,
-  /**
+    /**
    * The list of [LibraryLeak] found in the heap dump by [HeapAnalyzer].
    */
   val libraryLeaks: List<LibraryLeak>
@@ -120,6 +127,7 @@ ${if (metadata.isNotEmpty()) "\n" + metadata.map { "${it.key}: ${it.value}" }.jo
 Analysis duration: $analysisDurationMillis ms
 Heap dump file path: ${heapDumpFile.absolutePath}
 Heap dump timestamp: $createdAtTimeMillis
+Heap dump duration: ${if (dumpDurationMillis > -1) "$dumpDurationMillis ms" else "UNKNOWN"}
 ===================================="""
   }
 
@@ -154,6 +162,7 @@ Heap dump timestamp: $createdAtTimeMillis
       return HeapAnalysisSuccess(
           heapDumpFile = fromV20.heapDumpFile,
           createdAtTimeMillis = fromV20.createdAtTimeMillis,
+          dumpDurationMillis = fromV20.dumpDurationMillis,
           analysisDurationMillis = fromV20.analysisDurationMillis,
           metadata = fromV20.metadata,
           applicationLeaks = applicationLeaks,

--- a/shark/src/main/java/shark/HeapAnalysis.kt
+++ b/shark/src/main/java/shark/HeapAnalysis.kt
@@ -32,6 +32,7 @@ sealed class HeapAnalysis : Serializable {
 
   companion object {
     private const val serialVersionUID: Long = -8657286725869987172
+    const val DUMP_DURATION_UNKNOWN: Long = -1
   }
 }
 
@@ -39,14 +40,14 @@ sealed class HeapAnalysis : Serializable {
  * The analysis performed by [HeapAnalyzer] did not complete successfully.
  */
 data class HeapAnalysisFailure(
-    override val heapDumpFile: File,
-    override val createdAtTimeMillis: Long,
-    override val dumpDurationMillis: Long,
-    override val analysisDurationMillis: Long,
-    /**
-     * An exception wrapping the actual exception that was thrown.
-     */
-    val exception: HeapAnalysisException
+  override val heapDumpFile: File,
+  override val createdAtTimeMillis: Long,
+  override val dumpDurationMillis: Long = DUMP_DURATION_UNKNOWN,
+  override val analysisDurationMillis: Long,
+  /**
+   * An exception wrapping the actual exception that was thrown.
+   */
+  val exception: HeapAnalysisException
 ) : HeapAnalysis() {
 
   override fun toString(): String {
@@ -79,16 +80,16 @@ Heap dump timestamp: $createdAtTimeMillis
  * The result of a successful heap analysis performed by [HeapAnalyzer].
  */
 data class HeapAnalysisSuccess(
-    override val heapDumpFile: File,
-    override val createdAtTimeMillis: Long,
-    override val dumpDurationMillis: Long,
-    override val analysisDurationMillis: Long,
-    val metadata: Map<String, String>,
-    /**
+  override val heapDumpFile: File,
+  override val createdAtTimeMillis: Long,
+  override val dumpDurationMillis: Long = DUMP_DURATION_UNKNOWN,
+  override val analysisDurationMillis: Long,
+  val metadata: Map<String, String>,
+  /**
    * The list of [ApplicationLeak] found in the heap dump by [HeapAnalyzer].
    */
   val applicationLeaks: List<ApplicationLeak>,
-    /**
+  /**
    * The list of [LibraryLeak] found in the heap dump by [HeapAnalyzer].
    */
   val libraryLeaks: List<LibraryLeak>
@@ -127,7 +128,7 @@ ${if (metadata.isNotEmpty()) "\n" + metadata.map { "${it.key}: ${it.value}" }.jo
 Analysis duration: $analysisDurationMillis ms
 Heap dump file path: ${heapDumpFile.absolutePath}
 Heap dump timestamp: $createdAtTimeMillis
-Heap dump duration: ${if (dumpDurationMillis > -1) "$dumpDurationMillis ms" else "UNKNOWN"}
+Heap dump duration: ${if (dumpDurationMillis != DUMP_DURATION_UNKNOWN) "$dumpDurationMillis ms" else "Unknown"}
 ===================================="""
   }
 
@@ -162,7 +163,6 @@ Heap dump duration: ${if (dumpDurationMillis > -1) "$dumpDurationMillis ms" else
       return HeapAnalysisSuccess(
           heapDumpFile = fromV20.heapDumpFile,
           createdAtTimeMillis = fromV20.createdAtTimeMillis,
-          dumpDurationMillis = fromV20.dumpDurationMillis,
           analysisDurationMillis = fromV20.analysisDurationMillis,
           metadata = fromV20.metadata,
           applicationLeaks = applicationLeaks,
@@ -247,6 +247,7 @@ ${super.toString()}
 
   /** This field is kept to support backward compatible deserialization. */
   private val leakTrace: LeakTrace? = null
+
   /** This field is kept to support backward compatible deserialization. */
   private val retainedHeapByteSize: Int? = null
 
@@ -282,6 +283,7 @@ data class ApplicationLeak(
 
   /** This field is kept to support backward compatible deserialization. */
   private val leakTrace: LeakTrace? = null
+
   /** This field is kept to support backward compatible deserialization. */
   private val retainedHeapByteSize: Int? = null
 

--- a/shark/src/main/java/shark/HeapAnalyzer.kt
+++ b/shark/src/main/java/shark/HeapAnalyzer.kt
@@ -75,8 +75,7 @@ class HeapAnalyzer constructor(
     computeRetainedHeapSize: Boolean = false,
     objectInspectors: List<ObjectInspector> = emptyList(),
     metadataExtractor: MetadataExtractor = MetadataExtractor.NO_OP,
-    proguardMapping: ProguardMapping? = null,
-    heapDumpDurationMillis: Long = -1
+    proguardMapping: ProguardMapping? = null
   ): HeapAnalysis {
     val analysisStartNanoTime = System.nanoTime()
 
@@ -85,7 +84,6 @@ class HeapAnalyzer constructor(
       return HeapAnalysisFailure(
           heapDumpFile = heapDumpFile,
           createdAtTimeMillis = System.currentTimeMillis(),
-          dumpDurationMillis = heapDumpDurationMillis,
           analysisDurationMillis = since(analysisStartNanoTime),
           exception = HeapAnalysisException(exception)
       )
@@ -97,18 +95,13 @@ class HeapAnalyzer constructor(
         val helpers =
           FindLeakInput(graph, referenceMatchers, computeRetainedHeapSize, objectInspectors)
         helpers.analyzeGraph(
-            metadataExtractor = metadataExtractor,
-            leakingObjectFinder = leakingObjectFinder,
-            heapDumpFile = heapDumpFile,
-            dumpDurationMillis = heapDumpDurationMillis,
-            analysisStartNanoTime = analysisStartNanoTime
+            metadataExtractor, leakingObjectFinder, heapDumpFile, analysisStartNanoTime
         )
       }
     } catch (exception: Throwable) {
       HeapAnalysisFailure(
           heapDumpFile = heapDumpFile,
           createdAtTimeMillis = System.currentTimeMillis(),
-          dumpDurationMillis = heapDumpDurationMillis,
           analysisDurationMillis = since(analysisStartNanoTime),
           exception = HeapAnalysisException(exception)
       )
@@ -122,25 +115,19 @@ class HeapAnalyzer constructor(
     referenceMatchers: List<ReferenceMatcher> = emptyList(),
     computeRetainedHeapSize: Boolean = false,
     objectInspectors: List<ObjectInspector> = emptyList(),
-    metadataExtractor: MetadataExtractor = MetadataExtractor.NO_OP,
-    heapDumpDurationMillis: Long = -1
+    metadataExtractor: MetadataExtractor = MetadataExtractor.NO_OP
   ): HeapAnalysis {
     val analysisStartNanoTime = System.nanoTime()
     return try {
       val helpers =
         FindLeakInput(graph, referenceMatchers, computeRetainedHeapSize, objectInspectors)
       helpers.analyzeGraph(
-          metadataExtractor = metadataExtractor,
-          leakingObjectFinder = leakingObjectFinder,
-          heapDumpFile = heapDumpFile,
-          dumpDurationMillis = heapDumpDurationMillis,
-          analysisStartNanoTime = analysisStartNanoTime
+          metadataExtractor, leakingObjectFinder, heapDumpFile, analysisStartNanoTime
       )
     } catch (exception: Throwable) {
       HeapAnalysisFailure(
           heapDumpFile = heapDumpFile,
           createdAtTimeMillis = System.currentTimeMillis(),
-          dumpDurationMillis = heapDumpDurationMillis,
           analysisDurationMillis = since(analysisStartNanoTime),
           exception = HeapAnalysisException(exception)
       )
@@ -151,7 +138,6 @@ class HeapAnalyzer constructor(
     metadataExtractor: MetadataExtractor,
     leakingObjectFinder: LeakingObjectFinder,
     heapDumpFile: File,
-    dumpDurationMillis: Long,
     analysisStartNanoTime: Long
   ): HeapAnalysisSuccess {
     listener.onAnalysisProgress(EXTRACTING_METADATA)
@@ -165,7 +151,6 @@ class HeapAnalyzer constructor(
     return HeapAnalysisSuccess(
         heapDumpFile = heapDumpFile,
         createdAtTimeMillis = System.currentTimeMillis(),
-        dumpDurationMillis = dumpDurationMillis,
         analysisDurationMillis = since(analysisStartNanoTime),
         metadata = metadata,
         applicationLeaks = applicationLeaks,

--- a/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
+++ b/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
@@ -74,7 +74,7 @@ class HeapAnalysisStringRenderingTest {
       |Analysis duration: \d* ms
       |Heap dump file path: ${hprofFile.absolutePath}
       |Heap dump timestamp: \d*
-      |Heap dump duration: UNKNOWN
+      |Heap dump duration: Unknown
       |===================================="""
   }
 
@@ -116,7 +116,7 @@ class HeapAnalysisStringRenderingTest {
       |Analysis duration: \d* ms
       |Heap dump file path: ${hprofFile.absolutePath}
       |Heap dump timestamp: \d*
-      |Heap dump duration: UNKNOWN
+      |Heap dump duration: Unknown
       |===================================="""
   }
 

--- a/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
+++ b/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
@@ -74,6 +74,7 @@ class HeapAnalysisStringRenderingTest {
       |Analysis duration: \d* ms
       |Heap dump file path: ${hprofFile.absolutePath}
       |Heap dump timestamp: \d*
+      |Heap dump duration: UNKNOWN
       |===================================="""
   }
 
@@ -115,6 +116,7 @@ class HeapAnalysisStringRenderingTest {
       |Analysis duration: \d* ms
       |Heap dump file path: ${hprofFile.absolutePath}
       |Heap dump timestamp: \d*
+      |Heap dump duration: UNKNOWN
       |===================================="""
   }
 


### PR DESCRIPTION
On Android 11, we have experienced slow heap dumps as described in https://issuetracker.google.com/issues/168634429.
The heap dump was still relatively quick for a vanilla sampe project, so I would like to contribute to leak canary to verify the heap dump in a large-scale app to support the arguments.

Implementation-wise, I used -1 as an invalid duration and the corresponding formatted text would be "UNKNOWN". If the duration for the heap dump is valid, the text would be like "42 ms".

I have tested this patch manually by installing on my device as well as running `./gradlew test`. If there are other steps I need to take for testing, please let me know.