### PR TITLE
Improve View & Context labels

### DIFF
--- a/shark-android/src/test/java/shark/HprofIOPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofIOPerfTest.kt
@@ -177,7 +177,7 @@ class HprofIOPerfTest {
     val medianBytesRead = randomAccessReads.median()
     val totalBytesRead = randomAccessReads.sum()
     assertThat(listOf(readsCount, medianBytesRead, totalBytesRead))
-        .isEqualTo(listOf(28588, 40.0, 1849412))
+        .isEqualTo(listOf(28586, 40.0, 1849317))
   }
 
   @Test fun `freeze leak_asynctask_m hprof random access metrics`() {
@@ -190,7 +190,7 @@ class HprofIOPerfTest {
     val medianBytesRead = randomAccessReads.median()
     val totalBytesRead = randomAccessReads.sum()
     assertThat(listOf(readsCount, medianBytesRead, totalBytesRead))
-        .isEqualTo(listOf(27196, 40.0, 2704951))
+        .isEqualTo(listOf(27195, 40.0, 2704907))
   }
 
   @Test fun `freeze leak_asynctask_pre_m hprof random access metrics`() {
@@ -202,7 +202,7 @@ class HprofIOPerfTest {
     val size = randomAccessReads.size
     val median = randomAccessReads.median()
     val sum = randomAccessReads.sum()
-    assertThat(listOf(size, median, sum)).isEqualTo(listOf(20062, 32.0, 1105917))
+    assertThat(listOf(size, median, sum)).isEqualTo(listOf(20061, 32.0, 1105877))
   }
 
   private fun trackAnalyzeIoReadMetrics(hprofFile: File): List<List<Int>> {


### PR DESCRIPTION
* Find the root view and whether that view is ViewRootImpl (=> whether the view still belongs to a window view hierarchy)
* Identify Application & Service contexts when unwrapping contexts.

Fixes #1912