### PR TITLE
Fix ClassCastException in ServiceWatcher on Motorola devices

### DIFF
--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/ServiceWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/ServiceWatcher.kt
@@ -54,6 +54,10 @@ class ServiceWatcher(private val reachabilityWatcher: ReachabilityWatcher) : Ins
           }
         }
         Handler.Callback { msg ->
+          // https://github.com/square/leakcanary/issues/2114
+          // On some Motorola devices (Moto E5 and G6), the msg.obj returns an ActivityClientRecord
+          // instead of an IBinder. This crashes on a ClassCastException. Adding a type check
+          // here to prevent the crash.
           if (msg.obj !is IBinder) {
             return@Callback false
           }

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/ServiceWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/ServiceWatcher.kt
@@ -54,6 +54,10 @@ class ServiceWatcher(private val reachabilityWatcher: ReachabilityWatcher) : Ins
           }
         }
         Handler.Callback { msg ->
+          if (msg.obj !is IBinder) {
+            return@Callback false
+          }
+
           if (msg.what == STOP_SERVICE) {
             val key = msg.obj as IBinder
             activityThreadServices[key]?.let {


### PR DESCRIPTION
Per https://github.com/square/leakcanary/issues/2114, ServiceWatcher crashes on some Motorola devices (Moto E5). This actually happens in versions earlier than LeakCanary 2.7.

The Handler Callback message expects an `IBinder`, but instead received an `ActivityClientRecord`. Setting this to early exist when the wrong message type is passed.

I have access to a physical Motorola Moto E5 and was able to test and verify this fix resolves the issue.