### PR TITLE
Upgrade emulator runner Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         run: ./gradlew assembleAndroidTest --stacktrace
 
       - name: Espresso Checks
-        uses: reactivecircus/android-emulator-runner@v2.13.0
+        uses: reactivecircus/android-emulator-runner@v2.14.3
         with:
           api-level: 16
           script: ./gradlew leakcanary-android-core:connectedCheck leakcanary-android-instrumentation:connectedCheck --stacktrace


### PR DESCRIPTION
~~Hopefully makes the `sdkmanager: command not found` error go away.~~ Seems to do the job.
