### PR TITLE
Fix crash for methods with no arguments and rethrow exceptions

### DIFF
--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/ServiceWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/ServiceWatcher.kt
@@ -8,6 +8,7 @@ import android.os.IBinder
 import leakcanary.internal.friendly.checkMainThread
 import shark.SharkLog
 import java.lang.ref.WeakReference
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Proxy
 import java.util.WeakHashMap
 
@@ -77,7 +78,15 @@ class ServiceWatcher(private val reachabilityWatcher: ReachabilityWatcher) : Ins
               onServiceDestroyed(token)
             }
           }
-          method.invoke(activityManagerInstance, *args)
+          try {
+            if (args == null) {
+              method.invoke(activityManagerInstance)
+            } else {
+              method.invoke(activityManagerInstance, *args)
+            }
+          } catch (invocationException: InvocationTargetException) {
+            throw invocationException.targetException
+          }
         }
       }
     } catch (ignored: Throwable) {


### PR DESCRIPTION
cc @ChaosLeung Kotlin is a bit annoying with varargs, the spread operator calls `args.length` which will cause a NullPointerException when args is null (args is null if the proxied method call has no argument).