### PR TITLE
RootViewWatcher is a no op pre API 19

### DIFF
--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/RootViewWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/RootViewWatcher.kt
@@ -16,6 +16,7 @@
 package leakcanary
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.view.View
 import android.view.View.OnAttachStateChangeListener
 import leakcanary.internal.mainHandler
@@ -30,6 +31,9 @@ class RootViewWatcher(
 ) : InstallableWatcher {
 
   override fun install() {
+    if (Build.VERSION.SDK_INT < 19) {
+      return
+    }
     swapViewManagerGlobalMViews { mViews ->
       object : ArrayList<View>(mViews) {
         override fun add(element: View): Boolean {
@@ -41,6 +45,9 @@ class RootViewWatcher(
   }
 
   override fun uninstall() {
+    if (Build.VERSION.SDK_INT < 19) {
+      return
+    }
     swapViewManagerGlobalMViews { mViews ->
       ArrayList(mViews)
     }


### PR DESCRIPTION
The WindowManagerGlobal.mViews array list was added for API 19.

Fixes #2016