### PR TITLE
Display retain object size using human readable output

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
@@ -37,6 +37,7 @@ import leakcanary.internal.DisplayLeakConnectorView.Type.START
 import leakcanary.internal.DisplayLeakConnectorView.Type.START_LAST_REACHABLE
 import leakcanary.internal.navigation.getColorCompat
 import leakcanary.internal.navigation.inflate
+import leakcanary.internal.utils.humanReadableByteCount
 import shark.LeakTrace
 import shark.LeakTrace.GcRootType.JAVA_FRAME
 import shark.LeakTraceObject
@@ -177,9 +178,10 @@ internal class DisplayLeakAdapter constructor(
 
     htmlString += "$INDENTATION${extra("Leaking: ")}$reachabilityString<br>"
 
-    if (retainedHeapByteSize != null) {
-      htmlString += "${INDENTATION}${extra("Retaining ")}$retainedHeapByteSize${extra(
-          " bytes in "
+    retainedHeapByteSize?.let {
+      val humanReadableRetainedHeapSize = humanReadableByteCount(it.toLong(), si = true)
+      htmlString += "${INDENTATION}${extra("Retaining ")}$humanReadableRetainedHeapSize${extra(
+          " in "
       )}$retainedObjectCount${extra(" objects")}<br>"
     }
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
@@ -33,7 +33,7 @@ internal class RenderHeapDumpScreen(
       container.activity.title = resources.getString(R.string.leak_canary_loading_title)
 
       executeOnIo {
-        val byteCount = humanReadableByteCount(heapDumpFile.length(), false)
+        val byteCount = humanReadableByteCount(heapDumpFile.length(), si = true)
         updateUi {
           container.activity.title =
             resources.getString(R.string.leak_canary_heap_dump_screen_title, byteCount)

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/RenderHeapDumpScreen.kt
@@ -19,6 +19,7 @@ import leakcanary.internal.navigation.Screen
 import leakcanary.internal.navigation.activity
 import leakcanary.internal.navigation.inflate
 import leakcanary.internal.navigation.onCreateOptionsMenu
+import leakcanary.internal.utils.humanReadableByteCount
 import shark.SharkLog
 import java.io.File
 import java.io.FileOutputStream
@@ -128,18 +129,6 @@ internal class RenderHeapDumpScreen(
             }
       }
     }
-
-  // https://stackoverflow.com/a/3758880
-  fun humanReadableByteCount(
-    bytes: Long,
-    si: Boolean
-  ): String {
-    val unit = if (si) 1000 else 1024
-    if (bytes < unit) return "$bytes B"
-    val exp = (Math.log(bytes.toDouble()) / Math.log(unit.toDouble())).toInt()
-    val pre = (if (si) "kMGTPE" else "KMGTPE")[exp - 1] + if (si) "" else "i"
-    return String.format("%.1f %sB", bytes / Math.pow(unit.toDouble(), exp.toDouble()), pre)
-  }
 
   fun savePng(
     imageFile: File,

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/utils/Size.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/utils/Size.kt
@@ -1,5 +1,8 @@
 package leakcanary.internal.utils
 
+import kotlin.math.ln
+import kotlin.math.pow
+
 
 // https://stackoverflow.com/a/3758880
 internal fun humanReadableByteCount(
@@ -8,7 +11,7 @@ internal fun humanReadableByteCount(
 ): String {
     val unit = if (si) 1000 else 1024
     if (bytes < unit) return "$bytes B"
-    val exp = (Math.log(bytes.toDouble()) / Math.log(unit.toDouble())).toInt()
+    val exp = (ln(bytes.toDouble()) / ln(unit.toDouble())).toInt()
     val pre = (if (si) "kMGTPE" else "KMGTPE")[exp - 1] + if (si) "" else "i"
-    return String.format("%.1f %sB", bytes / Math.pow(unit.toDouble(), exp.toDouble()), pre)
+    return String.format("%.1f %sB", bytes / unit.toDouble().pow(exp.toDouble()), pre)
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/utils/Size.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/utils/Size.kt
@@ -1,0 +1,14 @@
+package leakcanary.internal.utils
+
+
+// https://stackoverflow.com/a/3758880
+internal fun humanReadableByteCount(
+        bytes: Long,
+        si: Boolean
+): String {
+    val unit = if (si) 1000 else 1024
+    if (bytes < unit) return "$bytes B"
+    val exp = (Math.log(bytes.toDouble()) / Math.log(unit.toDouble())).toInt()
+    val pre = (if (si) "kMGTPE" else "KMGTPE")[exp - 1] + if (si) "" else "i"
+    return String.format("%.1f %sB", bytes / Math.pow(unit.toDouble(), exp.toDouble()), pre)
+}

--- a/shark/src/main/java/shark/LeakTrace.kt
+++ b/shark/src/main/java/shark/LeakTrace.kt
@@ -7,6 +7,8 @@ import shark.LeakTraceObject.LeakingStatus.UNKNOWN
 import shark.LeakTraceReference.ReferenceType.STATIC_FIELD
 import shark.internal.createSHA1Hash
 import java.io.Serializable
+import kotlin.math.ln
+import kotlin.math.pow
 
 /**
  * The best strong reference path from a GC root to the leaking object. "Best" here means the
@@ -103,9 +105,9 @@ data class LeakTrace(
   ): String {
     val unit = if (si) 1000 else 1024
     if (bytes < unit) return "$bytes B"
-    val exp = (Math.log(bytes.toDouble()) / Math.log(unit.toDouble())).toInt()
+    val exp = (ln(bytes.toDouble()) / ln(unit.toDouble())).toInt()
     val pre = (if (si) "kMGTPE" else "KMGTPE")[exp - 1] + if (si) "" else "i"
-    return String.format("%.1f %sB", bytes / Math.pow(unit.toDouble(), exp.toDouble()), pre)
+    return String.format("%.1f %sB", bytes / unit.toDouble().pow(exp.toDouble()), pre)
   }
 
   private fun leakTraceAsString(showLeakingStatus: Boolean): String {


### PR DESCRIPTION
Here follows a first proposal of #1956 "Display retain object size using human readable output" solution.
Could be used as a basis for further discussion on best implementation.

For now, `humanReadableByteCount` is duplicated in `:shark` and `:leakcanary-android-core`.