### PR TITLE
Fix cutting ‘0’ when creating SHA1 hash

### DIFF
--- a/shark/src/main/java/shark/internal/Strings.kt
+++ b/shark/src/main/java/shark/internal/Strings.kt
@@ -1,5 +1,6 @@
 package shark.internal
 
+import java.math.BigInteger
 import java.nio.charset.Charset
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
@@ -14,10 +15,6 @@ internal fun String.lastSegment(segmentingChar: Char): String {
 
 internal fun String.createSHA1Hash(): String = createHash(this, "SHA-1")
 
-/**
- * Derived from
- * [this snippet](http://www.androidsnippets.com/create-a-md5-hash-and-dump-as-a-hex-string).
- */
 private fun createHash(
   text: String,
   algorithm: String
@@ -26,14 +23,8 @@ private fun createHash(
     // Create MD5 Hash.
     val digest = MessageDigest.getInstance(algorithm)
     digest.update(text.getBytes())
-    val messageDigest = digest.digest()
 
-    // Create Hex String.
-    val hexString = StringBuilder()
-    for (b in messageDigest) {
-      hexString.append(Integer.toHexString(0xff and b.toInt()))
-    }
-    return hexString.toString()
+    return BigInteger(1, digest.digest()).toString(16).padStart(40, '0')
   } catch (e: NoSuchAlgorithmException) {
     throw AssertionError("Unable to construct MessageDigest for $algorithm")
   }


### PR DESCRIPTION
The [current approach](http://www.androidsnippets.com/create-a-md5-hash-and-dump-as-a-hex-string) to generate SHA-1 signature is cutting '0' for some bytes. So the output of SHA-1 encryption is possible to be less than 40 in length. Theoretically, this will cause the problem that 2 distinct texts are judged as the same, and the hash value cannot be decrypted due to the length is not 40.

Example: 
SHA-1 for "Hello World" should be: `0a4d55a8d778e5022fab701977c5d840bbc486d0`(length 40). With current approcah, it is `a4d55a8d778e522fab701977c5d840bbc486d0`(length 38).