### PR TITLE
Watch detached root views

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/DisplayLeakAdapter.kt
@@ -177,7 +177,7 @@ internal class DisplayLeakAdapter constructor(
 
     val reachabilityString = when (leakingStatus) {
       UNKNOWN -> extra("UNKNOWN")
-      NOT_LEAKING -> extra("NO (${leakingStatusReason})")
+      NOT_LEAKING -> "NO" + extra(" (${leakingStatusReason})")
       LEAKING -> "YES" + extra(" (${leakingStatusReason})")
     }
 

--- a/leakcanary-android-core/src/main/res/values/leak_canary_public.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_public.xml
@@ -23,5 +23,4 @@
   <public name="leak_canary_heap_dump_toast" type="layout"/>
   <public name="leak_canary_icon" type="mipmap"/>
   <public name="leak_canary_test_class_name" type="string"/>
-  <public name="leak_canary_watcher_auto_install" type="bool"/>
 </resources>

--- a/leakcanary-android-sample/src/main/java/com/example/leakcanary/ExampleApplication.kt
+++ b/leakcanary-android-sample/src/main/java/com/example/leakcanary/ExampleApplication.kt
@@ -16,11 +16,13 @@
 package com.example.leakcanary
 
 import android.app.Application
+import android.app.Dialog
 import android.os.StrictMode
 import android.view.View
 
 open class ExampleApplication : Application() {
   val leakedViews = mutableListOf<View>()
+  val leakedDialogs = mutableListOf<Dialog>()
 
   override fun onCreate() {
     super.onCreate()

--- a/leakcanary-android-sample/src/main/java/com/example/leakcanary/MainActivity.kt
+++ b/leakcanary-android-sample/src/main/java/com/example/leakcanary/MainActivity.kt
@@ -16,6 +16,8 @@
 package com.example.leakcanary
 
 import android.app.Activity
+import android.app.AlertDialog
+import android.app.Dialog
 import android.os.Bundle
 import android.os.SystemClock
 import android.view.View
@@ -33,6 +35,15 @@ class MainActivity : Activity() {
     val leakedView = findViewById<View>(R.id.helper_text)
 
     findViewById<Button>(R.id.recreate_activity_button).setOnClickListener { recreate() }
+    findViewById<Button>(R.id.show_dialog_button).setOnClickListener {
+      AlertDialog.Builder(this)
+        .setTitle("Leaky dialog")
+        .setPositiveButton("Dismiss and leak dialog") { dialog, _ ->
+          app.leakedDialogs += dialog as AlertDialog
+        }
+        .show()
+    }
+
 
     when (Random.nextInt(4)) {
       // Leak from application class

--- a/leakcanary-android-sample/src/main/res/layout/main_activity.xml
+++ b/leakcanary-android-sample/src/main/res/layout/main_activity.xml
@@ -36,5 +36,12 @@
       android:layout_height="wrap_content"
       android:text="@string/recreate_activity_button_text"
       />
+  <Button
+      android:id="@+id/show_dialog_button"
+      android:layout_width="wrap_content"
+      android:layout_gravity="center"
+      android:layout_height="wrap_content"
+      android:text="Show dialog"
+      />
 
 </LinearLayout>

--- a/leakcanary-object-watcher-android/api/leakcanary-object-watcher-android.api
+++ b/leakcanary-object-watcher-android/api/leakcanary-object-watcher-android.api
@@ -9,22 +9,24 @@ public final class leakcanary/AppWatcher {
 
 public final class leakcanary/AppWatcher$Config {
 	public fun <init> ()V
-	public fun <init> (ZZZZJZ)V
-	public synthetic fun <init> (ZZZZJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZZJZ)V
+	public synthetic fun <init> (ZZZZZJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
-	public final fun component5 ()J
-	public final fun component6 ()Z
-	public final fun copy (ZZZZJZ)Lleakcanary/AppWatcher$Config;
-	public static synthetic fun copy$default (Lleakcanary/AppWatcher$Config;ZZZZJZILjava/lang/Object;)Lleakcanary/AppWatcher$Config;
+	public final fun component5 ()Z
+	public final fun component6 ()J
+	public final fun component7 ()Z
+	public final fun copy (ZZZZZJZ)Lleakcanary/AppWatcher$Config;
+	public static synthetic fun copy$default (Lleakcanary/AppWatcher$Config;ZZZZZJZILjava/lang/Object;)Lleakcanary/AppWatcher$Config;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnabled ()Z
 	public final fun getWatchActivities ()Z
 	public final fun getWatchDurationMillis ()J
 	public final fun getWatchFragmentViews ()Z
 	public final fun getWatchFragments ()Z
+	public final fun getWatchRootViews ()Z
 	public final fun getWatchViewModels ()Z
 	public fun hashCode ()I
 	public final fun newBuilder ()Lleakcanary/AppWatcher$Config$Builder;
@@ -38,6 +40,7 @@ public final class leakcanary/AppWatcher$Config$Builder {
 	public final fun watchDurationMillis (J)Lleakcanary/AppWatcher$Config$Builder;
 	public final fun watchFragmentViews (Z)Lleakcanary/AppWatcher$Config$Builder;
 	public final fun watchFragments (Z)Lleakcanary/AppWatcher$Config$Builder;
+	public final fun watchRootViews (Z)Lleakcanary/AppWatcher$Config$Builder;
 	public final fun watchViewModels (Z)Lleakcanary/AppWatcher$Config$Builder;
 }
 

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcher.kt
@@ -50,6 +50,24 @@ object AppWatcher {
     val watchViewModels: Boolean = true,
 
     /**
+     * Whether AppWatcher should automatically watch detached root view instances that
+     * were previously added to the window manager.
+     *
+     * Defaults to true.
+     *
+     * You can disable the spying of WindowManagerGlobal by overriding the
+     * `leak_canary_watcher_install_root_view_detach` boolean resource:
+     *
+     * ```
+     * <?xml version="1.0" encoding="utf-8"?>
+     * <resources>
+     *   <bool name="leak_canary_watcher_install_root_view_detach">false</bool>
+     * </resources>
+     * ```
+     */
+    val watchRootViews: Boolean = true,
+
+    /**
      * How long to wait before reporting a watched object as retained.
      *
      * Default to 5 seconds.
@@ -97,6 +115,7 @@ object AppWatcher {
       private var watchFragments = config.watchFragments
       private var watchFragmentViews = config.watchFragmentViews
       private var watchViewModels = config.watchViewModels
+      private var watchRootViews = config.watchRootViews
       private var watchDurationMillis = config.watchDurationMillis
 
       /** Deprecated. @see [Config.enabled] */
@@ -119,6 +138,10 @@ object AppWatcher {
       fun watchViewModels(watchViewModels: Boolean) =
         apply { this.watchViewModels = watchViewModels }
 
+      /** @see [Config.watchRootViews] */
+      fun watchRootViews(watchRootViews: Boolean) =
+        apply { this.watchRootViews = watchRootViews }
+
       /** @see [Config.watchDurationMillis] */
       fun watchDurationMillis(watchDurationMillis: Long) =
         apply { this.watchDurationMillis = watchDurationMillis }
@@ -128,6 +151,7 @@ object AppWatcher {
         watchFragments = watchFragments,
         watchFragmentViews = watchFragmentViews,
         watchViewModels = watchViewModels,
+        watchRootViews = watchRootViews,
         watchDurationMillis = watchDurationMillis
       )
     }

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/InternalAppWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/InternalAppWatcher.kt
@@ -5,6 +5,7 @@ import android.content.pm.ApplicationInfo
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import com.squareup.leakcanary.objectwatcher.R
 import leakcanary.AppWatcher
 import leakcanary.Clock
 import leakcanary.ObjectWatcher
@@ -74,6 +75,9 @@ internal object InternalAppWatcher {
     val configProvider = { AppWatcher.config }
     ActivityDestroyWatcher.install(application, objectWatcher, configProvider)
     FragmentDestroyWatcher.install(application, objectWatcher, configProvider)
+    if (application.resources.getBoolean(R.bool.leak_canary_watcher_install_root_view_detach)) {
+      RootViewDetachWatcher.install(objectWatcher, configProvider)
+    }
     onAppWatcherInstalled(application)
   }
 

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/RootViewDetachWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/internal/RootViewDetachWatcher.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package leakcanary.internal
+
+import android.annotation.SuppressLint
+import android.view.View
+import android.view.View.OnAttachStateChangeListener
+import leakcanary.AppWatcher.Config
+import leakcanary.ObjectWatcher
+import shark.SharkLog
+
+internal class RootViewDetachWatcher private constructor(
+  private val objectWatcher: ObjectWatcher,
+  private val configProvider: () -> Config
+) : OnAttachStateChangeListener {
+
+  private fun onRootViewAdded(rootView: View) {
+    rootView.addOnAttachStateChangeListener(this)
+  }
+
+  override fun onViewAttachedToWindow(view: View) {
+  }
+
+  override fun onViewDetachedFromWindow(view: View) {
+    if (configProvider().watchRootViews) {
+      objectWatcher.watch(
+        view, "${view::class.java.name} received View#onDetachedFromWindow() callback"
+      )
+    }
+  }
+
+  companion object {
+    @SuppressLint("PrivateApi")
+    fun install(
+      objectWatcher: ObjectWatcher,
+      configProvider: () -> Config
+    ) {
+      val rootViewDetachWatcher =
+        RootViewDetachWatcher(objectWatcher, configProvider)
+
+      try {
+        val windowManagerGlobalClass = Class.forName("android.view.WindowManagerGlobal")
+        val windowManagerGlobalInstance =
+          windowManagerGlobalClass.getDeclaredMethod("getInstance").invoke(null)
+
+        val mViewsField =
+          windowManagerGlobalClass.getDeclaredField("mViews").apply { isAccessible = true }
+
+        @Suppress("UNCHECKED_CAST")
+        val mViews = mViewsField[windowManagerGlobalInstance] as ArrayList<View>
+
+        mViewsField[windowManagerGlobalInstance] = object : ArrayList<View>(mViews) {
+          override fun add(element: View): Boolean {
+            rootViewDetachWatcher.onRootViewAdded(element)
+            return super.add(element)
+          }
+        }
+      } catch (ignored: Throwable) {
+        SharkLog.d(ignored) { "Could not watch detached root views" }
+      }
+    }
+  }
+}

--- a/leakcanary-object-watcher-android/src/main/res/values/leak_canary_public.xml
+++ b/leakcanary-object-watcher-android/src/main/res/values/leak_canary_public.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <public name="leak_canary_watcher_auto_install" type="bool"/>
+  <public name="leak_canary_watcher_install_root_view_detach" type="bool"/>
+</resources>

--- a/leakcanary-object-watcher-android/src/main/res/values/watcher_bools.xml
+++ b/leakcanary-object-watcher-android/src/main/res/values/watcher_bools.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <bool name="leak_canary_watcher_auto_install">true</bool>
+  <bool name="leak_canary_watcher_install_root_view_detach">true</bool>
 </resources>

--- a/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
+++ b/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
@@ -614,7 +614,8 @@ enum class AndroidObjectInspectors : ObjectInspector {
         if (mDestroyed.value.asBoolean!!) {
           leakingReasons += mDestroyed describedWithValue "true"
         } else {
-          notLeakingReasons += mDestroyed describedWithValue "false"
+          // A dialog window could be leaking, destroy is only set to false for activity windows.
+          labels += mDestroyed describedWithValue "false"
         }
       }
     }


### PR DESCRIPTION
LeakCanary will now automatically watch root views that are attached to the window manager and then detached. This should help detect leaks of dialogs, toasts.. and chatheads!

Fixes #1966

![Screenshot_1607379103](https://user-images.githubusercontent.com/557033/101411813-6f63e680-3896-11eb-969c-1a239dfb9e57.png)
