### PR TITLE
Add reason to NoAnalysis

### DIFF
--- a/leakcanary-android-instrumentation/api/leakcanary-android-instrumentation.api
+++ b/leakcanary-android-instrumentation/api/leakcanary-android-instrumentation.api
@@ -47,6 +47,7 @@ public final class leakcanary/InstrumentationLeakDetector$Result$AnalysisPerform
 }
 
 public final class leakcanary/InstrumentationLeakDetector$Result$NoAnalysis : leakcanary/InstrumentationLeakDetector$Result {
-	public static final field INSTANCE Lleakcanary/InstrumentationLeakDetector$Result$NoAnalysis;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getReason ()Ljava/lang/String;
 }
 

--- a/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/TestUtils.kt
+++ b/leakcanary-android-instrumentation/src/androidTest/java/leakcanary/TestUtils.kt
@@ -9,7 +9,9 @@ object TestUtils {
     val leakDetector = InstrumentationLeakDetector()
 
     val heapAnalysis = when (val result = leakDetector.detectLeaks()) {
-      is NoAnalysis -> throw AssertionError("Expected analysis to be performed")
+      is NoAnalysis -> throw AssertionError(
+        "Expected analysis to be performed but skipped because ${result.reason}"
+      )
       is AnalysisPerformed -> result.heapAnalysis
     }
 


### PR DESCRIPTION
Reimplement #2065.

I am trying to enable leak canary in tests in my repo's
CI pipeline but found that leak detector for all tests
are returned with NoAnalysis.

So I am adding logs in this commit to help us understand
where the exit point is, given that there are multiple
return statements and checking on the timestamp is not
always reliable.