### PR TITLE
Register intent-filter to import hprof files

### DIFF
--- a/leakcanary-android-core/src/androidTest/AndroidManifest.xml
+++ b/leakcanary-android-core/src/androidTest/AndroidManifest.xml
@@ -16,4 +16,7 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.squareup.leakcanary.core.test">
+    <application>
+        <service android:name="leakcanary.internal.HeapAnalyzerService"/>
+    </application>
 </manifest>

--- a/leakcanary-android-core/src/androidTest/java/leakcanary/LeakActivityTest.kt
+++ b/leakcanary-android-core/src/androidTest/java/leakcanary/LeakActivityTest.kt
@@ -1,20 +1,19 @@
 package leakcanary
 
-import android.os.SystemClock
+import android.content.Intent
+import android.net.Uri
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withSubstring
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import com.squareup.leakcanary.core.R
 import leakcanary.internal.activity.LeakActivity
 import leakcanary.internal.activity.db.HeapAnalysisTable
-import leakcanary.internal.activity.db.HeapAnalysisTable.Projection
 import leakcanary.internal.activity.db.LeakTable.AllLeaksProjection
 import leakcanary.internal.activity.db.LeaksDbHelper
 import org.hamcrest.Description
@@ -28,12 +27,10 @@ import shark.GcRoot.JniGlobal
 import shark.HeapAnalyzer
 import shark.HprofWriterHelper
 import shark.LeakTraceObject
-import shark.LeakTraceReference
 import shark.OnAnalysisProgressListener
-import shark.SharkLog
 import shark.ValueHolder.IntHolder
 import shark.dump
