### PR TITLE
Issue #2079. Fix a crash when targeting Android 12

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import leakcanary.internal.NotificationReceiver.Action.CANCEL_NOTIFICATION
 import leakcanary.internal.NotificationReceiver.Action.DUMP_HEAP
 import shark.SharkLog
@@ -39,7 +40,12 @@ internal class NotificationReceiver : BroadcastReceiver() {
     ): PendingIntent {
       val broadcastIntent = Intent(context, NotificationReceiver::class.java)
       broadcastIntent.action = action.name
-      return PendingIntent.getBroadcast(context, 0, broadcastIntent, 0)
+      val flags = if (Build.VERSION.SDK_INT > 30) {
+        PendingIntent.FLAG_IMMUTABLE
+      } else {
+        0
+      }
+      return PendingIntent.getBroadcast(context, 0, broadcastIntent, flags)
     }
   }
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
@@ -20,18 +20,19 @@ import android.annotation.TargetApi
 import android.app.Activity
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.pm.PackageManager.PERMISSION_GRANTED
-import android.os.Build.VERSION_CODES.M
 import android.os.Bundle
+import android.os.Build
 import android.widget.Toast
 import android.widget.Toast.LENGTH_LONG
 import com.squareup.leakcanary.core.R
 
-@TargetApi(M) //
+@TargetApi(Build.VERSION_CODES.M) //
 internal class RequestStoragePermissionActivity : Activity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -74,7 +75,12 @@ internal class RequestStoragePermissionActivity : Activity() {
     fun createPendingIntent(context: Context): PendingIntent {
       val intent = Intent(context, RequestStoragePermissionActivity::class.java)
       intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP
-      return PendingIntent.getActivity(context, 1, intent, FLAG_UPDATE_CURRENT)
+      val flags = if (Build.VERSION.SDK_INT > 30) {
+        FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE
+      } else {
+        FLAG_UPDATE_CURRENT
+      }
+      return PendingIntent.getActivity(context, 1, intent, flags)
     }
   }
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.AsyncTask
 import android.os.Bundle
+import android.os.Build
 import android.view.View
 import com.squareup.leakcanary.core.R
 import leakcanary.internal.HeapAnalyzerService
@@ -178,7 +179,12 @@ internal class LeakActivity : NavigatingActivity() {
       val intent = Intent(context, LeakActivity::class.java)
       intent.putExtra("screens", screens)
       intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-      return PendingIntent.getActivity(context, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+      val flags = if (Build.VERSION.SDK_INT > 30) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+      }
+      return PendingIntent.getActivity(context, 1, intent, flags)
     }
 
     fun createIntent(context: Context): Intent {


### PR DESCRIPTION
Since Android 12 we need to set PendingIntent mutability explicitly.

Here is the documentation: https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

Error message:
```Targeting S+ (version 10000 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent. Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.```

Fixes Issue #2079