### PR TITLE
Report cleared weak refs

### DIFF
--- a/leakcanary-object-watcher/api/leakcanary-object-watcher.api
+++ b/leakcanary-object-watcher/api/leakcanary-object-watcher.api
@@ -19,6 +19,7 @@ public final class leakcanary/GcTrigger$Default : leakcanary/GcTrigger {
 public final class leakcanary/KeyedWeakReference : java/lang/ref/WeakReference {
 	public static final field Companion Lleakcanary/KeyedWeakReference$Companion;
 	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;JLjava/lang/ref/ReferenceQueue;)V
+	public fun clear ()V
 	public final fun getDescription ()Ljava/lang/String;
 	public static final fun getHeapDumpUptimeMillis ()J
 	public final fun getKey ()Ljava/lang/String;

--- a/leakcanary-object-watcher/src/main/java/leakcanary/KeyedWeakReference.kt
+++ b/leakcanary-object-watcher/src/main/java/leakcanary/KeyedWeakReference.kt
@@ -43,6 +43,11 @@ class KeyedWeakReference(
   @Volatile
   var retainedUptimeMillis = -1L
 
+  override fun clear() {
+    super.clear()
+    retainedUptimeMillis = -1L
+  }
+
   companion object {
     @Volatile
     @JvmStatic var heapDumpUptimeMillis = 0L

--- a/shark/src/main/java/shark/KeyedWeakReferenceFinder.kt
+++ b/shark/src/main/java/shark/KeyedWeakReferenceFinder.kt
@@ -10,7 +10,9 @@ import shark.internal.KeyedWeakReferenceMirror
 object KeyedWeakReferenceFinder : LeakingObjectFinder {
 
   override fun findLeakingObjectIds(graph: HeapGraph): Set<Long> =
-    findKeyedWeakReferences(graph).map { it.referent.value }
+    findKeyedWeakReferences(graph)
+      .filter { it.hasReferent && it.isRetained }
+      .map { it.referent.value }
       .toSet()
 
   fun heapDumpUptimeMillis(graph: HeapGraph): Long? {
@@ -49,7 +51,6 @@ object KeyedWeakReferenceFinder : LeakingObjectFinder {
             it, heapDumpUptimeMillis
           )
         }
-        .filter { it.hasReferent }
         .toList()
       graph.context[KEYED_WEAK_REFERENCE.name] = addedToContext
       addedToContext

--- a/shark/src/main/java/shark/ObjectInspectors.kt
+++ b/shark/src/main/java/shark/ObjectInspectors.kt
@@ -29,6 +29,7 @@ enum class ObjectInspectors : ObjectInspector {
 
     override val leakingObjectFilter = { heapObject: HeapObject ->
       KeyedWeakReferenceFinder.findKeyedWeakReferences(heapObject.graph)
+        .filter { it.hasReferent && it.isRetained }
         .any { reference ->
           reference.referent.value == heapObject.objectId
         }


### PR DESCRIPTION
* Report when a WeakRef is considered "retained" (ie it contributed to triggering the heap dump) and yet the referent value was null. This should be rare but we should surface this information.
* If a weakref has not passed the time threshold (5 seconds), don't consider it retained at heap analysis time

Fixes #1985