-import kotlin.reflect.KClass
+import java.io.File
 
 internal class LeakActivityTest {
 
@@ -94,7 +91,22 @@ internal class LeakActivityTest {
       .check(matches(isDisplayed()))
   }
 
-  private fun insertHeapDump(block: HprofWriterHelper.() -> Unit) {
+  @Test
+  fun importHeapDumpFile() {
+    val hprof = writeHeapDump {
+      "Holder" clazz {
+        staticField["leak"] = "com.example.Leaking" watchedInstance {}
+      }
+    }
+    val intent = Intent(Intent.ACTION_VIEW, Uri.fromFile(hprof))
+    activityTestRule.launchActivity(intent)
+    onView(withText("1 Heap Dump")).check(matches(isDisplayed()))
+    onData(withItem<HeapAnalysisTable.Projection> { it.leakCount == 1 })
+      .perform(click())
+    onView(withText("1 Distinct Leak")).check(matches(isDisplayed()))
+  }
+
+  private fun writeHeapDump(block: HprofWriterHelper.() -> Unit): File {
     val hprofFile = testFolder.newFile("temp.hprof")
     hprofFile.dump {
       "android.os.Build" clazz {
@@ -105,7 +117,11 @@ internal class LeakActivityTest {
       }
       block()
     }
+    return hprofFile
+  }
 
+  private fun insertHeapDump(block: HprofWriterHelper.() -> Unit) {
+    val hprofFile = writeHeapDump(block)
     val heapAnalyzer = HeapAnalyzer(OnAnalysisProgressListener.NO_OP)
     val result = heapAnalyzer.analyze(
       heapDumpFile = hprofFile,

--- a/leakcanary-android-core/src/androidTest/java/leakcanary/LeakActivityTest.kt
+++ b/leakcanary-android-core/src/androidTest/java/leakcanary/LeakActivityTest.kt
@@ -94,7 +94,7 @@ internal class LeakActivityTest {
   }
 
   @Test
-  fun importHeapDumpFile() {
+  fun importHeapDumpFile() = tryAndRestoreConfig {
     val latch = CountDownLatch(1)
     LeakCanary.config = LeakCanary.config.copy(onHeapAnalyzedListener = {
       DefaultOnHeapAnalyzedListener.create().onHeapAnalyzed(it)
@@ -163,4 +163,14 @@ internal class LeakActivityTest {
       }
     }
   }
+
+  private fun tryAndRestoreConfig(block: () -> Unit) {
+    val original = LeakCanary.config
+    try {
+      block()
+    } finally {
+      LeakCanary.config = original
+    }
+  }
+
 }

--- a/leakcanary-android-core/src/main/AndroidManifest.xml
+++ b/leakcanary-android-core/src/main/AndroidManifest.xml
@@ -62,7 +62,12 @@
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.hprof"/>
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.hprof"/>
         <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.hprof"/>
-        <!--Since hprof isn't a standard MIME type, we have to declare such patterns.-->
+        <!--
+            Since hprof isn't a standard MIME type, we have to declare such patterns.
+            Most file providers will generate URIs including their own package name,
+            which contains `.` characters that must be explicitly escaped in pathPattern.
+            @see https://stackoverflow.com/a/31028507/703646
+        -->
       </intent-filter>
     </activity>
 

--- a/leakcanary-android-core/src/main/AndroidManifest.xml
+++ b/leakcanary-android-core/src/main/AndroidManifest.xml
@@ -43,7 +43,28 @@
         android:label="@string/leak_canary_display_activity_label"
         android:taskAffinity="com.squareup.leakcanary.${applicationId}"
         android:theme="@style/leak_canary_LeakCanary.Base"
-        />
+        >
+      <intent-filter android:label="@string/leak_canary_import_hprof_file">
+        <action android:name="android.intent.action.VIEW"/>
+
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+
+        <data android:scheme="file"/>
+        <data android:scheme="content"/>
+        <data android:mimeType="*/*"/>
+        <data android:host="*"/>
+
+        <data android:pathPattern=".*\\.hprof"/>
+        <data android:pathPattern=".*\\..*\\.hprof"/>
+        <data android:pathPattern=".*\\..*\\..*\\.hprof"/>
+        <data android:pathPattern=".*\\..*\\..*\\..*\\.hprof"/>
+        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.hprof"/>
+        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\.hprof"/>
+        <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\.hprof"/>
+        <!--Since hprof isn't a standard MIME type, we have to declare such patterns.-->
+      </intent-filter>
+    </activity>
 
     <activity-alias
         android:name="leakcanary.internal.activity.LeakLauncherActivity"

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -156,7 +156,7 @@ internal class LeakActivity : NavigatingActivity() {
                     input.copyTo(output, DEFAULT_BUFFER_SIZE)
                   }
               }
-              HeapAnalyzerService.runAnalysis(this, target)
+              HeapAnalyzerService.runAnalysis(this, target, heapDumpReason = "Imported by user")
             }
         }
     } catch (e: IOException) {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -60,6 +60,18 @@ internal class LeakActivity : NavigatingActivity() {
     leaksButton.setOnClickListener { resetTo(LeaksScreen()) }
     heapDumpsButton.setOnClickListener { resetTo(HeapDumpsScreen()) }
     aboutButton.setOnClickListener { resetTo(AboutScreen()) }
+
+    handleViewHprof(intent)
+  }
+
+  private fun handleViewHprof(intent: Intent?) {
+    if (intent?.action != Intent.ACTION_VIEW) return
+    val uri = intent.data ?: return
+    if (uri.lastPathSegment?.endsWith(".hprof") != true) return
+    resetTo(HeapDumpsScreen())
+    AsyncTask.THREAD_POOL_EXECUTOR.execute {
+      importHprof(uri)
+    }
   }
 
   override fun onNewScreen(screen: Screen) {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -8,6 +8,7 @@ import android.os.AsyncTask
 import android.os.Bundle
 import android.os.Build
 import android.view.View
+import android.widget.Toast
 import com.squareup.leakcanary.core.R
 import leakcanary.internal.HeapAnalyzerService
 import leakcanary.internal.InternalLeakCanary
@@ -67,7 +68,10 @@ internal class LeakActivity : NavigatingActivity() {
   private fun handleViewHprof(intent: Intent?) {
     if (intent?.action != Intent.ACTION_VIEW) return
     val uri = intent.data ?: return
-    if (uri.lastPathSegment?.endsWith(".hprof") != true) return
+    if (uri.lastPathSegment?.endsWith(".hprof") != true) {
+      Toast.makeText(this, getString(R.string.leak_canary_import_unsupported_file_extension, uri.lastPathSegment), Toast.LENGTH_LONG).show()
+      return
+    }
     resetTo(HeapDumpsScreen())
     AsyncTask.THREAD_POOL_EXECUTOR.execute {
       importHprof(uri)

--- a/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
+++ b/leakcanary-android-core/src/main/res/values/leak_canary_strings.xml
@@ -92,6 +92,7 @@
     <item quantity="other">%1$d leaks at %2$s</item>
   </plurals>
   <string name="leak_canary_group_list_time_label">Last leaked %s</string>
+  <string name="leak_canary_import_unsupported_file_extension">Could not import %s, this is not an hprof file.</string>
   <string name="leak_canary_import_from_title">Import From…</string>
   <string name="leak_canary_dump_heap">Dump Heap Now</string>
   <string name="leak_canary_import_hprof_file">Import Heap Dump</string>


### PR DESCRIPTION
Here is my take on this. Let me know what you think about the implementation.

It uses an intent-filter workaround because of how Android allow us to specify `pathPattern` (limited regex support and no standard MIME type).
I've also forced to reset to the HeapDumps screen which seems better for what we're trying to achieve here.

I've tested it on Android's file explorer (open with),  Google's Files app, and Solid Explorer.

There are 2 possible outcomes when we try to open such files:
- if there is only a single app supporting the intent, the system opens it immediately
- otherwise, a disambiguation dialog (the intent chooser) let the user pick an app (demo)

https://user-images.githubusercontent.com/1921278/117359059-310b3b80-aeb7-11eb-85d3-659afc3c33ab.mp4

Resolves #2096