### PR TITLE
Improve disabled log

### DIFF
--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -33,7 +33,7 @@
   <string name="leak_canary_heap_dump_enabled_text">LeakCanary is running and ready to detect memory leaks.</string>
   <string name="leak_canary_heap_dump_disabled_by_app">LeakCanary.Config.dumpHeap is set to false</string>
   <string name="leak_canary_heap_dump_disabled_from_ui">heap dumping disabled from LeakCanary About screen</string>
-  <string name="leak_canary_heap_dump_disabled_running_tests">test class "%s" was found in classpath</string>
+  <string name="leak_canary_heap_dump_disabled_running_tests">test class "%s" was found in classpath. See https://square.github.io/leakcanary/recipes/#running-leakcanary-in-instrumentation-tests</string>
   <string name="leak_canary_analysis_failed">Heap analysis failed</string>
   <string name="leak_canary_analysis_success_notification">Found %1$d retained objects grouped as %2$d distinct leaks</string>
   <string name="leak_canary_class_has_leaked">%1$s Leaked</string>


### PR DESCRIPTION
When LeakCanary detects `org.junit.Test` in the classpath it disables itself and logs the following message:

```
LeakCanary is currently disabled: test class org.junit.Test was found in classpath.
```

This change adds a link to the docs to make the message more actionable.