### PR TITLE
Add Kotlin Binary compatibility validator tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
       detekt: 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.6.0',
       junit: 'junit:junit:4.12',
       kotlin: [
+          binaryCompatibilityValidatorPlugin: "org.jetbrains.kotlinx:binary-compatibility-validator:0.2.3",
           gradlePlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
           stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
           reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
@@ -47,6 +48,8 @@ buildscript {
     google()
     maven { url 'https://plugins.gradle.org/m2/' }
     jcenter()
+    // For binary compatibility validator.
+    maven { url "https://kotlin.bintray.com/kotlinx" }
   }
   dependencies {
     classpath deps.kotlin.gradlePlugin
@@ -55,7 +58,20 @@ buildscript {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.18"
     classpath deps.detekt
+    classpath deps.kotlin.binaryCompatibilityValidatorPlugin
   }
+}
+
+// We use JetBrain's Kotlin Binary Compatibility Validator to track changes to our public binary
+// APIs.
+// When making a change that results in a public ABI change, the apiCheck task will fail. When this
+// happens, run ./gradlew apiDump to generate updated *.api files, and add those to your commit.
+// See https://github.com/Kotlin/binary-compatibility-validator
+apply plugin: 'binary-compatibility-validator'
+
+apiValidation {
+  // Ignore all sample projects, since they're not part of our API.
+  ignoredProjects += ["leakcanary-android-sample"]
 }
 
 subprojects {

--- a/leakcanary-android-core/api/leakcanary-android-core.api
+++ b/leakcanary-android-core/api/leakcanary-android-core.api
@@ -1,0 +1,91 @@
+public final class com/squareup/leakcanary/core/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field GIT_SHA Ljava/lang/String;
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field LIBRARY_VERSION Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class leakcanary/DefaultOnHeapAnalyzedListener : leakcanary/OnHeapAnalyzedListener {
+	public static final field Companion Lleakcanary/DefaultOnHeapAnalyzedListener$Companion;
+	public fun <init> (Landroid/app/Application;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun onHeapAnalyzed (Lshark/HeapAnalysis;)V
+}
+
+public final class leakcanary/DefaultOnHeapAnalyzedListener$Companion {
+	public final fun create ()Lleakcanary/OnHeapAnalyzedListener;
+}
+
+public final class leakcanary/LeakCanary {
+	public static final field INSTANCE Lleakcanary/LeakCanary;
+	public final fun dumpHeap ()V
+	public static final fun getConfig ()Lleakcanary/LeakCanary$Config;
+	public final fun newLeakDisplayActivityIntent ()Landroid/content/Intent;
+	public static final fun setConfig (Lleakcanary/LeakCanary$Config;)V
+	public final fun showLeakDisplayActivityLauncherIcon (Z)V
+}
+
+public final class leakcanary/LeakCanary$Config {
+	public fun <init> ()V
+	public fun <init> (ZZILjava/util/List;Ljava/util/List;Lleakcanary/OnHeapAnalyzedListener;Lshark/MetadataExtractor;ZIZLshark/LeakingObjectFinder;Z)V
+	public synthetic fun <init> (ZZILjava/util/List;Ljava/util/List;Lleakcanary/OnHeapAnalyzedListener;Lshark/MetadataExtractor;ZIZLshark/LeakingObjectFinder;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Z
+	public final fun component11 ()Lshark/LeakingObjectFinder;
+	public final fun component12 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lleakcanary/OnHeapAnalyzedListener;
+	public final fun component7 ()Lshark/MetadataExtractor;
+	public final fun component8 ()Z
+	public final fun component9 ()I
+	public final fun copy (ZZILjava/util/List;Ljava/util/List;Lleakcanary/OnHeapAnalyzedListener;Lshark/MetadataExtractor;ZIZLshark/LeakingObjectFinder;Z)Lleakcanary/LeakCanary$Config;
+	public static synthetic fun copy$default (Lleakcanary/LeakCanary$Config;ZZILjava/util/List;Ljava/util/List;Lleakcanary/OnHeapAnalyzedListener;Lshark/MetadataExtractor;ZIZLshark/LeakingObjectFinder;ZILjava/lang/Object;)Lleakcanary/LeakCanary$Config;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComputeRetainedHeapSize ()Z
+	public final fun getDumpHeap ()Z
+	public final fun getDumpHeapWhenDebugging ()Z
+	public final fun getLeakingObjectFinder ()Lshark/LeakingObjectFinder;
+	public final fun getMaxStoredHeapDumps ()I
+	public final fun getMetadataExtractor ()Lshark/MetadataExtractor;
+	public final fun getObjectInspectors ()Ljava/util/List;
+	public final fun getOnHeapAnalyzedListener ()Lleakcanary/OnHeapAnalyzedListener;
+	public final fun getReferenceMatchers ()Ljava/util/List;
+	public final fun getRequestWriteExternalStoragePermission ()Z
+	public final fun getRetainedVisibleThreshold ()I
+	public final fun getUseExperimentalLeakFinders ()Z
+	public fun hashCode ()I
+	public final fun newBuilder ()Lleakcanary/LeakCanary$Config$Builder;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class leakcanary/LeakCanary$Config$Builder {
+	public final fun build ()Lleakcanary/LeakCanary$Config;
+	public final fun computeRetainedHeapSize (Z)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun dumpHeap (Z)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun dumpHeapWhenDebugging (Z)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun leakingObjectFinder (Lshark/LeakingObjectFinder;)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun maxStoredHeapDumps (I)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun metadataExtractor (Lshark/MetadataExtractor;)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun objectInspectors (Ljava/util/List;)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun onHeapAnalyzedListener (Lleakcanary/OnHeapAnalyzedListener;)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun referenceMatchers (Ljava/util/List;)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun requestWriteExternalStoragePermission (Z)Lleakcanary/LeakCanary$Config$Builder;
+	public final fun retainedVisibleThreshold (I)Lleakcanary/LeakCanary$Config$Builder;
+}
+
+public abstract interface class leakcanary/OnHeapAnalyzedListener {
+	public static final field Companion Lleakcanary/OnHeapAnalyzedListener$Companion;
+	public abstract fun onHeapAnalyzed (Lshark/HeapAnalysis;)V
+}
+
+public final class leakcanary/OnHeapAnalyzedListener$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lleakcanary/OnHeapAnalyzedListener;
+}
+

--- a/leakcanary-android-instrumentation/api/leakcanary-android-instrumentation.api
+++ b/leakcanary-android-instrumentation/api/leakcanary-android-instrumentation.api
@@ -1,0 +1,52 @@
+public final class com/squareup/leakcanary/instrumentation/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class leakcanary/FailAnnotatedTestOnLeakRunListener : leakcanary/FailTestOnLeakRunListener {
+	public fun <init> ()V
+}
+
+public abstract interface annotation class leakcanary/FailTestOnLeak : java/lang/annotation/Annotation {
+}
+
+public class leakcanary/FailTestOnLeakRunListener : org/junit/runner/notification/RunListener {
+	public fun <init> ()V
+	protected final fun failTest (Ljava/lang/String;)V
+	protected fun onAnalysisPerformed (Lshark/HeapAnalysis;)V
+	protected fun skipLeakDetectionReason (Lorg/junit/runner/Description;)Ljava/lang/String;
+	public fun testAssumptionFailure (Lorg/junit/runner/notification/Failure;)V
+	public fun testFailure (Lorg/junit/runner/notification/Failure;)V
+	public fun testFinished (Lorg/junit/runner/Description;)V
+	public fun testIgnored (Lorg/junit/runner/Description;)V
+	public fun testRunFinished (Lorg/junit/runner/Result;)V
+	public fun testRunStarted (Lorg/junit/runner/Description;)V
+	public fun testStarted (Lorg/junit/runner/Description;)V
+}
+
+public final class leakcanary/InstrumentationLeakDetector {
+	public static final field Companion Lleakcanary/InstrumentationLeakDetector$Companion;
+	public fun <init> ()V
+	public final fun detectLeaks ()Lleakcanary/InstrumentationLeakDetector$Result;
+}
+
+public final class leakcanary/InstrumentationLeakDetector$Companion {
+	public final fun updateConfig ()V
+}
+
+public abstract class leakcanary/InstrumentationLeakDetector$Result {
+}
+
+public final class leakcanary/InstrumentationLeakDetector$Result$AnalysisPerformed : leakcanary/InstrumentationLeakDetector$Result {
+	public fun <init> (Lshark/HeapAnalysis;)V
+	public final fun getHeapAnalysis ()Lshark/HeapAnalysis;
+}
+
+public final class leakcanary/InstrumentationLeakDetector$Result$NoAnalysis : leakcanary/InstrumentationLeakDetector$Result {
+	public static final field INSTANCE Lleakcanary/InstrumentationLeakDetector$Result$NoAnalysis;
+}
+

--- a/leakcanary-android-process/api/leakcanary-android-process.api
+++ b/leakcanary-android-process/api/leakcanary-android-process.api
@@ -1,0 +1,14 @@
+public final class com/squareup/leakcanary/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class leakcanary/LeakCanaryProcess {
+	public static final field INSTANCE Lleakcanary/LeakCanaryProcess;
+	public final fun isInAnalyzerProcess (Landroid/content/Context;)Z
+}
+

--- a/leakcanary-deobfuscation-gradle-plugin/api/leakcanary-deobfuscation-gradle-plugin.api
+++ b/leakcanary-deobfuscation-gradle-plugin/api/leakcanary-deobfuscation-gradle-plugin.api
@@ -1,0 +1,24 @@
+public class com/squareup/leakcanary/deobfuscation/CopyObfuscationMappingFileTask : org/gradle/api/DefaultTask {
+	public fun <init> ()V
+	public final fun copyObfuscationMappingFile ()V
+	public final fun getLeakCanaryAssetsOutputFile ()Ljava/io/File;
+	public final fun getMappingFile ()Ljava/io/File;
+	public final fun getMergeAssetsDirectory ()Ljava/io/File;
+	public final fun getVariantName ()Ljava/lang/String;
+	public final fun setMappingFile (Ljava/io/File;)V
+	public final fun setMergeAssetsDirectory (Ljava/io/File;)V
+	public final fun setVariantName (Ljava/lang/String;)V
+}
+
+public class com/squareup/leakcanary/deobfuscation/LeakCanaryDeobfuscationExtension {
+	public fun <init> ()V
+	public final fun getFilterObfuscatedVariants ()Lkotlin/jvm/functions/Function1;
+	public final fun setFilterObfuscatedVariants (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+

--- a/leakcanary-object-watcher-android-androidx/api/leakcanary-object-watcher-android-androidx.api
+++ b/leakcanary-object-watcher-android-androidx/api/leakcanary-object-watcher-android-androidx.api
@@ -1,0 +1,9 @@
+public final class com/squareup/leakcanary/fragments/androidx/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+

--- a/leakcanary-object-watcher-android-support-fragments/api/leakcanary-object-watcher-android-support-fragments.api
+++ b/leakcanary-object-watcher-android-support-fragments/api/leakcanary-object-watcher-android-support-fragments.api
@@ -1,0 +1,9 @@
+public final class com/squareup/leakcanary/fragments/android_support/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+

--- a/leakcanary-object-watcher-android/api/leakcanary-object-watcher-android.api
+++ b/leakcanary-object-watcher-android/api/leakcanary-object-watcher-android.api
@@ -1,0 +1,43 @@
+public final class leakcanary/AppWatcher {
+	public static final field INSTANCE Lleakcanary/AppWatcher;
+	public static final fun getConfig ()Lleakcanary/AppWatcher$Config;
+	public final fun getObjectWatcher ()Lleakcanary/ObjectWatcher;
+	public final fun isInstalled ()Z
+	public final fun manualInstall (Landroid/app/Application;)V
+	public static final fun setConfig (Lleakcanary/AppWatcher$Config;)V
+}
+
+public final class leakcanary/AppWatcher$Config {
+	public fun <init> ()V
+	public fun <init> (ZZZZJZ)V
+	public synthetic fun <init> (ZZZZJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()J
+	public final fun component6 ()Z
+	public final fun copy (ZZZZJZ)Lleakcanary/AppWatcher$Config;
+	public static synthetic fun copy$default (Lleakcanary/AppWatcher$Config;ZZZZJZILjava/lang/Object;)Lleakcanary/AppWatcher$Config;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getWatchActivities ()Z
+	public final fun getWatchDurationMillis ()J
+	public final fun getWatchFragmentViews ()Z
+	public final fun getWatchFragments ()Z
+	public final fun getWatchViewModels ()Z
+	public fun hashCode ()I
+	public final fun newBuilder ()Lleakcanary/AppWatcher$Config$Builder;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class leakcanary/AppWatcher$Config$Builder {
+	public final fun build ()Lleakcanary/AppWatcher$Config;
+	public final fun enabled (Z)Lleakcanary/AppWatcher$Config$Builder;
+	public final fun watchActivities (Z)Lleakcanary/AppWatcher$Config$Builder;
+	public final fun watchDurationMillis (J)Lleakcanary/AppWatcher$Config$Builder;
+	public final fun watchFragmentViews (Z)Lleakcanary/AppWatcher$Config$Builder;
+	public final fun watchFragments (Z)Lleakcanary/AppWatcher$Config$Builder;
+	public final fun watchViewModels (Z)Lleakcanary/AppWatcher$Config$Builder;
+}
+

--- a/leakcanary-object-watcher/api/leakcanary-object-watcher.api
+++ b/leakcanary-object-watcher/api/leakcanary-object-watcher.api
@@ -1,0 +1,59 @@
+public abstract interface class leakcanary/Clock {
+	public static final field Companion Lleakcanary/Clock$Companion;
+	public abstract fun uptimeMillis ()J
+}
+
+public final class leakcanary/Clock$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function0;)Lleakcanary/Clock;
+}
+
+public abstract interface class leakcanary/GcTrigger {
+	public abstract fun runGc ()V
+}
+
+public final class leakcanary/GcTrigger$Default : leakcanary/GcTrigger {
+	public static final field INSTANCE Lleakcanary/GcTrigger$Default;
+	public fun runGc ()V
+}
+
+public final class leakcanary/KeyedWeakReference : java/lang/ref/WeakReference {
+	public static final field Companion Lleakcanary/KeyedWeakReference$Companion;
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;JLjava/lang/ref/ReferenceQueue;)V
+	public final fun getDescription ()Ljava/lang/String;
+	public static final fun getHeapDumpUptimeMillis ()J
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getRetainedUptimeMillis ()J
+	public final fun getWatchUptimeMillis ()J
+	public static final fun setHeapDumpUptimeMillis (J)V
+	public final fun setRetainedUptimeMillis (J)V
+}
+
+public final class leakcanary/KeyedWeakReference$Companion {
+	public final fun getHeapDumpUptimeMillis ()J
+	public final fun setHeapDumpUptimeMillis (J)V
+}
+
+public final class leakcanary/ObjectWatcher {
+	public fun <init> (Lleakcanary/Clock;Ljava/util/concurrent/Executor;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lleakcanary/Clock;Ljava/util/concurrent/Executor;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addOnObjectRetainedListener (Lleakcanary/OnObjectRetainedListener;)V
+	public final fun clearObjectsWatchedBefore (J)V
+	public final fun clearWatchedObjects ()V
+	public final fun getHasRetainedObjects ()Z
+	public final fun getHasWatchedObjects ()Z
+	public final fun getRetainedObjectCount ()I
+	public final fun getRetainedObjects ()Ljava/util/List;
+	public final fun removeOnObjectRetainedListener (Lleakcanary/OnObjectRetainedListener;)V
+	public final fun watch (Ljava/lang/Object;)V
+	public final fun watch (Ljava/lang/Object;Ljava/lang/String;)V
+}
+
+public abstract interface class leakcanary/OnObjectRetainedListener {
+	public static final field Companion Lleakcanary/OnObjectRetainedListener$Companion;
+	public abstract fun onObjectRetained ()V
+}
+
+public final class leakcanary/OnObjectRetainedListener$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function0;)Lleakcanary/OnObjectRetainedListener;
+}
+

--- a/plumber-android/api/plumber-android.api
+++ b/plumber-android/api/plumber-android.api
@@ -1,0 +1,38 @@
+public final class com/squareup/leakcanary/plumber/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public abstract class leakcanary/AndroidLeakFixes : java/lang/Enum {
+	public static final field ACCESSIBILITY_NODE_INFO Lleakcanary/AndroidLeakFixes;
+	public static final field ACTIVITY_MANAGER Lleakcanary/AndroidLeakFixes;
+	public static final field BUBBLE_POPUP Lleakcanary/AndroidLeakFixes;
+	public static final field CONNECTIVITY_MANAGER Lleakcanary/AndroidLeakFixes;
+	public static final field Companion Lleakcanary/AndroidLeakFixes$Companion;
+	public static final field FLUSH_HANDLER_THREADS Lleakcanary/AndroidLeakFixes;
+	public static final field LAST_HOVERED_VIEW Lleakcanary/AndroidLeakFixes;
+	public static final field MEDIA_SESSION_LEGACY_HELPER Lleakcanary/AndroidLeakFixes;
+	public static final field SAMSUNG_CLIPBOARD_MANAGER Lleakcanary/AndroidLeakFixes;
+	public static final field TEXT_LINE_POOL Lleakcanary/AndroidLeakFixes;
+	public static final field USER_MANAGER Lleakcanary/AndroidLeakFixes;
+	public static final field VIEW_LOCATION_HOLDER Lleakcanary/AndroidLeakFixes;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected abstract fun apply (Landroid/app/Application;)V
+	public static fun valueOf (Ljava/lang/String;)Lleakcanary/AndroidLeakFixes;
+	public static fun values ()[Lleakcanary/AndroidLeakFixes;
+}
+
+public final class leakcanary/AndroidLeakFixes$Companion {
+	public final fun applyFixes (Landroid/app/Application;Ljava/util/Set;)V
+	public static synthetic fun applyFixes$default (Lleakcanary/AndroidLeakFixes$Companion;Landroid/app/Application;Ljava/util/Set;ILjava/lang/Object;)V
+}
+
+public final class leakcanary/ViewLocationHolderLeakFix {
+	public static final field INSTANCE Lleakcanary/ViewLocationHolderLeakFix;
+	public final fun clearStaticPool (Landroid/app/Application;)V
+}
+

--- a/shark-android/api/shark-android.api
+++ b/shark-android/api/shark-android.api
@@ -1,0 +1,168 @@
+public final class shark/AndroidBuildMirror {
+	public static final field Companion Lshark/AndroidBuildMirror$Companion;
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun getManufacturer ()Ljava/lang/String;
+	public final fun getSdkInt ()I
+}
+
+public final class shark/AndroidBuildMirror$Companion {
+	public final fun fromHeapGraph (Lshark/HeapGraph;)Lshark/AndroidBuildMirror;
+}
+
+public final class shark/AndroidMetadataExtractor : shark/MetadataExtractor {
+	public static final field INSTANCE Lshark/AndroidMetadataExtractor;
+	public fun extractMetadata (Lshark/HeapGraph;)Ljava/util/Map;
+}
+
+public abstract class shark/AndroidObjectInspectors : java/lang/Enum, shark/ObjectInspector {
+	public static final field ACTIVITY Lshark/AndroidObjectInspectors;
+	public static final field ANDROIDX_FRAGMENT Lshark/AndroidObjectInspectors;
+	public static final field APPLICATION Lshark/AndroidObjectInspectors;
+	public static final field APPLICATION_PACKAGE_MANAGER Lshark/AndroidObjectInspectors;
+	public static final field CONTEXT_FIELD Lshark/AndroidObjectInspectors;
+	public static final field CONTEXT_IMPL Lshark/AndroidObjectInspectors;
+	public static final field CONTEXT_WRAPPER Lshark/AndroidObjectInspectors;
+	public static final field COORDINATOR Lshark/AndroidObjectInspectors;
+	public static final field Companion Lshark/AndroidObjectInspectors$Companion;
+	public static final field DIALOG Lshark/AndroidObjectInspectors;
+	public static final field EDITOR Lshark/AndroidObjectInspectors;
+	public static final field FRAGMENT Lshark/AndroidObjectInspectors;
+	public static final field INPUT_METHOD_MANAGER Lshark/AndroidObjectInspectors;
+	public static final field MAIN_THREAD Lshark/AndroidObjectInspectors;
+	public static final field MESSAGE Lshark/AndroidObjectInspectors;
+	public static final field MESSAGE_QUEUE Lshark/AndroidObjectInspectors;
+	public static final field MORTAR_PRESENTER Lshark/AndroidObjectInspectors;
+	public static final field MORTAR_SCOPE Lshark/AndroidObjectInspectors;
+	public static final field SUPPORT_FRAGMENT Lshark/AndroidObjectInspectors;
+	public static final field TOAST Lshark/AndroidObjectInspectors;
+	public static final field VIEW Lshark/AndroidObjectInspectors;
+	public static final field VIEW_ROOT_IMPL Lshark/AndroidObjectInspectors;
+	public static final field WINDOW Lshark/AndroidObjectInspectors;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static fun valueOf (Ljava/lang/String;)Lshark/AndroidObjectInspectors;
+	public static fun values ()[Lshark/AndroidObjectInspectors;
+}
+
+public final class shark/AndroidObjectInspectors$Companion {
+	public final fun createLeakingObjectFilters (Ljava/util/Set;)Ljava/util/List;
+	public final fun getAppDefaults ()Ljava/util/List;
+	public final fun getAppLeakingObjectFilters ()Ljava/util/List;
+}
+
+public abstract class shark/AndroidReferenceMatchers : java/lang/Enum {
+	public static final field ACCESSIBILITY_ITERATORS Lshark/AndroidReferenceMatchers;
+	public static final field ACCESSIBILITY_NODE_ID_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field ACCESSIBILITY_NODE_INFO__MORIGINALTEXT Lshark/AndroidReferenceMatchers;
+	public static final field ACCOUNT_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field ACTIVITY_CHOOSE_MODEL Lshark/AndroidReferenceMatchers;
+	public static final field ACTIVITY_CLIENT_RECORD__NEXT_IDLE Lshark/AndroidReferenceMatchers;
+	public static final field ACTIVITY_MANAGER_MCONTEXT Lshark/AndroidReferenceMatchers;
+	public static final field APP_WIDGET_HOST_CALLBACKS Lshark/AndroidReferenceMatchers;
+	public static final field ASSIST_STRUCTURE Lshark/AndroidReferenceMatchers;
+	public static final field AUDIO_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field AUDIO_MANAGER__MCONTEXT_STATIC Lshark/AndroidReferenceMatchers;
+	public static final field AW_RESOURCE__SRESOURCES Lshark/AndroidReferenceMatchers;
+	public static final field BACKDROP_FRAME_RENDERER__MDECORVIEW Lshark/AndroidReferenceMatchers;
+	public static final field BIOMETRIC_PROMPT Lshark/AndroidReferenceMatchers;
+	public static final field BLOCKING_QUEUE Lshark/AndroidReferenceMatchers;
+	public static final field BUBBLE_POPUP_HELPER__SHELPER Lshark/AndroidReferenceMatchers;
+	public static final field CLIPBOARD_EX_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field CLIPBOARD_UI_MANAGER__SINSTANCE Lshark/AndroidReferenceMatchers;
+	public static final field CONNECTIVITY_MANAGER__SINSTANCE Lshark/AndroidReferenceMatchers;
+	public static final field CONTROLLED_INPUT_CONNECTION_WRAPPER Lshark/AndroidReferenceMatchers;
+	public static final field Companion Lshark/AndroidReferenceMatchers$Companion;
+	public static final field DEVICE_POLICY_MANAGER__SETTINGS_OBSERVER Lshark/AndroidReferenceMatchers;
+	public static final field EDITTEXT_BLINK_MESSAGEQUEUE Lshark/AndroidReferenceMatchers;
+	public static final field EVENT_RECEIVER__MMESSAGE_QUEUE Lshark/AndroidReferenceMatchers;
+	public static final field EXTENDED_STATUS_BAR_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field FINALIZER_WATCHDOG_DAEMON Lshark/AndroidReferenceMatchers;
+	public static final field GESTURE_BOOST_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field HUAWEI Ljava/lang/String;
+	public static final field INPUT_METHOD_MANAGER_IS_TERRIBLE Lshark/AndroidReferenceMatchers;
+	public static final field INSTRUMENTATION_RECOMMEND_ACTIVITY Lshark/AndroidReferenceMatchers;
+	public static final field IREQUEST_FINISH_CALLBACK Lshark/AndroidReferenceMatchers;
+	public static final field LAYOUT_TRANSITION Lshark/AndroidReferenceMatchers;
+	public static final field LEAK_CANARY_HEAP_DUMPER Lshark/AndroidReferenceMatchers;
+	public static final field LEAK_CANARY_INTERNAL Lshark/AndroidReferenceMatchers;
+	public static final field LEAK_CANARY_THREAD Lshark/AndroidReferenceMatchers;
+	public static final field LENOVO Ljava/lang/String;
+	public static final field LG Ljava/lang/String;
+	public static final field LGCONTEXT__MCONTEXT Lshark/AndroidReferenceMatchers;
+	public static final field MAGNIFIER Lshark/AndroidReferenceMatchers;
+	public static final field MAIN Lshark/AndroidReferenceMatchers;
+	public static final field MAPPER_CLIENT Lshark/AndroidReferenceMatchers;
+	public static final field MEDIA_PROJECTION_CALLBACK Lshark/AndroidReferenceMatchers;
+	public static final field MEDIA_SCANNER_CONNECTION Lshark/AndroidReferenceMatchers;
+	public static final field MEDIA_SESSION_LEGACY_HELPER__SINSTANCE Lshark/AndroidReferenceMatchers;
+	public static final field MEIZU Ljava/lang/String;
+	public static final field MOTOROLA Ljava/lang/String;
+	public static final field MULTI_WINDOW_DECOR_SUPPORT__MWINDOW Lshark/AndroidReferenceMatchers;
+	public static final field NVIDIA Ljava/lang/String;
+	public static final field OEM_SCENE_CALL_BLOCKER Lshark/AndroidReferenceMatchers;
+	public static final field ONE_PLUS Ljava/lang/String;
+	public static final field PERSONA_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field RAZER Ljava/lang/String;
+	public static final field RAZER_TEXT_KEY_LISTENER__MCONTEXT Lshark/AndroidReferenceMatchers;
+	public static final field REFERENCES Lshark/AndroidReferenceMatchers;
+	public static final field RESOURCES__MCONTEXT Lshark/AndroidReferenceMatchers;
+	public static final field SAMSUNG Ljava/lang/String;
+	public static final field SEM_APP_ICON_SOLUTION Lshark/AndroidReferenceMatchers;
+	public static final field SEM_CLIPBOARD_MANAGER__MCONTEXT Lshark/AndroidReferenceMatchers;
+	public static final field SEM_EMERGENCY_MANAGER__MCONTEXT Lshark/AndroidReferenceMatchers;
+	public static final field SEM_PERSONA_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field SHARP Ljava/lang/String;
+	public static final field SMART_COVER_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field SPAN_CONTROLLER Lshark/AndroidReferenceMatchers;
+	public static final field SPEECH_RECOGNIZER Lshark/AndroidReferenceMatchers;
+	public static final field SPELL_CHECKER Lshark/AndroidReferenceMatchers;
+	public static final field SPELL_CHECKER_SESSION Lshark/AndroidReferenceMatchers;
+	public static final field SPEN_GESTURE_MANAGER Lshark/AndroidReferenceMatchers;
+	public static final field STATIC_MTARGET_VIEW Lshark/AndroidReferenceMatchers;
+	public static final field SYSTEM_SENSOR_MANAGER__MAPPCONTEXTIMPL Lshark/AndroidReferenceMatchers;
+	public static final field TEXT_LINE__SCACHED Lshark/AndroidReferenceMatchers;
+	public static final field TEXT_TO_SPEECH Lshark/AndroidReferenceMatchers;
+	public static final field TEXT_VIEW__MLAST_HOVERED_VIEW Lshark/AndroidReferenceMatchers;
+	public static final field TOAST_TN Lshark/AndroidReferenceMatchers;
+	public static final field USER_MANAGER__SINSTANCE Lshark/AndroidReferenceMatchers;
+	public static final field VIEWLOCATIONHOLDER_ROOT Lshark/AndroidReferenceMatchers;
+	public static final field VIEW_CONFIGURATION__MCONTEXT Lshark/AndroidReferenceMatchers;
+	public static final field VIVO Ljava/lang/String;
+	public static final field WINDOW_MANAGER_GLOBAL Lshark/AndroidReferenceMatchers;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun buildKnownReferences (Ljava/util/Set;)Ljava/util/List;
+	public static final fun getAppDefaults ()Ljava/util/List;
+	public static final fun getIgnoredReferencesOnly ()Ljava/util/List;
+	public static final fun ignoredInstanceField (Ljava/lang/String;Ljava/lang/String;)Lshark/IgnoredReferenceMatcher;
+	public static final fun ignoredJavaLocal (Ljava/lang/String;)Lshark/IgnoredReferenceMatcher;
+	public static final fun instanceFieldLeak (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/LibraryLeakReferenceMatcher;
+	public static final fun nativeGlobalVariableLeak (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/LibraryLeakReferenceMatcher;
+	public static final fun staticFieldLeak (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/LibraryLeakReferenceMatcher;
+	public static fun valueOf (Ljava/lang/String;)Lshark/AndroidReferenceMatchers;
+	public static fun values ()[Lshark/AndroidReferenceMatchers;
+}
+
+public final class shark/AndroidReferenceMatchers$Companion {
+	public final fun buildKnownReferences (Ljava/util/Set;)Ljava/util/List;
+	public final fun getAppDefaults ()Ljava/util/List;
+	public final fun getIgnoredReferencesOnly ()Ljava/util/List;
+	public final fun ignoredInstanceField (Ljava/lang/String;Ljava/lang/String;)Lshark/IgnoredReferenceMatcher;
+	public final fun ignoredJavaLocal (Ljava/lang/String;)Lshark/IgnoredReferenceMatcher;
+	public final fun instanceFieldLeak (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/LibraryLeakReferenceMatcher;
+	public static synthetic fun instanceFieldLeak$default (Lshark/AndroidReferenceMatchers$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lshark/LibraryLeakReferenceMatcher;
+	public final fun nativeGlobalVariableLeak (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/LibraryLeakReferenceMatcher;
+	public static synthetic fun nativeGlobalVariableLeak$default (Lshark/AndroidReferenceMatchers$Companion;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lshark/LibraryLeakReferenceMatcher;
+	public final fun staticFieldLeak (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/LibraryLeakReferenceMatcher;
+	public static synthetic fun staticFieldLeak$default (Lshark/AndroidReferenceMatchers$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lshark/LibraryLeakReferenceMatcher;
+}
+
+public final class shark/AndroidResourceIdNames {
+	public static final field Companion Lshark/AndroidResourceIdNames$Companion;
+	public synthetic fun <init> ([I[Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun get (I)Ljava/lang/String;
+}
+
+public final class shark/AndroidResourceIdNames$Companion {
+	public final fun readFromHeap (Lshark/HeapGraph;)Lshark/AndroidResourceIdNames;
+	public final fun saveToMemory (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+}
+

--- a/shark-cli/api/shark-cli.api
+++ b/shark-cli/api/shark-cli.api
@@ -1,0 +1,99 @@
+public final class shark/AnalyzeCommand : com/github/ajalt/clikt/core/CliktCommand {
+	public static final field Companion Lshark/AnalyzeCommand$Companion;
+	public fun <init> ()V
+	public fun run ()V
+}
+
+public final class shark/AnalyzeCommand$Companion {
+	public final fun analyze (Lcom/github/ajalt/clikt/core/CliktCommand;Ljava/io/File;Ljava/io/File;)V
+}
+
+public final class shark/DeobfuscateHprofCommand : com/github/ajalt/clikt/core/CliktCommand {
+	public fun <init> ()V
+	public fun run ()V
+}
+
+public final class shark/DumpProcessCommand : com/github/ajalt/clikt/core/CliktCommand {
+	public static final field Companion Lshark/DumpProcessCommand$Companion;
+	public fun <init> ()V
+	public fun run ()V
+}
+
+public final class shark/DumpProcessCommand$Companion {
+	public final fun dumpHeap (Lcom/github/ajalt/clikt/core/CliktCommand;Ljava/lang/String;Ljava/lang/String;)Ljava/io/File;
+}
+
+public final class shark/InteractiveCommand : com/github/ajalt/clikt/core/CliktCommand {
+	public fun <init> ()V
+	public fun run ()V
+}
+
+public final class shark/InteractiveCommand$COMMAND : java/lang/Enum {
+	public static final field ANALYZE Lshark/InteractiveCommand$COMMAND;
+	public static final field ARRAY Lshark/InteractiveCommand$COMMAND;
+	public static final field CLASS Lshark/InteractiveCommand$COMMAND;
+	public static final field Companion Lshark/InteractiveCommand$COMMAND$Companion;
+	public static final field DETAILED_PATH_TO_INSTANCE Lshark/InteractiveCommand$COMMAND;
+	public static final field EXIT Lshark/InteractiveCommand$COMMAND;
+	public static final field HELP Lshark/InteractiveCommand$COMMAND;
+	public static final field INSTANCE Lshark/InteractiveCommand$COMMAND;
+	public static final field PATH_TO_INSTANCE Lshark/InteractiveCommand$COMMAND;
+	public final fun getCommandName ()Ljava/lang/String;
+	public final fun getHelp ()Ljava/lang/String;
+	public final fun getPattern ()Ljava/lang/String;
+	public final fun getPatternHelp ()Ljava/lang/String;
+	public final fun getSuffix ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lshark/InteractiveCommand$COMMAND;
+	public static fun values ()[Lshark/InteractiveCommand$COMMAND;
+}
+
+public final class shark/InteractiveCommand$COMMAND$Companion {
+	public final fun matchesCommand (Ljava/lang/String;Lshark/InteractiveCommand$COMMAND;)Z
+}
+
+public final class shark/MainKt {
+	public static final fun main ([Ljava/lang/String;)V
+}
+
+public final class shark/SharkCliCommand : com/github/ajalt/clikt/core/CliktCommand {
+	public static final field Companion Lshark/SharkCliCommand$Companion;
+	public fun <init> ()V
+	public fun run ()V
+}
+
+public final class shark/SharkCliCommand$CommandParams {
+	public fun <init> (Lshark/SharkCliCommand$HeapDumpSource;Ljava/io/File;)V
+	public final fun getObfuscationMappingPath ()Ljava/io/File;
+	public final fun getSource ()Lshark/SharkCliCommand$HeapDumpSource;
+}
+
+public final class shark/SharkCliCommand$Companion {
+	public final fun echo (Lcom/github/ajalt/clikt/core/CliktCommand;Ljava/lang/Object;ZZLjava/lang/String;)V
+	public static synthetic fun echo$default (Lshark/SharkCliCommand$Companion;Lcom/github/ajalt/clikt/core/CliktCommand;Ljava/lang/Object;ZZLjava/lang/String;ILjava/lang/Object;)V
+	public final fun echoNewline (Lcom/github/ajalt/clikt/core/CliktCommand;)V
+	public final fun getSharkCliParams (Lcom/github/ajalt/clikt/core/Context;)Lshark/SharkCliCommand$CommandParams;
+	public final fun retrieveHeapDumpFile (Lcom/github/ajalt/clikt/core/CliktCommand;Lshark/SharkCliCommand$CommandParams;)Ljava/io/File;
+	public final fun runCommand (Ljava/io/File;[Ljava/lang/String;)Ljava/lang/String;
+	public final fun setSharkCliParams (Lcom/github/ajalt/clikt/core/Context;Lshark/SharkCliCommand$CommandParams;)V
+}
+
+public abstract class shark/SharkCliCommand$HeapDumpSource {
+}
+
+public final class shark/SharkCliCommand$HeapDumpSource$HprofFileSource : shark/SharkCliCommand$HeapDumpSource {
+	public fun <init> (Ljava/io/File;)V
+	public final fun getFile ()Ljava/io/File;
+}
+
+public final class shark/SharkCliCommand$HeapDumpSource$ProcessSource : shark/SharkCliCommand$HeapDumpSource {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getDeviceId ()Ljava/lang/String;
+	public final fun getProcessName ()Ljava/lang/String;
+}
+
+public final class shark/StripHprofCommand : com/github/ajalt/clikt/core/CliktCommand {
+	public fun <init> ()V
+	public fun run ()V
+}
+

--- a/shark-graph/api/shark-graph.api
+++ b/shark-graph/api/shark-graph.api
@@ -1,0 +1,215 @@
+public abstract interface class shark/CloseableHeapGraph : java/io/Closeable, shark/HeapGraph {
+}
+
+public final class shark/GraphContext {
+	public fun <init> ()V
+	public final fun contains (Ljava/lang/String;)Z
+	public final fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun getOrPut (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun minusAssign (Ljava/lang/String;)V
+	public final fun set (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public final class shark/HeapField {
+	public fun <init> (Lshark/HeapObject$HeapClass;Ljava/lang/String;Lshark/HeapValue;)V
+	public final fun getDeclaringClass ()Lshark/HeapObject$HeapClass;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Lshark/HeapValue;
+	public final fun getValueAsClass ()Lshark/HeapObject$HeapClass;
+	public final fun getValueAsInstance ()Lshark/HeapObject$HeapInstance;
+	public final fun getValueAsObjectArray ()Lshark/HeapObject$HeapObjectArray;
+	public final fun getValueAsPrimitiveArray ()Lshark/HeapObject$HeapPrimitiveArray;
+}
+
+public abstract interface class shark/HeapGraph {
+	public abstract fun findClassByName (Ljava/lang/String;)Lshark/HeapObject$HeapClass;
+	public abstract fun findObjectById (J)Lshark/HeapObject;
+	public abstract fun findObjectByIdOrNull (J)Lshark/HeapObject;
+	public abstract fun findObjectByIndex (I)Lshark/HeapObject;
+	public abstract fun getClassCount ()I
+	public abstract fun getClasses ()Lkotlin/sequences/Sequence;
+	public abstract fun getContext ()Lshark/GraphContext;
+	public abstract fun getGcRoots ()Ljava/util/List;
+	public abstract fun getIdentifierByteSize ()I
+	public abstract fun getInstanceCount ()I
+	public abstract fun getInstances ()Lkotlin/sequences/Sequence;
+	public abstract fun getObjectArrayCount ()I
+	public abstract fun getObjectArrays ()Lkotlin/sequences/Sequence;
+	public abstract fun getObjectCount ()I
+	public abstract fun getObjects ()Lkotlin/sequences/Sequence;
+	public abstract fun getPrimitiveArrayCount ()I
+	public abstract fun getPrimitiveArrays ()Lkotlin/sequences/Sequence;
+	public abstract fun objectExists (J)Z
+}
+
+public abstract class shark/HeapObject {
+	public static final field Companion Lshark/HeapObject$Companion;
+	public final fun getAsClass ()Lshark/HeapObject$HeapClass;
+	public final fun getAsInstance ()Lshark/HeapObject$HeapInstance;
+	public final fun getAsObjectArray ()Lshark/HeapObject$HeapObjectArray;
+	public final fun getAsPrimitiveArray ()Lshark/HeapObject$HeapPrimitiveArray;
+	public abstract fun getGraph ()Lshark/HeapGraph;
+	public abstract fun getObjectId ()J
+	public abstract fun getObjectIndex ()I
+	public abstract fun getRecordSize ()I
+	public abstract fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord;
+}
+
+public final class shark/HeapObject$Companion {
+}
+
+public final class shark/HeapObject$HeapClass : shark/HeapObject {
+	public final fun get (Ljava/lang/String;)Lshark/HeapField;
+	public final fun getClassHierarchy ()Lkotlin/sequences/Sequence;
+	public final fun getDirectInstances ()Lkotlin/sequences/Sequence;
+	public fun getGraph ()Lshark/HeapGraph;
+	public final fun getHasReferenceInstanceFields ()Z
+	public final fun getInstanceByteSize ()I
+	public final fun getInstances ()Lkotlin/sequences/Sequence;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getObjectArrayInstances ()Lkotlin/sequences/Sequence;
+	public fun getObjectId ()J
+	public fun getObjectIndex ()I
+	public final fun getPrimitiveArrayInstances ()Lkotlin/sequences/Sequence;
+	public fun getRecordSize ()I
+	public final fun getSimpleName ()Ljava/lang/String;
+	public final fun getSubclasses ()Lkotlin/sequences/Sequence;
+	public final fun getSuperclass ()Lshark/HeapObject$HeapClass;
+	public final fun instanceFieldName (Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$FieldRecord;)Ljava/lang/String;
+	public final fun isArrayClass ()Z
+	public final fun isObjectArrayClass ()Z
+	public final fun isPrimitiveArrayClass ()Z
+	public final fun isPrimitiveWrapperClass ()Z
+	public final fun readFieldsByteSize ()I
+	public fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord;
+	public synthetic fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord;
+	public final fun readRecordFields ()Ljava/util/List;
+	public final fun readRecordStaticFields ()Ljava/util/List;
+	public final fun readStaticField (Ljava/lang/String;)Lshark/HeapField;
+	public final fun readStaticFields ()Lkotlin/sequences/Sequence;
+	public final fun subclassOf (Lshark/HeapObject$HeapClass;)Z
+	public final fun superclassOf (Lshark/HeapObject$HeapClass;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapObject$HeapInstance : shark/HeapObject {
+	public final fun get (Ljava/lang/String;Ljava/lang/String;)Lshark/HeapField;
+	public final fun get (Lkotlin/reflect/KClass;Ljava/lang/String;)Lshark/HeapField;
+	public final fun getByteSize ()I
+	public fun getGraph ()Lshark/HeapGraph;
+	public final fun getInstanceClass ()Lshark/HeapObject$HeapClass;
+	public final fun getInstanceClassId ()J
+	public final fun getInstanceClassName ()Ljava/lang/String;
+	public final fun getInstanceClassSimpleName ()Ljava/lang/String;
+	public fun getObjectId ()J
+	public fun getObjectIndex ()I
+	public fun getRecordSize ()I
+	public final fun instanceOf (Ljava/lang/String;)Z
+	public final fun instanceOf (Lkotlin/reflect/KClass;)Z
+	public final fun instanceOf (Lshark/HeapObject$HeapClass;)Z
+	public final fun isPrimitiveWrapper ()Z
+	public final fun readAsJavaString ()Ljava/lang/String;
+	public final fun readField (Ljava/lang/String;Ljava/lang/String;)Lshark/HeapField;
+	public final fun readField (Lkotlin/reflect/KClass;Ljava/lang/String;)Lshark/HeapField;
+	public final fun readFields ()Lkotlin/sequences/Sequence;
+	public fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$InstanceDumpRecord;
+	public synthetic fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapObject$HeapObjectArray : shark/HeapObject {
+	public final fun getArrayClass ()Lshark/HeapObject$HeapClass;
+	public final fun getArrayClassName ()Ljava/lang/String;
+	public final fun getArrayClassSimpleName ()Ljava/lang/String;
+	public fun getGraph ()Lshark/HeapGraph;
+	public fun getObjectId ()J
+	public fun getObjectIndex ()I
+	public fun getRecordSize ()I
+	public final fun readByteSize ()I
+	public final fun readElements ()Lkotlin/sequences/Sequence;
+	public fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ObjectArrayDumpRecord;
+	public synthetic fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapObject$HeapPrimitiveArray : shark/HeapObject {
+	public final fun getArrayClass ()Lshark/HeapObject$HeapClass;
+	public final fun getArrayClassName ()Ljava/lang/String;
+	public fun getGraph ()Lshark/HeapGraph;
+	public fun getObjectId ()J
+	public fun getObjectIndex ()I
+	public final fun getPrimitiveType ()Lshark/PrimitiveType;
+	public fun getRecordSize ()I
+	public final fun readByteSize ()I
+	public fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord;
+	public synthetic fun readRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapValue {
+	public fun <init> (Lshark/HeapGraph;Lshark/ValueHolder;)V
+	public final fun getAsBoolean ()Ljava/lang/Boolean;
+	public final fun getAsByte ()Ljava/lang/Byte;
+	public final fun getAsChar ()Ljava/lang/Character;
+	public final fun getAsDouble ()Ljava/lang/Double;
+	public final fun getAsFloat ()Ljava/lang/Float;
+	public final fun getAsInt ()Ljava/lang/Integer;
+	public final fun getAsLong ()Ljava/lang/Long;
+	public final fun getAsNonNullObjectId ()Ljava/lang/Long;
+	public final fun getAsObject ()Lshark/HeapObject;
+	public final fun getAsObjectId ()Ljava/lang/Long;
+	public final fun getAsShort ()Ljava/lang/Short;
+	public final fun getGraph ()Lshark/HeapGraph;
+	public final fun getHolder ()Lshark/ValueHolder;
+	public final fun isNonNullReference ()Z
+	public final fun isNullReference ()Z
+	public final fun readAsJavaString ()Ljava/lang/String;
+}
+
+public final class shark/HprofHeapGraph : shark/CloseableHeapGraph {
+	public static final field Companion Lshark/HprofHeapGraph$Companion;
+	public fun close ()V
+	public fun findClassByName (Ljava/lang/String;)Lshark/HeapObject$HeapClass;
+	public fun findObjectById (J)Lshark/HeapObject;
+	public fun findObjectByIdOrNull (J)Lshark/HeapObject;
+	public fun findObjectByIndex (I)Lshark/HeapObject;
+	public fun getClassCount ()I
+	public fun getClasses ()Lkotlin/sequences/Sequence;
+	public fun getContext ()Lshark/GraphContext;
+	public fun getGcRoots ()Ljava/util/List;
+	public fun getIdentifierByteSize ()I
+	public fun getInstanceCount ()I
+	public fun getInstances ()Lkotlin/sequences/Sequence;
+	public fun getObjectArrayCount ()I
+	public fun getObjectArrays ()Lkotlin/sequences/Sequence;
+	public fun getObjectCount ()I
+	public fun getObjects ()Lkotlin/sequences/Sequence;
+	public fun getPrimitiveArrayCount ()I
+	public fun getPrimitiveArrays ()Lkotlin/sequences/Sequence;
+	public final fun lruCacheStats ()Ljava/lang/String;
+	public fun objectExists (J)Z
+}
+
+public final class shark/HprofHeapGraph$Companion {
+	public final fun getINTERNAL_LRU_CACHE_SIZE ()I
+	public final fun indexHprof (Lshark/Hprof;Lshark/ProguardMapping;Ljava/util/Set;)Lshark/HeapGraph;
+	public static synthetic fun indexHprof$default (Lshark/HprofHeapGraph$Companion;Lshark/Hprof;Lshark/ProguardMapping;Ljava/util/Set;ILjava/lang/Object;)Lshark/HeapGraph;
+	public final fun openHeapGraph (Ljava/io/File;Lshark/ProguardMapping;Ljava/util/Set;)Lshark/CloseableHeapGraph;
+	public final fun openHeapGraph (Lshark/DualSourceProvider;Lshark/ProguardMapping;Ljava/util/Set;)Lshark/CloseableHeapGraph;
+	public static synthetic fun openHeapGraph$default (Lshark/HprofHeapGraph$Companion;Ljava/io/File;Lshark/ProguardMapping;Ljava/util/Set;ILjava/lang/Object;)Lshark/CloseableHeapGraph;
+	public static synthetic fun openHeapGraph$default (Lshark/HprofHeapGraph$Companion;Lshark/DualSourceProvider;Lshark/ProguardMapping;Ljava/util/Set;ILjava/lang/Object;)Lshark/CloseableHeapGraph;
+	public final fun setINTERNAL_LRU_CACHE_SIZE (I)V
+}
+
+public final class shark/HprofIndex {
+	public static final field Companion Lshark/HprofIndex$Companion;
+	public synthetic fun <init> (Lshark/RandomAccessSourceProvider;Lshark/HprofHeader;Lshark/internal/HprofInMemoryIndex;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun openHeapGraph ()Lshark/CloseableHeapGraph;
+}
+
+public final class shark/HprofIndex$Companion {
+	public final fun defaultIndexedGcRootTags ()Ljava/util/EnumSet;
+	public final fun indexRecordsOf (Lshark/DualSourceProvider;Lshark/HprofHeader;Lshark/ProguardMapping;Ljava/util/Set;)Lshark/HprofIndex;
+	public static synthetic fun indexRecordsOf$default (Lshark/HprofIndex$Companion;Lshark/DualSourceProvider;Lshark/HprofHeader;Lshark/ProguardMapping;Ljava/util/Set;ILjava/lang/Object;)Lshark/HprofIndex;
+}
+

--- a/shark-hprof-test/api/shark-hprof-test.api
+++ b/shark-hprof-test/api/shark-hprof-test.api
@@ -1,0 +1,58 @@
+public final class shark/HprofWriterHelper : java/io/Closeable {
+	public fun <init> (Lshark/HprofWriter;)V
+	public final fun arrayClass (Ljava/lang/String;)J
+	public final fun clazz (Ljava/lang/String;JLjava/util/List;Ljava/util/List;)J
+	public final fun clazz (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)J
+	public final fun clazz (Lshark/HprofRecord$StringRecord;JLjava/util/List;Ljava/util/List;)J
+	public static synthetic fun clazz$default (Lshark/HprofWriterHelper;Ljava/lang/String;JLjava/util/List;Ljava/util/List;ILjava/lang/Object;)J
+	public static synthetic fun clazz$default (Lshark/HprofWriterHelper;Lshark/HprofRecord$StringRecord;JLjava/util/List;Ljava/util/List;ILjava/lang/Object;)J
+	public fun close ()V
+	public final fun gcRoot (Lshark/GcRoot;)V
+	public final fun getCharArrayDump (Ljava/lang/String;)Lshark/ValueHolder$ReferenceHolder;
+	public final fun instance (JLjava/util/List;)Lshark/ValueHolder$ReferenceHolder;
+	public final fun instance (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/ValueHolder$ReferenceHolder;
+	public static synthetic fun instance$default (Lshark/HprofWriterHelper;JLjava/util/List;ILjava/lang/Object;)Lshark/ValueHolder$ReferenceHolder;
+	public final fun keyedWeakReference (Lshark/ValueHolder$ReferenceHolder;)Lshark/ValueHolder$ReferenceHolder;
+	public final fun objectArray (J[J)J
+	public final fun objectArray ([Lshark/ValueHolder$ReferenceHolder;)Lshark/ValueHolder$ReferenceHolder;
+	public final fun objectArrayOf (J[Lshark/ValueHolder$ReferenceHolder;)Lshark/ValueHolder$ReferenceHolder;
+	public final fun string (Ljava/lang/String;)Lshark/ValueHolder$ReferenceHolder;
+	public final fun stringRecord (Ljava/lang/String;)Lshark/HprofRecord$StringRecord;
+	public final fun watchedInstance (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/ValueHolder$ReferenceHolder;
+}
+
+public final class shark/HprofWriterHelper$ClassDefinition {
+	public fun <init> (Lshark/HprofWriterHelper;)V
+	public final fun getStaticField ()Ljava/util/LinkedHashMap;
+}
+
+public final class shark/HprofWriterHelper$InstanceAndClassDefinition {
+	public fun <init> (Lshark/HprofWriterHelper;)V
+	public final fun getField ()Ljava/util/LinkedHashMap;
+	public final fun getStaticField ()Ljava/util/LinkedHashMap;
+}
+
+public final class shark/HprofWriterHelperKt {
+	public static final fun asHprofBytes (Ljava/util/List;)Lshark/DualSourceProvider;
+	public static final fun dump (Ljava/io/File;Lkotlin/jvm/functions/Function1;)V
+	public static final fun dump (Lshark/HprofHeader;Lkotlin/jvm/functions/Function1;)Lshark/DualSourceProvider;
+	public static synthetic fun dump$default (Lshark/HprofHeader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lshark/DualSourceProvider;
+}
+
+public final class shark/ProguardMappingHelper {
+	public fun <init> (Lshark/ProguardMapping;)V
+	public final fun clazz (Lkotlin/Pair;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun clazz$default (Lshark/ProguardMappingHelper;Lkotlin/Pair;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun field (Lshark/ProguardMappingHelper$Class;Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class shark/ProguardMappingHelper$Class {
+	public fun <init> (Lshark/ProguardMappingHelper;Lkotlin/Pair;)V
+	public final fun getFieldMappings ()Ljava/util/Set;
+	public final fun getNameMapping ()Lkotlin/Pair;
+}
+
+public final class shark/ProguardMappingHelperKt {
+	public static final fun create (Lshark/ProguardMapping;Lkotlin/jvm/functions/Function1;)Lshark/ProguardMapping;
+}
+

--- a/shark-hprof/api/shark-hprof.api
+++ b/shark-hprof/api/shark-hprof.api
@@ -1,0 +1,737 @@
+public final class shark/ByteArraySourceProvider : shark/DualSourceProvider {
+	public fun <init> ([B)V
+	public fun openRandomAccessSource ()Lshark/RandomAccessSource;
+	public fun openStreamingSource ()Lokio/BufferedSource;
+}
+
+public final class shark/ConstantMemoryMetricsDualSourceProvider : shark/DualSourceProvider {
+	public fun <init> (Lshark/DualSourceProvider;)V
+	public final fun getByteTravelRange ()J
+	public final fun getRandomAccessByteReads ()J
+	public final fun getRandomAccessByteTravel ()J
+	public final fun getRandomAccessReadCount ()J
+	public fun openRandomAccessSource ()Lshark/RandomAccessSource;
+	public fun openStreamingSource ()Lokio/BufferedSource;
+}
+
+public abstract interface class shark/DualSourceProvider : shark/RandomAccessSourceProvider, shark/StreamingSourceProvider {
+}
+
+public final class shark/FileSourceProvider : shark/DualSourceProvider {
+	public fun <init> (Ljava/io/File;)V
+	public fun openRandomAccessSource ()Lshark/RandomAccessSource;
+	public fun openStreamingSource ()Lokio/BufferedSource;
+}
+
+public abstract class shark/GcRoot {
+	public abstract fun getId ()J
+}
+
+public final class shark/GcRoot$Debugger : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$Finalizing : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$InternedString : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$JavaFrame : shark/GcRoot {
+	public fun <init> (JII)V
+	public final fun getFrameNumber ()I
+	public fun getId ()J
+	public final fun getThreadSerialNumber ()I
+}
+
+public final class shark/GcRoot$JniGlobal : shark/GcRoot {
+	public fun <init> (JJ)V
+	public fun getId ()J
+	public final fun getJniGlobalRefId ()J
+}
+
+public final class shark/GcRoot$JniLocal : shark/GcRoot {
+	public fun <init> (JII)V
+	public final fun getFrameNumber ()I
+	public fun getId ()J
+	public final fun getThreadSerialNumber ()I
+}
+
+public final class shark/GcRoot$JniMonitor : shark/GcRoot {
+	public fun <init> (JII)V
+	public fun getId ()J
+	public final fun getStackDepth ()I
+	public final fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/GcRoot$MonitorUsed : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$NativeStack : shark/GcRoot {
+	public fun <init> (JI)V
+	public fun getId ()J
+	public final fun getThreadSerialNumber ()I
+}
+
+public final class shark/GcRoot$ReferenceCleanup : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$StickyClass : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$ThreadBlock : shark/GcRoot {
+	public fun <init> (JI)V
+	public fun getId ()J
+	public final fun getThreadSerialNumber ()I
+}
+
+public final class shark/GcRoot$ThreadObject : shark/GcRoot {
+	public fun <init> (JII)V
+	public fun getId ()J
+	public final fun getStackTraceSerialNumber ()I
+	public final fun getThreadSerialNumber ()I
+}
+
+public final class shark/GcRoot$Unknown : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$Unreachable : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/GcRoot$VmInternal : shark/GcRoot {
+	public fun <init> (J)V
+	public fun getId ()J
+}
+
+public final class shark/Hprof : java/io/Closeable {
+	public static final field Companion Lshark/Hprof$Companion;
+	public synthetic fun <init> (Ljava/io/File;Lshark/HprofHeader;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun attachClosable (Ljava/io/Closeable;)V
+	public fun close ()V
+	public final fun getFile ()Ljava/io/File;
+	public final fun getFileLength ()J
+	public final fun getHeader ()Lshark/HprofHeader;
+	public final fun getHeapDumpTimestamp ()J
+	public final fun getHprofVersion ()Lshark/Hprof$HprofVersion;
+	public final fun getReader ()Lshark/HprofReader;
+}
+
+public final class shark/Hprof$Companion {
+	public final fun open (Ljava/io/File;)Lshark/Hprof;
+}
+
+public final class shark/Hprof$HprofVersion : java/lang/Enum {
+	public static final field ANDROID Lshark/Hprof$HprofVersion;
+	public static final field JDK1_2_BETA3 Lshark/Hprof$HprofVersion;
+	public static final field JDK1_2_BETA4 Lshark/Hprof$HprofVersion;
+	public static final field JDK_6 Lshark/Hprof$HprofVersion;
+	public final fun getVersionString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lshark/Hprof$HprofVersion;
+	public static fun values ()[Lshark/Hprof$HprofVersion;
+}
+
+public final class shark/HprofDeobfuscator {
+	public fun <init> ()V
+	public final fun deobfuscate (Lshark/ProguardMapping;Ljava/io/File;Ljava/io/File;)Ljava/io/File;
+	public static synthetic fun deobfuscate$default (Lshark/HprofDeobfuscator;Lshark/ProguardMapping;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)Ljava/io/File;
+}
+
+public final class shark/HprofHeader {
+	public static final field Companion Lshark/HprofHeader$Companion;
+	public fun <init> ()V
+	public fun <init> (JLshark/HprofVersion;I)V
+	public synthetic fun <init> (JLshark/HprofVersion;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Lshark/HprofVersion;
+	public final fun component3 ()I
+	public final fun copy (JLshark/HprofVersion;I)Lshark/HprofHeader;
+	public static synthetic fun copy$default (Lshark/HprofHeader;JLshark/HprofVersion;IILjava/lang/Object;)Lshark/HprofHeader;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeapDumpTimestamp ()J
+	public final fun getIdentifierByteSize ()I
+	public final fun getRecordsPosition ()I
+	public final fun getVersion ()Lshark/HprofVersion;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HprofHeader$Companion {
+	public final fun parseHeaderOf (Ljava/io/File;)Lshark/HprofHeader;
+	public final fun parseHeaderOf (Lokio/BufferedSource;)Lshark/HprofHeader;
+}
+
+public final class shark/HprofPrimitiveArrayStripper {
+	public fun <init> ()V
+	public final fun stripPrimitiveArrays (Ljava/io/File;Ljava/io/File;)Ljava/io/File;
+	public final fun stripPrimitiveArrays (Lshark/StreamingSourceProvider;Lokio/BufferedSink;)V
+	public static synthetic fun stripPrimitiveArrays$default (Lshark/HprofPrimitiveArrayStripper;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)Ljava/io/File;
+}
+
+public final class shark/HprofReader {
+	public final fun getIdentifierByteSize ()I
+	public final fun getStartPosition ()J
+	public final fun readHprofRecords (Ljava/util/Set;Lshark/OnHprofRecordListener;)V
+}
+
+public abstract class shark/HprofRecord {
+}
+
+public final class shark/HprofRecord$HeapDumpEndRecord : shark/HprofRecord {
+	public static final field INSTANCE Lshark/HprofRecord$HeapDumpEndRecord;
+}
+
+public abstract class shark/HprofRecord$HeapDumpRecord : shark/HprofRecord {
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$GcRootRecord : shark/HprofRecord$HeapDumpRecord {
+	public fun <init> (Lshark/GcRoot;)V
+	public final fun getGcRoot ()Lshark/GcRoot;
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$HeapDumpInfoRecord : shark/HprofRecord$HeapDumpRecord {
+	public fun <init> (IJ)V
+	public final fun getHeapId ()I
+	public final fun getHeapNameStringId ()J
+}
+
+public abstract class shark/HprofRecord$HeapDumpRecord$ObjectRecord : shark/HprofRecord$HeapDumpRecord {
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord : shark/HprofRecord$HeapDumpRecord$ObjectRecord {
+	public fun <init> (JIJJJJILjava/util/List;Ljava/util/List;)V
+	public final fun getClassLoaderId ()J
+	public final fun getFields ()Ljava/util/List;
+	public final fun getId ()J
+	public final fun getInstanceSize ()I
+	public final fun getProtectionDomainId ()J
+	public final fun getSignersId ()J
+	public final fun getStackTraceSerialNumber ()I
+	public final fun getStaticFields ()Ljava/util/List;
+	public final fun getSuperclassId ()J
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$FieldRecord {
+	public fun <init> (JI)V
+	public final fun component1 ()J
+	public final fun component2 ()I
+	public final fun copy (JI)Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$FieldRecord;
+	public static synthetic fun copy$default (Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$FieldRecord;JIILjava/lang/Object;)Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$FieldRecord;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNameStringId ()J
+	public final fun getType ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$StaticFieldRecord {
+	public fun <init> (JILshark/ValueHolder;)V
+	public final fun component1 ()J
+	public final fun component2 ()I
+	public final fun component3 ()Lshark/ValueHolder;
+	public final fun copy (JILshark/ValueHolder;)Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$StaticFieldRecord;
+	public static synthetic fun copy$default (Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$StaticFieldRecord;JILshark/ValueHolder;ILjava/lang/Object;)Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord$StaticFieldRecord;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNameStringId ()J
+	public final fun getType ()I
+	public final fun getValue ()Lshark/ValueHolder;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$InstanceDumpRecord : shark/HprofRecord$HeapDumpRecord$ObjectRecord {
+	public fun <init> (JIJ[B)V
+	public final fun getClassId ()J
+	public final fun getFieldValues ()[B
+	public final fun getId ()J
+	public final fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$ObjectArrayDumpRecord : shark/HprofRecord$HeapDumpRecord$ObjectRecord {
+	public fun <init> (JIJ[J)V
+	public final fun getArrayClassId ()J
+	public final fun getElementIds ()[J
+	public final fun getId ()J
+	public final fun getStackTraceSerialNumber ()I
+}
+
+public abstract class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord : shark/HprofRecord$HeapDumpRecord$ObjectRecord {
+	public abstract fun getId ()J
+	public abstract fun getSize ()I
+	public abstract fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$BooleanArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[Z)V
+	public final fun getArray ()[Z
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$ByteArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[B)V
+	public final fun getArray ()[B
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$CharArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[C)V
+	public final fun getArray ()[C
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$DoubleArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[D)V
+	public final fun getArray ()[D
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$FloatArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[F)V
+	public final fun getArray ()[F
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$IntArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[I)V
+	public final fun getArray ()[I
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$LongArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[J)V
+	public final fun getArray ()[J
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord$ShortArrayDump : shark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord {
+	public fun <init> (JI[S)V
+	public final fun getArray ()[S
+	public fun getId ()J
+	public fun getSize ()I
+	public fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$LoadClassRecord : shark/HprofRecord {
+	public fun <init> (IJIJ)V
+	public final fun getClassNameStringId ()J
+	public final fun getClassSerialNumber ()I
+	public final fun getId ()J
+	public final fun getStackTraceSerialNumber ()I
+}
+
+public final class shark/HprofRecord$StackFrameRecord : shark/HprofRecord {
+	public fun <init> (JJJJII)V
+	public final fun getClassSerialNumber ()I
+	public final fun getId ()J
+	public final fun getLineNumber ()I
+	public final fun getMethodNameStringId ()J
+	public final fun getMethodSignatureStringId ()J
+	public final fun getSourceFileNameStringId ()J
+}
+
+public final class shark/HprofRecord$StackTraceRecord : shark/HprofRecord {
+	public fun <init> (II[J)V
+	public final fun getStackFrameIds ()[J
+	public final fun getStackTraceSerialNumber ()I
+	public final fun getThreadSerialNumber ()I
+}
+
+public final class shark/HprofRecord$StringRecord : shark/HprofRecord {
+	public fun <init> (JLjava/lang/String;)V
+	public final fun getId ()J
+	public final fun getString ()Ljava/lang/String;
+}
+
+public final class shark/HprofRecordReader {
+	public static final field Companion Lshark/HprofRecordReader$Companion;
+	public final fun getBytesRead ()J
+	public final fun readBoolean ()Z
+	public final fun readBooleanArray (I)[Z
+	public final fun readByte ()B
+	public final fun readByteArray (I)[B
+	public final fun readChar ()C
+	public final fun readCharArray (I)[C
+	public final fun readClassDumpRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ClassDumpRecord;
+	public final fun readDebuggerGcRootRecord ()Lshark/GcRoot$Debugger;
+	public final fun readDouble ()D
+	public final fun readDoubleArray (I)[D
+	public final fun readFinalizingGcRootRecord ()Lshark/GcRoot$Finalizing;
+	public final fun readFloat ()F
+	public final fun readFloatArray (I)[F
+	public final fun readHeapDumpInfoRecord ()Lshark/HprofRecord$HeapDumpRecord$HeapDumpInfoRecord;
+	public final fun readId ()J
+	public final fun readIdArray (I)[J
+	public final fun readInstanceDumpRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$InstanceDumpRecord;
+	public final fun readInt ()I
+	public final fun readIntArray (I)[I
+	public final fun readInternedStringGcRootRecord ()Lshark/GcRoot$InternedString;
+	public final fun readJavaFrameGcRootRecord ()Lshark/GcRoot$JavaFrame;
+	public final fun readJniGlobalGcRootRecord ()Lshark/GcRoot$JniGlobal;
+	public final fun readJniLocalGcRootRecord ()Lshark/GcRoot$JniLocal;
+	public final fun readJniMonitorGcRootRecord ()Lshark/GcRoot$JniMonitor;
+	public final fun readLoadClassRecord ()Lshark/HprofRecord$LoadClassRecord;
+	public final fun readLong ()J
+	public final fun readLongArray (I)[J
+	public final fun readMonitorUsedGcRootRecord ()Lshark/GcRoot$MonitorUsed;
+	public final fun readNativeStackGcRootRecord ()Lshark/GcRoot$NativeStack;
+	public final fun readObjectArrayDumpRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$ObjectArrayDumpRecord;
+	public final fun readPrimitiveArrayDumpRecord ()Lshark/HprofRecord$HeapDumpRecord$ObjectRecord$PrimitiveArrayDumpRecord;
+	public final fun readReferenceCleanupGcRootRecord ()Lshark/GcRoot$ReferenceCleanup;
+	public final fun readShort ()S
+	public final fun readShortArray (I)[S
+	public final fun readStackFrameRecord ()Lshark/HprofRecord$StackFrameRecord;
+	public final fun readStackTraceRecord ()Lshark/HprofRecord$StackTraceRecord;
+	public final fun readStickyClassGcRootRecord ()Lshark/GcRoot$StickyClass;
+	public final fun readString (ILjava/nio/charset/Charset;)Ljava/lang/String;
+	public final fun readStringRecord (J)Lshark/HprofRecord$StringRecord;
+	public final fun readThreadBlockGcRootRecord ()Lshark/GcRoot$ThreadBlock;
+	public final fun readThreadObjectGcRootRecord ()Lshark/GcRoot$ThreadObject;
+	public final fun readUnknownGcRootRecord ()Lshark/GcRoot$Unknown;
+	public final fun readUnreachableGcRootRecord ()Lshark/GcRoot$Unreachable;
+	public final fun readUnsignedByte ()I
+	public final fun readUnsignedInt ()J
+	public final fun readUnsignedShort ()I
+	public final fun readUtf8 (J)Ljava/lang/String;
+	public final fun readValue (I)Lshark/ValueHolder;
+	public final fun readVmInternalGcRootRecord ()Lshark/GcRoot$VmInternal;
+	public final fun sizeOf (I)I
+	public final fun skip (I)V
+	public final fun skip (J)V
+	public final fun skipClassDumpConstantPool ()V
+	public final fun skipClassDumpFields ()V
+	public final fun skipClassDumpHeader ()V
+	public final fun skipClassDumpRecord ()V
+	public final fun skipClassDumpStaticFields ()V
+	public final fun skipHeapDumpInfoRecord ()V
+	public final fun skipInstanceDumpRecord ()V
+	public final fun skipObjectArrayDumpRecord ()V
+	public final fun skipPrimitiveArrayDumpRecord ()V
+}
+
+public final class shark/HprofRecordReader$Companion {
+}
+
+public final class shark/HprofRecordTag : java/lang/Enum {
+	public static final field ALLOC_SITES Lshark/HprofRecordTag;
+	public static final field CLASS_DUMP Lshark/HprofRecordTag;
+	public static final field CONTROL_SETTINGS Lshark/HprofRecordTag;
+	public static final field CPU_SAMPLES Lshark/HprofRecordTag;
+	public static final field Companion Lshark/HprofRecordTag$Companion;
+	public static final field END_THREAD Lshark/HprofRecordTag;
+	public static final field HEAP_DUMP Lshark/HprofRecordTag;
+	public static final field HEAP_DUMP_END Lshark/HprofRecordTag;
+	public static final field HEAP_DUMP_INFO Lshark/HprofRecordTag;
+	public static final field HEAP_DUMP_SEGMENT Lshark/HprofRecordTag;
+	public static final field HEAP_SUMMARY Lshark/HprofRecordTag;
+	public static final field INSTANCE_DUMP Lshark/HprofRecordTag;
+	public static final field LOAD_CLASS Lshark/HprofRecordTag;
+	public static final field OBJECT_ARRAY_DUMP Lshark/HprofRecordTag;
+	public static final field PRIMITIVE_ARRAY_DUMP Lshark/HprofRecordTag;
+	public static final field PRIMITIVE_ARRAY_NODATA Lshark/HprofRecordTag;
+	public static final field ROOT_DEBUGGER Lshark/HprofRecordTag;
+	public static final field ROOT_FINALIZING Lshark/HprofRecordTag;
+	public static final field ROOT_INTERNED_STRING Lshark/HprofRecordTag;
+	public static final field ROOT_JAVA_FRAME Lshark/HprofRecordTag;
+	public static final field ROOT_JNI_GLOBAL Lshark/HprofRecordTag;
+	public static final field ROOT_JNI_LOCAL Lshark/HprofRecordTag;
+	public static final field ROOT_JNI_MONITOR Lshark/HprofRecordTag;
+	public static final field ROOT_MONITOR_USED Lshark/HprofRecordTag;
+	public static final field ROOT_NATIVE_STACK Lshark/HprofRecordTag;
+	public static final field ROOT_REFERENCE_CLEANUP Lshark/HprofRecordTag;
+	public static final field ROOT_STICKY_CLASS Lshark/HprofRecordTag;
+	public static final field ROOT_THREAD_BLOCK Lshark/HprofRecordTag;
+	public static final field ROOT_THREAD_OBJECT Lshark/HprofRecordTag;
+	public static final field ROOT_UNKNOWN Lshark/HprofRecordTag;
+	public static final field ROOT_UNREACHABLE Lshark/HprofRecordTag;
+	public static final field ROOT_VM_INTERNAL Lshark/HprofRecordTag;
+	public static final field STACK_FRAME Lshark/HprofRecordTag;
+	public static final field STACK_TRACE Lshark/HprofRecordTag;
+	public static final field START_THREAD Lshark/HprofRecordTag;
+	public static final field STRING_IN_UTF8 Lshark/HprofRecordTag;
+	public static final field UNLOAD_CLASS Lshark/HprofRecordTag;
+	public final fun getTag ()I
+	public static fun valueOf (Ljava/lang/String;)Lshark/HprofRecordTag;
+	public static fun values ()[Lshark/HprofRecordTag;
+}
+
+public final class shark/HprofRecordTag$Companion {
+	public final fun getRootTags ()Ljava/util/EnumSet;
+}
+
+public final class shark/HprofVersion : java/lang/Enum {
+	public static final field ANDROID Lshark/HprofVersion;
+	public static final field JDK1_2_BETA3 Lshark/HprofVersion;
+	public static final field JDK1_2_BETA4 Lshark/HprofVersion;
+	public static final field JDK_6 Lshark/HprofVersion;
+	public final fun getVersionString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lshark/HprofVersion;
+	public static fun values ()[Lshark/HprofVersion;
+}
+
+public final class shark/HprofWriter : java/io/Closeable {
+	public static final field Companion Lshark/HprofWriter$Companion;
+	public synthetic fun <init> (Lokio/BufferedSink;Lshark/HprofHeader;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun getHprofHeader ()Lshark/HprofHeader;
+	public final fun getHprofVersion ()Lshark/Hprof$HprofVersion;
+	public final fun getIdentifierByteSize ()I
+	public final fun valuesToBytes (Ljava/util/List;)[B
+	public final fun write (Lshark/HprofRecord;)V
+}
+
+public final class shark/HprofWriter$Companion {
+	public final fun open (Ljava/io/File;ILshark/Hprof$HprofVersion;)Lshark/HprofWriter;
+	public static synthetic fun open$default (Lshark/HprofWriter$Companion;Ljava/io/File;ILshark/Hprof$HprofVersion;ILjava/lang/Object;)Lshark/HprofWriter;
+	public final fun openWriterFor (Ljava/io/File;Lshark/HprofHeader;)Lshark/HprofWriter;
+	public final fun openWriterFor (Lokio/BufferedSink;Lshark/HprofHeader;)Lshark/HprofWriter;
+	public static synthetic fun openWriterFor$default (Lshark/HprofWriter$Companion;Ljava/io/File;Lshark/HprofHeader;ILjava/lang/Object;)Lshark/HprofWriter;
+	public static synthetic fun openWriterFor$default (Lshark/HprofWriter$Companion;Lokio/BufferedSink;Lshark/HprofHeader;ILjava/lang/Object;)Lshark/HprofWriter;
+}
+
+public abstract interface class shark/OnHprofRecordListener {
+	public static final field Companion Lshark/OnHprofRecordListener$Companion;
+	public abstract fun onHprofRecord (JLshark/HprofRecord;)V
+}
+
+public final class shark/OnHprofRecordListener$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function2;)Lshark/OnHprofRecordListener;
+}
+
+public abstract interface class shark/OnHprofRecordTagListener {
+	public static final field Companion Lshark/OnHprofRecordTagListener$Companion;
+	public abstract fun onHprofRecord (Lshark/HprofRecordTag;JLshark/HprofRecordReader;)V
+}
+
+public final class shark/OnHprofRecordTagListener$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function3;)Lshark/OnHprofRecordTagListener;
+}
+
+public final class shark/PrimitiveType : java/lang/Enum {
+	public static final field BOOLEAN Lshark/PrimitiveType;
+	public static final field BYTE Lshark/PrimitiveType;
+	public static final field CHAR Lshark/PrimitiveType;
+	public static final field Companion Lshark/PrimitiveType$Companion;
+	public static final field DOUBLE Lshark/PrimitiveType;
+	public static final field FLOAT Lshark/PrimitiveType;
+	public static final field INT Lshark/PrimitiveType;
+	public static final field LONG Lshark/PrimitiveType;
+	public static final field REFERENCE_HPROF_TYPE I
+	public static final field SHORT Lshark/PrimitiveType;
+	public final fun getByteSize ()I
+	public final fun getHprofType ()I
+	public static fun valueOf (Ljava/lang/String;)Lshark/PrimitiveType;
+	public static fun values ()[Lshark/PrimitiveType;
+}
+
+public final class shark/PrimitiveType$Companion {
+	public final fun getByteSizeByHprofType ()Ljava/util/Map;
+	public final fun getPrimitiveTypeByHprofType ()Ljava/util/Map;
+}
+
+public final class shark/ProguardMapping {
+	public fun <init> ()V
+	public final fun addMapping (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun deobfuscateClassName (Ljava/lang/String;)Ljava/lang/String;
+	public final fun deobfuscateFieldName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class shark/ProguardMappingReader {
+	public static final field Companion Lshark/ProguardMappingReader$Companion;
+	public fun <init> (Ljava/io/InputStream;)V
+	public final fun readProguardMapping ()Lshark/ProguardMapping;
+}
+
+public final class shark/ProguardMappingReader$Companion {
+}
+
+public final class shark/RandomAccessHprofReader : java/io/Closeable {
+	public static final field Companion Lshark/RandomAccessHprofReader$Companion;
+	public synthetic fun <init> (Lshark/RandomAccessSource;Lshark/HprofHeader;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun readRecord (JJLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class shark/RandomAccessHprofReader$Companion {
+	public final fun openReaderFor (Ljava/io/File;Lshark/HprofHeader;)Lshark/RandomAccessHprofReader;
+	public final fun openReaderFor (Lshark/RandomAccessSourceProvider;Lshark/HprofHeader;)Lshark/RandomAccessHprofReader;
+	public static synthetic fun openReaderFor$default (Lshark/RandomAccessHprofReader$Companion;Ljava/io/File;Lshark/HprofHeader;ILjava/lang/Object;)Lshark/RandomAccessHprofReader;
+	public static synthetic fun openReaderFor$default (Lshark/RandomAccessHprofReader$Companion;Lshark/RandomAccessSourceProvider;Lshark/HprofHeader;ILjava/lang/Object;)Lshark/RandomAccessHprofReader;
+}
+
+public abstract interface class shark/RandomAccessSource : java/io/Closeable {
+	public abstract fun asStreamingSource ()Lokio/BufferedSource;
+	public abstract fun read (Lokio/Buffer;JJ)J
+}
+
+public final class shark/RandomAccessSource$DefaultImpls {
+	public static fun asStreamingSource (Lshark/RandomAccessSource;)Lokio/BufferedSource;
+}
+
+public abstract interface class shark/RandomAccessSourceProvider {
+	public abstract fun openRandomAccessSource ()Lshark/RandomAccessSource;
+}
+
+public final class shark/StreamingHprofReader {
+	public static final field Companion Lshark/StreamingHprofReader$Companion;
+	public synthetic fun <init> (Lshark/StreamingSourceProvider;Lshark/HprofHeader;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun readRecords (Ljava/util/Set;Lshark/OnHprofRecordTagListener;)J
+}
+
+public final class shark/StreamingHprofReader$Companion {
+	public final fun readerFor (Ljava/io/File;Lshark/HprofHeader;)Lshark/StreamingHprofReader;
+	public final fun readerFor (Lshark/StreamingSourceProvider;Lshark/HprofHeader;)Lshark/StreamingHprofReader;
+	public static synthetic fun readerFor$default (Lshark/StreamingHprofReader$Companion;Ljava/io/File;Lshark/HprofHeader;ILjava/lang/Object;)Lshark/StreamingHprofReader;
+	public static synthetic fun readerFor$default (Lshark/StreamingHprofReader$Companion;Lshark/StreamingSourceProvider;Lshark/HprofHeader;ILjava/lang/Object;)Lshark/StreamingHprofReader;
+}
+
+public final class shark/StreamingRecordReaderAdapter {
+	public static final field Companion Lshark/StreamingRecordReaderAdapter$Companion;
+	public fun <init> (Lshark/StreamingHprofReader;)V
+	public final fun readRecords (Ljava/util/Set;Lshark/OnHprofRecordListener;)J
+}
+
+public final class shark/StreamingRecordReaderAdapter$Companion {
+	public final fun asHprofTags (Ljava/util/Set;)Ljava/util/EnumSet;
+	public final fun asStreamingRecordReader (Lshark/StreamingHprofReader;)Lshark/StreamingRecordReaderAdapter;
+}
+
+public abstract interface class shark/StreamingSourceProvider {
+	public abstract fun openStreamingSource ()Lokio/BufferedSource;
+}
+
+public abstract class shark/ValueHolder {
+	public static final field Companion Lshark/ValueHolder$Companion;
+	public static final field NULL_REFERENCE J
+}
+
+public final class shark/ValueHolder$BooleanHolder : shark/ValueHolder {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lshark/ValueHolder$BooleanHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$BooleanHolder;ZILjava/lang/Object;)Lshark/ValueHolder$BooleanHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$ByteHolder : shark/ValueHolder {
+	public fun <init> (B)V
+	public final fun component1 ()B
+	public final fun copy (B)Lshark/ValueHolder$ByteHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$ByteHolder;BILjava/lang/Object;)Lshark/ValueHolder$ByteHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$CharHolder : shark/ValueHolder {
+	public fun <init> (C)V
+	public final fun component1 ()C
+	public final fun copy (C)Lshark/ValueHolder$CharHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$CharHolder;CILjava/lang/Object;)Lshark/ValueHolder$CharHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()C
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$Companion {
+}
+
+public final class shark/ValueHolder$DoubleHolder : shark/ValueHolder {
+	public fun <init> (D)V
+	public final fun component1 ()D
+	public final fun copy (D)Lshark/ValueHolder$DoubleHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$DoubleHolder;DILjava/lang/Object;)Lshark/ValueHolder$DoubleHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$FloatHolder : shark/ValueHolder {
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lshark/ValueHolder$FloatHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$FloatHolder;FILjava/lang/Object;)Lshark/ValueHolder$FloatHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$IntHolder : shark/ValueHolder {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lshark/ValueHolder$IntHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$IntHolder;IILjava/lang/Object;)Lshark/ValueHolder$IntHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$LongHolder : shark/ValueHolder {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lshark/ValueHolder$LongHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$LongHolder;JILjava/lang/Object;)Lshark/ValueHolder$LongHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$ReferenceHolder : shark/ValueHolder {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lshark/ValueHolder$ReferenceHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$ReferenceHolder;JILjava/lang/Object;)Lshark/ValueHolder$ReferenceHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public final fun isNull ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ValueHolder$ShortHolder : shark/ValueHolder {
+	public fun <init> (S)V
+	public final fun component1 ()S
+	public final fun copy (S)Lshark/ValueHolder$ShortHolder;
+	public static synthetic fun copy$default (Lshark/ValueHolder$ShortHolder;SILjava/lang/Object;)Lshark/ValueHolder$ShortHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()S
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/shark-log/api/shark-log.api
+++ b/shark-log/api/shark-log.api
@@ -1,0 +1,13 @@
+public final class shark/SharkLog {
+	public static final field INSTANCE Lshark/SharkLog;
+	public final fun d (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public final fun d (Lkotlin/jvm/functions/Function0;)V
+	public final fun getLogger ()Lshark/SharkLog$Logger;
+	public final fun setLogger (Lshark/SharkLog$Logger;)V
+}
+
+public abstract interface class shark/SharkLog$Logger {
+	public abstract fun d (Ljava/lang/String;)V
+	public abstract fun d (Ljava/lang/Throwable;Ljava/lang/String;)V
+}
+

--- a/shark-test/api/shark-test.api
+++ b/shark-test/api/shark-test.api
@@ -1,0 +1,10 @@
+public final class shark/HeapDumpRule : org/junit/rules/ExternalResource {
+	public fun <init> ()V
+	public final fun dumpHeap ()Ljava/io/File;
+}
+
+public final class shark/JvmTestHeapDumper {
+	public static final field INSTANCE Lshark/JvmTestHeapDumper;
+	public final fun dumpHeap (Ljava/lang/String;)V
+}
+

--- a/shark/api/shark.api
+++ b/shark/api/shark.api
@@ -1,0 +1,462 @@
+public final class shark/AppSingletonInspector : shark/ObjectInspector {
+	public fun <init> ([Ljava/lang/String;)V
+	public fun inspect (Lshark/ObjectReporter;)V
+}
+
+public final class shark/ApplicationLeak : shark/Leak {
+	public static final field Companion Lshark/ApplicationLeak$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lshark/ApplicationLeak;
+	public static synthetic fun copy$default (Lshark/ApplicationLeak;Ljava/util/List;ILjava/lang/Object;)Lshark/ApplicationLeak;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLeakTraces ()Ljava/util/List;
+	public fun getShortDescription ()Ljava/lang/String;
+	public fun getSignature ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ApplicationLeak$Companion {
+}
+
+public final class shark/FilteringLeakingObjectFinder : shark/LeakingObjectFinder {
+	public fun <init> (Ljava/util/List;)V
+	public fun findLeakingObjectIds (Lshark/HeapGraph;)Ljava/util/Set;
+}
+
+public abstract interface class shark/FilteringLeakingObjectFinder$LeakingObjectFilter {
+	public abstract fun isLeakingObject (Lshark/HeapObject;)Z
+}
+
+public abstract class shark/HeapAnalysis : java/io/Serializable {
+	public static final field Companion Lshark/HeapAnalysis$Companion;
+	public static final field DUMP_DURATION_UNKNOWN J
+	public abstract fun getAnalysisDurationMillis ()J
+	public abstract fun getCreatedAtTimeMillis ()J
+	public abstract fun getDumpDurationMillis ()J
+	public abstract fun getHeapDumpFile ()Ljava/io/File;
+}
+
+public final class shark/HeapAnalysis$Companion {
+}
+
+public final class shark/HeapAnalysisException : java/lang/RuntimeException {
+	public static final field Companion Lshark/HeapAnalysisException$Companion;
+	public fun <init> (Ljava/lang/Throwable;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapAnalysisException$Companion {
+}
+
+public final class shark/HeapAnalysisFailure : shark/HeapAnalysis {
+	public static final field Companion Lshark/HeapAnalysisFailure$Companion;
+	public fun <init> (Ljava/io/File;JJJLshark/HeapAnalysisException;)V
+	public synthetic fun <init> (Ljava/io/File;JJJLshark/HeapAnalysisException;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Lshark/HeapAnalysisException;
+	public final fun copy (Ljava/io/File;JJJLshark/HeapAnalysisException;)Lshark/HeapAnalysisFailure;
+	public static synthetic fun copy$default (Lshark/HeapAnalysisFailure;Ljava/io/File;JJJLshark/HeapAnalysisException;ILjava/lang/Object;)Lshark/HeapAnalysisFailure;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAnalysisDurationMillis ()J
+	public fun getCreatedAtTimeMillis ()J
+	public fun getDumpDurationMillis ()J
+	public final fun getException ()Lshark/HeapAnalysisException;
+	public fun getHeapDumpFile ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapAnalysisFailure$Companion {
+}
+
+public final class shark/HeapAnalysisSuccess : shark/HeapAnalysis {
+	public static final field Companion Lshark/HeapAnalysisSuccess$Companion;
+	public fun <init> (Ljava/io/File;JJJLjava/util/Map;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/io/File;JJJLjava/util/Map;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/io/File;JJJLjava/util/Map;Ljava/util/List;Ljava/util/List;)Lshark/HeapAnalysisSuccess;
+	public static synthetic fun copy$default (Lshark/HeapAnalysisSuccess;Ljava/io/File;JJJLjava/util/Map;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lshark/HeapAnalysisSuccess;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllLeaks ()Lkotlin/sequences/Sequence;
+	public fun getAnalysisDurationMillis ()J
+	public final fun getApplicationLeaks ()Ljava/util/List;
+	public fun getCreatedAtTimeMillis ()J
+	public fun getDumpDurationMillis ()J
+	public fun getHeapDumpFile ()Ljava/io/File;
+	public final fun getLibraryLeaks ()Ljava/util/List;
+	public final fun getMetadata ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapAnalysisSuccess$Companion {
+	public final fun upgradeFrom20Deserialized (Lshark/HeapAnalysisSuccess;)Lshark/HeapAnalysisSuccess;
+}
+
+public final class shark/HeapAnalyzer {
+	public fun <init> (Lshark/OnAnalysisProgressListener;)V
+	public final fun analyze (Ljava/io/File;Lshark/HeapGraph;Lshark/LeakingObjectFinder;Ljava/util/List;ZLjava/util/List;Lshark/MetadataExtractor;)Lshark/HeapAnalysis;
+	public final fun analyze (Ljava/io/File;Lshark/LeakingObjectFinder;Ljava/util/List;ZLjava/util/List;Lshark/MetadataExtractor;Lshark/ProguardMapping;)Lshark/HeapAnalysis;
+	public static synthetic fun analyze$default (Lshark/HeapAnalyzer;Ljava/io/File;Lshark/HeapGraph;Lshark/LeakingObjectFinder;Ljava/util/List;ZLjava/util/List;Lshark/MetadataExtractor;ILjava/lang/Object;)Lshark/HeapAnalysis;
+	public static synthetic fun analyze$default (Lshark/HeapAnalyzer;Ljava/io/File;Lshark/LeakingObjectFinder;Ljava/util/List;ZLjava/util/List;Lshark/MetadataExtractor;Lshark/ProguardMapping;ILjava/lang/Object;)Lshark/HeapAnalysis;
+}
+
+public final class shark/IgnoredReferenceMatcher : shark/ReferenceMatcher {
+	public fun <init> (Lshark/ReferencePattern;)V
+	public fun getPattern ()Lshark/ReferencePattern;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/KeyedWeakReferenceFinder : shark/LeakingObjectFinder {
+	public static final field INSTANCE Lshark/KeyedWeakReferenceFinder;
+	public fun findLeakingObjectIds (Lshark/HeapGraph;)Ljava/util/Set;
+	public final fun heapDumpUptimeMillis (Lshark/HeapGraph;)Ljava/lang/Long;
+}
+
+public abstract class shark/Leak : java/io/Serializable {
+	public static final field Companion Lshark/Leak$Companion;
+	public abstract fun getLeakTraces ()Ljava/util/List;
+	public abstract fun getShortDescription ()Ljava/lang/String;
+	public abstract fun getSignature ()Ljava/lang/String;
+	public final fun getTotalRetainedHeapByteSize ()Ljava/lang/Integer;
+	public final fun getTotalRetainedObjectCount ()Ljava/lang/Integer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/Leak$Companion {
+}
+
+public final class shark/LeakTrace : java/io/Serializable {
+	public static final field Companion Lshark/LeakTrace$Companion;
+	public fun <init> (Lshark/LeakTrace$GcRootType;Ljava/util/List;Lshark/LeakTraceObject;)V
+	public final fun component1 ()Lshark/LeakTrace$GcRootType;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lshark/LeakTraceObject;
+	public final fun copy (Lshark/LeakTrace$GcRootType;Ljava/util/List;Lshark/LeakTraceObject;)Lshark/LeakTrace;
+	public static synthetic fun copy$default (Lshark/LeakTrace;Lshark/LeakTrace$GcRootType;Ljava/util/List;Lshark/LeakTraceObject;ILjava/lang/Object;)Lshark/LeakTrace;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGcRootType ()Lshark/LeakTrace$GcRootType;
+	public final fun getLeakingObject ()Lshark/LeakTraceObject;
+	public final fun getReferencePath ()Ljava/util/List;
+	public final fun getRetainedHeapByteSize ()Ljava/lang/Integer;
+	public final fun getRetainedObjectCount ()Ljava/lang/Integer;
+	public final fun getSignature ()Ljava/lang/String;
+	public final fun getSuspectReferenceSubpath ()Lkotlin/sequences/Sequence;
+	public fun hashCode ()I
+	public final fun referencePathElementIsSuspect (I)Z
+	public final fun toSimplePathString ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/LeakTrace$Companion {
+}
+
+public final class shark/LeakTrace$GcRootType : java/lang/Enum {
+	public static final field Companion Lshark/LeakTrace$GcRootType$Companion;
+	public static final field JAVA_FRAME Lshark/LeakTrace$GcRootType;
+	public static final field JNI_GLOBAL Lshark/LeakTrace$GcRootType;
+	public static final field JNI_LOCAL Lshark/LeakTrace$GcRootType;
+	public static final field JNI_MONITOR Lshark/LeakTrace$GcRootType;
+	public static final field MONITOR_USED Lshark/LeakTrace$GcRootType;
+	public static final field NATIVE_STACK Lshark/LeakTrace$GcRootType;
+	public static final field STICKY_CLASS Lshark/LeakTrace$GcRootType;
+	public static final field THREAD_BLOCK Lshark/LeakTrace$GcRootType;
+	public static final field THREAD_OBJECT Lshark/LeakTrace$GcRootType;
+	public final fun getDescription ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lshark/LeakTrace$GcRootType;
+	public static fun values ()[Lshark/LeakTrace$GcRootType;
+}
+
+public final class shark/LeakTrace$GcRootType$Companion {
+	public final fun fromGcRoot (Lshark/GcRoot;)Lshark/LeakTrace$GcRootType;
+}
+
+public final class shark/LeakTraceObject : java/io/Serializable {
+	public static final field Companion Lshark/LeakTraceObject$Companion;
+	public fun <init> (Lshark/LeakTraceObject$ObjectType;Ljava/lang/String;Ljava/util/Set;Lshark/LeakTraceObject$LeakingStatus;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public final fun component1 ()Lshark/LeakTraceObject$ObjectType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Set;
+	public final fun component4 ()Lshark/LeakTraceObject$LeakingStatus;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy (Lshark/LeakTraceObject$ObjectType;Ljava/lang/String;Ljava/util/Set;Lshark/LeakTraceObject$LeakingStatus;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)Lshark/LeakTraceObject;
+	public static synthetic fun copy$default (Lshark/LeakTraceObject;Lshark/LeakTraceObject$ObjectType;Ljava/lang/String;Ljava/util/Set;Lshark/LeakTraceObject$LeakingStatus;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lshark/LeakTraceObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getClassSimpleName ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/Set;
+	public final fun getLeakingStatus ()Lshark/LeakTraceObject$LeakingStatus;
+	public final fun getLeakingStatusReason ()Ljava/lang/String;
+	public final fun getRetainedHeapByteSize ()Ljava/lang/Integer;
+	public final fun getRetainedObjectCount ()Ljava/lang/Integer;
+	public final fun getType ()Lshark/LeakTraceObject$ObjectType;
+	public final fun getTypeName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/LeakTraceObject$Companion {
+}
+
+public final class shark/LeakTraceObject$LeakingStatus : java/lang/Enum {
+	public static final field LEAKING Lshark/LeakTraceObject$LeakingStatus;
+	public static final field NOT_LEAKING Lshark/LeakTraceObject$LeakingStatus;
+	public static final field UNKNOWN Lshark/LeakTraceObject$LeakingStatus;
+	public static fun valueOf (Ljava/lang/String;)Lshark/LeakTraceObject$LeakingStatus;
+	public static fun values ()[Lshark/LeakTraceObject$LeakingStatus;
+}
+
+public final class shark/LeakTraceObject$ObjectType : java/lang/Enum {
+	public static final field ARRAY Lshark/LeakTraceObject$ObjectType;
+	public static final field CLASS Lshark/LeakTraceObject$ObjectType;
+	public static final field INSTANCE Lshark/LeakTraceObject$ObjectType;
+	public static fun valueOf (Ljava/lang/String;)Lshark/LeakTraceObject$ObjectType;
+	public static fun values ()[Lshark/LeakTraceObject$ObjectType;
+}
+
+public final class shark/LeakTraceReference : java/io/Serializable {
+	public static final field Companion Lshark/LeakTraceReference$Companion;
+	public fun <init> (Lshark/LeakTraceObject;Lshark/LeakTraceReference$ReferenceType;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lshark/LeakTraceObject;
+	public final fun component2 ()Lshark/LeakTraceReference$ReferenceType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lshark/LeakTraceObject;Lshark/LeakTraceReference$ReferenceType;Ljava/lang/String;Ljava/lang/String;)Lshark/LeakTraceReference;
+	public static synthetic fun copy$default (Lshark/LeakTraceReference;Lshark/LeakTraceObject;Lshark/LeakTraceReference$ReferenceType;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lshark/LeakTraceReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOriginObject ()Lshark/LeakTraceObject;
+	public final fun getOwningClassName ()Ljava/lang/String;
+	public final fun getOwningClassSimpleName ()Ljava/lang/String;
+	public final fun getReferenceDisplayName ()Ljava/lang/String;
+	public final fun getReferenceGenericName ()Ljava/lang/String;
+	public final fun getReferenceName ()Ljava/lang/String;
+	public final fun getReferenceType ()Lshark/LeakTraceReference$ReferenceType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/LeakTraceReference$Companion {
+}
+
+public final class shark/LeakTraceReference$ReferenceType : java/lang/Enum {
+	public static final field ARRAY_ENTRY Lshark/LeakTraceReference$ReferenceType;
+	public static final field INSTANCE_FIELD Lshark/LeakTraceReference$ReferenceType;
+	public static final field LOCAL Lshark/LeakTraceReference$ReferenceType;
+	public static final field STATIC_FIELD Lshark/LeakTraceReference$ReferenceType;
+	public static fun valueOf (Ljava/lang/String;)Lshark/LeakTraceReference$ReferenceType;
+	public static fun values ()[Lshark/LeakTraceReference$ReferenceType;
+}
+
+public abstract interface class shark/LeakingObjectFinder {
+	public static final field Companion Lshark/LeakingObjectFinder$Companion;
+	public abstract fun findLeakingObjectIds (Lshark/HeapGraph;)Ljava/util/Set;
+}
+
+public final class shark/LeakingObjectFinder$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lshark/LeakingObjectFinder;
+}
+
+public final class shark/LibraryLeak : shark/Leak {
+	public static final field Companion Lshark/LibraryLeak$Companion;
+	public fun <init> (Ljava/util/List;Lshark/ReferencePattern;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lshark/ReferencePattern;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Lshark/ReferencePattern;Ljava/lang/String;)Lshark/LibraryLeak;
+	public static synthetic fun copy$default (Lshark/LibraryLeak;Ljava/util/List;Lshark/ReferencePattern;Ljava/lang/String;ILjava/lang/Object;)Lshark/LibraryLeak;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public fun getLeakTraces ()Ljava/util/List;
+	public final fun getPattern ()Lshark/ReferencePattern;
+	public fun getShortDescription ()Ljava/lang/String;
+	public fun getSignature ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/LibraryLeak$Companion {
+}
+
+public final class shark/LibraryLeakReferenceMatcher : shark/ReferenceMatcher {
+	public fun <init> (Lshark/ReferencePattern;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lshark/ReferencePattern;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lshark/ReferencePattern;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lshark/ReferencePattern;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lshark/LibraryLeakReferenceMatcher;
+	public static synthetic fun copy$default (Lshark/LibraryLeakReferenceMatcher;Lshark/ReferencePattern;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lshark/LibraryLeakReferenceMatcher;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public fun getPattern ()Lshark/ReferencePattern;
+	public final fun getPatternApplies ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class shark/MetadataExtractor {
+	public static final field Companion Lshark/MetadataExtractor$Companion;
+	public abstract fun extractMetadata (Lshark/HeapGraph;)Ljava/util/Map;
+}
+
+public final class shark/MetadataExtractor$Companion {
+	public final fun getNO_OP ()Lshark/MetadataExtractor;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lshark/MetadataExtractor;
+}
+
+public abstract interface class shark/ObjectInspector {
+	public static final field Companion Lshark/ObjectInspector$Companion;
+	public abstract fun inspect (Lshark/ObjectReporter;)V
+}
+
+public final class shark/ObjectInspector$Companion {
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lshark/ObjectInspector;
+}
+
+public abstract class shark/ObjectInspectors : java/lang/Enum, shark/ObjectInspector {
+	public static final field ANONYMOUS_CLASS Lshark/ObjectInspectors;
+	public static final field CLASS Lshark/ObjectInspectors;
+	public static final field CLASSLOADER Lshark/ObjectInspectors;
+	public static final field Companion Lshark/ObjectInspectors$Companion;
+	public static final field KEYED_WEAK_REFERENCE Lshark/ObjectInspectors;
+	public static final field THREAD Lshark/ObjectInspectors;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static fun valueOf (Ljava/lang/String;)Lshark/ObjectInspectors;
+	public static fun values ()[Lshark/ObjectInspectors;
+}
+
+public final class shark/ObjectInspectors$Companion {
+	public final fun createLeakingObjectFilters (Ljava/util/Set;)Ljava/util/List;
+	public final fun getJdkDefaults ()Ljava/util/List;
+	public final fun getJdkLeakingObjectFilters ()Ljava/util/List;
+}
+
+public final class shark/ObjectReporter {
+	public fun <init> (Lshark/HeapObject;)V
+	public final fun getHeapObject ()Lshark/HeapObject;
+	public final fun getLabels ()Ljava/util/LinkedHashSet;
+	public final fun getLeakingReasons ()Ljava/util/Set;
+	public final fun getLikelyLeakingReasons ()Ljava/util/Set;
+	public final fun getNotLeakingReasons ()Ljava/util/Set;
+	public final fun whenInstanceOf (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public final fun whenInstanceOf (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;)V
+}
+
+public abstract interface class shark/OnAnalysisProgressListener {
+	public static final field Companion Lshark/OnAnalysisProgressListener$Companion;
+	public abstract fun onAnalysisProgress (Lshark/OnAnalysisProgressListener$Step;)V
+}
+
+public final class shark/OnAnalysisProgressListener$Companion {
+	public final fun getNO_OP ()Lshark/OnAnalysisProgressListener;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lshark/OnAnalysisProgressListener;
+}
+
+public final class shark/OnAnalysisProgressListener$Step : java/lang/Enum {
+	public static final field BUILDING_LEAK_TRACES Lshark/OnAnalysisProgressListener$Step;
+	public static final field COMPUTING_NATIVE_RETAINED_SIZE Lshark/OnAnalysisProgressListener$Step;
+	public static final field COMPUTING_RETAINED_SIZE Lshark/OnAnalysisProgressListener$Step;
+	public static final field EXTRACTING_METADATA Lshark/OnAnalysisProgressListener$Step;
+	public static final field FINDING_DOMINATORS Lshark/OnAnalysisProgressListener$Step;
+	public static final field FINDING_PATHS_TO_RETAINED_OBJECTS Lshark/OnAnalysisProgressListener$Step;
+	public static final field FINDING_RETAINED_OBJECTS Lshark/OnAnalysisProgressListener$Step;
+	public static final field INSPECTING_OBJECTS Lshark/OnAnalysisProgressListener$Step;
+	public static final field PARSING_HEAP_DUMP Lshark/OnAnalysisProgressListener$Step;
+	public static final field REPORTING_HEAP_ANALYSIS Lshark/OnAnalysisProgressListener$Step;
+	public static fun valueOf (Ljava/lang/String;)Lshark/OnAnalysisProgressListener$Step;
+	public static fun values ()[Lshark/OnAnalysisProgressListener$Step;
+}
+
+public abstract class shark/ReferenceMatcher {
+	public abstract fun getPattern ()Lshark/ReferencePattern;
+}
+
+public abstract class shark/ReferencePattern : java/io/Serializable {
+	public static final field Companion Lshark/ReferencePattern$Companion;
+}
+
+public final class shark/ReferencePattern$Companion {
+}
+
+public final class shark/ReferencePattern$InstanceFieldPattern : shark/ReferencePattern {
+	public static final field Companion Lshark/ReferencePattern$InstanceFieldPattern$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lshark/ReferencePattern$InstanceFieldPattern;
+	public static synthetic fun copy$default (Lshark/ReferencePattern$InstanceFieldPattern;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lshark/ReferencePattern$InstanceFieldPattern;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getFieldName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ReferencePattern$InstanceFieldPattern$Companion {
+}
+
+public final class shark/ReferencePattern$JavaLocalPattern : shark/ReferencePattern {
+	public static final field Companion Lshark/ReferencePattern$JavaLocalPattern$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lshark/ReferencePattern$JavaLocalPattern;
+	public static synthetic fun copy$default (Lshark/ReferencePattern$JavaLocalPattern;Ljava/lang/String;ILjava/lang/Object;)Lshark/ReferencePattern$JavaLocalPattern;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThreadName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ReferencePattern$JavaLocalPattern$Companion {
+}
+
+public final class shark/ReferencePattern$NativeGlobalVariablePattern : shark/ReferencePattern {
+	public static final field Companion Lshark/ReferencePattern$NativeGlobalVariablePattern$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lshark/ReferencePattern$NativeGlobalVariablePattern;
+	public static synthetic fun copy$default (Lshark/ReferencePattern$NativeGlobalVariablePattern;Ljava/lang/String;ILjava/lang/Object;)Lshark/ReferencePattern$NativeGlobalVariablePattern;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ReferencePattern$NativeGlobalVariablePattern$Companion {
+}
+
+public final class shark/ReferencePattern$StaticFieldPattern : shark/ReferencePattern {
+	public static final field Companion Lshark/ReferencePattern$StaticFieldPattern$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lshark/ReferencePattern$StaticFieldPattern;
+	public static synthetic fun copy$default (Lshark/ReferencePattern$StaticFieldPattern;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lshark/ReferencePattern$StaticFieldPattern;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getFieldName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/ReferencePattern$StaticFieldPattern$Companion {
+}
+
+public final class shark/internal/ObjectDominators {
+	public fun <init> ()V
+	public final fun renderDominatorTree (Lshark/HeapGraph;Ljava/util/List;ILjava/lang/String;Z)Ljava/lang/String;
+	public static synthetic fun renderDominatorTree$default (Lshark/internal/ObjectDominators;Lshark/HeapGraph;Ljava/util/List;ILjava/lang/String;ZILjava/lang/Object;)Ljava/lang/String;
+}
+


### PR DESCRIPTION
This PR adds the [Kotlin Binary compatibility validator](https://github.com/Kotlin/binary-compatibility-validator) tool to LeakCanary.

Resolves https://github.com/square/leakcanary/issues/1955

~~There are some public classes/functions in the `leakcanary.internal` and `shark.internal` packages, so I excluded those packages for the API dump (for example [Timing.kt](https://github.com/square/leakcanary/blob/main/leakcanary-android-core/src/main/java/leakcanary/internal/utils/Timing.kt) and [ObjectDominators.kt](https://github.com/square/leakcanary/blob/main/shark/src/main/java/shark/internal/ObjectDominators.kt)). If you would like me to change that, please let me know.~~