### PR TITLE
Fix false positive when running instrumentation tests (fixes #1986)

### DIFF
--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeakRunListener.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeakRunListener.kt
@@ -54,7 +54,7 @@ open class FailTestOnLeakRunListener : RunListener() {
 
   private var skipLeakDetectionReason: String? = null
 
-  private lateinit var testResultPublisher: TestResultPublisher
+  private var testResultPublisher: TestResultPublisher? = null
 
   @Volatile
   private var allActivitiesDestroyedLatch: CountDownLatch? = null
@@ -131,7 +131,7 @@ open class FailTestOnLeakRunListener : RunListener() {
     }
     AppWatcher.objectWatcher.clearWatchedObjects()
     _currentTestDescription = null
-    testResultPublisher.publishTestFinished()
+    testResultPublisher?.publishTestFinished()
   }
 
   private fun detectLeaks() {
@@ -181,7 +181,7 @@ open class FailTestOnLeakRunListener : RunListener() {
    */
   protected fun failTest(trace: String) {
     SharkLog.d { trace }
-    testResultPublisher.publishTestFailure(currentTestDescription, trace)
+    testResultPublisher?.publishTestFailure(currentTestDescription, trace)
   }
 
   private inline fun <reified T : Any> noOpDelegate(): T {

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/TestResultPublisher.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/TestResultPublisher.kt
@@ -19,11 +19,18 @@ internal interface TestResultPublisher {
     fun install(): TestResultPublisher {
       val instrumentation = InstrumentationRegistry.getInstrumentation()
       val orchestratorListener = if (instrumentation is AndroidJUnitRunner) {
-        AndroidJUnitRunner::class.java.getDeclaredField("orchestratorListener")
+        try {
+          AndroidJUnitRunner::class.java.getDeclaredField("orchestratorListener")
             .run {
               isAccessible = true
               get(instrumentation) as OrchestratedInstrumentationListener?
             }
+        } catch (e: NoSuchFieldException) {
+          // Starting from `android-test 1.3.1-alpha02`, test failure aren't properly reported
+          // due to missing `orchestratorListener` field. Avoid failure for now.
+          // See https://github.com/square/leakcanary/issues/1986
+          null
+        }
       } else null
       return if (orchestratorListener != null) {
         SharkLog.d { "Android Test Orchestrator detected, failures will be sent via binder callback" }


### PR DESCRIPTION
I share a change for discussion but I'm not sure it's the way to go.
At least the issue spotted in #1986 is fixed this way.
I'm not 100% sure of the consequence of the defensive code I introduce.
That being said, I think accessing private member of third party code by reflection deserves defensive code 😃 