### PR TITLE
Mark PendingIntents with FLAG_IMMUTABLE

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
@@ -40,7 +40,7 @@ internal class NotificationReceiver : BroadcastReceiver() {
     ): PendingIntent {
       val broadcastIntent = Intent(context, NotificationReceiver::class.java)
       broadcastIntent.action = action.name
-      val flags = if (Build.VERSION.SDK_INT > 30) {
+      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         PendingIntent.FLAG_IMMUTABLE
       } else {
         0

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
@@ -40,7 +40,7 @@ internal class NotificationReceiver : BroadcastReceiver() {
     ): PendingIntent {
       val broadcastIntent = Intent(context, NotificationReceiver::class.java)
       broadcastIntent.action = action.name
-      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      val flags = if (Build.VERSION.SDK_INT >= 23) {
         PendingIntent.FLAG_IMMUTABLE
       } else {
         0

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
@@ -75,7 +75,7 @@ internal class RequestStoragePermissionActivity : Activity() {
     fun createPendingIntent(context: Context): PendingIntent {
       val intent = Intent(context, RequestStoragePermissionActivity::class.java)
       intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT > 30) {
+      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE
       } else {
         FLAG_UPDATE_CURRENT

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
@@ -75,7 +75,7 @@ internal class RequestStoragePermissionActivity : Activity() {
     fun createPendingIntent(context: Context): PendingIntent {
       val intent = Intent(context, RequestStoragePermissionActivity::class.java)
       intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      val flags = if (Build.VERSION.SDK_INT >= 23) {
         FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE
       } else {
         FLAG_UPDATE_CURRENT

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -179,7 +179,7 @@ internal class LeakActivity : NavigatingActivity() {
       val intent = Intent(context, LeakActivity::class.java)
       intent.putExtra("screens", screens)
       intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      val flags = if (Build.VERSION.SDK_INT >= 23) {
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
       } else {
         PendingIntent.FLAG_UPDATE_CURRENT

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -179,7 +179,7 @@ internal class LeakActivity : NavigatingActivity() {
       val intent = Intent(context, LeakActivity::class.java)
       intent.putExtra("screens", screens)
       intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT > 30) {
+      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
       } else {
         PendingIntent.FLAG_UPDATE_CURRENT


### PR DESCRIPTION
Checking for SDK_INT > 30 doesn't work on Android 12 because, while it is in developer preview, SDK_INT is still 30. FLAG_IMMUTABLE was introduced in M, so it can be used in M+ devices.