### PR TITLE
Add instructions of installation from AUR

### DIFF
--- a/docs/shark.md
+++ b/docs/shark.md
@@ -38,6 +38,11 @@ Install it via [Homebrew](https://brew.sh/):
 brew install leakcanary-shark
 ```
 
+Also available on [Archlinux AUR](https://aur.archlinux.org/packages/leakcanary-shark-cli/)
+```bash
+yay -S leakcanary-shark-cli
+```
+
 You can also download it [here](https://github.com/square/leakcanary/releases/download/v{{ leak_canary.release }}/shark-cli-{{ leak_canary.release }}.zip).
 
 You can then look for leaks in apps on any connected device, for example: 


### PR DESCRIPTION
Add instruction about AUR installation: https://aur.archlinux.org/packages/leakcanary-shark-cli/