### PR TITLE
Keep class fields in memory

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
@@ -32,6 +32,7 @@ import shark.HprofRecord.StackTraceRecord
 import shark.HprofRecord.StringRecord
 import shark.StreamingHprofReader
 import shark.OnHprofRecordListener
+import shark.StreamingRecordReaderAdapter.Companion.asStreamingRecordReader
 import java.io.File
 
 internal object HeapDumpRenderer {
@@ -101,7 +102,7 @@ internal object HeapDumpRenderer {
 
     var lastPosition = 0L
 
-    val reader = StreamingHprofReader.readerFor(heapDumpFile)
+    val reader = StreamingHprofReader.readerFor(heapDumpFile).asStreamingRecordReader()
     val hprofStringCache = mutableMapOf<Long, String>()
     val classNames = mutableMapOf<Long, Long>()
     reader.readRecords(

--- a/shark-android/src/test/java/shark/HprofIOPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofIOPerfTest.kt
@@ -3,6 +3,7 @@ package shark
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.nield.kotlinstatistics.median
+import shark.HeapObject.HeapClass
 import shark.HprofHeapGraph.Companion.openHeapGraph
 import shark.PrimitiveType.INT
 import java.io.File
@@ -178,10 +179,10 @@ class HprofIOPerfTest {
             metrics.second.readsCount, metrics.second.medianBytesRead, metrics.second.totalBytesRead
         )
     )
-    .isEqualTo(
+        .isEqualTo(
             listOf(
-                25491, 42.0, 1726799,
-                26933, 42.0, 1784986
+                19676, 40.0, 1016798,
+                21115, 40.0, 1074786
             )
         )
   }
@@ -199,8 +200,8 @@ class HprofIOPerfTest {
     )
         .isEqualTo(
             listOf(
-                22491, 40.0, 2535319,
-                22637, 40.0, 2536163
+                17383, 40.0, 1951122,
+                17528, 40.0, 1951862
             )
         )
   }
@@ -218,8 +219,8 @@ class HprofIOPerfTest {
     )
         .isEqualTo(
             listOf(
-                15863, 36.0, 992644,
-                15935, 36.0, 993121
+                11767, 32.0, 553258,
+                11838, 32.0, 553626
             )
         )
   }

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -54,7 +54,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(4.8 MB +-5 % margin)
+    assertThat(retained).isEqualTo(5.07 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory when indexing leak_asynctask_m`() {
@@ -111,14 +111,14 @@ class HprofRetainedHeapPerfTest {
       retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
-    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.70 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(4.75 MB +-5 % margin)
-    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(4.85 MB +-5 % margin)
-    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.25 MB +-5 % margin)
-    assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.25 MB +-5 % margin)
-    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(6.26 MB +-5 % margin)
-    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(6.26 MB +-5 % margin)
-    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.18 MB +-5 % margin)
+    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.07 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.12 MB +-5 % margin)
+    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.22 MB +-5 % margin)
+    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.62 MB +-5 % margin)
+    assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.62 MB +-5 % margin)
+    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(6.63 MB +-5 % margin)
+    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(6.63 MB +-5 % margin)
+    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.55 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {

--- a/shark-graph/src/main/java/shark/HprofIndex.kt
+++ b/shark-graph/src/main/java/shark/HprofIndex.kt
@@ -1,17 +1,7 @@
 package shark
 
-import shark.GcRoot.JavaFrame
-import shark.GcRoot.JniGlobal
-import shark.GcRoot.JniLocal
-import shark.GcRoot.JniMonitor
-import shark.GcRoot.MonitorUsed
-import shark.GcRoot.NativeStack
-import shark.GcRoot.StickyClass
-import shark.GcRoot.ThreadBlock
-import shark.GcRoot.ThreadObject
 import shark.internal.HprofInMemoryIndex
-import java.io.File
-import kotlin.reflect.KClass
+import java.util.EnumSet
 
 /**
  * An index on a Hprof file. See [openHeapGraph].
@@ -38,30 +28,30 @@ class HprofIndex private constructor(
       hprofSourceProvider: DualSourceProvider,
       hprofHeader: HprofHeader,
       proguardMapping: ProguardMapping? = null,
-      indexedGcRootTypes: Set<KClass<out GcRoot>> = defaultIndexedGcRootTypes()
+      indexedGcRootTags: Set<HprofRecordTag> = defaultIndexedGcRootTags()
     ): HprofIndex {
       val reader = StreamingHprofReader.readerFor(hprofSourceProvider, hprofHeader)
       val index = HprofInMemoryIndex.indexHprof(
           reader = reader,
           hprofHeader = hprofHeader,
           proguardMapping = proguardMapping,
-          indexedGcRootTypes = indexedGcRootTypes
+          indexedGcRootTags = indexedGcRootTags
       )
       return HprofIndex(hprofSourceProvider, hprofHeader, index)
     }
 
-    fun defaultIndexedGcRootTypes() = setOf(
-        JniGlobal::class,
-        JavaFrame::class,
-        JniLocal::class,
-        MonitorUsed::class,
-        NativeStack::class,
-        StickyClass::class,
-        ThreadBlock::class,
+    fun defaultIndexedGcRootTags() = EnumSet.of(
+        HprofRecordTag.ROOT_JNI_GLOBAL,
+        HprofRecordTag.ROOT_JAVA_FRAME,
+        HprofRecordTag.ROOT_JNI_LOCAL,
+        HprofRecordTag.ROOT_MONITOR_USED,
+        HprofRecordTag.ROOT_NATIVE_STACK,
+        HprofRecordTag.ROOT_STICKY_CLASS,
+        HprofRecordTag.ROOT_THREAD_BLOCK,
         // ThreadObject points to threads, which we need to find the thread that a JavaLocalPattern
         // belongs to
-        ThreadObject::class,
-        JniMonitor::class
+        HprofRecordTag.ROOT_THREAD_OBJECT,
+        HprofRecordTag.ROOT_JNI_MONITOR
         /*
         Not included here:
 

--- a/shark-graph/src/main/java/shark/internal/ClassFieldsReader.kt
+++ b/shark-graph/src/main/java/shark/internal/ClassFieldsReader.kt
@@ -1,0 +1,180 @@
+package shark.internal
+
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord.FieldRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord.StaticFieldRecord
+import shark.PrimitiveType
+import shark.PrimitiveType.BOOLEAN
+import shark.PrimitiveType.BYTE
+import shark.PrimitiveType.CHAR
+import shark.PrimitiveType.DOUBLE
+import shark.PrimitiveType.FLOAT
+import shark.PrimitiveType.INT
+import shark.PrimitiveType.LONG
+import shark.PrimitiveType.SHORT
+import shark.ValueHolder
+import shark.ValueHolder.BooleanHolder
+import shark.ValueHolder.ByteHolder
+import shark.ValueHolder.CharHolder
+import shark.ValueHolder.DoubleHolder
+import shark.ValueHolder.FloatHolder
+import shark.ValueHolder.IntHolder
+import shark.ValueHolder.LongHolder
+import shark.ValueHolder.ReferenceHolder
+import shark.ValueHolder.ShortHolder
+import shark.internal.IndexedObject.IndexedClass
+
+internal class ClassFieldsReader(
+  private val identifierByteSize: Int,
+  private val classFieldBytes: ByteArray
+) {
+
+  private var position = 0
+
+  fun classDumpStaticFields(indexedClass: IndexedClass): List<StaticFieldRecord> {
+    position = indexedClass.fieldsIndex
+    val staticFieldCount = readUnsignedShort()
+    val staticFields = ArrayList<StaticFieldRecord>(staticFieldCount)
+    for (i in 0 until staticFieldCount) {
+      val nameStringId = readId()
+      val type = readUnsignedByte()
+      val value = readValue(type)
+      staticFields.add(
+          StaticFieldRecord(
+              nameStringId = nameStringId,
+              type = type,
+              value = value
+          )
+      )
+    }
+    return staticFields
+  }
+
+  fun classDumpFields(indexedClass: IndexedClass): List<FieldRecord> {
+    position = indexedClass.fieldsIndex
+
+    skipStaticFields()
+
+    val fieldCount = readUnsignedShort()
+    val fields = ArrayList<FieldRecord>(fieldCount)
+    for (i in 0 until fieldCount) {
+      fields.add(FieldRecord(nameStringId = readId(), type = readUnsignedByte()))
+    }
+    return fields
+  }
+
+  fun classDumpHasReferenceFields(indexedClass: IndexedClass): Boolean {
+    position = indexedClass.fieldsIndex
+    skipStaticFields()
+    val fieldCount = readUnsignedShort()
+    for (i in 0 until fieldCount) {
+      position += identifierByteSize
+      val type = readUnsignedByte()
+      if (type == PrimitiveType.REFERENCE_HPROF_TYPE) {
+        return true
+      }
+    }
+    return false
+  }
+
+  private fun skipStaticFields() {
+    val staticFieldCount = readUnsignedShort()
+    for (i in 0 until staticFieldCount) {
+      position += identifierByteSize
+      val type = readUnsignedByte()
+      position += if (type == PrimitiveType.REFERENCE_HPROF_TYPE) {
+        identifierByteSize
+      } else {
+        PrimitiveType.byteSizeByHprofType.getValue(type)
+      }
+    }
+  }
+
+  private fun readValue(type: Int): ValueHolder {
+    return when (type) {
+      PrimitiveType.REFERENCE_HPROF_TYPE -> ReferenceHolder(readId())
+      BOOLEAN_TYPE -> BooleanHolder(readBoolean())
+      CHAR_TYPE -> CharHolder(readChar())
+      FLOAT_TYPE -> FloatHolder(readFloat())
+      DOUBLE_TYPE -> DoubleHolder(readDouble())
+      BYTE_TYPE -> ByteHolder(readByte())
+      SHORT_TYPE -> ShortHolder(readShort())
+      INT_TYPE -> IntHolder(readInt())
+      LONG_TYPE -> LongHolder(readLong())
+      else -> throw IllegalStateException("Unknown type $type")
+    }
+  }
+
+  private fun readByte(): Byte {
+    return classFieldBytes[position++]
+  }
+
+  private fun readInt(): Int {
+    return (classFieldBytes[position++].toInt() and 0xff shl 24) or
+        (classFieldBytes[position++].toInt() and 0xff shl 16) or
+        (classFieldBytes[position++].toInt() and 0xff shl 8) or
+        (classFieldBytes[position++].toInt() and 0xff)
+  }
+
+  private fun readLong(): Long {
+    return (classFieldBytes[position++].toLong() and 0xff shl 56) or
+        (classFieldBytes[position++].toLong() and 0xff shl 48) or
+        (classFieldBytes[position++].toLong() and 0xff shl 40) or
+        (classFieldBytes[position++].toLong() and 0xff shl 32) or
+        (classFieldBytes[position++].toLong() and 0xff shl 24) or
+        (classFieldBytes[position++].toLong() and 0xff shl 16) or
+        (classFieldBytes[position++].toLong() and 0xff shl 8) or
+        (classFieldBytes[position++].toLong() and 0xff)
+  }
+
+  private fun readShort(): Short {
+    return ((classFieldBytes[position++].toInt() and 0xff shl 8) or
+        (classFieldBytes[position++].toInt() and 0xff)).toShort()
+  }
+
+  private fun readUnsignedShort(): Int {
+    return readShort().toInt() and 0xFFFF
+  }
+
+  private fun readUnsignedByte(): Int {
+    return readByte().toInt() and 0xFF
+  }
+
+  private fun readId(): Long {
+    // As long as we don't interpret IDs, reading signed values here is fine.
+    return when (identifierByteSize) {
+      1 -> readByte().toLong()
+      2 -> readShort().toLong()
+      4 -> readInt().toLong()
+      8 -> readLong()
+      else -> throw IllegalArgumentException("ID Length must be 1, 2, 4, or 8")
+    }
+  }
+
+  private fun readBoolean(): Boolean {
+    return readByte()
+        .toInt() != 0
+  }
+
+  private fun readChar(): Char {
+    return readShort().toChar()
+  }
+
+  private fun readFloat(): Float {
+    return Float.fromBits(readInt())
+  }
+
+  private fun readDouble(): Double {
+    return Double.fromBits(readLong())
+  }
+
+  companion object {
+    private val BOOLEAN_TYPE = BOOLEAN.hprofType
+    private val CHAR_TYPE = CHAR.hprofType
+    private val FLOAT_TYPE = FLOAT.hprofType
+    private val DOUBLE_TYPE = DOUBLE.hprofType
+    private val BYTE_TYPE = BYTE.hprofType
+    private val SHORT_TYPE = SHORT.hprofType
+    private val INT_TYPE = INT.hprofType
+    private val LONG_TYPE = LONG.hprofType
+  }
+}

--- a/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -2,19 +2,36 @@ package shark.internal
 
 import shark.GcRoot
 import shark.HprofHeader
-import shark.HprofRecord
-import shark.HprofRecord.HeapDumpRecord.GcRootRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassSkipContentRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.InstanceSkipContentRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ObjectArraySkipContentRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArraySkipContentRecord
-import shark.HprofRecord.LoadClassRecord
-import shark.HprofRecord.StringRecord
+import shark.HprofRecordReader
+import shark.HprofRecordTag
+import shark.HprofRecordTag.CLASS_DUMP
+import shark.HprofRecordTag.INSTANCE_DUMP
+import shark.HprofRecordTag.LOAD_CLASS
+import shark.HprofRecordTag.OBJECT_ARRAY_DUMP
+import shark.HprofRecordTag.PRIMITIVE_ARRAY_DUMP
+import shark.HprofRecordTag.ROOT_DEBUGGER
+import shark.HprofRecordTag.ROOT_FINALIZING
+import shark.HprofRecordTag.ROOT_INTERNED_STRING
+import shark.HprofRecordTag.ROOT_JAVA_FRAME
+import shark.HprofRecordTag.ROOT_JNI_GLOBAL
+import shark.HprofRecordTag.ROOT_JNI_LOCAL
+import shark.HprofRecordTag.ROOT_JNI_MONITOR
+import shark.HprofRecordTag.ROOT_MONITOR_USED
+import shark.HprofRecordTag.ROOT_NATIVE_STACK
+import shark.HprofRecordTag.ROOT_REFERENCE_CLEANUP
+import shark.HprofRecordTag.ROOT_STICKY_CLASS
+import shark.HprofRecordTag.ROOT_THREAD_BLOCK
+import shark.HprofRecordTag.ROOT_THREAD_OBJECT
+import shark.HprofRecordTag.ROOT_UNKNOWN
+import shark.HprofRecordTag.ROOT_UNREACHABLE
+import shark.HprofRecordTag.ROOT_VM_INTERNAL
+import shark.HprofRecordTag.STRING_IN_UTF8
 import shark.HprofVersion.ANDROID
-import shark.StreamingHprofReader
-import shark.OnHprofRecordListener
+import shark.OnHprofRecordTagListener
 import shark.PrimitiveType
+import shark.PrimitiveType.INT
 import shark.ProguardMapping
+import shark.StreamingHprofReader
 import shark.ValueHolder
 import shark.internal.IndexedObject.IndexedClass
 import shark.internal.IndexedObject.IndexedInstance
@@ -25,8 +42,8 @@ import shark.internal.hppc.LongLongScatterMap
 import shark.internal.hppc.LongObjectPair
 import shark.internal.hppc.LongObjectScatterMap
 import shark.internal.hppc.to
+import java.util.EnumSet
 import kotlin.math.max
-import kotlin.reflect.KClass
 
 /**
  * This class is not thread safe, should be used from a single thread.
@@ -46,7 +63,8 @@ internal class HprofInMemoryIndex private constructor(
   private val bytesForObjectArraySize: Int,
   private val bytesForPrimitiveArraySize: Int,
   private val useForwardSlashClassPackageSeparator: Boolean,
-  private val canUseClassSizeHighestBit: Boolean
+  val classFieldsReader: ClassFieldsReader,
+  private val classFieldsIndexSize: Int
 ) {
 
   val classCount: Int
@@ -248,25 +266,15 @@ internal class HprofInMemoryIndex private constructor(
     val superclassId = readId()
     val instanceSize = readInt()
 
-    val allBitsButRefFields = (1L shl (7 + (bytesForClassSize - 1) * 8)).inv()
-
-    val recordSize: Long
-    val hasRefFields: Boolean
-    if (canUseClassSizeHighestBit) {
-      val packedSizeAndHasRefFields = readTruncatedLong(bytesForClassSize)
-      recordSize = packedSizeAndHasRefFields and allBitsButRefFields
-      hasRefFields = (packedSizeAndHasRefFields shr (7 + (bytesForClassSize - 1) * 8)) == 1L
-    } else {
-      recordSize = readTruncatedLong(bytesForClassSize)
-      hasRefFields = readByte() == 1.toByte()
-    }
+    val recordSize = readTruncatedLong(bytesForClassSize)
+    val fieldsIndex = readTruncatedLong(classFieldsIndexSize).toInt()
 
     return IndexedClass(
         position = position,
         superclassId = superclassId,
         instanceSize = instanceSize,
         recordSize = recordSize,
-        hasRefFields = hasRefFields
+        fieldsIndex = fieldsIndex
     )
   }
 
@@ -298,18 +306,16 @@ internal class HprofInMemoryIndex private constructor(
     instanceCount: Int,
     objectArrayCount: Int,
     primitiveArrayCount: Int,
-    private val indexedGcRootsTypes: Set<Class<out GcRoot>>,
     val bytesForClassSize: Int,
     val bytesForInstanceSize: Int,
     val bytesForObjectArraySize: Int,
     val bytesForPrimitiveArraySize: Int,
-    val canUseClassSizeHighestBit: Boolean
-  ) : OnHprofRecordListener {
+    val classFieldsTotalBytes: Int
+  ) : OnHprofRecordTagListener {
 
     private val identifierSize = if (longIdentifiers) 8 else 4
     private val positionSize = byteSizeForUnsigned(maxPosition)
-
-    private val classSizeHighestBitSet = 1L shl (7 + (bytesForClassSize - 1) * 8)
+    private val classFieldsIndexSize = byteSizeForUnsigned(classFieldsTotalBytes.toLong())
 
     /**
      * Map of string id to string
@@ -328,8 +334,12 @@ internal class HprofInMemoryIndex private constructor(
      */
     private val classNames = LongLongScatterMap(expectedElements = classCount)
 
+    private val classFieldBytes = ByteArray(classFieldsTotalBytes)
+
+    private var classFieldsIndex = 0
+
     private val classIndex = UnsortedByteEntries(
-        bytesPerValue = positionSize + identifierSize + 4 + bytesForClassSize + if (canUseClassSizeHighestBit) 0 else 1,
+        bytesPerValue = positionSize + identifierSize + 4 + bytesForClassSize + classFieldsIndexSize,
         longIdentifiers = longIdentifiers,
         initialCapacity = classCount
     )
@@ -351,69 +361,243 @@ internal class HprofInMemoryIndex private constructor(
 
     private val gcRoots = mutableListOf<GcRoot>()
 
+    private fun HprofRecordReader.copyToClassFields(byteCount: Int) {
+      for (i in 1..byteCount) {
+        classFieldBytes[classFieldsIndex++] = readByte()
+      }
+    }
+
+    private fun lastClassFieldsShort() =
+      ((classFieldBytes[classFieldsIndex - 2].toInt() and 0xff shl 8) or
+          (classFieldBytes[classFieldsIndex - 1].toInt() and 0xff)).toShort()
+
+    @Suppress("LongMethod")
     override fun onHprofRecord(
-      position: Long,
-      record: HprofRecord
+      tag: HprofRecordTag,
+      length: Long,
+      reader: HprofRecordReader
     ) {
-      when (record) {
-        is StringRecord -> {
-          hprofStringCache[record.id] = record.string
+      when (tag) {
+        STRING_IN_UTF8 -> {
+          hprofStringCache[reader.readId()] = reader.readUtf8(length - identifierSize)
         }
-        is LoadClassRecord -> {
-          classNames[record.id] = record.classNameStringId
+        LOAD_CLASS -> {
+          // classSerialNumber
+          reader.skip(INT.byteSize)
+          val id = reader.readId()
+          // stackTraceSerialNumber
+          reader.skip(INT.byteSize)
+          val classNameStringId = reader.readId()
+          classNames[id] = classNameStringId
         }
-        is GcRootRecord -> {
-          val gcRoot = record.gcRoot
-          if (gcRoot.id != ValueHolder.NULL_REFERENCE
-              && indexedGcRootsTypes.contains(gcRoot.javaClass)
-          ) {
-            gcRoots += gcRoot
+        ROOT_UNKNOWN -> {
+          reader.readUnknownGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
           }
         }
-        is ClassSkipContentRecord -> {
-          classIndex.append(record.id)
+        ROOT_JNI_GLOBAL -> {
+          reader.readJniGlobalGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_JNI_LOCAL -> {
+          reader.readJniLocalGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_JAVA_FRAME -> {
+          reader.readJavaFrameGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_NATIVE_STACK -> {
+          reader.readNativeStackGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_STICKY_CLASS -> {
+          reader.readStickyClassGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_THREAD_BLOCK -> {
+          reader.readThreadBlockGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_MONITOR_USED -> {
+          reader.readMonitorUsedGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_THREAD_OBJECT -> {
+          reader.readThreadObjectGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_INTERNED_STRING -> {
+          reader.readInternedStringGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_FINALIZING -> {
+          reader.readFinalizingGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_DEBUGGER -> {
+          reader.readDebuggerGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_REFERENCE_CLEANUP -> {
+          reader.readReferenceCleanupGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_VM_INTERNAL -> {
+          reader.readVmInternalGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_JNI_MONITOR -> {
+          reader.readJniMonitorGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        ROOT_UNREACHABLE -> {
+          reader.readUnreachableGcRootRecord().apply {
+            if (id != ValueHolder.NULL_REFERENCE) {
+              gcRoots += this
+            }
+          }
+        }
+        CLASS_DUMP -> {
+          val bytesReadStart = reader.bytesRead
+          val id = reader.readId()
+          // stack trace serial number
+          reader.skip(INT.byteSize)
+          val superclassId = reader.readId()
+          reader.skip(5 * identifierSize)
+
+          // instance size (in bytes)
+          // Useful to compute retained size
+          val instanceSize = reader.readInt()
+
+          reader.skipClassDumpConstantPool()
+
+          val startPosition = classFieldsIndex
+
+          val bytesReadFieldStart = reader.bytesRead
+
+          reader.copyToClassFields(2)
+          val staticFieldCount = lastClassFieldsShort().toInt() and 0xFFFF
+          for (i in 0 until staticFieldCount) {
+            reader.copyToClassFields(identifierSize)
+            reader.copyToClassFields(1)
+            val type = classFieldBytes[classFieldsIndex - 1].toInt() and 0xff
+            if (type == PrimitiveType.REFERENCE_HPROF_TYPE) {
+              reader.copyToClassFields(identifierSize)
+            } else {
+              reader.copyToClassFields(PrimitiveType.byteSizeByHprofType.getValue(type))
+            }
+          }
+
+          reader.copyToClassFields(2)
+          val fieldCount = lastClassFieldsShort().toInt() and 0xFFFF
+          for (i in 0 until fieldCount) {
+            reader.copyToClassFields(identifierSize)
+            reader.copyToClassFields(1)
+          }
+
+          val fieldsSize = (reader.bytesRead - bytesReadFieldStart).toInt()
+          val recordSize = reader.bytesRead - bytesReadStart
+
+          classIndex.append(id)
               .apply {
-                writeTruncatedLong(position, positionSize)
-                writeId(record.superclassId)
-                writeInt(record.instanceSize)
-                if (canUseClassSizeHighestBit) {
-                  // The highest bit of bytesForClassSize bytes is unused, we can set it to
-                  // record.hasRefFields.
-                  val packedRecordSize =
-                    if (record.hasRefFields) {
-                      record.recordSize or classSizeHighestBitSet
-                    } else {
-                      record.recordSize
-                    }
-                  writeTruncatedLong(packedRecordSize, bytesForClassSize)
-                } else {
-                  writeTruncatedLong(record.recordSize, bytesForClassSize)
-                  writeByte(if (record.hasRefFields) 1 else 0)
-                }
+                writeTruncatedLong(bytesReadStart, positionSize)
+                writeId(superclassId)
+                writeInt(instanceSize)
+                writeTruncatedLong(recordSize, bytesForClassSize)
+                writeTruncatedLong(startPosition.toLong(), classFieldsIndexSize)
+              }
+          require(startPosition + fieldsSize == classFieldsIndex) {
+            "Expected $classFieldsIndex to have moved by $fieldsSize and be equal to ${startPosition + fieldsSize}"
+          }
+        }
+        INSTANCE_DUMP -> {
+          val bytesReadStart = reader.bytesRead
+          val id = reader.readId()
+          reader.skip(INT.byteSize)
+          val classId = reader.readId()
+          val remainingBytesInInstance = reader.readInt()
+          reader.skip(remainingBytesInInstance)
+          val recordSize = reader.bytesRead - bytesReadStart
+          instanceIndex.append(id)
+              .apply {
+                writeTruncatedLong(bytesReadStart, positionSize)
+                writeId(classId)
+                writeTruncatedLong(recordSize, bytesForInstanceSize)
               }
         }
-        is InstanceSkipContentRecord -> {
-          instanceIndex.append(record.id)
+        OBJECT_ARRAY_DUMP -> {
+          val bytesReadStart = reader.bytesRead
+          val id = reader.readId()
+          reader.skip(INT.byteSize)
+          val size = reader.readInt()
+          val arrayClassId = reader.readId()
+          reader.skip(identifierSize * size)
+          val recordSize = reader.bytesRead - bytesReadStart
+          objectArrayIndex.append(id)
               .apply {
-                writeTruncatedLong(position, positionSize)
-                writeId(record.classId)
-                writeTruncatedLong(record.recordSize, bytesForInstanceSize)
+                writeTruncatedLong(bytesReadStart, positionSize)
+                writeId(arrayClassId)
+                writeTruncatedLong(recordSize, bytesForObjectArraySize)
               }
         }
-        is ObjectArraySkipContentRecord -> {
-          objectArrayIndex.append(record.id)
+        PRIMITIVE_ARRAY_DUMP -> {
+          val bytesReadStart = reader.bytesRead
+          val id = reader.readId()
+          reader.skip(INT.byteSize)
+          val size = reader.readInt()
+          val type = PrimitiveType.primitiveTypeByHprofType.getValue(reader.readUnsignedByte())
+          reader.skip(size * type.byteSize)
+          val recordSize = reader.bytesRead - bytesReadStart
+          primitiveArrayIndex.append(id)
               .apply {
-                writeTruncatedLong(position, positionSize)
-                writeId(record.arrayClassId)
-                writeTruncatedLong(record.recordSize, bytesForObjectArraySize)
-              }
-        }
-        is PrimitiveArraySkipContentRecord -> {
-          primitiveArrayIndex.append(record.id)
-              .apply {
-                writeTruncatedLong(position, positionSize)
-                writeByte(record.type.ordinal.toByte())
-                writeTruncatedLong(record.recordSize, bytesForPrimitiveArraySize)
+                writeTruncatedLong(bytesReadStart, positionSize)
+                writeByte(type.ordinal.toByte())
+                writeTruncatedLong(recordSize, bytesForPrimitiveArraySize)
               }
         }
       }
@@ -423,6 +607,10 @@ internal class HprofInMemoryIndex private constructor(
       proguardMapping: ProguardMapping?,
       hprofHeader: HprofHeader
     ): HprofInMemoryIndex {
+      require(classFieldsIndex == classFieldBytes.size) {
+        "Read $classFieldsIndex into fields bytes instead of expected ${classFieldBytes.size}"
+      }
+
       val sortedInstanceIndex = instanceIndex.moveToSortedMap()
       val sortedObjectArrayIndex = objectArrayIndex.moveToSortedMap()
       val sortedPrimitiveArrayIndex = primitiveArrayIndex.moveToSortedMap()
@@ -443,7 +631,8 @@ internal class HprofInMemoryIndex private constructor(
           bytesForObjectArraySize = bytesForObjectArraySize,
           bytesForPrimitiveArraySize = bytesForPrimitiveArraySize,
           useForwardSlashClassPackageSeparator = hprofHeader.version != ANDROID,
-          canUseClassSizeHighestBit = canUseClassSizeHighestBit
+          classFieldsReader = ClassFieldsReader(identifierSize, classFieldBytes),
+          classFieldsIndexSize = classFieldsIndexSize
       )
     }
 
@@ -461,28 +650,12 @@ internal class HprofInMemoryIndex private constructor(
       return byteCount
     }
 
-    private fun canUseHighestBitForUnsigned(
-      maxValue: Long,
-      byteCount: Int
-    ): Boolean {
-      return (maxValue shr (7 + 8 * (byteCount - 1))) == 0L
-    }
-
     fun indexHprof(
       reader: StreamingHprofReader,
       hprofHeader: HprofHeader,
       proguardMapping: ProguardMapping?,
-      indexedGcRootTypes: Set<KClass<out GcRoot>>
+      indexedGcRootTags: Set<HprofRecordTag>
     ): HprofInMemoryIndex {
-      val recordTypes = setOf(
-          StringRecord::class,
-          LoadClassRecord::class,
-          ClassSkipContentRecord::class,
-          InstanceSkipContentRecord::class,
-          ObjectArraySkipContentRecord::class,
-          PrimitiveArraySkipContentRecord::class,
-          GcRootRecord::class
-      )
 
       // First pass to count and correctly size arrays once and for all.
       var maxClassSize = 0L
@@ -493,32 +666,39 @@ internal class HprofInMemoryIndex private constructor(
       var instanceCount = 0
       var objectArrayCount = 0
       var primitiveArrayCount = 0
+      var classFieldsTotalBytes = 0
 
-      val bytesRead = reader.readRecords(setOf(
-          ClassSkipContentRecord::class,
-          InstanceSkipContentRecord::class,
-          ObjectArraySkipContentRecord::class,
-          PrimitiveArraySkipContentRecord::class
-      ), OnHprofRecordListener { _, record ->
-        when (record) {
-          is ClassSkipContentRecord -> {
-            classCount++
-            maxClassSize = max(maxClassSize, record.recordSize)
-          }
-          is InstanceSkipContentRecord -> {
-            instanceCount++
-            maxInstanceSize = max(maxInstanceSize, record.recordSize)
-          }
-          is ObjectArraySkipContentRecord -> {
-            objectArrayCount++
-            maxObjectArraySize = max(maxObjectArraySize, record.recordSize)
-          }
-          is PrimitiveArraySkipContentRecord -> {
-            primitiveArrayCount++
-            maxPrimitiveArraySize = max(maxPrimitiveArraySize, record.recordSize)
-          }
-        }
-      })
+      val bytesRead = reader.readRecords(
+          EnumSet.of(CLASS_DUMP, INSTANCE_DUMP, OBJECT_ARRAY_DUMP, PRIMITIVE_ARRAY_DUMP),
+          OnHprofRecordTagListener { tag, _, reader ->
+            val bytesReadStart = reader.bytesRead
+            when (tag) {
+              CLASS_DUMP -> {
+                classCount++
+                reader.skipClassDumpHeader()
+                val bytesReadStaticFieldStart = reader.bytesRead
+                reader.skipClassDumpStaticFields()
+                reader.skipClassDumpFields()
+                maxClassSize = max(maxClassSize, reader.bytesRead - bytesReadStart)
+                classFieldsTotalBytes += (reader.bytesRead - bytesReadStaticFieldStart).toInt()
+              }
+              INSTANCE_DUMP -> {
+                instanceCount++
+                reader.skipInstanceDumpRecord()
+                maxInstanceSize = max(maxInstanceSize, reader.bytesRead - bytesReadStart)
+              }
+              OBJECT_ARRAY_DUMP -> {
+                objectArrayCount++
+                reader.skipObjectArrayDumpRecord()
+                maxObjectArraySize = max(maxObjectArraySize, reader.bytesRead - bytesReadStart)
+              }
+              PRIMITIVE_ARRAY_DUMP -> {
+                primitiveArrayCount++
+                reader.skipPrimitiveArrayDumpRecord()
+                maxPrimitiveArraySize = max(maxPrimitiveArraySize, reader.bytesRead - bytesReadStart)
+              }
+            }
+          })
 
       val bytesForClassSize = byteSizeForUnsigned(maxClassSize)
       val bytesForInstanceSize = byteSizeForUnsigned(maxInstanceSize)
@@ -532,14 +712,21 @@ internal class HprofInMemoryIndex private constructor(
           instanceCount = instanceCount,
           objectArrayCount = objectArrayCount,
           primitiveArrayCount = primitiveArrayCount,
-          indexedGcRootsTypes = indexedGcRootTypes.map { it.java }
-              .toSet(),
           bytesForClassSize = bytesForClassSize,
           bytesForInstanceSize = bytesForInstanceSize,
           bytesForObjectArraySize = bytesForObjectArraySize,
           bytesForPrimitiveArraySize = bytesForPrimitiveArraySize,
-          canUseClassSizeHighestBit = canUseHighestBitForUnsigned(maxClassSize, bytesForClassSize)
+          classFieldsTotalBytes = classFieldsTotalBytes
       )
+
+      val recordTypes = EnumSet.of(
+          STRING_IN_UTF8,
+          LOAD_CLASS,
+          CLASS_DUMP,
+          INSTANCE_DUMP,
+          OBJECT_ARRAY_DUMP,
+          PRIMITIVE_ARRAY_DUMP
+      ) + HprofRecordTag.rootTags.intersect(indexedGcRootTags)
 
       reader.readRecords(recordTypes, indexBuilderListener)
       return indexBuilderListener.buildIndex(proguardMapping, hprofHeader)

--- a/shark-graph/src/main/java/shark/internal/IndexedObject.kt
+++ b/shark-graph/src/main/java/shark/internal/IndexedObject.kt
@@ -11,7 +11,7 @@ internal sealed class IndexedObject {
     val superclassId: Long,
     val instanceSize: Int,
     override val recordSize: Long,
-    val hasRefFields: Boolean
+    val fieldsIndex: Int
   ) : IndexedObject()
 
   class IndexedInstance(

--- a/shark-graph/src/test/java/shark/HprofWriterTest.kt
+++ b/shark-graph/src/test/java/shark/HprofWriterTest.kt
@@ -10,6 +10,7 @@ import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord.StaticField
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.InstanceDumpRecord
 import shark.HprofRecord.LoadClassRecord
 import shark.HprofRecord.StringRecord
+import shark.StreamingRecordReaderAdapter.Companion.asStreamingRecordReader
 import shark.ValueHolder.BooleanHolder
 import shark.ValueHolder.IntHolder
 import shark.ValueHolder.ReferenceHolder
@@ -179,7 +180,7 @@ class HprofWriterTest {
 
   private fun DualSourceProvider.readAllRecords(): MutableList<HprofRecord> {
     val readRecords = mutableListOf<HprofRecord>()
-    StreamingHprofReader.readerFor(this)
+    StreamingHprofReader.readerFor(this).asStreamingRecordReader()
         .readRecords(setOf(HprofRecord::class), OnHprofRecordListener { position, record ->
           readRecords += record
         })

--- a/shark-hprof/src/main/java/shark/HprofPrimitiveArrayStripper.kt
+++ b/shark-hprof/src/main/java/shark/HprofPrimitiveArrayStripper.kt
@@ -11,6 +11,7 @@ import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.Fl
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.IntArrayDump
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.LongArrayDump
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ShortArrayDump
+import shark.StreamingRecordReaderAdapter.Companion.asStreamingRecordReader
 import java.io.File
 
 /**
@@ -50,7 +51,8 @@ class HprofPrimitiveArrayStripper {
     hprofSink: BufferedSink
   ) {
     val header = hprofSourceProvider.openStreamingSource().use { HprofHeader.parseHeaderOf(it) }
-    val reader = StreamingHprofReader.readerFor(hprofSourceProvider, header)
+    val reader =
+      StreamingHprofReader.readerFor(hprofSourceProvider, header).asStreamingRecordReader()
     HprofWriter.openWriterFor(
         hprofSink,
         hprofHeader = HprofHeader(

--- a/shark-hprof/src/main/java/shark/HprofReader.kt
+++ b/shark-hprof/src/main/java/shark/HprofReader.kt
@@ -1,5 +1,6 @@
 package shark
 
+import shark.StreamingRecordReaderAdapter.Companion.asStreamingRecordReader
 import kotlin.reflect.KClass
 
 @Deprecated("Replaced by HprofStreamingReader.readerFor or HprofRandomAccessReader.openReaderFor")
@@ -16,7 +17,7 @@ class HprofReader internal constructor(
     recordTypes: Set<KClass<out HprofRecord>>,
     listener: OnHprofRecordListener
   ) {
-    val reader = StreamingHprofReader.readerFor(hprof.file, hprof.header)
+    val reader = StreamingHprofReader.readerFor(hprof.file, hprof.header).asStreamingRecordReader()
     reader.readRecords(recordTypes, listener)
   }
 }

--- a/shark-hprof/src/main/java/shark/HprofRecord.kt
+++ b/shark-hprof/src/main/java/shark/HprofRecord.kt
@@ -9,31 +9,12 @@ sealed class HprofRecord {
     val string: String
   ) : HprofRecord()
 
-  /**
-   * To limit object allocation while parsing, [HprofReader] uses a single instance which is
-   * reused after each call to [OnHprofRecordListener.onHprofRecord].
-   */
   class LoadClassRecord(
-    classSerialNumber: Int,
-    id: Long,
-    stackTraceSerialNumber: Int,
-    classNameStringId: Long
-  ) : HprofRecord() {
-    var classSerialNumber: Int
-      internal set
-    var id: Long
-      internal set
-    var stackTraceSerialNumber: Int
-      internal set
-    var classNameStringId: Long
-      internal set
-    init {
-      this.classSerialNumber = classSerialNumber
-      this.id = id
-      this.stackTraceSerialNumber = stackTraceSerialNumber
-      this.classNameStringId = classNameStringId
-    }
-  }
+    val classSerialNumber: Int,
+    val id: Long,
+    val stackTraceSerialNumber: Int,
+    val classNameStringId: Long
+  ) : HprofRecord()
 
   /**
    * Terminates a series of heap dump segments. Concatenation of heap dump segments equals a
@@ -92,60 +73,6 @@ sealed class HprofRecord {
         )
       }
 
-      /**
-       * This isn't a real record type as found in the heap dump. It's an alternative to
-       * [ClassDumpRecord] for when you don't need the class content.
-       *
-       * To limit object allocation while parsing, [HprofReader] uses a single instance which is
-       * reused after each call to [OnHprofRecordListener.onHprofRecord].
-       */
-      class ClassSkipContentRecord(
-        id: Long,
-        stackTraceSerialNumber: Int,
-        superclassId: Long,
-        classLoaderId: Long,
-        signersId: Long,
-        protectionDomainId: Long,
-        instanceSize: Int,
-        staticFieldCount: Int,
-        fieldCount: Int
-      ) : ObjectRecord() {
-        var id: Long
-          internal set
-        var stackTraceSerialNumber: Int
-          internal set
-        var superclassId: Long
-          internal set
-        var classLoaderId: Long
-          internal set
-        var signersId: Long
-          internal set
-        var protectionDomainId: Long
-          internal set
-        var instanceSize: Int
-          internal set
-        var staticFieldCount: Int
-          internal set
-        var fieldCount: Int
-          internal set
-        var recordSize: Long = 0
-          internal set
-        var hasRefFields: Boolean = false
-          internal set
-
-        init {
-          this.id = id
-          this.stackTraceSerialNumber = stackTraceSerialNumber
-          this.superclassId = superclassId
-          this.classLoaderId = classLoaderId
-          this.signersId = signersId
-          this.protectionDomainId = protectionDomainId
-          this.instanceSize = instanceSize
-          this.staticFieldCount = staticFieldCount
-          this.fieldCount = fieldCount
-        }
-      }
-
       class InstanceDumpRecord(
         val id: Long,
         val stackTraceSerialNumber: Int,
@@ -156,72 +83,12 @@ sealed class HprofRecord {
         val fieldValues: ByteArray
       ) : ObjectRecord()
 
-      /**
-       * This isn't a real record type as found in the heap dump. It's an alternative to
-       * [InstanceDumpRecord] for when you don't need the instance content.
-       *
-       * To limit object allocation while parsing, [HprofReader] uses a single instance which is
-       * reused after each call to [OnHprofRecordListener.onHprofRecord].
-       */
-      class InstanceSkipContentRecord(
-        id: Long,
-        stackTraceSerialNumber: Int,
-        classId: Long
-      ) : ObjectRecord() {
-        var id: Long
-          internal set
-        var stackTraceSerialNumber: Int
-          internal set
-        var classId: Long
-          internal set
-        var recordSize: Long = 0
-          internal set
-
-        init {
-          this.id = id
-          this.stackTraceSerialNumber = stackTraceSerialNumber
-          this.classId = classId
-        }
-      }
-
       class ObjectArrayDumpRecord(
         val id: Long,
         val stackTraceSerialNumber: Int,
         val arrayClassId: Long,
         val elementIds: LongArray
       ) : ObjectRecord()
-
-      /**
-       * This isn't a real record type as found in the heap dump. It's an alternative to
-       * [ObjectArrayDumpRecord] for when you don't need the array content.
-       *
-       * To limit object allocation while parsing, [HprofReader] uses a single instance which is
-       * reused after each call to [OnHprofRecordListener.onHprofRecord].
-       */
-      class ObjectArraySkipContentRecord(
-        id: Long,
-        stackTraceSerialNumber: Int,
-        arrayClassId: Long,
-        size: Int
-      ) : ObjectRecord() {
-        var id: Long
-          internal set
-        var stackTraceSerialNumber: Int
-          internal set
-        var arrayClassId: Long
-          internal set
-        var size: Int
-          internal set
-        var recordSize: Long = 0
-          internal set
-
-        init {
-          this.id = id
-          this.stackTraceSerialNumber = stackTraceSerialNumber
-          this.arrayClassId = arrayClassId
-          this.size = size
-        }
-      }
 
       sealed class PrimitiveArrayDumpRecord : ObjectRecord() {
         abstract val id: Long
@@ -298,38 +165,6 @@ sealed class HprofRecord {
         ) : PrimitiveArrayDumpRecord() {
           override val size: Int
             get() = array.size
-        }
-      }
-
-      /**
-       * This isn't a real record type as found in the heap dump. It's an alternative to
-       * [PrimitiveArrayDumpRecord] for when you don't need the array content.
-       *
-       * To limit object allocation while parsing, [HprofReader] uses a single instance which is
-       * reused after each call to [OnHprofRecordListener.onHprofRecord].
-       */
-      class PrimitiveArraySkipContentRecord(
-        id: Long,
-        stackTraceSerialNumber: Int,
-        size: Int,
-        type: PrimitiveType
-      ) : ObjectRecord() {
-        var id: Long
-          internal set
-        var stackTraceSerialNumber: Int
-          internal set
-        var size: Int
-          internal set
-        var type: PrimitiveType
-          internal set
-        var recordSize: Long = 0
-          internal set
-
-        init {
-          this.id = id
-          this.stackTraceSerialNumber = stackTraceSerialNumber
-          this.size = size
-          this.type = type
         }
       }
     }

--- a/shark-hprof/src/main/java/shark/HprofRecordReader.kt
+++ b/shark-hprof/src/main/java/shark/HprofRecordReader.kt
@@ -17,16 +17,12 @@ import shark.GcRoot.ThreadObject
 import shark.GcRoot.Unknown
 import shark.GcRoot.Unreachable
 import shark.GcRoot.VmInternal
-import shark.HprofRecord.HeapDumpRecord.GcRootRecord
 import shark.HprofRecord.HeapDumpRecord.HeapDumpInfoRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord.FieldRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord.StaticFieldRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassSkipContentRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.InstanceDumpRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.InstanceSkipContentRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ObjectArrayDumpRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ObjectArraySkipContentRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.BooleanArrayDump
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ByteArrayDump
@@ -36,7 +32,6 @@ import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.Fl
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.IntArrayDump
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.LongArrayDump
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ShortArrayDump
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArraySkipContentRecord
 import shark.HprofRecord.LoadClassRecord
 import shark.HprofRecord.StackFrameRecord
 import shark.HprofRecord.StackTraceRecord
@@ -106,12 +101,12 @@ class HprofRecordReader internal constructor(
       string = readUtf8(length - identifierByteSize)
   )
 
-  fun LoadClassRecord.read() {
-    classSerialNumber = readInt()
-    id = readId()
-    stackTraceSerialNumber = readInt()
+  fun readLoadClassRecord() = LoadClassRecord(
+    classSerialNumber = readInt(),
+    id = readId(),
+    stackTraceSerialNumber = readInt(),
     classNameStringId = readId()
-  }
+  )
 
   fun readStackFrameRecord() = StackFrameRecord(
       id = readId(),
@@ -128,89 +123,59 @@ class HprofRecordReader internal constructor(
       stackFrameIds = readIdArray(readInt())
   )
 
-  fun readUnknownGcRootRecord() = GcRootRecord(
-      gcRoot = Unknown(id = readId())
+  fun readUnknownGcRootRecord() = Unknown(id = readId())
+
+  fun readJniGlobalGcRootRecord() = JniGlobal(
+      id = readId(),
+      jniGlobalRefId = readId()
   )
 
-  fun readJniGlobalGcRootRecord() = GcRootRecord(
-      gcRoot = JniGlobal(
-          id = readId(),
-          jniGlobalRefId = readId()
-      )
+  fun readJniLocalGcRootRecord() = JniLocal(
+      id = readId(),
+      threadSerialNumber = readInt(),
+      frameNumber = readInt()
   )
 
-  fun readJniLocalGcRootRecord() = GcRootRecord(
-      gcRoot = JniLocal(
-          id = readId(),
-          threadSerialNumber = readInt(),
-          frameNumber = readInt()
-      )
+  fun readJavaFrameGcRootRecord() = JavaFrame(
+      id = readId(),
+      threadSerialNumber = readInt(),
+      frameNumber = readInt()
   )
 
-  fun readJavaFrameGcRootRecord() = GcRootRecord(
-      gcRoot = JavaFrame(
-          id = readId(),
-          threadSerialNumber = readInt(),
-          frameNumber = readInt()
-      )
+  fun readNativeStackGcRootRecord() = NativeStack(
+      id = readId(),
+      threadSerialNumber = readInt()
   )
 
-  fun readNativeStackGcRootRecord() = GcRootRecord(
-      gcRoot = NativeStack(
-          id = readId(),
-          threadSerialNumber = readInt()
-      )
+  fun readStickyClassGcRootRecord() = StickyClass(id = readId())
+
+  fun readThreadBlockGcRootRecord() = ThreadBlock(id = readId(), threadSerialNumber = readInt())
+
+  fun readMonitorUsedGcRootRecord() =  MonitorUsed(id = readId())
+
+  fun readThreadObjectGcRootRecord() = ThreadObject(
+      id = readId(),
+      threadSerialNumber = readInt(),
+      stackTraceSerialNumber = readInt()
   )
 
-  fun readStickyClassGcRootRecord() = GcRootRecord(
-      gcRoot = StickyClass(id = readId())
+  fun readInternedStringGcRootRecord() = InternedString(id = readId())
+
+  fun readFinalizingGcRootRecord() = Finalizing(id = readId())
+
+  fun readDebuggerGcRootRecord() = Debugger(id = readId())
+
+  fun readReferenceCleanupGcRootRecord() = ReferenceCleanup(id = readId())
+
+  fun readVmInternalGcRootRecord() = VmInternal(id = readId())
+
+  fun readJniMonitorGcRootRecord() = JniMonitor(
+      id = readId(),
+      stackTraceSerialNumber = readInt(),
+      stackDepth = readInt()
   )
 
-  fun readThreadBlockGcRootRecord() = GcRootRecord(
-      gcRoot = ThreadBlock(id = readId(), threadSerialNumber = readInt())
-  )
-
-  fun readMonitorUsedGcRootRecord() = GcRootRecord(
-      gcRoot = MonitorUsed(id = readId())
-  )
-
-  fun readThreadObjectGcRootRecord() = GcRootRecord(
-      gcRoot = ThreadObject(
-          id = readId(),
-          threadSerialNumber = readInt(),
-          stackTraceSerialNumber = readInt()
-      )
-  )
-
-  fun readInternedStringGcRootRecord() = GcRootRecord(gcRoot = InternedString(id = readId()))
-
-  fun readFinalizingGcRootRecord() = GcRootRecord(
-      gcRoot = Finalizing(id = readId())
-  )
-
-  fun readDebuggerGcRootRecord() = GcRootRecord(
-      gcRoot = Debugger(id = readId())
-  )
-
-  fun readReferenceCleanupGcRootRecord() = GcRootRecord(
-      gcRoot = ReferenceCleanup(id = readId())
-  )
-
-  fun readVmInternalGcRootRecord() = GcRootRecord(
-      gcRoot = VmInternal(id = readId())
-  )
-
-  fun readJniMonitorGcRootRecord() = GcRootRecord(
-      gcRoot = JniMonitor(
-          id = readId(),
-          stackTraceSerialNumber = readInt(),
-          stackDepth = readInt()
-      )
-  )
-
-  fun readUnreachableGcRootRecord() = GcRootRecord(
-      gcRoot = Unreachable(id = readId())
-  )
+  fun readUnreachableGcRootRecord() = Unreachable(id = readId())
 
   /**
    * Reads a full instance record after a instance dump tag.
@@ -356,30 +321,12 @@ class HprofRecordReader internal constructor(
     )
   }
 
-  /**
-   * Reads a class record after a class dump tag, skipping its content.
-   */
-  fun ClassSkipContentRecord.read(): ClassSkipContentRecord {
-    val bytesReadStart = bytesRead
-    this.id = readId()
-    // stack trace serial number
-    stackTraceSerialNumber = readInt()
-    superclassId = readId()
-    // class loader object ID
-    classLoaderId = readId()
-    // signers object ID
-    signersId = readId()
-    // protection domain object ID
-    protectionDomainId = readId()
-    // reserved
-    readId()
-    // reserved
-    readId()
+  fun skipClassDumpHeader() {
+    skip(INT_SIZE * 2 + identifierByteSize * 7)
+    skipClassDumpConstantPool()
+  }
 
-    // instance size (in bytes)
-    // Useful to compute retained size
-    instanceSize = readInt()
-
+  fun skipClassDumpConstantPool() {
     // Skip over the constant pool
     val constantPoolCount = readUnsignedShort()
     for (i in 0 until constantPoolCount) {
@@ -387,8 +334,10 @@ class HprofRecordReader internal constructor(
       skip(SHORT.byteSize)
       skip(sizeOf(readUnsignedByte()))
     }
+  }
 
-    staticFieldCount = readUnsignedShort()
+  fun skipClassDumpStaticFields() {
+    val staticFieldCount = readUnsignedShort()
     for (i in 0 until staticFieldCount) {
       skip(identifierByteSize)
       val type = readUnsignedByte()
@@ -400,72 +349,11 @@ class HprofRecordReader internal constructor(
           }
       )
     }
-
-    fieldCount = readUnsignedShort()
-
-    var remainingFields = 0
-    var foundRef = false
-    for (i in 0 until fieldCount) {
-      skip(identifierByteSize)
-      val type = readUnsignedByte()
-      if (type == PrimitiveType.REFERENCE_HPROF_TYPE) {
-        foundRef = true
-        remainingFields = (fieldCount - i) - 1
-        break
-      }
-    }
-    hasRefFields = foundRef
-
-    // Each field takes id + byte.
-    if (remainingFields > 0) {
-      skip((identifierByteSize + 1) * remainingFields)
-    }
-    recordSize = bytesRead - bytesReadStart
-    return this
   }
 
-  /**
-   * Reads an instance record after a instance dump tag, skipping its content.
-   */
-  fun InstanceSkipContentRecord.read(): InstanceSkipContentRecord {
-    val bytesReadStart = bytesRead
-    id = readId()
-    stackTraceSerialNumber = readInt()
-    classId = readId()
-    val remainingBytesInInstance = readInt()
-    skip(remainingBytesInInstance)
-    recordSize = bytesRead - bytesReadStart
-    return this
-  }
-
-  /**
-   * Reads an object array record after a object array dump tag, skipping its content.
-   */
-  fun ObjectArraySkipContentRecord.read(): ObjectArraySkipContentRecord {
-    val bytesReadStart = bytesRead
-    id = readId()
-    // stack trace serial number
-    stackTraceSerialNumber = readInt()
-    size = readInt()
-    arrayClassId = readId()
-    skip(identifierByteSize * size)
-    recordSize = bytesRead - bytesReadStart
-    return this
-  }
-
-  /**
-   * Reads a primitive array record after a primitive array dump tag, skipping its content.
-   */
-  fun PrimitiveArraySkipContentRecord.read(): PrimitiveArraySkipContentRecord {
-    val bytesReadStart = bytesRead
-    id = readId()
-    stackTraceSerialNumber = readInt()
-    // length
-    size = readInt()
-    type = PrimitiveType.primitiveTypeByHprofType.getValue(readUnsignedByte())
-    skip(size * type.byteSize)
-    recordSize = bytesRead - bytesReadStart
-    return this
+  fun skipClassDumpFields() {
+    val fieldCount = readUnsignedShort()
+    skip((identifierByteSize + 1) * fieldCount)
   }
 
   fun skipInstanceDumpRecord() {

--- a/shark-hprof/src/main/java/shark/HprofRecordTag.kt
+++ b/shark-hprof/src/main/java/shark/HprofRecordTag.kt
@@ -1,0 +1,89 @@
+package shark
+
+import java.util.EnumSet
+
+enum class HprofRecordTag(val tag: Int) {
+  STRING_IN_UTF8(0x01),
+  LOAD_CLASS(0x02),
+  // Currently ignored
+  UNLOAD_CLASS(0x03),
+  STACK_FRAME(0x04),
+  STACK_TRACE(0x05),
+  // Currently ignored
+  ALLOC_SITES(0x06),
+  // Currently ignored
+  HEAP_SUMMARY(0x07),
+  // Currently ignored
+  START_THREAD(0x0a),
+  // Currently ignored
+  END_THREAD(0x0b),
+  // Currently not reported
+  HEAP_DUMP(0x0c),
+  // Currently not reported
+  HEAP_DUMP_SEGMENT(0x1c),
+  HEAP_DUMP_END(0x2c),
+  // Currently ignored
+  CPU_SAMPLES(0x0d),
+  // Currently ignored
+  CONTROL_SETTINGS(0x0e),
+  ROOT_UNKNOWN(0xff),
+  ROOT_JNI_GLOBAL(0x01),
+  ROOT_JNI_LOCAL(0x02),
+  ROOT_JAVA_FRAME(0x03),
+  ROOT_NATIVE_STACK(0x04),
+  ROOT_STICKY_CLASS(0x05),
+
+  // An object that was referenced from an active thread block.
+  ROOT_THREAD_BLOCK(0x06),
+  ROOT_MONITOR_USED(0x07),
+  ROOT_THREAD_OBJECT(0x08),
+
+  /**
+   * Android format addition
+   *
+   * Specifies information about which heap certain objects came from. When a sub-tag of this type
+   * appears in a HPROF_HEAP_DUMP or HPROF_HEAP_DUMP_SEGMENT record, entries that follow it will
+   * be associated with the specified heap.  The HEAP_DUMP_INFO data is reset at the end of the
+   * HEAP_DUMP[_SEGMENT].  Multiple HEAP_DUMP_INFO entries may appear in a single
+   * HEAP_DUMP[_SEGMENT].
+   *
+   * Format: u1: Tag value (0xFE) u4: heap ID ID: heap name string ID
+   */
+  HEAP_DUMP_INFO(0xfe),
+  ROOT_INTERNED_STRING(0x89),
+  ROOT_FINALIZING(0x8a),
+  ROOT_DEBUGGER(0x8b),
+  ROOT_REFERENCE_CLEANUP(0x8c),
+  ROOT_VM_INTERNAL(0x8d),
+  ROOT_JNI_MONITOR(0x8e),
+  ROOT_UNREACHABLE(0x90),
+  // Not supported.
+  PRIMITIVE_ARRAY_NODATA(0xc3),
+  CLASS_DUMP(0x20),
+  INSTANCE_DUMP(0x21),
+  OBJECT_ARRAY_DUMP(0x22),
+  PRIMITIVE_ARRAY_DUMP(0x23),
+  ;
+
+  companion object {
+    val rootTags: EnumSet<HprofRecordTag> = EnumSet.of(
+        ROOT_UNKNOWN,
+        ROOT_JNI_GLOBAL,
+        ROOT_JNI_LOCAL,
+        ROOT_JAVA_FRAME,
+        ROOT_NATIVE_STACK,
+        ROOT_STICKY_CLASS,
+        ROOT_THREAD_BLOCK,
+        ROOT_MONITOR_USED,
+        ROOT_THREAD_OBJECT,
+        ROOT_INTERNED_STRING,
+        ROOT_FINALIZING,
+        ROOT_DEBUGGER,
+        ROOT_REFERENCE_CLEANUP,
+        ROOT_VM_INTERNAL,
+        ROOT_JNI_MONITOR,
+        ROOT_UNREACHABLE
+    )
+  }
+
+}

--- a/shark-hprof/src/main/java/shark/HprofWriter.kt
+++ b/shark-hprof/src/main/java/shark/HprofWriter.kt
@@ -133,13 +133,13 @@ class HprofWriter private constructor(
   private fun BufferedSink.write(record: HprofRecord) {
     when (record) {
       is StringRecord -> {
-        writeNonHeapRecord(StreamingHprofReader.STRING_IN_UTF8) {
+        writeNonHeapRecord(HprofRecordTag.STRING_IN_UTF8.tag) {
           writeId(record.id)
           writeUtf8(record.string)
         }
       }
       is LoadClassRecord -> {
-        writeNonHeapRecord(StreamingHprofReader.LOAD_CLASS) {
+        writeNonHeapRecord(HprofRecordTag.LOAD_CLASS.tag) {
           writeInt(record.classSerialNumber)
           writeId(record.id)
           writeInt(record.stackTraceSerialNumber)
@@ -147,7 +147,7 @@ class HprofWriter private constructor(
         }
       }
       is StackTraceRecord -> {
-        writeNonHeapRecord(StreamingHprofReader.STACK_TRACE) {
+        writeNonHeapRecord(HprofRecordTag.STACK_TRACE.tag) {
           writeInt(record.stackTraceSerialNumber)
           writeInt(record.threadSerialNumber)
           writeInt(record.stackFrameIds.size)
@@ -158,80 +158,80 @@ class HprofWriter private constructor(
         with(workBuffer) {
           when (val gcRoot = record.gcRoot) {
             is Unknown -> {
-              writeByte(StreamingHprofReader.ROOT_UNKNOWN)
+              writeByte(HprofRecordTag.ROOT_UNKNOWN.tag)
               writeId(gcRoot.id)
             }
             is JniGlobal -> {
               writeByte(
-                  StreamingHprofReader.ROOT_JNI_GLOBAL
+                  HprofRecordTag.ROOT_JNI_GLOBAL.tag
               )
               writeId(gcRoot.id)
               writeId(gcRoot.jniGlobalRefId)
             }
             is JniLocal -> {
-              writeByte(StreamingHprofReader.ROOT_JNI_LOCAL)
+              writeByte(HprofRecordTag.ROOT_JNI_LOCAL.tag)
               writeId(gcRoot.id)
               writeInt(gcRoot.threadSerialNumber)
               writeInt(gcRoot.frameNumber)
             }
             is JavaFrame -> {
-              writeByte(StreamingHprofReader.ROOT_JAVA_FRAME)
+              writeByte(HprofRecordTag.ROOT_JAVA_FRAME.tag)
               writeId(gcRoot.id)
               writeInt(gcRoot.threadSerialNumber)
               writeInt(gcRoot.frameNumber)
             }
             is NativeStack -> {
-              writeByte(StreamingHprofReader.ROOT_NATIVE_STACK)
+              writeByte(HprofRecordTag.ROOT_NATIVE_STACK.tag)
               writeId(gcRoot.id)
               writeInt(gcRoot.threadSerialNumber)
             }
             is StickyClass -> {
-              writeByte(StreamingHprofReader.ROOT_STICKY_CLASS)
+              writeByte(HprofRecordTag.ROOT_STICKY_CLASS.tag)
               writeId(gcRoot.id)
             }
             is ThreadBlock -> {
-              writeByte(StreamingHprofReader.ROOT_THREAD_BLOCK)
+              writeByte(HprofRecordTag.ROOT_THREAD_BLOCK.tag)
               writeId(gcRoot.id)
               writeInt(gcRoot.threadSerialNumber)
             }
             is MonitorUsed -> {
-              writeByte(StreamingHprofReader.ROOT_MONITOR_USED)
+              writeByte(HprofRecordTag.ROOT_MONITOR_USED.tag)
               writeId(gcRoot.id)
             }
             is ThreadObject -> {
-              writeByte(StreamingHprofReader.ROOT_THREAD_OBJECT)
+              writeByte(HprofRecordTag.ROOT_THREAD_OBJECT.tag)
               writeId(gcRoot.id)
               writeInt(gcRoot.threadSerialNumber)
               writeInt(gcRoot.stackTraceSerialNumber)
             }
             is ReferenceCleanup -> {
-              writeByte(StreamingHprofReader.ROOT_REFERENCE_CLEANUP)
+              writeByte(HprofRecordTag.ROOT_REFERENCE_CLEANUP.tag)
               writeId(gcRoot.id)
             }
             is VmInternal -> {
-              writeByte(StreamingHprofReader.ROOT_VM_INTERNAL)
+              writeByte(HprofRecordTag.ROOT_VM_INTERNAL.tag)
               writeId(gcRoot.id)
             }
             is JniMonitor -> {
-              writeByte(StreamingHprofReader.ROOT_JNI_MONITOR)
+              writeByte(HprofRecordTag.ROOT_JNI_MONITOR.tag)
               writeId(gcRoot.id)
               writeInt(gcRoot.stackTraceSerialNumber)
               writeInt(gcRoot.stackDepth)
             }
             is InternedString -> {
-              writeByte(StreamingHprofReader.ROOT_INTERNED_STRING)
+              writeByte(HprofRecordTag.ROOT_INTERNED_STRING.tag)
               writeId(gcRoot.id)
             }
             is Finalizing -> {
-              writeByte(StreamingHprofReader.ROOT_FINALIZING)
+              writeByte(HprofRecordTag.ROOT_FINALIZING.tag)
               writeId(gcRoot.id)
             }
             is Debugger -> {
-              writeByte(StreamingHprofReader.ROOT_DEBUGGER)
+              writeByte(HprofRecordTag.ROOT_DEBUGGER.tag)
               writeId(gcRoot.id)
             }
             is Unreachable -> {
-              writeByte(StreamingHprofReader.ROOT_UNREACHABLE)
+              writeByte(HprofRecordTag.ROOT_UNREACHABLE.tag)
               writeId(gcRoot.id)
             }
           }
@@ -239,7 +239,7 @@ class HprofWriter private constructor(
       }
       is ClassDumpRecord -> {
         with(workBuffer) {
-          writeByte(StreamingHprofReader.CLASS_DUMP)
+          writeByte(HprofRecordTag.CLASS_DUMP.tag)
           writeId(record.id)
           writeInt(record.stackTraceSerialNumber)
           writeId(record.superclassId)
@@ -269,7 +269,7 @@ class HprofWriter private constructor(
       }
       is InstanceDumpRecord -> {
         with(workBuffer) {
-          writeByte(StreamingHprofReader.INSTANCE_DUMP)
+          writeByte(HprofRecordTag.INSTANCE_DUMP.tag)
           writeId(record.id)
           writeInt(record.stackTraceSerialNumber)
           writeId(record.classId)
@@ -279,7 +279,7 @@ class HprofWriter private constructor(
       }
       is ObjectArrayDumpRecord -> {
         with(workBuffer) {
-          writeByte(StreamingHprofReader.OBJECT_ARRAY_DUMP)
+          writeByte(HprofRecordTag.OBJECT_ARRAY_DUMP.tag)
           writeId(record.id)
           writeInt(record.stackTraceSerialNumber)
           writeInt(record.elementIds.size)
@@ -289,7 +289,7 @@ class HprofWriter private constructor(
       }
       is PrimitiveArrayDumpRecord -> {
         with(workBuffer) {
-          writeByte(StreamingHprofReader.PRIMITIVE_ARRAY_DUMP)
+          writeByte(HprofRecordTag.PRIMITIVE_ARRAY_DUMP.tag)
           writeId(record.id)
           writeInt(record.stackTraceSerialNumber)
 
@@ -339,7 +339,7 @@ class HprofWriter private constructor(
       }
       is HeapDumpInfoRecord -> {
         with(workBuffer) {
-          writeByte(StreamingHprofReader.HEAP_DUMP_INFO)
+          writeByte(HprofRecordTag.HEAP_DUMP_INFO.tag)
           writeInt(record.heapId)
           writeId(record.heapNameStringId)
         }
@@ -406,9 +406,9 @@ class HprofWriter private constructor(
 
   private fun BufferedSink.flushHeapBuffer() {
     if (workBuffer.size() > 0) {
-      writeTagHeader(StreamingHprofReader.HEAP_DUMP, workBuffer.size())
+      writeTagHeader(HprofRecordTag.HEAP_DUMP.tag, workBuffer.size())
       writeAll(workBuffer)
-      writeTagHeader(StreamingHprofReader.HEAP_DUMP_END, 0)
+      writeTagHeader(HprofRecordTag.HEAP_DUMP_END.tag, 0)
     }
   }
 

--- a/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
+++ b/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
@@ -1,9 +1,9 @@
 package shark
 
 /**
- * Listener passed in to [HprofReader.readHprofRecords], gets notified for each [HprofRecord]
+ * Listener passed in to [StreamingHprofReader.readRecords], gets notified for each [HprofRecord]
  * found in the heap dump which types is in the set of the recordTypes parameter passed to
- * [HprofReader.readHprofRecords].
+ * [StreamingHprofReader.readRecords].
  */
 interface OnHprofRecordListener {
   fun onHprofRecord(

--- a/shark-hprof/src/main/java/shark/OnHprofRecordTagListener.kt
+++ b/shark-hprof/src/main/java/shark/OnHprofRecordTagListener.kt
@@ -1,0 +1,44 @@
+package shark
+
+/**
+ * Listener passed in to [StreamingHprofReader.readRecords], gets notified for each
+ * [HprofRecordTag] found in the heap dump.
+ *
+ * Listener implementations are expected to read all bytes corresponding to a given tag from the
+ * provided reader before returning.
+ */
+interface OnHprofRecordTagListener {
+  fun onHprofRecord(
+    tag: HprofRecordTag,
+    /**
+     * Length of the record or -1 if there is the length is not known
+     */
+    length: Long,
+    reader: HprofRecordReader
+  )
+
+  companion object {
+    /**
+     * Utility function to create a [OnHprofRecordTagListener] from the passed in [block] lambda
+     * instead of using the anonymous `object : OnHprofRecordTagListener` syntax.
+     *
+     * Usage:
+     *
+     * ```kotlin
+     * val listener = OnHprofRecordTagListener { tag, length, reader ->
+     *
+     * }
+     * ```
+     */
+    inline operator fun invoke(crossinline block: (HprofRecordTag, Long, HprofRecordReader) -> Unit): OnHprofRecordTagListener =
+      object : OnHprofRecordTagListener {
+        override fun onHprofRecord(
+          tag: HprofRecordTag,
+          length: Long,
+          reader: HprofRecordReader
+        ) {
+          block(tag, length, reader)
+        }
+      }
+  }
+}

--- a/shark-hprof/src/main/java/shark/StreamingHprofReader.kt
+++ b/shark-hprof/src/main/java/shark/StreamingHprofReader.kt
@@ -7,21 +7,46 @@ import shark.HprofRecord.HeapDumpRecord.GcRootRecord
 import shark.HprofRecord.HeapDumpRecord.HeapDumpInfoRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassSkipContentRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.InstanceDumpRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.InstanceSkipContentRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ObjectArrayDumpRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ObjectArraySkipContentRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord
-import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArraySkipContentRecord
 import shark.HprofRecord.LoadClassRecord
 import shark.HprofRecord.StackFrameRecord
 import shark.HprofRecord.StackTraceRecord
 import shark.HprofRecord.StringRecord
-import shark.PrimitiveType.BOOLEAN
+import shark.HprofRecordTag.CLASS_DUMP
+import shark.HprofRecordTag.HEAP_DUMP
+import shark.HprofRecordTag.HEAP_DUMP_END
+import shark.HprofRecordTag.HEAP_DUMP_INFO
+import shark.HprofRecordTag.HEAP_DUMP_SEGMENT
+import shark.HprofRecordTag.INSTANCE_DUMP
+import shark.HprofRecordTag.LOAD_CLASS
+import shark.HprofRecordTag.OBJECT_ARRAY_DUMP
+import shark.HprofRecordTag.PRIMITIVE_ARRAY_DUMP
+import shark.HprofRecordTag.PRIMITIVE_ARRAY_NODATA
+import shark.HprofRecordTag.ROOT_DEBUGGER
+import shark.HprofRecordTag.ROOT_FINALIZING
+import shark.HprofRecordTag.ROOT_INTERNED_STRING
+import shark.HprofRecordTag.ROOT_JAVA_FRAME
+import shark.HprofRecordTag.ROOT_JNI_GLOBAL
+import shark.HprofRecordTag.ROOT_JNI_LOCAL
+import shark.HprofRecordTag.ROOT_JNI_MONITOR
+import shark.HprofRecordTag.ROOT_MONITOR_USED
+import shark.HprofRecordTag.ROOT_NATIVE_STACK
+import shark.HprofRecordTag.ROOT_REFERENCE_CLEANUP
+import shark.HprofRecordTag.ROOT_STICKY_CLASS
+import shark.HprofRecordTag.ROOT_THREAD_BLOCK
+import shark.HprofRecordTag.ROOT_THREAD_OBJECT
+import shark.HprofRecordTag.ROOT_UNKNOWN
+import shark.HprofRecordTag.ROOT_UNREACHABLE
+import shark.HprofRecordTag.ROOT_VM_INTERNAL
+import shark.HprofRecordTag.STACK_FRAME
+import shark.HprofRecordTag.STACK_TRACE
+import shark.HprofRecordTag.STRING_IN_UTF8
 import shark.PrimitiveType.Companion.REFERENCE_HPROF_TYPE
 import shark.PrimitiveType.INT
 import java.io.File
+import java.util.EnumSet
 import kotlin.reflect.KClass
 
 /**
@@ -35,43 +60,15 @@ class StreamingHprofReader private constructor(
 
   /**
    * Obtains a new source to read all hprof records from and calls [listener] back for each record
-   * that matches one of the provided [recordTypes].
+   * that matches one of the provided [recordTags].
    *
    * @return the number of bytes read from the source
    */
   @Suppress("ComplexMethod", "LongMethod", "NestedBlockDepth")
   fun readRecords(
-    recordTypes: Set<KClass<out HprofRecord>>,
-    listener: OnHprofRecordListener
+    recordTags: Set<HprofRecordTag>,
+    listener: OnHprofRecordTagListener
   ): Long {
-    val readAllRecords = HprofRecord::class in recordTypes
-    val readStringRecord = readAllRecords || StringRecord::class in recordTypes
-    val readLoadClassRecord = readAllRecords || LoadClassRecord::class in recordTypes
-    val readHeapDumpEndRecord = readAllRecords || HeapDumpEndRecord::class in recordTypes
-    val readStackFrameRecord = readAllRecords || StackFrameRecord::class in recordTypes
-    val readStackTraceRecord = readAllRecords || StackTraceRecord::class in recordTypes
-    val readAllHeapDumpRecords = readAllRecords || HeapDumpRecord::class in recordTypes
-    val readGcRootRecord = readAllHeapDumpRecords || GcRootRecord::class in recordTypes
-    val readHeapDumpInfoRecord = readAllRecords || HeapDumpInfoRecord::class in recordTypes
-    val readAllObjectRecords = readAllHeapDumpRecords || ObjectRecord::class in recordTypes
-    val readClassDumpRecord = readAllObjectRecords || ClassDumpRecord::class in recordTypes
-    val readClassSkipContentRecord = ClassSkipContentRecord::class in recordTypes
-    val readInstanceDumpRecord = readAllObjectRecords || InstanceDumpRecord::class in recordTypes
-    val readInstanceSkipContentRecord = InstanceSkipContentRecord::class in recordTypes
-    val readObjectArrayDumpRecord =
-      readAllObjectRecords || ObjectArrayDumpRecord::class in recordTypes
-    val readObjectArraySkipContentRecord = ObjectArraySkipContentRecord::class in recordTypes
-    val readPrimitiveArrayDumpRecord =
-      readAllObjectRecords || PrimitiveArrayDumpRecord::class in recordTypes
-    val readPrimitiveArraySkipContentRecord = PrimitiveArraySkipContentRecord::class in recordTypes
-
-    val reusedInstanceSkipContentRecord = InstanceSkipContentRecord(0, 0, 0)
-    val reusedClassSkipContentRecord = ClassSkipContentRecord(0, 0, 0, 0, 0, 0, 0, 0, 0)
-    val reusedObjectArraySkipContentRecord = ObjectArraySkipContentRecord(0, 0, 0, 0)
-    val reusedPrimitiveArraySkipContentRecord =
-      PrimitiveArraySkipContentRecord(0, 0, 0, BOOLEAN)
-    val reusedLoadClassRecord = LoadClassRecord(0, 0, 0, 0)
-
     return sourceProvider.openStreamingSource().use { source ->
       val reader = HprofRecordReader(header, source)
       reader.skip(header.recordsPosition)
@@ -79,7 +76,6 @@ class StreamingHprofReader private constructor(
       // Local ref optimizations
       val intByteSize = INT.byteSize
       val identifierByteSize = reader.sizeOf(REFERENCE_HPROF_TYPE)
-
 
       while (!source.exhausted()) {
         // type of the record
@@ -92,45 +88,35 @@ class StreamingHprofReader private constructor(
         val length = reader.readUnsignedInt()
 
         when (tag) {
-          STRING_IN_UTF8 -> {
-            if (readStringRecord) {
-              val recordPosition = reader.bytesRead
-              val record = reader.readStringRecord(length)
-              listener.onHprofRecord(recordPosition, record)
+          STRING_IN_UTF8.tag -> {
+            if (STRING_IN_UTF8 in recordTags) {
+              listener.onHprofRecord(STRING_IN_UTF8, length, reader)
             } else {
               reader.skip(length)
             }
           }
-          LOAD_CLASS -> {
-            if (readLoadClassRecord) {
-              val recordPosition = reader.bytesRead
-              with(reader) {
-                reusedLoadClassRecord.read()
-              }
-              listener.onHprofRecord(recordPosition, reusedLoadClassRecord)
+          LOAD_CLASS.tag -> {
+            if (LOAD_CLASS in recordTags) {
+              listener.onHprofRecord(LOAD_CLASS, length, reader)
             } else {
               reader.skip(length)
             }
           }
-          STACK_FRAME -> {
-            if (readStackFrameRecord) {
-              val recordPosition = reader.bytesRead
-              val record = reader.readStackFrameRecord()
-              listener.onHprofRecord(recordPosition, record)
+          STACK_FRAME.tag -> {
+            if (STACK_FRAME in recordTags) {
+              listener.onHprofRecord(STACK_FRAME, length, reader)
             } else {
               reader.skip(length)
             }
           }
-          STACK_TRACE -> {
-            if (readStackTraceRecord) {
-              val recordPosition = reader.bytesRead
-              val record = reader.readStackTraceRecord()
-              listener.onHprofRecord(recordPosition, record)
+          STACK_TRACE.tag -> {
+            if (STACK_TRACE in recordTags) {
+              listener.onHprofRecord(STACK_TRACE, length, reader)
             } else {
               reader.skip(length)
             }
           }
-          HEAP_DUMP, HEAP_DUMP_SEGMENT -> {
+          HEAP_DUMP.tag, HEAP_DUMP_SEGMENT.tag -> {
             val heapDumpStart = reader.bytesRead
             var previousTag = 0
             var previousTagPosition = 0L
@@ -138,245 +124,168 @@ class StreamingHprofReader private constructor(
               val heapDumpTagPosition = reader.bytesRead
               val heapDumpTag = reader.readUnsignedByte()
               when (heapDumpTag) {
-                ROOT_UNKNOWN -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val record = reader.readUnknownGcRootRecord()
-                    listener.onHprofRecord(recordPosition, record)
+                ROOT_UNKNOWN.tag -> {
+                  if (ROOT_UNKNOWN in recordTags) {
+                    listener.onHprofRecord(ROOT_UNKNOWN, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
-                ROOT_JNI_GLOBAL -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readJniGlobalGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_JNI_GLOBAL.tag -> {
+                  if (ROOT_JNI_GLOBAL in recordTags) {
+                    listener.onHprofRecord(ROOT_JNI_GLOBAL, -1, reader)
                   } else {
                     reader.skip(identifierByteSize + identifierByteSize)
                   }
                 }
-                ROOT_JNI_LOCAL -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readJniLocalGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_JNI_LOCAL.tag -> {
+                  if (ROOT_JNI_LOCAL in recordTags) {
+                    listener.onHprofRecord(ROOT_JNI_LOCAL, -1, reader)
                   } else {
                     reader.skip(identifierByteSize + intByteSize + intByteSize)
                   }
                 }
 
-                ROOT_JAVA_FRAME -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readJavaFrameGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_JAVA_FRAME.tag -> {
+                  if (ROOT_JAVA_FRAME in recordTags) {
+                    listener.onHprofRecord(ROOT_JAVA_FRAME, -1, reader)
                   } else {
                     reader.skip(identifierByteSize + intByteSize + intByteSize)
                   }
                 }
 
-                ROOT_NATIVE_STACK -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readNativeStackGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_NATIVE_STACK.tag -> {
+                  if (ROOT_NATIVE_STACK in recordTags) {
+                    listener.onHprofRecord(ROOT_NATIVE_STACK, -1, reader)
                   } else {
                     reader.skip(identifierByteSize + intByteSize)
                   }
                 }
 
-                ROOT_STICKY_CLASS -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readStickyClassGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_STICKY_CLASS.tag -> {
+                  if (ROOT_STICKY_CLASS in recordTags) {
+                    listener.onHprofRecord(ROOT_STICKY_CLASS, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
-
-                // An object that was referenced from an active thread block.
-                ROOT_THREAD_BLOCK -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    listener.onHprofRecord(recordPosition, reader.readThreadBlockGcRootRecord())
+                ROOT_THREAD_BLOCK.tag -> {
+                  if (ROOT_THREAD_BLOCK in recordTags) {
+                    listener.onHprofRecord(ROOT_THREAD_BLOCK, -1, reader)
                   } else {
                     reader.skip(identifierByteSize + intByteSize)
                   }
                 }
 
-                ROOT_MONITOR_USED -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readMonitorUsedGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_MONITOR_USED.tag -> {
+                  if (ROOT_MONITOR_USED in recordTags) {
+                    listener.onHprofRecord(ROOT_MONITOR_USED, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
 
-                ROOT_THREAD_OBJECT -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readThreadObjectGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_THREAD_OBJECT.tag -> {
+                  if (ROOT_THREAD_OBJECT in recordTags) {
+                    listener.onHprofRecord(ROOT_THREAD_OBJECT, -1, reader)
                   } else {
                     reader.skip(identifierByteSize + intByteSize + intByteSize)
                   }
                 }
 
-                ROOT_INTERNED_STRING -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readInternedStringGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_INTERNED_STRING.tag -> {
+                  if (ROOT_INTERNED_STRING in recordTags) {
+                    listener.onHprofRecord(ROOT_INTERNED_STRING, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
 
-                ROOT_FINALIZING -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readFinalizingGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_FINALIZING.tag -> {
+                  if (ROOT_FINALIZING in recordTags) {
+                    listener.onHprofRecord(ROOT_FINALIZING, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
 
-                ROOT_DEBUGGER -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readDebuggerGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_DEBUGGER.tag -> {
+                  if (ROOT_DEBUGGER in recordTags) {
+                    listener.onHprofRecord(ROOT_DEBUGGER, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
 
-                ROOT_REFERENCE_CLEANUP -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readReferenceCleanupGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_REFERENCE_CLEANUP.tag -> {
+                  if (ROOT_REFERENCE_CLEANUP in recordTags) {
+                    listener.onHprofRecord(ROOT_REFERENCE_CLEANUP, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
 
-                ROOT_VM_INTERNAL -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readVmInternalGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_VM_INTERNAL.tag -> {
+                  if (ROOT_VM_INTERNAL in recordTags) {
+                    listener.onHprofRecord(ROOT_VM_INTERNAL, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
 
-                ROOT_JNI_MONITOR -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readJniMonitorGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_JNI_MONITOR.tag -> {
+                  if (ROOT_JNI_MONITOR in recordTags) {
+                    listener.onHprofRecord(ROOT_JNI_MONITOR, -1, reader)
                   } else {
                     reader.skip(identifierByteSize + intByteSize + intByteSize)
                   }
                 }
 
-                ROOT_UNREACHABLE -> {
-                  if (readGcRootRecord) {
-                    val recordPosition = reader.bytesRead
-                    val gcRootRecord = reader.readUnreachableGcRootRecord()
-                    listener.onHprofRecord(recordPosition, gcRootRecord)
+                ROOT_UNREACHABLE.tag -> {
+                  if (ROOT_UNREACHABLE in recordTags) {
+                    listener.onHprofRecord(ROOT_UNREACHABLE, -1, reader)
                   } else {
                     reader.skip(identifierByteSize)
                   }
                 }
-                CLASS_DUMP -> {
-                  when {
-                    readClassDumpRecord -> {
-                      val recordPosition = reader.bytesRead
-                      val record = reader.readClassDumpRecord()
-                      listener.onHprofRecord(recordPosition, record)
-                    }
-                    readClassSkipContentRecord -> {
-                      val recordPosition = reader.bytesRead
-                      with(reader) {
-                        reusedClassSkipContentRecord.read()
-                      }
-                      listener.onHprofRecord(recordPosition, reusedClassSkipContentRecord)
-                    }
-                    else -> reader.skipClassDumpRecord()
+                CLASS_DUMP.tag -> {
+                  if (CLASS_DUMP in recordTags) {
+                    listener.onHprofRecord(CLASS_DUMP, -1, reader)
+                  } else {
+                    reader.skipClassDumpRecord()
                   }
                 }
-                INSTANCE_DUMP -> {
-                  when {
-                    readInstanceDumpRecord -> {
-                      val recordPosition = reader.bytesRead
-                      val record = reader.readInstanceDumpRecord()
-                      listener.onHprofRecord(recordPosition, record)
-                    }
-                    readInstanceSkipContentRecord -> {
-                      val recordPosition = reader.bytesRead
-                      with(reader) {
-                        reusedInstanceSkipContentRecord.read()
-                      }
-                      listener.onHprofRecord(recordPosition, reusedInstanceSkipContentRecord)
-                    }
-                    else -> reader.skipInstanceDumpRecord()
+                INSTANCE_DUMP.tag -> {
+                  if (INSTANCE_DUMP in recordTags) {
+                    listener.onHprofRecord(INSTANCE_DUMP, -1, reader)
+                  } else {
+                    reader.skipInstanceDumpRecord()
                   }
                 }
 
-                OBJECT_ARRAY_DUMP -> {
-                  when {
-                    readObjectArrayDumpRecord -> {
-                      val recordPosition = reader.bytesRead
-                      val arrayRecord = reader.readObjectArrayDumpRecord()
-                      listener.onHprofRecord(recordPosition, arrayRecord)
-                    }
-                    readObjectArraySkipContentRecord -> {
-                      val recordPosition = reader.bytesRead
-                      with(reader) {
-                        reusedObjectArraySkipContentRecord.read()
-                      }
-                      listener.onHprofRecord(recordPosition, reusedObjectArraySkipContentRecord)
-                    }
-                    else -> reader.skipObjectArrayDumpRecord()
+                OBJECT_ARRAY_DUMP.tag -> {
+                  if (OBJECT_ARRAY_DUMP in recordTags) {
+                    listener.onHprofRecord(OBJECT_ARRAY_DUMP, -1, reader)
+                  } else {
+                    reader.skipObjectArrayDumpRecord()
                   }
                 }
 
-                PRIMITIVE_ARRAY_DUMP -> {
-                  when {
-                    readPrimitiveArrayDumpRecord -> {
-                      val recordPosition = reader.bytesRead
-                      val record = reader.readPrimitiveArrayDumpRecord()
-                      listener.onHprofRecord(recordPosition, record)
-                    }
-                    readPrimitiveArraySkipContentRecord -> {
-                      val recordPosition = reader.bytesRead
-                      with(reader) {
-                        reusedPrimitiveArraySkipContentRecord.read()
-                      }
-                      listener.onHprofRecord(
-                          recordPosition, reusedPrimitiveArraySkipContentRecord
-                      )
-                    }
-                    else -> reader.skipPrimitiveArrayDumpRecord()
+                PRIMITIVE_ARRAY_DUMP.tag -> {
+                  if (PRIMITIVE_ARRAY_DUMP in recordTags) {
+                    listener.onHprofRecord(PRIMITIVE_ARRAY_DUMP, -1, reader)
+                  } else {
+                    reader.skipPrimitiveArrayDumpRecord()
                   }
                 }
 
-                PRIMITIVE_ARRAY_NODATA -> {
-                  throw UnsupportedOperationException("PRIMITIVE_ARRAY_NODATA cannot be parsed")
+                PRIMITIVE_ARRAY_NODATA.tag -> {
+                  throw UnsupportedOperationException("$PRIMITIVE_ARRAY_NODATA cannot be parsed")
                 }
 
-                HEAP_DUMP_INFO -> {
-                  if (readHeapDumpInfoRecord) {
-                    val recordPosition = reader.bytesRead
-                    val record = reader.readHeapDumpInfoRecord()
-                    listener.onHprofRecord(recordPosition, record)
+                HEAP_DUMP_INFO.tag -> {
+                  if (HEAP_DUMP_INFO in recordTags) {
+                    listener.onHprofRecord(HEAP_DUMP_INFO, -1, reader)
                   } else {
                     reader.skipHeapDumpInfoRecord()
                   }
@@ -393,11 +302,9 @@ class StreamingHprofReader private constructor(
               previousTagPosition = heapDumpTagPosition
             }
           }
-          HEAP_DUMP_END -> {
-            if (readHeapDumpEndRecord) {
-              val recordPosition = reader.bytesRead
-              val record = HeapDumpEndRecord
-              listener.onHprofRecord(recordPosition, record)
+          HEAP_DUMP_END.tag -> {
+            if (HEAP_DUMP_END in recordTags) {
+              listener.onHprofRecord(HEAP_DUMP_END, length, reader)
             }
           }
           else -> {
@@ -409,57 +316,9 @@ class StreamingHprofReader private constructor(
     }
   }
 
+
+
   companion object {
-    internal const val STRING_IN_UTF8 = 0x01
-    internal const val LOAD_CLASS = 0x02
-    internal const val UNLOAD_CLASS = 0x03
-    internal const val STACK_FRAME = 0x04
-    internal const val STACK_TRACE = 0x05
-    internal const val ALLOC_SITES = 0x06
-    internal const val HEAP_SUMMARY = 0x07
-
-    // TODO Maybe parse this?
-    internal const val START_THREAD = 0x0a
-    internal const val END_THREAD = 0x0b
-    internal const val HEAP_DUMP = 0x0c
-    internal const val HEAP_DUMP_SEGMENT = 0x1c
-    internal const val HEAP_DUMP_END = 0x2c
-    internal const val CPU_SAMPLES = 0x0d
-    internal const val CONTROL_SETTINGS = 0x0e
-    internal const val ROOT_UNKNOWN = 0xff
-    internal const val ROOT_JNI_GLOBAL = 0x01
-    internal const val ROOT_JNI_LOCAL = 0x02
-    internal const val ROOT_JAVA_FRAME = 0x03
-    internal const val ROOT_NATIVE_STACK = 0x04
-    internal const val ROOT_STICKY_CLASS = 0x05
-    internal const val ROOT_THREAD_BLOCK = 0x06
-    internal const val ROOT_MONITOR_USED = 0x07
-    internal const val ROOT_THREAD_OBJECT = 0x08
-    internal const val CLASS_DUMP = 0x20
-    internal const val INSTANCE_DUMP = 0x21
-    internal const val OBJECT_ARRAY_DUMP = 0x22
-    internal const val PRIMITIVE_ARRAY_DUMP = 0x23
-
-    /**
-     * Android format addition
-     *
-     * Specifies information about which heap certain objects came from. When a sub-tag of this type
-     * appears in a HPROF_HEAP_DUMP or HPROF_HEAP_DUMP_SEGMENT record, entries that follow it will
-     * be associated with the specified heap.  The HEAP_DUMP_INFO data is reset at the end of the
-     * HEAP_DUMP[_SEGMENT].  Multiple HEAP_DUMP_INFO entries may appear in a single
-     * HEAP_DUMP[_SEGMENT].
-     *
-     * Format: u1: Tag value (0xFE) u4: heap ID ID: heap name string ID
-     */
-    internal const val HEAP_DUMP_INFO = 0xfe
-    internal const val ROOT_INTERNED_STRING = 0x89
-    internal const val ROOT_FINALIZING = 0x8a
-    internal const val ROOT_DEBUGGER = 0x8b
-    internal const val ROOT_REFERENCE_CLEANUP = 0x8c
-    internal const val ROOT_VM_INTERNAL = 0x8d
-    internal const val ROOT_JNI_MONITOR = 0x8e
-    internal const val ROOT_UNREACHABLE = 0x90
-    internal const val PRIMITIVE_ARRAY_NODATA = 0xc3
 
     /**
      * Creates a [StreamingHprofReader] for the provided [hprofFile]. [hprofHeader] will be read from

--- a/shark-hprof/src/main/java/shark/StreamingRecordReaderAdapter.kt
+++ b/shark-hprof/src/main/java/shark/StreamingRecordReaderAdapter.kt
@@ -1,0 +1,266 @@
+package shark
+
+import shark.HprofRecord.HeapDumpEndRecord
+import shark.HprofRecord.HeapDumpRecord
+import shark.HprofRecord.HeapDumpRecord.GcRootRecord
+import shark.HprofRecord.HeapDumpRecord.HeapDumpInfoRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.InstanceDumpRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ObjectArrayDumpRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord
+import shark.HprofRecord.LoadClassRecord
+import shark.HprofRecord.StackFrameRecord
+import shark.HprofRecord.StackTraceRecord
+import shark.HprofRecord.StringRecord
+import shark.HprofRecordTag.CLASS_DUMP
+import shark.HprofRecordTag.HEAP_DUMP_END
+import shark.HprofRecordTag.HEAP_DUMP_INFO
+import shark.HprofRecordTag.INSTANCE_DUMP
+import shark.HprofRecordTag.LOAD_CLASS
+import shark.HprofRecordTag.OBJECT_ARRAY_DUMP
+import shark.HprofRecordTag.PRIMITIVE_ARRAY_DUMP
+import shark.HprofRecordTag.ROOT_DEBUGGER
+import shark.HprofRecordTag.ROOT_FINALIZING
+import shark.HprofRecordTag.ROOT_INTERNED_STRING
+import shark.HprofRecordTag.ROOT_JAVA_FRAME
+import shark.HprofRecordTag.ROOT_JNI_GLOBAL
+import shark.HprofRecordTag.ROOT_JNI_LOCAL
+import shark.HprofRecordTag.ROOT_JNI_MONITOR
+import shark.HprofRecordTag.ROOT_MONITOR_USED
+import shark.HprofRecordTag.ROOT_NATIVE_STACK
+import shark.HprofRecordTag.ROOT_REFERENCE_CLEANUP
+import shark.HprofRecordTag.ROOT_STICKY_CLASS
+import shark.HprofRecordTag.ROOT_THREAD_BLOCK
+import shark.HprofRecordTag.ROOT_THREAD_OBJECT
+import shark.HprofRecordTag.ROOT_UNKNOWN
+import shark.HprofRecordTag.ROOT_UNREACHABLE
+import shark.HprofRecordTag.ROOT_VM_INTERNAL
+import shark.HprofRecordTag.STACK_FRAME
+import shark.HprofRecordTag.STACK_TRACE
+import shark.HprofRecordTag.STRING_IN_UTF8
+import java.util.EnumSet
+import kotlin.reflect.KClass
+
+/**
+ * Wraps a [StreamingHprofReader] to provide a higher level API that streams [HprofRecord]
+ * instances.
+ */
+class StreamingRecordReaderAdapter(private val streamingHprofReader: StreamingHprofReader) {
+
+  /**
+   * Obtains a new source to read all hprof records from and calls [listener] back for each record
+   * that matches one of the provided [recordTypes].
+   *
+   * @return the number of bytes read from the source
+   */
+  @Suppress("ComplexMethod", "LongMethod", "NestedBlockDepth")
+  fun readRecords(
+    recordTypes: Set<KClass<out HprofRecord>>,
+    listener: OnHprofRecordListener
+  ): Long {
+    val recordTags = recordTypes.asHprofTags()
+    return streamingHprofReader.readRecords(
+        recordTags, OnHprofRecordTagListener { tag, length, reader ->
+      when (tag) {
+        STRING_IN_UTF8 -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readStringRecord(length)
+          listener.onHprofRecord(recordPosition, record)
+        }
+        LOAD_CLASS -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readLoadClassRecord()
+          listener.onHprofRecord(recordPosition, record)
+        }
+        STACK_FRAME -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readStackFrameRecord()
+          listener.onHprofRecord(recordPosition, record)
+        }
+        STACK_TRACE -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readStackTraceRecord()
+          listener.onHprofRecord(recordPosition, record)
+        }
+        ROOT_UNKNOWN -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readUnknownGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(record))
+        }
+        ROOT_JNI_GLOBAL -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readJniGlobalGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+        ROOT_JNI_LOCAL -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readJniLocalGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_JAVA_FRAME -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readJavaFrameGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_NATIVE_STACK -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readNativeStackGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_STICKY_CLASS -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readStickyClassGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_THREAD_BLOCK -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readThreadBlockGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_MONITOR_USED -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readMonitorUsedGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_THREAD_OBJECT -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readThreadObjectGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_INTERNED_STRING -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readInternedStringGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_FINALIZING -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readFinalizingGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_DEBUGGER -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readDebuggerGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_REFERENCE_CLEANUP -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readReferenceCleanupGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_VM_INTERNAL -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readVmInternalGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_JNI_MONITOR -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readJniMonitorGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+
+        ROOT_UNREACHABLE -> {
+          val recordPosition = reader.bytesRead
+          val gcRootRecord = reader.readUnreachableGcRootRecord()
+          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+        }
+        CLASS_DUMP -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readClassDumpRecord()
+          listener.onHprofRecord(recordPosition, record)
+        }
+        INSTANCE_DUMP -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readInstanceDumpRecord()
+          listener.onHprofRecord(recordPosition, record)
+        }
+
+        OBJECT_ARRAY_DUMP -> {
+          val recordPosition = reader.bytesRead
+          val arrayRecord = reader.readObjectArrayDumpRecord()
+          listener.onHprofRecord(recordPosition, arrayRecord)
+        }
+
+        PRIMITIVE_ARRAY_DUMP -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readPrimitiveArrayDumpRecord()
+          listener.onHprofRecord(recordPosition, record)
+        }
+
+        HEAP_DUMP_INFO -> {
+          val recordPosition = reader.bytesRead
+          val record = reader.readHeapDumpInfoRecord()
+          listener.onHprofRecord(recordPosition, record)
+        }
+        HEAP_DUMP_END -> {
+          val recordPosition = reader.bytesRead
+          val record = HeapDumpEndRecord
+          listener.onHprofRecord(recordPosition, record)
+        }
+        else -> error("Unexpected heap dump tag $tag at position ${reader.bytesRead}")
+      }
+    })
+  }
+
+  companion object {
+    fun StreamingHprofReader.asStreamingRecordReader() = StreamingRecordReaderAdapter(this)
+
+    fun Set<KClass<out HprofRecord>>.asHprofTags(): EnumSet<HprofRecordTag> {
+      val recordTypes = this
+      return if (HprofRecord::class in recordTypes) {
+        EnumSet.allOf(HprofRecordTag::class.java)
+      } else {
+        EnumSet.noneOf(HprofRecordTag::class.java).apply {
+          if (StringRecord::class in recordTypes) {
+            add(STRING_IN_UTF8)
+          }
+          if (LoadClassRecord::class in recordTypes) {
+            add(LOAD_CLASS)
+          }
+          if (HeapDumpEndRecord::class in recordTypes) {
+            add(HEAP_DUMP_END)
+          }
+          if (StackFrameRecord::class in recordTypes) {
+            add(STACK_FRAME)
+          }
+          if (StackTraceRecord::class in recordTypes) {
+            add(STACK_TRACE)
+          }
+          if (HeapDumpInfoRecord::class in recordTypes) {
+            add(HEAP_DUMP_INFO)
+          }
+          val readAllHeapDumpRecords = HeapDumpRecord::class in recordTypes
+          if (readAllHeapDumpRecords || GcRootRecord::class in recordTypes) {
+            addAll(HprofRecordTag.rootTags)
+          }
+          val readAllObjectRecords = readAllHeapDumpRecords || ObjectRecord::class in recordTypes
+          if (readAllObjectRecords || ClassDumpRecord::class in recordTypes) {
+            add(CLASS_DUMP)
+          }
+          if (readAllObjectRecords || InstanceDumpRecord::class in recordTypes) {
+            add(INSTANCE_DUMP)
+          }
+          if (readAllObjectRecords || ObjectArrayDumpRecord::class in recordTypes) {
+            add(OBJECT_ARRAY_DUMP)
+          }
+          if (readAllObjectRecords || PrimitiveArrayDumpRecord::class in recordTypes) {
+            add(PRIMITIVE_ARRAY_DUMP)
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/shark/src/main/java/shark/internal/PathFinder.kt
+++ b/shark/src/main/java/shark/internal/PathFinder.kt
@@ -530,7 +530,7 @@ internal class PathFinder(
     var skipBytesCount = 0
 
     for (heapClass in classHierarchy) {
-      for (fieldRecord in heapClass.readRecord().fields) {
+      for (fieldRecord in heapClass.readRecordFields()) {
         if (fieldRecord.type != PrimitiveType.REFERENCE_HPROF_TYPE) {
           // Skip all fields that are not references. Track how many bytes to skip
           skipBytesCount += hprofGraph.getRecordSize(fieldRecord)

--- a/shark/src/test/java/shark/HprofHeapGraphTest.kt
+++ b/shark/src/test/java/shark/HprofHeapGraphTest.kt
@@ -5,6 +5,7 @@ import org.junit.Test
 import shark.HeapObject.HeapClass
 import shark.HeapObject.HeapInstance
 import shark.HprofHeapGraph.Companion.openHeapGraph
+import shark.ValueHolder.CharHolder
 
 class HprofHeapGraphTest {
 
@@ -42,4 +43,14 @@ class HprofHeapGraphTest {
     }
   }
 
+  @Test fun `char is correctly converted back`() {
+    val heapDump = dump {
+      "SomeClass" clazz { staticField["myChar"] = CharHolder('p') }
+    }
+    val myChar = heapDump.openHeapGraph().use { graph ->
+      val myClass = graph.findClassByName("SomeClass")!!
+      myClass.readStaticField("myChar")!!.value.asChar!!
+    }
+    assertThat(myChar).isEqualTo('p')
+  }
 }


### PR DESCRIPTION
This reduces IO reads by more than 20% by keeping the fields part of the class dump records in memory. To limit the impact
on retained memory, the fields are stored as the exact bytes that are found in the heap dump. In the example heap dumps
this adds 200 to 300 KB which is reasonable.

Also changed StreamingHprofReader to provide a lower level API that gives a reader for each heap dump tag found. This allow
consumers to read exactly the bytes they need and avoid creating a lot of temporary objects. Previously this was done
by introducing special "skip" record types, but the needs kept changing.

The previous API is still available for convenience: `StreamingHprofReader.readerFor(heapDumpFile).asStreamingRecordReader()`