### PR TITLE
Use Curtains for root view leak detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
       ],
       android_support: 'com.android.support:support-v4:28.0.0',
       clikt: 'com.github.ajalt:clikt:2.3.0',
+      curtains: 'com.squareup.curtains:curtains:1.0.1',
       jline: 'jline:jline:2.14.6',
       detekt: 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.6.0',
       junit: 'junit:junit:4.12',

--- a/leakcanary-object-watcher-android/build.gradle
+++ b/leakcanary-object-watcher-android/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   api project(':leakcanary-object-watcher')
   api project(':leakcanary-android-utils')
 
+  implementation deps.curtains
   implementation deps.kotlin.stdlib
 
   testImplementation deps.assertj_core

--- a/leakcanary-object-watcher-android/src/main/res/values/leak_canary_public.xml
+++ b/leakcanary-object-watcher-android/src/main/res/values/leak_canary_public.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <public name="leak_canary_watcher_auto_install" type="bool"/>
+  <public name="leak_canary_watcher_watch_dismissed_dialogs" type="bool"/>
 </resources>

--- a/leakcanary-object-watcher-android/src/main/res/values/watcher_bools.xml
+++ b/leakcanary-object-watcher-android/src/main/res/values/watcher_bools.xml
@@ -4,4 +4,5 @@
    If false, you need to call AppWatcher.manualInstall().
    -->
   <bool name="leak_canary_watcher_auto_install">true</bool>
+  <bool name="leak_canary_watcher_watch_dismissed_dialogs">false</bool>
 </resources>


### PR DESCRIPTION
- Remove the internal hacks and leverage the ones in Curtains
- More fine grained approach to root view leak detection with less annoying defaults.
- New leak_canary_watcher_watch_dismissed_dialogs boolean which defaults to false as holding dialogs for reuse seems to be a common pattern.

Fixes #2051