### PR TITLE
Fixes disk read violation for SharedPrefs on API >= 27

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpControl.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpControl.kt
@@ -10,7 +10,6 @@ import leakcanary.internal.HeapDumpControl.ICanHazHeap.Nope
 import leakcanary.internal.HeapDumpControl.ICanHazHeap.NotifyingNope
 import leakcanary.internal.HeapDumpControl.ICanHazHeap.SilentNope
 import leakcanary.internal.HeapDumpControl.ICanHazHeap.Yup
-import leakcanary.internal.activity.screen.dumpEnabledInAboutScreen
 
 internal object HeapDumpControl {
 
@@ -55,7 +54,7 @@ internal object HeapDumpControl {
     val dumpHeap = if (!AppWatcher.isInstalled) {
       // Can't use a resource, we don't have an Application instance when not installed
       SilentNope { "AppWatcher is not installed." }
-    } else if (!app.dumpEnabledInAboutScreen) {
+    } else if (!InternalLeakCanary.dumpEnabledInAboutScreen) {
       NotifyingNope {
         app.getString(R.string.leak_canary_heap_dump_disabled_from_ui)
       }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -20,6 +20,7 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.StrictMode
 import com.squareup.leakcanary.core.BuildConfig
 import com.squareup.leakcanary.core.R
 import leakcanary.AppWatcher
@@ -105,6 +106,26 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
   }
 
   var resumedActivity: Activity? = null
+
+  private val heapDumpPrefs by lazy {
+    val oldPolicy = StrictMode.allowThreadDiskReads()
+    application.getSharedPreferences("LeakCanaryHeapDumpPrefs", Context.MODE_PRIVATE)
+            .also {
+              StrictMode.setThreadPolicy(oldPolicy)
+            }
+  }
+
+  internal var dumpEnabledInAboutScreen: Boolean
+    get() {
+      return heapDumpPrefs
+                .getBoolean("AboutScreenDumpEnabled", true)
+    }
+    set(value) {
+      heapDumpPrefs
+                .edit()
+                .putBoolean("AboutScreenDumpEnabled", value)
+                .apply()
+    }
 
   override fun invoke(application: Application) {
     _application = application

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/AboutScreen.kt
@@ -11,6 +11,7 @@ import com.squareup.leakcanary.core.R
 import leakcanary.internal.HeapDumpControl
 import leakcanary.internal.HeapDumpControl.ICanHazHeap.Nope
 import leakcanary.internal.HeapDumpControl.ICanHazHeap.Yup
+import leakcanary.internal.InternalLeakCanary
 import leakcanary.internal.navigation.Screen
 import leakcanary.internal.navigation.activity
 import leakcanary.internal.navigation.inflate
@@ -37,12 +38,12 @@ internal class AboutScreen : Screen() {
           updateHeapDumpTextView(heapDumpTextView)
           val heapDumpSwitchView =
             findViewById<Switch>(R.id.leak_canary_about_heap_dump_switch_button)
-          heapDumpSwitchView.isChecked = context.dumpEnabledInAboutScreen
+          heapDumpSwitchView.isChecked = InternalLeakCanary.dumpEnabledInAboutScreen
           heapDumpSwitchView.setOnCheckedChangeListener { _, checked ->
             // Updating the value wouldn't normally immediately trigger a heap dump, however
             // by updating the view we also have a side effect of querying which will notify
             // the heap dumper if the value has become positive.
-            context.dumpEnabledInAboutScreen = checked
+            InternalLeakCanary.dumpEnabledInAboutScreen = checked
             updateHeapDumpTextView(heapDumpTextView)
           }
         }
@@ -57,15 +58,3 @@ internal class AboutScreen : Screen() {
     }
   }
 }
-
-internal var Context.dumpEnabledInAboutScreen: Boolean
-  get() {
-    return getSharedPreferences("LeakCanaryHeapDumpPrefs", Context.MODE_PRIVATE)
-        .getBoolean("AboutScreenDumpEnabled", true)
-  }
-  set(value) {
-    getSharedPreferences("LeakCanaryHeapDumpPrefs", Context.MODE_PRIVATE)
-        .edit()
-        .putBoolean("AboutScreenDumpEnabled", value)
-        .apply()
-  }


### PR DESCRIPTION
Fixes #1981 

- Initialized Heap Dump Shared prefs on a background thread during initialization
- Moved `dumpEnabledInAboutScreen` to InternalLeakCanary object

Investigated the disk read violation for loading shared prefs, the loading of the prefs file is still async but AOSP changes might be marking `File.exists()` under disk read violation for API >= 27. 

Although needs more analysis around why it isn't marked as a violation before API 27.