### PR TITLE
Update launcher activity attribute to Android 12

### DIFF
--- a/leakcanary-android-core/src/main/AndroidManifest.xml
+++ b/leakcanary-android-core/src/main/AndroidManifest.xml
@@ -54,6 +54,7 @@
         android:targetActivity="leakcanary.internal.activity.LeakActivity"
         android:taskAffinity="com.squareup.leakcanary.${applicationId}"
         android:theme="@style/leak_canary_LeakCanary.Base"
+        android:exported="true"
         >
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
To be able to target Android 12 all activities that use intent filters must declare the `android:exported` attribute.
Reference:   https://developer.android.com/about/versions/12/behavior-changes-12#exported

This pull request adds the attribute on `LeakLauncherActivity`.
Without it, apps that have a dependency on LeakCanary will not be able to target Android 12.

I got the following error when trying to build an app that depends on LeakCanary targeting Android 12:
>Failed to commit install session 473003211 with command cmd package install-commit 473003211. Error: INSTALL_PARSE_FAILED_MANIFEST_MALFORMED: Failed parse during installPackageLI: /data/app/vmdl473003211.tmp/base.apk (at Binary XML file line 752): leakcanary.internal.activity.LeakLauncherActivity: Targeting S+ (version 10000 and above) requires that an explicit value for android:exported be defined when intent filters are present
