### PR TITLE
Fix exception

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/HeapAnalysisTable.kt
@@ -14,10 +14,11 @@ import shark.HeapAnalysisFailure
 import shark.HeapAnalysisSuccess
 import shark.SharkLog
 import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 
 internal object HeapAnalysisTable {
 
-  private val updateListeners = mutableListOf<() -> Unit>()
+  private val updateListeners = CopyOnWriteArrayList<() -> Unit>()
 
   private val mainHandler = Handler(Looper.getMainLooper())
 


### PR DESCRIPTION
Another rare crash that our monkey found, 2 crashes/day
```
Non-fatal Exception: java.util.ConcurrentModificationException
       at java.util.ArrayList$Itr.next(ArrayList.java:860)
       at leakcanary.internal.activity.db.HeapAnalysisTable$notifyUpdateOnMainThread$1.run(HeapAnalysisTable.kt:207)
       at android.os.Handler.handleCallback(Handler.java:790)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6494)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```