### PR TITLE
Update Kotlin 1.4.10 to leverage Kotlin SAM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,10 @@ buildscript {
       'minSdk': 14,
       'compileSdk': 29,
       'errorProne': '2.3.1',
-      'kotlin': '1.4.10',
+      // We would like to use Kotlin 1.4 language features but keep Kotlin 1.3 library APIs
+      // The benefit is that depending clients do not have to upgrade to Kotlin 1.4
+      'kotlinCompiler': '1.4.10',
+      'kotlinLib': '1.3.72',
   ]
   ext.deps = [
       assertj_core: 'org.assertj:assertj-core:3.9.1',
@@ -32,9 +35,9 @@ buildscript {
       detekt: 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.6.0',
       junit: 'junit:junit:4.12',
       kotlin: [
-          gradlePlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
-          stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
-          reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
+          gradlePlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlinCompiler}",
+          stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlinLib}",
+          reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlinLib}"
       ],
       kotlin_statistics: 'org.nield:kotlin-statistics:1.2.1',
       mockito: 'org.mockito:mockito-core:3.5.10',
@@ -104,6 +107,14 @@ subprojects {
         // '-Werror'
     ]
   }
+
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+      // Avoid warnings of using older stdlib version 1.3 than compiler version 1.4
+      apiVersion = "1.3"
+    }
+  }
+
 
   configurations.all {
     resolutionStrategy {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
       'minSdk': 14,
       'compileSdk': 29,
       'errorProne': '2.3.1',
-      'kotlin': '1.3.72',
+      'kotlin': '1.4.10',
   ]
   ext.deps = [
       assertj_core: 'org.assertj:assertj-core:3.9.1',

--- a/leakcanary-android-core/src/main/java/leakcanary/OnHeapAnalyzedListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/OnHeapAnalyzedListener.kt
@@ -1,40 +1,25 @@
 package leakcanary
 
-import leakcanary.OnHeapAnalyzedListener.Companion.invoke
 import shark.HeapAnalysis
-import shark.ObjectInspector.Companion.invoke
 
 /**
  * Listener set in [LeakCanary.Config] and called by LeakCanary on a background thread when the
  * heap analysis is complete.
  *
- * You can create a [OnHeapAnalyzedListener] from a lambda by calling [invoke].
+ * This is a functional interface with which you can create a [OnHeapAnalyzedListener] from a lambda.
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val listener = OnHeapAnalyzedListener { heapAnalysis ->
+ *   process(heapAnalysis)
+ * }
+ * ```
  */
-interface OnHeapAnalyzedListener {
+fun interface OnHeapAnalyzedListener {
 
   /**
    * @see OnHeapAnalyzedListener
    */
   fun onHeapAnalyzed(heapAnalysis: HeapAnalysis)
-
-  companion object {
-    /**
-     * Utility function to create a [OnHeapAnalyzedListener] from the passed in [block] lambda
-     * instead of using the anonymous `object : OnHeapAnalyzedListener` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val listener = OnHeapAnalyzedListener {
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: (HeapAnalysis) -> Unit): OnHeapAnalyzedListener =
-      object : OnHeapAnalyzedListener {
-        override fun onHeapAnalyzed(heapAnalysis: HeapAnalysis) {
-          block(heapAnalysis)
-        }
-      }
-  }
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/OnHeapAnalyzedListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/OnHeapAnalyzedListener.kt
@@ -24,8 +24,18 @@ fun interface OnHeapAnalyzedListener {
   fun onHeapAnalyzed(heapAnalysis: HeapAnalysis)
 
   companion object {
-
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [OnHeapAnalyzedListener] from the passed in [block] lambda
+     * instead of using the anonymous `object : OnHeapAnalyzedListener` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val listener = OnHeapAnalyzedListener {
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: (HeapAnalysis) -> Unit): OnHeapAnalyzedListener =
       object : OnHeapAnalyzedListener {
         override fun onHeapAnalyzed(heapAnalysis: HeapAnalysis) {

--- a/leakcanary-android-core/src/main/java/leakcanary/OnHeapAnalyzedListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/OnHeapAnalyzedListener.kt
@@ -22,4 +22,15 @@ fun interface OnHeapAnalyzedListener {
    * @see OnHeapAnalyzedListener
    */
   fun onHeapAnalyzed(heapAnalysis: HeapAnalysis)
+
+  companion object {
+
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: (HeapAnalysis) -> Unit): OnHeapAnalyzedListener =
+      object : OnHeapAnalyzedListener {
+        override fun onHeapAnalyzed(heapAnalysis: HeapAnalysis) {
+          block(heapAnalysis)
+        }
+      }
+  }
 }

--- a/leakcanary-object-watcher/src/main/java/leakcanary/Clock.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/Clock.kt
@@ -3,30 +3,11 @@ package leakcanary
 /**
  * An interface to abstract the SystemClock.uptimeMillis() Android API in non Android artifacts.
  *
- * You can create a [Clock] from a lambda by calling [invoke].
+ * This is a functional interface with which you can create a [Clock] from a lambda.
  */
-interface Clock {
+fun interface Clock {
   /**
    * On Android VMs, this should return android.os.SystemClock.uptimeMillis().
    */
   fun uptimeMillis(): Long
-
-  companion object {
-    /**
-     * Utility function to create a [Clock] from the passed in [block] lambda
-     * instead of using the anonymous `object : Clock` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val clock = Clock {
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: () -> Long): Clock =
-      object : Clock {
-        override fun uptimeMillis(): Long = block()
-      }
-  }
 }

--- a/leakcanary-object-watcher/src/main/java/leakcanary/Clock.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/Clock.kt
@@ -10,4 +10,13 @@ fun interface Clock {
    * On Android VMs, this should return android.os.SystemClock.uptimeMillis().
    */
   fun uptimeMillis(): Long
+
+  companion object {
+
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: () -> Long): Clock =
+      object : Clock {
+        override fun uptimeMillis(): Long = block()
+      }
+  }
 }

--- a/leakcanary-object-watcher/src/main/java/leakcanary/Clock.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/Clock.kt
@@ -12,8 +12,18 @@ fun interface Clock {
   fun uptimeMillis(): Long
 
   companion object {
-
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [Clock] from the passed in [block] lambda
+     * instead of using the anonymous `object : Clock` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val clock = Clock {
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: () -> Long): Clock =
       object : Clock {
         override fun uptimeMillis(): Long = block()

--- a/leakcanary-object-watcher/src/main/java/leakcanary/OnObjectRetainedListener.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/OnObjectRetainedListener.kt
@@ -13,8 +13,18 @@ fun interface OnObjectRetainedListener {
   fun onObjectRetained()
 
   companion object {
-
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [OnObjectRetainedListener] from the passed in [block] lambda
+     * instead of using the anonymous `object : OnObjectRetainedListener` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val listener = OnObjectRetainedListener {
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: () -> Unit): OnObjectRetainedListener =
       object : OnObjectRetainedListener {
         override fun onObjectRetained() {

--- a/leakcanary-object-watcher/src/main/java/leakcanary/OnObjectRetainedListener.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/OnObjectRetainedListener.kt
@@ -11,4 +11,15 @@ fun interface OnObjectRetainedListener {
    * A watched object became retained.
    */
   fun onObjectRetained()
+
+  companion object {
+
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: () -> Unit): OnObjectRetainedListener =
+      object : OnObjectRetainedListener {
+        override fun onObjectRetained() {
+          block()
+        }
+      }
+  }
 }

--- a/leakcanary-object-watcher/src/main/java/leakcanary/OnObjectRetainedListener.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/OnObjectRetainedListener.kt
@@ -2,32 +2,13 @@ package leakcanary
 
 /**
  * Listener used by [ObjectWatcher] to report retained objects.
+ *
+ * This is a functional interface with which you can create a [OnObjectRetainedListener] from a lambda.
  */
-interface OnObjectRetainedListener {
+fun interface OnObjectRetainedListener {
 
   /**
    * A watched object became retained.
    */
   fun onObjectRetained()
-
-  companion object {
-    /**
-     * Utility function to create a [OnObjectRetainedListener] from the passed in [block] lambda
-     * instead of using the anonymous `object : OnObjectRetainedListener` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val listener = OnObjectRetainedListener {
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: () -> Unit): OnObjectRetainedListener =
-      object : OnObjectRetainedListener {
-        override fun onObjectRetained() {
-          block()
-        }
-      }
-  }
 }

--- a/leakcanary-object-watcher/src/test/java/leakcanary/ObjectWatcherTest.kt
+++ b/leakcanary-object-watcher/src/test/java/leakcanary/ObjectWatcherTest.kt
@@ -15,9 +15,7 @@ class ObjectWatcherTest {
     override fun uptimeMillis(): Long {
       return time
     }
-  }, checkRetainedExecutor).apply {
-    addOnObjectRetainedListener{}
-  }
+  }, checkRetainedExecutor).apply { addOnObjectRetainedListener(OnObjectRetainedListener {}) }
   var time: Long = 0
 
   var ref: Any? = Any()

--- a/leakcanary-object-watcher/src/test/java/leakcanary/ObjectWatcherTest.kt
+++ b/leakcanary-object-watcher/src/test/java/leakcanary/ObjectWatcherTest.kt
@@ -15,7 +15,9 @@ class ObjectWatcherTest {
     override fun uptimeMillis(): Long {
       return time
     }
-  }, checkRetainedExecutor).apply { addOnObjectRetainedListener(OnObjectRetainedListener {}) }
+  }, checkRetainedExecutor).apply {
+    addOnObjectRetainedListener{}
+  }
   var time: Long = 0
 
   var ref: Any? = Any()

--- a/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
+++ b/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
@@ -17,8 +17,18 @@ fun interface OnHprofRecordListener {
   )
 
   companion object {
-
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [OnHprofRecordListener] from the passed in [block] lambda
+     * instead of using the anonymous `object : OnHprofRecordListener` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val listener = OnHprofRecordListener { position, record ->
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: (Long, HprofRecord) -> Unit): OnHprofRecordListener =
       object : OnHprofRecordListener {
         override fun onHprofRecord(

--- a/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
+++ b/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
@@ -15,4 +15,18 @@ fun interface OnHprofRecordListener {
     position: Long,
     record: HprofRecord
   )
+
+  companion object {
+
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: (Long, HprofRecord) -> Unit): OnHprofRecordListener =
+      object : OnHprofRecordListener {
+        override fun onHprofRecord(
+          position: Long,
+          record: HprofRecord
+        ) {
+          block(position, record)
+        }
+      }
+  }
 }

--- a/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
+++ b/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
@@ -4,8 +4,10 @@ package shark
  * Listener passed in to [StreamingHprofReader.readRecords], gets notified for each [HprofRecord]
  * found in the heap dump which types is in the set of the recordTypes parameter passed to
  * [StreamingHprofReader.readRecords].
+ *
+ * This is a functional interface with which you can create a [OnHprofRecordListener] from a lambda.
  */
-interface OnHprofRecordListener {
+fun interface OnHprofRecordListener {
   fun onHprofRecord(
     /**
      * The position of the record in the underlying hprof file.
@@ -13,28 +15,4 @@ interface OnHprofRecordListener {
     position: Long,
     record: HprofRecord
   )
-
-  companion object {
-    /**
-     * Utility function to create a [OnHprofRecordListener] from the passed in [block] lambda
-     * instead of using the anonymous `object : OnHprofRecordListener` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val listener = OnHprofRecordListener { position, record ->
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: (Long, HprofRecord) -> Unit): OnHprofRecordListener =
-      object : OnHprofRecordListener {
-        override fun onHprofRecord(
-          position: Long,
-          record: HprofRecord
-        ) {
-          block(position, record)
-        }
-      }
-  }
 }

--- a/shark/src/main/java/shark/LeakingObjectFinder.kt
+++ b/shark/src/main/java/shark/LeakingObjectFinder.kt
@@ -13,4 +13,12 @@ fun interface LeakingObjectFinder {
    */
   fun findLeakingObjectIds(graph: HeapGraph): Set<Long>
 
+  companion object {
+
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: (HeapGraph) -> Set<Long>): LeakingObjectFinder =
+      object : LeakingObjectFinder {
+        override fun findLeakingObjectIds(graph: HeapGraph): Set<Long> = block(graph)
+      }
+  }
 }

--- a/shark/src/main/java/shark/LeakingObjectFinder.kt
+++ b/shark/src/main/java/shark/LeakingObjectFinder.kt
@@ -1,38 +1,16 @@
 package shark
 
-import shark.ObjectInspector.Companion.invoke
-
 /**
  * Finds the objects that are leaking, for which Shark will compute
  * leak traces.
  *
- * You can create a [LeakingObjectFinder] from a lambda by calling [invoke].
+ * This is a functional interface with which you can create a [LeakingObjectFinder] from a lambda.
  */
-interface LeakingObjectFinder {
+fun interface LeakingObjectFinder {
 
   /**
    * For a given heap graph, returns a set of object ids for the objects that are leaking.
    */
   fun findLeakingObjectIds(graph: HeapGraph): Set<Long>
-
-  companion object {
-    /**
-     * Utility function to create a [LeakingObjectFinder] from the passed in [block] lambda
-     * instead of using the anonymous `object : LeakingObjectFinder` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val listener = LeakingObjectFinder {
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: (HeapGraph) -> Set<Long>): LeakingObjectFinder =
-      object : LeakingObjectFinder {
-        override fun findLeakingObjectIds(graph: HeapGraph): Set<Long> = block(graph)
-
-      }
-  }
 
 }

--- a/shark/src/main/java/shark/LeakingObjectFinder.kt
+++ b/shark/src/main/java/shark/LeakingObjectFinder.kt
@@ -14,8 +14,18 @@ fun interface LeakingObjectFinder {
   fun findLeakingObjectIds(graph: HeapGraph): Set<Long>
 
   companion object {
-
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [LeakingObjectFinder] from the passed in [block] lambda
+     * instead of using the anonymous `object : LeakingObjectFinder` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val listener = LeakingObjectFinder {
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: (HeapGraph) -> Set<Long>): LeakingObjectFinder =
       object : LeakingObjectFinder {
         override fun findLeakingObjectIds(graph: HeapGraph): Set<Long> = block(graph)

--- a/shark/src/main/java/shark/MetadataExtractor.kt
+++ b/shark/src/main/java/shark/MetadataExtractor.kt
@@ -14,6 +14,11 @@ fun interface MetadataExtractor {
      * A no-op [MetadataExtractor]
      */
     val NO_OP = MetadataExtractor { emptyMap() }
-  }
 
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: (HeapGraph) -> Map<String, String>): MetadataExtractor =
+      object : MetadataExtractor {
+        override fun extractMetadata(graph: HeapGraph): Map<String, String> = block(graph)
+      }
+  }
 }

--- a/shark/src/main/java/shark/MetadataExtractor.kt
+++ b/shark/src/main/java/shark/MetadataExtractor.kt
@@ -15,7 +15,18 @@ fun interface MetadataExtractor {
      */
     val NO_OP = MetadataExtractor { emptyMap() }
 
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [MetadataExtractor] from the passed in [block] lambda instead of
+     * using the anonymous `object : MetadataExtractor` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val inspector = MetadataExtractor { graph ->
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: (HeapGraph) -> Map<String, String>): MetadataExtractor =
       object : MetadataExtractor {
         override fun extractMetadata(graph: HeapGraph): Map<String, String> = block(graph)

--- a/shark/src/main/java/shark/MetadataExtractor.kt
+++ b/shark/src/main/java/shark/MetadataExtractor.kt
@@ -1,14 +1,11 @@
 package shark
 
-import shark.MetadataExtractor.Companion.invoke
-import shark.ObjectInspector.Companion.invoke
-
 /**
  * Extracts metadata from a hprof to be reported in [HeapAnalysisSuccess.metadata].
  *
- * You can create a [MetadataExtractor] from a lambda by calling [invoke].
+ * This is a functional interface with which you can create a [MetadataExtractor] from a lambda.
  */
-interface MetadataExtractor {
+fun interface MetadataExtractor {
   fun extractMetadata(graph: HeapGraph): Map<String, String>
 
   companion object {
@@ -17,23 +14,6 @@ interface MetadataExtractor {
      * A no-op [MetadataExtractor]
      */
     val NO_OP = MetadataExtractor { emptyMap() }
-
-    /**
-     * Utility function to create a [MetadataExtractor] from the passed in [block] lambda instead of
-     * using the anonymous `object : MetadataExtractor` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val inspector = MetadataExtractor { graph ->
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: (HeapGraph) -> Map<String, String>): MetadataExtractor =
-      object : MetadataExtractor {
-        override fun extractMetadata(graph: HeapGraph): Map<String, String> = block(graph)
-      }
   }
 
 }

--- a/shark/src/main/java/shark/ObjectInspector.kt
+++ b/shark/src/main/java/shark/ObjectInspector.kt
@@ -15,4 +15,16 @@ fun interface ObjectInspector {
    */
   fun inspect(reporter: ObjectReporter)
 
+  companion object {
+
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: (ObjectReporter) -> Unit): ObjectInspector =
+      object : ObjectInspector {
+        override fun inspect(
+          reporter: ObjectReporter
+        ) {
+          block(reporter)
+        }
+      }
+  }
 }

--- a/shark/src/main/java/shark/ObjectInspector.kt
+++ b/shark/src/main/java/shark/ObjectInspector.kt
@@ -16,8 +16,18 @@ fun interface ObjectInspector {
   fun inspect(reporter: ObjectReporter)
 
   companion object {
-
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [ObjectInspector] from the passed in [block] lambda instead of
+     * using the anonymous `object : OnHeapAnalyzedListener` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val inspector = ObjectInspector { reporter ->
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: (ObjectReporter) -> Unit): ObjectInspector =
       object : ObjectInspector {
         override fun inspect(

--- a/shark/src/main/java/shark/ObjectInspector.kt
+++ b/shark/src/main/java/shark/ObjectInspector.kt
@@ -1,42 +1,18 @@
 package shark
 
-import shark.ObjectInspector.Companion.invoke
-
 /**
  * Provides LeakCanary with insights about objects (classes, instances and arrays) found in the
  * heap. [inspect] will be called for each object that LeakCanary wants to know more about.
  * The implementation can then use the provided [ObjectReporter] to provide insights for that
  * object.
  *
- * You can create a [ObjectInspector] from a lambda by calling [invoke].
+ * This is a functional interface with which you can create a [ObjectInspector] from a lambda.
  */
-interface ObjectInspector {
+fun interface ObjectInspector {
 
   /**
    * @see [ObjectInspector]
    */
   fun inspect(reporter: ObjectReporter)
 
-  companion object {
-    /**
-     * Utility function to create a [ObjectInspector] from the passed in [block] lambda instead of
-     * using the anonymous `object : OnHeapAnalyzedListener` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val inspector = ObjectInspector { reporter ->
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: (ObjectReporter) -> Unit): ObjectInspector =
-      object : ObjectInspector {
-        override fun inspect(
-          reporter: ObjectReporter
-        ) {
-          block(reporter)
-        }
-      }
-  }
 }

--- a/shark/src/main/java/shark/OnAnalysisProgressListener.kt
+++ b/shark/src/main/java/shark/OnAnalysisProgressListener.kt
@@ -29,5 +29,13 @@ fun interface OnAnalysisProgressListener {
      * A no-op [OnAnalysisProgressListener]
      */
     val NO_OP = OnAnalysisProgressListener {}
+
+    @Deprecated("Leverage Kotlin SAM lambda expression")
+    inline operator fun invoke(crossinline block: (Step) -> Unit): OnAnalysisProgressListener =
+      object : OnAnalysisProgressListener {
+        override fun onAnalysisProgress(step: Step) {
+          block(step)
+        }
+      }
   }
 }

--- a/shark/src/main/java/shark/OnAnalysisProgressListener.kt
+++ b/shark/src/main/java/shark/OnAnalysisProgressListener.kt
@@ -2,8 +2,10 @@ package shark
 
 /**
  * Reports progress from the [HeapAnalyzer] as they occur, as [Step] values.
+ *
+ * This is a functional interface with which you can create a [OnAnalysisProgressListener] from a lambda.
  */
-interface OnAnalysisProgressListener {
+fun interface OnAnalysisProgressListener {
 
   // These steps are defined in the order in which they occur.
   enum class Step {
@@ -27,24 +29,5 @@ interface OnAnalysisProgressListener {
      * A no-op [OnAnalysisProgressListener]
      */
     val NO_OP = OnAnalysisProgressListener {}
-
-    /**
-     * Utility function to create a [OnAnalysisProgressListener] from the passed in [block] lambda
-     * instead of using the anonymous `object : OnAnalysisProgressListener` syntax.
-     *
-     * Usage:
-     *
-     * ```kotlin
-     * val listener = OnAnalysisProgressListener {
-     *
-     * }
-     * ```
-     */
-    inline operator fun invoke(crossinline block: (Step) -> Unit): OnAnalysisProgressListener =
-      object : OnAnalysisProgressListener {
-        override fun onAnalysisProgress(step: Step) {
-          block(step)
-        }
-      }
   }
 }

--- a/shark/src/main/java/shark/OnAnalysisProgressListener.kt
+++ b/shark/src/main/java/shark/OnAnalysisProgressListener.kt
@@ -30,7 +30,18 @@ fun interface OnAnalysisProgressListener {
      */
     val NO_OP = OnAnalysisProgressListener {}
 
-    @Deprecated("Leverage Kotlin SAM lambda expression")
+    /**
+     * Utility function to create a [OnAnalysisProgressListener] from the passed in [block] lambda
+     * instead of using the anonymous `object : OnAnalysisProgressListener` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val listener = OnAnalysisProgressListener {
+     *
+     * }
+     * ```
+     */
     inline operator fun invoke(crossinline block: (Step) -> Unit): OnAnalysisProgressListener =
       object : OnAnalysisProgressListener {
         override fun onAnalysisProgress(step: Step) {


### PR DESCRIPTION
So that we do not need to declare a companion object implementing invoke operator