### PR TITLE
Improve dominator tree

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/Serializables.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/Serializables.kt
@@ -1,5 +1,6 @@
 package leakcanary.internal
 
+import shark.SharkLog
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.ObjectInputStream
@@ -19,6 +20,7 @@ internal object Serializables {
     return try {
       ObjectInputStream(inputStream).readObject() as? T
     } catch (ignored: Throwable) {
+      SharkLog.d(ignored) { "Could not deserialize bytes, ignoring" }
       null
     }
   }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -91,27 +91,25 @@ internal object HeapAnalysisTable {
     db: SQLiteDatabase,
     id: Long
   ): T? {
-    db.inTransaction {
-      return db.rawQuery(
-          """
+    return db.rawQuery(
+        """
               SELECT
               object
               FROM heap_analysis
               WHERE id=$id
               """, null
-      )
-          .use { cursor ->
-            if (cursor.moveToNext()) {
-              val analysis = Serializables.fromByteArray<T>(cursor.getBlob(0))
-              if (analysis == null) {
-                delete(db, id, null)
-              }
-              analysis
-            } else {
-              null
+    )
+        .use { cursor ->
+          if (cursor.moveToNext()) {
+            val analysis = Serializables.fromByteArray<T>(cursor.getBlob(0))
+            if (analysis == null) {
+              delete(db, id, null)
             }
-          } ?: return null
-    }
+            analysis
+          } else {
+            null
+          }
+        }
   }
 
   fun retrieveAll(db: SQLiteDatabase): List<Projection> {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/LeakTable.kt
@@ -213,6 +213,7 @@ internal object LeakTable {
       SELECT *
       FROM leak_trace lt
       WHERE leak.id = lt.leak_id)
-    """)
+    """
+    )
   }
 }

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -9,6 +9,7 @@ import shark.AndroidReferenceMatchers.Companion.buildKnownReferences
 import shark.AndroidReferenceMatchers.FINALIZER_WATCHDOG_DAEMON
 import shark.AndroidReferenceMatchers.REFERENCES
 import shark.GcRoot.ThreadObject
+import shark.HprofHeapGraph.Companion.openHeapGraph
 import shark.OnAnalysisProgressListener.Step.COMPUTING_NATIVE_RETAINED_SIZE
 import shark.OnAnalysisProgressListener.Step.COMPUTING_RETAINED_SIZE
 import shark.OnAnalysisProgressListener.Step.EXTRACTING_METADATA
@@ -17,6 +18,7 @@ import shark.OnAnalysisProgressListener.Step.FINDING_PATHS_TO_RETAINED_OBJECTS
 import shark.OnAnalysisProgressListener.Step.FINDING_RETAINED_OBJECTS
 import shark.OnAnalysisProgressListener.Step.INSPECTING_OBJECTS
 import shark.OnAnalysisProgressListener.Step.PARSING_HEAP_DUMP
+import shark.internal.ObjectDominators
 import java.io.File
 import java.util.EnumSet
 import java.util.concurrent.CountDownLatch
@@ -48,8 +50,9 @@ class HprofRetainedHeapPerfTest {
       baselineHeap to heapWithIndex
     }
 
-    val retained =
-      heapWithIndex.retainedHeap(ANALYSIS_THREAD) - baselineHeap.retainedHeap(ANALYSIS_THREAD)
+    val (analysisRetained, dominators) = heapWithIndex.retainedHeap(ANALYSIS_THREAD)
+
+    val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
     assertThat(retained).isEqualTo(4.8 MB +-5 % margin)
   }
@@ -64,8 +67,9 @@ class HprofRetainedHeapPerfTest {
       baselineHeap to heapWithIndex
     }
 
-    val retained =
-      heapWithIndex.retainedHeap(ANALYSIS_THREAD) - baselineHeap.retainedHeap(ANALYSIS_THREAD)
+    val (analysisRetained, dominators) = heapWithIndex.retainedHeap(ANALYSIS_THREAD)
+
+    val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
     assertThat(retained).isEqualTo(8.2 MB +-5 % margin)
   }
@@ -101,9 +105,10 @@ class HprofRetainedHeapPerfTest {
       baselineHeap
     }
 
-    val retainedBeforeAnalysis = baselineHeap.retainedHeap(ANALYSIS_THREAD)
+    val retainedBeforeAnalysis = baselineHeap.retainedHeap(ANALYSIS_THREAD).first
     val retained = stepsToHeapDumpFile.mapValues {
-      it.value.retainedHeap(ANALYSIS_THREAD) - retainedBeforeAnalysis
+      val retainedPair = it.value.retainedHeap(ANALYSIS_THREAD, computeDominators = true)
+      retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
     assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.70 MB +-5 % margin)
@@ -160,42 +165,73 @@ class HprofRetainedHeapPerfTest {
     return result
   }
 
-  private infix fun Map<OnAnalysisProgressListener.Step, Bytes>.after(step: OnAnalysisProgressListener.Step): Bytes {
+  private infix fun Map<OnAnalysisProgressListener.Step, Pair<Bytes, String>>.after(step: OnAnalysisProgressListener.Step): Pair<Bytes, String> {
     val values = OnAnalysisProgressListener.Step.values()
     for (nextOrdinal in step.ordinal + 1 until values.size) {
-      val nextStepRetained = this[values[nextOrdinal]]
-      if (nextStepRetained != null) {
-        return nextStepRetained
+      val pair = this[values[nextOrdinal]]
+      if (pair != null) {
+        val (nextStepRetained, dominatorTree) = pair
+
+        return nextStepRetained to "\n$nextStepRetained retained by analysis thread after step ${step.name} not valid\n" + dominatorTree
       }
     }
     error("No step in $this after $step")
   }
 
-  private fun File.retainedHeap(threadName: String): Bytes {
+  private fun File.retainedHeap(
+    threadName: String,
+    computeDominators: Boolean = false
+  ): Pair<Bytes, String> {
     val heapAnalyzer = HeapAnalyzer(OnAnalysisProgressListener.NO_OP)
-    val analysis = heapAnalyzer.analyze(
-        heapDumpFile = this,
-        referenceMatchers = buildKnownReferences(EnumSet.of(REFERENCES, FINALIZER_WATCHDOG_DAEMON)),
-        leakingObjectFinder = LeakingObjectFinder { graph ->
-          setOf(graph.gcRoots.first { gcRoot ->
-            gcRoot is ThreadObject &&
-                graph.objectExists(gcRoot.id) &&
-                graph.findObjectById(gcRoot.id)
-                    .asInstance!!["java.lang.Thread", "name"]!!
-                    .value.readAsJavaString() == threadName
-          }.id)
-        },
-        computeRetainedHeapSize = true
-    )
-    check(analysis is HeapAnalysisSuccess) {
-      "Expected success not $analysis"
+
+    val (analysis, dominatorTree) = openHeapGraph().use { graph ->
+      val analysis = heapAnalyzer.analyze(
+          heapDumpFile = this,
+          graph = graph,
+          referenceMatchers = buildKnownReferences(
+              EnumSet.of(REFERENCES, FINALIZER_WATCHDOG_DAEMON)
+          ),
+          leakingObjectFinder = LeakingObjectFinder { graph ->
+            setOf(graph.gcRoots.first { gcRoot ->
+              gcRoot is ThreadObject &&
+                  graph.objectExists(gcRoot.id) &&
+                  graph.findObjectById(gcRoot.id)
+                      .asInstance!!["java.lang.Thread", "name"]!!
+                      .value.readAsJavaString() == threadName
+            }.id)
+          },
+          computeRetainedHeapSize = true
+      )
+      check(analysis is HeapAnalysisSuccess) {
+        "Expected success not $analysis"
+      }
+
+      val dominatorTree = if (computeDominators) {
+        val weakAndFinalizerRefs = EnumSet.of(REFERENCES, FINALIZER_WATCHDOG_DAEMON)
+        val ignoredRefs = buildKnownReferences(weakAndFinalizerRefs).map { matcher ->
+          matcher as IgnoredReferenceMatcher
+        }
+        ObjectDominators().renderDominatorTree(
+            graph, ignoredRefs, 200, threadName, true
+        )
+      } else ""
+      analysis to dominatorTree
     }
-    return analysis.applicationLeaks.single().leakTraces.single().retainedHeapByteSize!!.bytes
+
+    return analysis.applicationLeaks.single().leakTraces.single().retainedHeapByteSize!!.bytes to dominatorTree
   }
 
-  class BytesAssert(bytes: Bytes) : AbstractIntegerAssert<BytesAssert>(
+  class BytesAssert(
+    bytes: Bytes,
+    description: String
+  ) : AbstractIntegerAssert<BytesAssert>(
       bytes.count, BytesAssert::class.java
   ) {
+
+    init {
+      describedAs(description)
+    }
+
     fun isEqualTo(expected: BytesWithError): BytesAssert {
       val errorPercentage = expected.error.percentage.absoluteValue
       return isBetween(
@@ -205,7 +241,9 @@ class HprofRetainedHeapPerfTest {
     }
   }
 
-  private fun assertThat(bytes: Bytes?) = BytesAssert(bytes!!)
+  private fun assertThat(bytes: Bytes) = BytesAssert(bytes, "")
+
+  private fun assertThat(pair: Pair<Bytes, String>) = BytesAssert(pair.first, pair.second)
 
   data class Bytes(val count: Int)
 

--- a/shark-graph/src/main/java/shark/HeapGraph.kt
+++ b/shark-graph/src/main/java/shark/HeapGraph.kt
@@ -77,6 +77,13 @@ interface HeapGraph {
   fun findObjectById(objectId: Long): HeapObject
 
   /**
+   * Returns the [HeapObject] corresponding to the provided [objectIndex], and throws
+   * [IllegalArgumentException] if [objectIndex] is less than 0 or more than [objectCount] - 1.
+   */
+  @Throws(IllegalArgumentException::class)
+  fun findObjectByIndex(objectIndex: Int): HeapObject
+
+  /**
    * Returns the [HeapObject] corresponding to the provided [objectId] or null if it cannot be
    * found.
    */

--- a/shark-graph/src/main/java/shark/internal/SortedBytesMap.kt
+++ b/shark-graph/src/main/java/shark/internal/SortedBytesMap.kt
@@ -26,6 +26,14 @@ internal class SortedBytesMap(
     if (keyIndex < 0) {
       return null
     }
+    return getAtIndex(keyIndex)
+  }
+
+  fun indexOf(key: Long): Int {
+    return binarySearch(key)
+  }
+
+  fun getAtIndex(keyIndex: Int): ByteSubArray {
     val valueIndex = keyIndex * bytesPerEntry + bytesPerKey
     return ByteSubArray(sortedEntries, valueIndex, bytesPerValue, longIdentifiers)
   }
@@ -62,7 +70,7 @@ internal class SortedBytesMap(
     return lo.inv()
   }
 
-  private fun keyAt(index: Int): Long {
+  fun keyAt(index: Int): Long {
     val keyIndex = index * bytesPerEntry
     return if (longIdentifiers) {
       sortedEntries.readLong(keyIndex)

--- a/shark-graph/src/main/java/shark/internal/hppc/Tuples.kt
+++ b/shark-graph/src/main/java/shark/internal/hppc/Tuples.kt
@@ -6,6 +6,12 @@ internal data class LongObjectPair<out B>(
   val second: B
 )
 
+/** Alternative to Pair<Int, Object> that doesn't box int.*/
+internal data class IntObjectPair<out B>(
+  val first: Int,
+  val second: B
+)
+
 /** Alternative to Pair<Long, Long> that doesn't box longs. */
 internal data class LongLongPair(
   val first: Long,
@@ -13,5 +19,7 @@ internal data class LongLongPair(
 )
 
 internal infix fun <B> Long.to(that: B): LongObjectPair<B> = LongObjectPair(this, that)
+
+internal infix fun <B> Int.to(that: B): IntObjectPair<B> = IntObjectPair(this, that)
 
 internal infix fun Long.to(that: Long): LongLongPair = LongLongPair(this, that)

--- a/shark-graph/src/test/java/shark/JvmHprofParsingTest.kt
+++ b/shark-graph/src/test/java/shark/JvmHprofParsingTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import shark.HprofHeapGraph.Companion.openHeapGraph
 import java.io.File
 import kotlin.reflect.KClass
 
@@ -18,9 +19,7 @@ class JvmHprofParsingTest {
 
     JvmTestHeapDumper.dumpHeap(hprofFile.absolutePath)
 
-    Hprof.open(hprofFile)
-        .use { hprof ->
-          val graph = HprofHeapGraph.indexHprof(hprof)
+    hprofFile.openHeapGraph().use { graph ->
           val testInstances = graph.instances
               .filter { it.instanceClassName == JvmHprofParsingTest::class.name }
               .toList()
@@ -34,6 +33,29 @@ class JvmHprofParsingTest {
 
           assertThat(folderPath).isEqualTo(testFolder.root.path)
         }
+  }
+
+  @Test fun `JVM object array class name is translated to brackets`() {
+    val objectArray = arrayOfNulls<JvmHprofParsingTest>(0)
+    val hprofFolder = testFolder.newFolder()
+    val hprofFile = File(hprofFolder, "jvm_heap.hprof")
+    JvmTestHeapDumper.dumpHeap(hprofFile.absolutePath)
+    // Dumb check to prevent instance from being garbage collected.
+    check(objectArray::class::class.isInstance(KClass::class))
+
+    val expectedArrayClassName = "${JvmHprofParsingTest::class.java.name}[]"
+
+    hprofFile.openHeapGraph().use { graph ->
+      val arrayClass = graph.findClassByName(expectedArrayClassName)
+      assertThat(arrayClass).isNotNull
+      assertThat(arrayClass!!.isObjectArrayClass).isTrue()
+      assertThat(arrayClass!!.name).isEqualTo(expectedArrayClassName)
+
+      val arrayInstances = arrayClass.objectArrayInstances.toList()
+      assertThat(arrayInstances).hasSize(1)
+      val array = arrayInstances.single()
+      assertThat(array.readByteSize()).isEqualTo(0)
+    }
   }
 }
 

--- a/shark-hprof-test/src/main/kotlin/shark/HprofWriterHelper.kt
+++ b/shark-hprof-test/src/main/kotlin/shark/HprofWriterHelper.kt
@@ -348,6 +348,16 @@ fun File.dump(block: HprofWriterHelper.() -> Unit) {
       .use(block)
 }
 
+fun dump(
+  hprofHeader: HprofHeader = HprofHeader(),
+  block: HprofWriterHelper.() -> Unit
+): DualSourceProvider {
+  val buffer = Buffer()
+  HprofWriterHelper(HprofWriter.openWriterFor(buffer))
+      .use(block)
+  return ByteArraySourceProvider(buffer.readByteArray())
+}
+
 fun List<HprofRecord>.asHprofBytes(): DualSourceProvider {
   val buffer = Buffer()
   HprofWriter.openWriterFor(buffer)

--- a/shark/src/main/java/shark/HeapAnalysis.kt
+++ b/shark/src/main/java/shark/HeapAnalysis.kt
@@ -194,6 +194,17 @@ sealed class Leak : Serializable {
     }
 
   /**
+   * Sum of [LeakTrace.retainedObjectCount] for all elements in [leakTraces].
+   * Null if the retained heap size was not computed.
+   */
+  val totalRetainedObjectCount: Int?
+    get() = if (leakTraces.first().retainedObjectCount == null) {
+      null
+    } else {
+      leakTraces.sumBy { it.retainedObjectCount!! }
+    }
+
+  /**
    * A unique SHA1 hash that represents this group of leak traces.
    *
    * For [ApplicationLeak] this is based on [LeakTrace.signature] and for [LibraryLeak] this is

--- a/shark/src/main/java/shark/LeakTraceElement.kt
+++ b/shark/src/main/java/shark/LeakTraceElement.kt
@@ -71,7 +71,9 @@ internal class LeakTraceElement : Serializable {
         LEAKING -> LeakingStatus.LEAKING
         UNKNOWN -> LeakingStatus.UNKNOWN
       },
-      leakingStatusReason = leakStatusReason!!
+      leakingStatusReason = leakStatusReason!!,
+      retainedHeapByteSize = null,
+      retainedObjectCount = null
   )
 
   companion object {

--- a/shark/src/main/java/shark/LeakTraceObject.kt
+++ b/shark/src/main/java/shark/LeakTraceObject.kt
@@ -18,7 +18,19 @@ data class LeakTraceObject(
    */
   val labels: Set<String>,
   val leakingStatus: LeakingStatus,
-  val leakingStatusReason: String
+  val leakingStatusReason: String,
+  /**
+   * The minimum number of bytes which would be freed if all references to this object were
+   * released. Not null only if the retained heap size was computed AND [leakingStatus] is
+   * equal to [LeakingStatus.UNKNOWN] or [LeakingStatus.LEAKING].
+   */
+  val retainedHeapByteSize: Int?,
+  /**
+   * The minimum number of objects which would be unreachable if all references to this object were
+   * released. Not null only if the retained heap size was computed AND [leakingStatus] is
+   * equal to [LeakingStatus.UNKNOWN] or [LeakingStatus.LEAKING].
+   */
+  val retainedObjectCount: Int?
 ) : Serializable {
 
   /**
@@ -39,9 +51,15 @@ data class LeakTraceObject(
   enum class LeakingStatus {
     /** The object was needed and therefore expected to be reachable. */
     NOT_LEAKING,
+
     /** The object was no longer needed and therefore expected to be unreachable. */
     LEAKING,
+
     /** No decision can be made about the provided object. */
     UNKNOWN;
+  }
+
+  companion object {
+    private const val serialVersionUID = -3616216391305196341L
   }
 }

--- a/shark/src/main/java/shark/internal/ObjectDominators.kt
+++ b/shark/src/main/java/shark/internal/ObjectDominators.kt
@@ -1,0 +1,154 @@
+package shark.internal
+
+import shark.GcRoot.ThreadObject
+import shark.HeapGraph
+import shark.HeapObject.HeapClass
+import shark.HeapObject.HeapInstance
+import shark.HeapObject.HeapObjectArray
+import shark.HeapObject.HeapPrimitiveArray
+import shark.IgnoredReferenceMatcher
+import shark.OnAnalysisProgressListener
+import shark.ValueHolder
+
+/**
+ * Exposes high level APIs to compute and render a dominator tree. This class
+ * needs to be public to be used by other LeakCanary modules but is internal and
+ * its API might change at any moment.
+ *
+ * Note that the exposed APIs are not optimized for speed, memory or IO.
+ *
+ * Eventually this capability should become part of the Shark public APIs, please
+ * open an issue if you'd like to use this directly.
+ */
+class ObjectDominators {
+
+  internal data class DominatorNode(
+    val shallowSize: Int,
+    val retainedSize: Int,
+    val retainedCount: Int,
+    val dominatedObjectIds: List<Long>
+  )
+
+  fun renderDominatorTree(
+    graph: HeapGraph,
+    ignoredRefs: List<IgnoredReferenceMatcher>,
+    minRetainedSize: Int,
+    threadName: String? = null,
+    printStringContent: Boolean = false
+  ): String {
+    val stringBuilder = StringBuilder()
+
+    val dominatorTree = buildDominatorTree(graph, ignoredRefs)
+
+    val root = dominatorTree.getValue(ValueHolder.NULL_REFERENCE)
+    stringBuilder.append(
+        "Total retained: ${root.retainedSize} bytes in ${root.retainedCount} objects. Root dominators: ${root.dominatedObjectIds.size}\n\n"
+    )
+
+    val rootIds = if (threadName != null) {
+      setOf(graph.gcRoots.first { gcRoot ->
+        gcRoot is ThreadObject &&
+            graph.objectExists(gcRoot.id) &&
+            graph.findObjectById(gcRoot.id)
+                .asInstance!!["java.lang.Thread", "name"]!!
+                .value.readAsJavaString() == threadName
+      }.id)
+    } else {
+      root.dominatedObjectIds.filter { dominatorTree.getValue(it).retainedSize > minRetainedSize }
+    }
+
+    rootIds
+        .forEach { objectId ->
+          printTree(
+              stringBuilder, graph, dominatorTree, objectId, minRetainedSize, 0, "", true,
+              printStringContent
+          )
+          stringBuilder.append("\n")
+        }
+    return stringBuilder.toString()
+  }
+
+  @Suppress("LongParameterList")
+  private fun printTree(
+    stringBuilder: StringBuilder,
+    graph: HeapGraph,
+    tree: Map<Long, DominatorNode>,
+    objectId: Long,
+    minSize: Int,
+    depth: Int,
+    prefix: String,
+    isLast: Boolean,
+    printStringContent: Boolean
+  ) {
+    val node = tree.getValue(objectId)
+    val heapObject = graph.findObjectById(objectId)
+    val className = when (heapObject) {
+      is HeapClass -> "class ${heapObject.name}"
+      is HeapInstance -> heapObject.instanceClassName
+      is HeapObjectArray -> heapObject.arrayClassName
+      is HeapPrimitiveArray -> heapObject.arrayClassName
+    }
+    val anchor = if (depth == 0) "" else if (isLast) "╰─" else "├─"
+    val size = if (node.retainedSize != node.shallowSize) {
+      "${node.retainedSize} bytes (${node.shallowSize} self)"
+    } else {
+      "${node.shallowSize} bytes"
+    }
+    val count = if (node.retainedCount > 1) {
+      " ${node.retainedCount} objects"
+    } else {
+      ""
+    }
+    val stringContent = if (
+        printStringContent &&
+        heapObject is HeapInstance &&
+            heapObject.instanceClassName == "java.lang.String"
+    ) " \"${heapObject.readAsJavaString()}\"" else ""
+    stringBuilder.append(
+        "$prefix$anchor$className #${heapObject.objectIndex} Retained: $size$count$stringContent\n"
+    )
+
+    val newPrefix = when {
+      depth == 0 -> ""
+      isLast -> {
+        "$prefix  "
+      }
+      else -> {
+        "$prefix│ "
+      }
+    }
+
+    val largeChildren = node.dominatedObjectIds.filter { tree.getValue(it).retainedSize > minSize }
+    val lastIndex = node.dominatedObjectIds.lastIndex
+
+    largeChildren.forEachIndexed { index, objectId ->
+      printTree(
+          stringBuilder,
+          graph, tree, objectId, minSize, depth + 1, newPrefix,
+          index == lastIndex,
+          printStringContent
+      )
+    }
+    if (largeChildren.size < node.dominatedObjectIds.size) {
+      stringBuilder.append("$newPrefix╰┄\n")
+    }
+  }
+
+  private fun buildDominatorTree(
+    graph: HeapGraph,
+    ignoredRefs: List<IgnoredReferenceMatcher>
+  ): Map<Long, DominatorNode> {
+    val pathFinder = PathFinder(graph,
+        OnAnalysisProgressListener.NO_OP, ignoredRefs)
+    val nativeSizeMapper = AndroidNativeSizeMapper(graph)
+    val nativeSizes = nativeSizeMapper.mapNativeSizes()
+    val shallowSizeCalculator = ShallowSizeCalculator(graph)
+
+    val result = pathFinder.findPathsFromGcRoots(setOf(), true)
+    return result.dominatorTree!!.buildFullDominatorTree { objectId ->
+      val nativeSize = nativeSizes[objectId] ?: 0
+      val shallowSize = shallowSizeCalculator.computeShallowSize(objectId)
+      nativeSize + shallowSize
+    }
+  }
+}

--- a/shark/src/test/java/shark/HprofHeapGraphTest.kt
+++ b/shark/src/test/java/shark/HprofHeapGraphTest.kt
@@ -1,0 +1,45 @@
+package shark
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.HeapObject.HeapClass
+import shark.HeapObject.HeapInstance
+import shark.HprofHeapGraph.Companion.openHeapGraph
+
+class HprofHeapGraphTest {
+
+  @Test fun `class index is consistent when parsing dump twice`() {
+    val heapDump = dump {
+      "SomeClass" clazz {}
+    }
+
+    val classIndex = heapDump.openHeapGraph().use { graph ->
+      graph.findClassByName("SomeClass")!!.objectIndex
+    }
+
+    heapDump.openHeapGraph().use { graph ->
+      val heapObject = graph.findObjectByIndex(classIndex)
+      assertThat(heapObject).isInstanceOf(HeapClass::class.java)
+      heapObject as HeapClass
+      assertThat(heapObject.name).isEqualTo("SomeClass")
+    }
+  }
+
+  @Test fun `instance index is consistent when parsing dump twice`() {
+    val heapDump = dump {
+      "SomeClass" instance {}
+    }
+
+    val instanceIndex = heapDump.openHeapGraph().use { graph ->
+      graph.findClassByName("SomeClass")!!.instances.single().objectIndex
+    }
+
+    heapDump.openHeapGraph().use { graph ->
+      val heapObject = graph.findObjectByIndex(instanceIndex)
+      assertThat(heapObject).isInstanceOf(HeapInstance::class.java)
+      heapObject as HeapInstance
+      assertThat(heapObject.instanceClassName).isEqualTo("SomeClass")
+    }
+  }
+
+}


### PR DESCRIPTION
* Report retained sizes and retained object count for all objects that have the UNKNOWN or LEAKING status.
* Added printing of dominator tree when HprofRetainedHeapPerfTest fails. This can help identify why that test might succeed locally but fail in CI due to differences in how VMs manage memory.
* Exposes a new `HeapObject.objectIndex` identifier as an alternative to `HeapObject.objectId`. `HeapObject.objectIndex` maps to the actual position of the object in the memory index array. It's exposed as a more human readable identifier as it starts at 0 and ends at `HeapGraph.objectCount - 1`. Objects can now be retrieved with `HeapGraph.findObjectByIndex()`
* Bug fix: Improve support for object arrays on JVMs. Object arrays have their class names stored as `[Lcom.example.Foo;` inside JVM heap dumps, Shark now properly translates back and forth top `com.example.Foo[]`
* Bug fix: add missing serialVersionUID to LeakTraceObject
* Bug fix: HeapAnalysisTable.retrieve() was running the query in a transaction, preventing deletion to work.