### PR TITLE
More natural list selector

### DIFF
--- a/leakcanary-android-core/src/main/res/drawable-v21/leak_canary_gray_fill.xml
+++ b/leakcanary-android-core/src/main/res/drawable-v21/leak_canary_gray_fill.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:attr/colorControlHighlight">
+    <item android:id="@android:id/mask">
         <shape>
-            <solid android:color="@color/leak_canary_gray_3f" />
+            <solid android:color="@color/leak_canary_gray" />
             <corners android:radius="20dp" />
         </shape>
     </item>
@@ -12,4 +13,4 @@
             <corners android:radius="20dp" />
         </shape>
     </item>
-</selector>
+</ripple>

--- a/leakcanary-android-core/src/main/res/drawable-v21/leak_canary_list_selector.xml
+++ b/leakcanary-android-core/src/main/res/drawable-v21/leak_canary_list_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:state_pressed="false">
+        <color android:color="?android:attr/colorControlHighlight" />
+    </item>
+    <item>
+        <color android:color="@android:color/transparent" />
+    </item>
+</selector>

--- a/leakcanary-android-core/src/main/res/drawable/leak_canary_list_selector.xml
+++ b/leakcanary-android-core/src/main/res/drawable/leak_canary_list_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:state_pressed="false">
+        <color android:color="@color/leak_canary_gray_3f" />
+    </item>
+    <item>
+        <color android:color="@android:color/transparent" />
+    </item>
+</selector>

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_heap_dumps_screen.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_heap_dumps_screen.xml
@@ -9,6 +9,7 @@
       android:layout_width="match_parent"
       android:layout_height="0dp"
       android:layout_weight="1"
+      android:listSelector="@drawable/leak_canary_list_selector"
       android:divider="@null"
       android:dividerHeight="0dp"
       />

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_leak_screen.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_leak_screen.xml
@@ -31,6 +31,7 @@
       android:id="@+id/leak_canary_list"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      android:listSelector="@drawable/leak_canary_list_selector"
       android:divider="@null"
       android:dividerHeight="0dp"
       />

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_list.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_list.xml
@@ -7,6 +7,7 @@
       android:id="@+id/leak_canary_list"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      android:listSelector="@drawable/leak_canary_list_selector"
       android:divider="@null"
       android:dividerHeight="0dp"
       />


### PR DESCRIPTION
List item background is replaced by a ripple on supported APIs.

ListView's listSelector is explicitly overridden with a custom Drawable that restores the focused state which is kind of clunky in ListView.
Unfortunately, using itemsCanFocus with a focusable View inside the list item will prevent the AdapterView.OnItemClickListener to work as intended.


- Focused state on API < 21

  | Current | New |
  | --- | --- |
  | ![api19-focused-old](https://user-images.githubusercontent.com/1921278/118843840-b684e780-b8ca-11eb-98fa-1cccf3c1548f.png) | ![api19-focused-new](https://user-images.githubusercontent.com/1921278/118843792-acfb7f80-b8ca-11eb-86a7-c6a0d105b7ac.png) |
- Focused state on API >= 21

  | Current | New |
  | --- | --- |
  | ![api21-focused-old](https://user-images.githubusercontent.com/1921278/118843883-c0a6e600-b8ca-11eb-87bf-64f309847d58.png) | ![api21-focused-new](https://user-images.githubusercontent.com/1921278/118843916-ca304e00-b8ca-11eb-95f3-827c986c5995.png) |

- Pressed state on API < 21

  | Current | New |
  | --- | --- |
  | ![api19-pressed-old](https://user-images.githubusercontent.com/1921278/118843949-d3b9b600-b8ca-11eb-9a9a-2868dde5e686.png) | ![api19-pressed-new](https://user-images.githubusercontent.com/1921278/118843986-dddbb480-b8ca-11eb-83a1-ed9558d70c35.png) |
- Pressed state on API >= 21

  | Current | New |
  | --- | --- |
  | ![api21-pressed-old](https://user-images.githubusercontent.com/1921278/118844020-e6cc8600-b8ca-11eb-801e-75620e752017.png) | ![api21-pressed-new](https://user-images.githubusercontent.com/1921278/118844041-eb913a00-b8ca-11eb-87ba-192c0b5e9730.png) |



And here are demo clips on a real device running Android 11:

https://user-images.githubusercontent.com/1921278/118844229-167b8e00-b8cb-11eb-9a1a-ff1e405c272b.mp4

https://user-images.githubusercontent.com/1921278/118844246-1bd8d880-b8cb-11eb-9f35-d1989d2c0faa.mp4
