### PR TITLE
Fix for 2123 Missing FLAG_IMMUTABLE and support  for Android 12 - API 31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
   ext.versions = [
       'minSdk': 14,
-      'compileSdk': 29,
+      'compileSdk': 31,
       'errorProne': '2.3.1',
       // We would like to use Kotlin 1.4 language features but keep Kotlin 1.3 library APIs
       // The benefit is that depending clients do not have to upgrade to Kotlin 1.4

--- a/leakcanary-android-core/src/main/AndroidManifest.xml
+++ b/leakcanary-android-core/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
         android:label="@string/leak_canary_display_activity_label"
         android:taskAffinity="com.squareup.leakcanary.${applicationId}"
         android:theme="@style/leak_canary_LeakCanary.Base"
-        >
+        android:exported="true">
       <intent-filter android:label="@string/leak_canary_import_hprof_file">
         <action android:name="android.intent.action.VIEW"/>
 

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -101,12 +101,12 @@ internal class AndroidHeapDumper(
       toast.view = inflater.inflate(R.layout.leak_canary_heap_dump_toast, null)
       toast.show()
 
-      val toastIcon = toast.view?.findViewById<View>(R.id.leak_canary_toast_icon)
+      val toastIcon = toast.view!!.findViewById<View>(R.id.leak_canary_toast_icon)
       toastIcon?.translationY = -iconSize.toFloat()
       toastIcon
-        ?.animate()
-        ?.translationY(0f)
-        ?.setListener(object : AnimatorListenerAdapter() {
+        .animate()
+        .translationY(0f)
+        .setListener(object : AnimatorListenerAdapter() {
           override fun onAnimationEnd(animation: Animator) {
             waitingForToast.set(toast)
           }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/AndroidHeapDumper.kt
@@ -101,12 +101,12 @@ internal class AndroidHeapDumper(
       toast.view = inflater.inflate(R.layout.leak_canary_heap_dump_toast, null)
       toast.show()
 
-      val toastIcon = toast.view.findViewById<View>(R.id.leak_canary_toast_icon)
-      toastIcon.translationY = -iconSize.toFloat()
+      val toastIcon = toast.view?.findViewById<View>(R.id.leak_canary_toast_icon)
+      toastIcon?.translationY = -iconSize.toFloat()
       toastIcon
-        .animate()
-        .translationY(0f)
-        .setListener(object : AnimatorListenerAdapter() {
+        ?.animate()
+        ?.translationY(0f)
+        ?.setListener(object : AnimatorListenerAdapter() {
           override fun onAnimationEnd(animation: Animator) {
             waitingForToast.set(toast)
           }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
@@ -65,7 +65,7 @@ internal class HeapAnalyzerService : ForegroundService(
     val fullHeapAnalysis = when (heapAnalysis) {
       is HeapAnalysisSuccess -> heapAnalysis.copy(
         dumpDurationMillis = heapDumpDurationMillis,
-        metadata = heapAnalysis.metadata + ("Heap dump reason" to heapDumpReason)
+        metadata = heapAnalysis.metadata + ("Heap dump reason" to heapDumpReason!!)
       )
       is HeapAnalysisFailure -> heapAnalysis.copy(dumpDurationMillis = heapDumpDurationMillis)
     }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerService.kt
@@ -53,7 +53,7 @@ internal class HeapAnalyzerService : ForegroundService(
     // Since we're running in the main process we should be careful not to impact it.
     Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND)
     val heapDumpFile = intent.getSerializableExtra(HEAPDUMP_FILE_EXTRA) as File
-    val heapDumpReason = intent.getStringExtra(HEAPDUMP_REASON_EXTRA)
+    val heapDumpReason = intent.getStringExtra(HEAPDUMP_REASON_EXTRA)!!
     val heapDumpDurationMillis = intent.getLongExtra(HEAPDUMP_DURATION_MILLIS_EXTRA, -1)
 
     val config = LeakCanary.config
@@ -65,7 +65,7 @@ internal class HeapAnalyzerService : ForegroundService(
     val fullHeapAnalysis = when (heapAnalysis) {
       is HeapAnalysisSuccess -> heapAnalysis.copy(
         dumpDurationMillis = heapDumpDurationMillis,
-        metadata = heapAnalysis.metadata + ("Heap dump reason" to heapDumpReason!!)
+        metadata = heapAnalysis.metadata + ("Heap dump reason" to heapDumpReason)
       )
       is HeapAnalysisFailure -> heapAnalysis.copy(dumpDurationMillis = heapDumpDurationMillis)
     }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/NotificationReceiver.kt
@@ -40,7 +40,7 @@ internal class NotificationReceiver : BroadcastReceiver() {
     ): PendingIntent {
       val broadcastIntent = Intent(context, NotificationReceiver::class.java)
       broadcastIntent.action = action.name
-      val flags = if (Build.VERSION.SDK_INT >= 23) {
+      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         PendingIntent.FLAG_IMMUTABLE
       } else {
         0

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
@@ -75,7 +75,7 @@ internal class RequestStoragePermissionActivity : Activity() {
     fun createPendingIntent(context: Context): PendingIntent {
       val intent = Intent(context, RequestStoragePermissionActivity::class.java)
       intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      val flags = if (Build.VERSION.SDK_INT >= 31) {
         FLAG_MUTABLE
       } else {
         FLAG_UPDATE_CURRENT

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
@@ -20,7 +20,7 @@ import android.annotation.TargetApi
 import android.app.Activity
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
-import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.app.PendingIntent.FLAG_MUTABLE
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
@@ -76,7 +76,7 @@ internal class RequestStoragePermissionActivity : Activity() {
       val intent = Intent(context, RequestStoragePermissionActivity::class.java)
       intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP
       val flags = if (Build.VERSION.SDK_INT >= 23) {
-        FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE
+        FLAG_MUTABLE
       } else {
         FLAG_UPDATE_CURRENT
       }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/RequestStoragePermissionActivity.kt
@@ -75,7 +75,7 @@ internal class RequestStoragePermissionActivity : Activity() {
     fun createPendingIntent(context: Context): PendingIntent {
       val intent = Intent(context, RequestStoragePermissionActivity::class.java)
       intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT >= 23) {
+      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         FLAG_MUTABLE
       } else {
         FLAG_UPDATE_CURRENT

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -196,7 +196,7 @@ internal class LeakActivity : NavigatingActivity() {
       intent.putExtra("screens", screens)
       intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
       val flags = if (Build.VERSION.SDK_INT >= 23) {
-        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        PendingIntent.FLAG_MUTABLE
       } else {
         PendingIntent.FLAG_UPDATE_CURRENT
       }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -195,7 +195,7 @@ internal class LeakActivity : NavigatingActivity() {
       val intent = Intent(context, LeakActivity::class.java)
       intent.putExtra("screens", screens)
       intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT >= 23) {
+      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         PendingIntent.FLAG_MUTABLE
       } else {
         PendingIntent.FLAG_UPDATE_CURRENT

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/LeakActivity.kt
@@ -195,7 +195,7 @@ internal class LeakActivity : NavigatingActivity() {
       val intent = Intent(context, LeakActivity::class.java)
       intent.putExtra("screens", screens)
       intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-      val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      val flags = if (Build.VERSION.SDK_INT >= 31) {
         PendingIntent.FLAG_MUTABLE
       } else {
         PendingIntent.FLAG_UPDATE_CURRENT

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/tv/TvToast.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/tv/TvToast.kt
@@ -25,9 +25,9 @@ internal object TvToast {
     text: CharSequence
   ): Toast {
     val toast: Toast = Toast.makeText(activity, text, Toast.LENGTH_LONG)
-    val textView = toast.view.findViewById<TextView>(android.R.id.message)
-    textView.setCompoundDrawablesWithIntrinsicBounds(R.drawable.leak_canary_icon, 0, 0, 0)
-    textView.compoundDrawablePadding =
+    val textView = toast.view?.findViewById<TextView>(android.R.id.message)
+    textView?.setCompoundDrawablesWithIntrinsicBounds(R.drawable.leak_canary_icon, 0, 0, 0)
+    textView?.compoundDrawablePadding =
       activity.resources.getDimensionPixelSize(R.dimen.leak_canary_toast_icon_tv_padding)
     return toast
   }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/tv/TvToast.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/tv/TvToast.kt
@@ -33,7 +33,7 @@ internal object TvToast {
     // Custom toast views are deprecated from API level 30 on, see
     // https://developer.android.com/reference/android/widget/Toast#getView()
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
-      val textView = toast.view.findViewById<TextView>(android.R.id.message)
+      val textView = toast.view!!.findViewById<TextView>(android.R.id.message)
       textView.setCompoundDrawablesWithIntrinsicBounds(R.drawable.leak_canary_icon, 0, 0, 0)
       textView.compoundDrawablePadding =
         activity.resources.getDimensionPixelSize(R.dimen.leak_canary_toast_icon_tv_padding)

--- a/leakcanary-android-sample/src/main/AndroidManifest.xml
+++ b/leakcanary-android-sample/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <activity
         android:name=".MainActivity"
         android:banner="@drawable/leak_canary_sample_icon"
+        android:exported="true"
         >
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
Fix the issue for: **Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.**
issue: https://github.com/square/leakcanary/issues/2123

This branch also includes some small code changes where toast API has deprecated custom toast.