### PR TITLE
Use the new way of plugins application. Migrate to lazy Gradle api to avoid eager tasks configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+insert_final_newline = true
+
+[*.gradle]
+indent_size = 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   checks:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
 
       - name: Project Checkout

--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,7 @@ buildscript {
   ]
   repositories {
     google()
-    maven { url 'https://plugins.gradle.org/m2/' }
-    jcenter()
+    gradlePluginPortal()
     // For binary compatibility validator.
     maven { url "https://kotlin.bintray.com/kotlinx" }
   }
@@ -114,7 +113,7 @@ subprojects {
     outputDirectory = "$rootDir/docs/api"
   }
 
-  tasks.withType(JavaCompile) {
+  tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [
         '-Xlint:all',
         '-Xlint:-serial',
@@ -132,8 +131,7 @@ subprojects {
     }
   }
 
-
-  configurations.all {
+  configurations.configureEach {
     resolutionStrategy {
       eachDependency { details ->
         // Force all the error-prone dependencies to use the same version.
@@ -145,7 +143,7 @@ subprojects {
     }
   }
 
-  tasks.withType(Test) {
+  tasks.withType(Test).configureEach {
     testLogging {
       exceptionFormat 'FULL'
       showCauses true
@@ -162,10 +160,10 @@ subprojects {
     }
   }
 
-  afterEvaluate {
-    tasks.getByName('check').dependsOn 'detekt'
-    tasks.getByName('assemble').dependsOn installGitHooks
-    tasks.getByName('clean').dependsOn installGitHooks
+  pluginManager.withPlugin("java") {
+    tasks.named("check") { dependsOn("detekt") }
+    tasks.named("assemble") { dependsOn(rootProject.tasks.named("installGitHooks")) }
+    tasks.named("clean") { dependsOn(rootProject.tasks.named("installGitHooks")) }
   }
 
   dependencies {
@@ -175,7 +173,7 @@ subprojects {
 
 //Copies git hooks from /hooks folder into .git; currently used to run Detekt during push
 //Git hook installation
-task installGitHooks(type: Copy) {
+tasks.register("installGitHooks", Copy) {
   from new File(rootProject.rootDir, 'hooks')
   into { new File(rootProject.rootDir, '.git/hooks') }
   fileMode 0777 //Make files executable

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -79,7 +79,7 @@ afterEvaluate { project ->
 
     def plugins = project.getPlugins()
     if (plugins.hasPlugin('com.android.application') || plugins.hasPlugin('com.android.library')) {
-      task androidJavadocs(type: Javadoc) {
+      tasks.register("androidJavadocs", Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         // TODO Update to include KT files OR stop publishing javadoc artifacts.
         exclude "**/*.kt"
@@ -95,12 +95,13 @@ afterEvaluate { project ->
         classpath += releaseVariant.javaCompile.outputs.files
       }
 
-      task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+      tasks.register("androidJavadocsJar", Jar) {
+        dependsOn("androidJavadocs")
         classifier = 'javadoc'
         from androidJavadocs.destinationDir
       }
 
-      task androidSourcesJar(type: Jar) {
+      tasks.register("androidSourcesJar", Jar) {
         classifier = 'sources'
         from android.sourceSets.main.java.source
       }
@@ -111,12 +112,13 @@ afterEvaluate { project ->
       }
     }
     else {
-      task sourcesJar(type: Jar, dependsOn: classes) {
+      tasks.register("sourcesJar", Jar) {
+        dependsOn("classes")
         classifier = 'sources'
         from sourceSets.main.allSource
       }
 
-      task javadocsJar(type: Jar, dependsOn: javadoc) {
+      tasks.register("javadocsJar", Jar) {
         classifier = 'javadoc'
         from javadoc.destinationDir
       }
@@ -129,7 +131,7 @@ afterEvaluate { project ->
 
     if (JavaVersion.current().isJava8Compatible()) {
       allprojects {
-        tasks.withType(Javadoc) {
+        tasks.withType(Javadoc).configureEach {
           options.addStringOption('Xdoclint:none', '-quiet')
         }
       }

--- a/leakcanary-android-core/build.gradle
+++ b/leakcanary-android-core/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':shark-android')

--- a/leakcanary-android-instrumentation/build.gradle
+++ b/leakcanary-android-instrumentation/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':leakcanary-android-core')

--- a/leakcanary-android-process/build.gradle
+++ b/leakcanary-android-process/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':leakcanary-android-core')

--- a/leakcanary-android-release/build.gradle
+++ b/leakcanary-android-release/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':shark-android')

--- a/leakcanary-android-sample/build.gradle
+++ b/leakcanary-android-sample/build.gradle
@@ -1,15 +1,14 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-// Required to run obfuscated instrumentation tests:
-// ./gradlew leakcanary-android-sample:connectedCheck -Pminify
-apply plugin: 'com.slack.keeper'
+plugins {
+  id("com.android.application")
+  id("org.jetbrains.kotlin.android")
+  // Required to run obfuscated instrumentation tests:
+  // ./gradlew leakcanary-android-sample:connectedCheck -Pminify
+  id("com.slack.keeper") version "0.7.0"
+}
 
-buildscript {
-  repositories {
-    maven { url 'https://plugins.gradle.org/m2/' }
-  }
-  dependencies {
-    classpath 'com.slack.keeper:keeper:0.2.0'
+keeper {
+  variantFilter {
+    setIgnore(!project.hasProperty('minify'))
   }
 }
 
@@ -84,18 +83,6 @@ android {
   testOptions {
     unitTests {
       includeAndroidResources = true
-    }
-  }
-}
-
-// Instrumentation test dependencies resolve to 27.1.1 so we align the sample.
-configurations.all {
-  resolutionStrategy {
-    eachDependency { details ->
-      // Force all of the primary support libraries to use the same version.
-      if (details.requested.group == 'com.android.support') {
-        details.useVersion "27.1.1"
-      }
     }
   }
 }

--- a/leakcanary-android-utils/build.gradle
+++ b/leakcanary-android-utils/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':shark-log')

--- a/leakcanary-android/build.gradle
+++ b/leakcanary-android/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':leakcanary-android-core')

--- a/leakcanary-deobfuscation-gradle-plugin/build.gradle
+++ b/leakcanary-deobfuscation-gradle-plugin/build.gradle
@@ -1,6 +1,7 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'java-gradle-plugin'
-apply plugin: 'maven'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("java-gradle-plugin")
+}
 
 gradlePlugin {
   plugins {

--- a/leakcanary-deobfuscation-gradle-plugin/src/main/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPlugin.kt
+++ b/leakcanary-deobfuscation-gradle-plugin/src/main/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPlugin.kt
@@ -38,7 +38,7 @@ class LeakCanaryLeakDeobfuscationPlugin : Plugin<Project> {
     val leakCanaryPluginAction = Action<AppliedPlugin> {
       val leakCanaryExtension = createLeakCanaryExtension(project)
       val variants = findAndroidVariants(project)
-      variants.all { variant ->
+      variants.configureEach { variant ->
         if (leakCanaryExtension.filterObfuscatedVariants(variant)) {
           setupTasks(project, variant)
         }

--- a/leakcanary-object-watcher-android-androidx/build.gradle
+++ b/leakcanary-object-watcher-android-androidx/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':leakcanary-object-watcher-android')

--- a/leakcanary-object-watcher-android-support-fragments/build.gradle
+++ b/leakcanary-object-watcher-android-support-fragments/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':leakcanary-object-watcher-android')

--- a/leakcanary-object-watcher-android/build.gradle
+++ b/leakcanary-object-watcher-android/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':leakcanary-object-watcher')
@@ -28,7 +30,7 @@ android {
   }
 
   // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-  libraryVariants.all {
+  libraryVariants.configureEach {
     it.generateBuildConfig.enabled = false
   }
 }

--- a/leakcanary-object-watcher/build.gradle
+++ b/leakcanary-object-watcher/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/plumber-android/build.gradle
+++ b/plumber-android/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 dependencies {
   api project(':shark-log')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,23 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.android.application") {
+                useModule("com.android.tools.build:gradle:${requested.version}")
+            }
+        }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.android.library") {
+                useModule("com.android.tools.build:gradle:${requested.version}")
+            }
+        }
+    }
+}
 include ':plumber-android'
 include ':leakcanary-android'
 include ':leakcanary-android-core'

--- a/shark-android/build.gradle
+++ b/shark-android/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/shark-cli/build.gradle
+++ b/shark-cli/build.gradle
@@ -1,12 +1,18 @@
-apply plugin: 'java'
-apply plugin: 'kotlin'
-apply plugin: 'application'
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("application")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+
 // Workaround for https://stackoverflow.com/questions/48988778
 // /cannot-inline-bytecode-built-with-jvm-target-1-8-into-bytecode-that-is-being-bui
-compileKotlin.kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+}
 
 dependencies {
   api project(':shark-android')
@@ -30,7 +36,7 @@ sourceSets {
   }
 }
 
-task generateVersionProperties {
+tasks.register("generateVersionProperties") {
   doLast {
     def propertiesFile = file "$generatedVersionDir/version.properties"
     propertiesFile.parentFile.mkdirs()
@@ -39,4 +45,7 @@ task generateVersionProperties {
     propertiesFile.withWriter { properties.store(it, null) }
   }
 }
-processResources.dependsOn generateVersionProperties
+tasks.named("processResources") {
+  dependsOn("generateVersionProperties")
+}
+

--- a/shark-graph/build.gradle
+++ b/shark-graph/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/shark-hprof-test/build.gradle
+++ b/shark-hprof-test/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/shark-hprof/build.gradle
+++ b/shark-hprof/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/shark-log/build.gradle
+++ b/shark-log/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/shark-test/build.gradle
+++ b/shark-test/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/shark/build.gradle
+++ b/shark/build.gradle
@@ -1,5 +1,6 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7


### PR DESCRIPTION
### Motivation
I wanted to see if I can help with #1986, but after opening the project I saw tons of deprecations, outdated api usage and it didn't work for me locally (the project requires compiling with Java 8). I thought I should start by updating project configuration, so my first goal is to make the plugin use Gradle 7 and be able to build it with higher java version, using recent dependency versions

### What this PR does
As a warmup I created this PR which:
1. Migrates away from [legacy plugins application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application)
2. Makes sure project configuration leverages Gradle's lazy configuration apis and tasks aren't configured eagerly
3. Removes a few lines of configuration code I found useless