### PR TITLE
Fix exception

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakScreen.kt
@@ -52,12 +52,14 @@ internal class LeakScreen(
             val selectedLeakIndex =
               if (selectedHeapAnalysisId == null) 0 else leak.leakTraces.indexOfFirst { it.heapAnalysisId == selectedHeapAnalysisId }
 
-            val heapAnalysisId = leak.leakTraces[selectedLeakIndex].heapAnalysisId
-            val selectedHeapAnalysis =
-              HeapAnalysisTable.retrieve<HeapAnalysisSuccess>(db, heapAnalysisId)!!
+            if (selectedLeakIndex != -1) {
+              val heapAnalysisId = leak.leakTraces[selectedLeakIndex].heapAnalysisId
+              val selectedHeapAnalysis =
+                      HeapAnalysisTable.retrieve<HeapAnalysisSuccess>(db, heapAnalysisId)!!
 
-            updateUi {
-              onLeaksRetrieved(leak, selectedLeakIndex, selectedHeapAnalysis)
+              updateUi {
+                onLeaksRetrieved(leak, selectedLeakIndex, selectedHeapAnalysis)
+              }
             }
             LeakTable.markAsRead(db, leakSignature)
           }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakScreen.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/LeakScreen.kt
@@ -55,10 +55,17 @@ internal class LeakScreen(
             if (selectedLeakIndex != -1) {
               val heapAnalysisId = leak.leakTraces[selectedLeakIndex].heapAnalysisId
               val selectedHeapAnalysis =
-                      HeapAnalysisTable.retrieve<HeapAnalysisSuccess>(db, heapAnalysisId)!!
+                HeapAnalysisTable.retrieve<HeapAnalysisSuccess>(db, heapAnalysisId)!!
 
               updateUi {
                 onLeaksRetrieved(leak, selectedLeakIndex, selectedHeapAnalysis)
+              }
+            } else {
+              // This can happen if a delete was enqueued and is slow and the user tapped on a leak
+              // row before the deletion is perform and the UI update that leaves the screen
+              // executes.
+              updateUi {
+                activity.title = "Selected heap analysis deleted"
               }
             }
             LeakTable.markAsRead(db, leakSignature)


### PR DESCRIPTION
This happened on our monkey-test stand with 24 exceptions/day rate. Accept please :)
```
Exception: java.lang.ArrayIndexOutOfBoundsException: length=10; index=-1
       at java.util.ArrayList.get(ArrayList.java:439)
       at leakcanary.internal.activity.screen.LeakScreen$createView$$inlined$apply$lambda$1.invoke(LeakScreen.kt:54)
       at leakcanary.internal.activity.screen.LeakScreen$createView$$inlined$apply$lambda$1.invoke(LeakScreen.kt:35)
       at leakcanary.internal.activity.db.Db$execute$1.invoke(Db.kt:37)
       at leakcanary.internal.activity.db.Db$execute$1.invoke(Db.kt:10)
       at leakcanary.internal.activity.db.Io$execute$2.invoke(Io.kt:47)
       at leakcanary.internal.activity.db.Io$execute$2.run(Io.kt:12)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
       at java.lang.Thread.run(Thread.java:764)
```