### PR TITLE
Add initial (not strict) support for AndroidX  Startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,17 @@ buildscript {
       // resolution strategy.
       androidGradlePlugin: "com.android.tools.build:gradle:4.0.0",
       androidx: [
-          annotation: 'androidx.annotation:annotation:1.0.2',
-          core: 'androidx.core:core:1.0.1',
-          fragment: 'androidx.fragment:fragment:1.0.0',
-          test: [
-              core: 'androidx.test:core:1.0.0',
-              espresso: 'androidx.test.espresso:espresso-core:3.1.0',
-              rules: 'androidx.test:rules:1.1.0',
-              runner: 'androidx.test:runner:1.1.0',
-              orchestrator: 'androidx.test:orchestrator:1.1.0',
-          ],
+        annotation: 'androidx.annotation:annotation:1.0.2',
+        core      : 'androidx.core:core:1.0.1',
+        fragment  : 'androidx.fragment:fragment:1.0.0',
+        startup   : 'androidx.startup:startup-runtime:1.1.0',
+        test      : [
+          core        : 'androidx.test:core:1.0.0',
+          espresso    : 'androidx.test.espresso:espresso-core:3.1.0',
+          rules       : 'androidx.test:rules:1.1.0',
+          runner      : 'androidx.test:runner:1.1.0',
+          orchestrator: 'androidx.test:orchestrator:1.1.0',
+        ],
       ],
       android_support: 'com.android.support:support-v4:28.0.0',
       clikt: 'com.github.ajalt:clikt:2.3.0',

--- a/plumber-android-startup/build.gradle
+++ b/plumber-android-startup/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
+
+dependencies {
+  api project(':plumber-android')
+  implementation deps.androidx.startup
+}
+
+android {
+  resourcePrefix 'leak_canary_plumber'
+  compileSdkVersion versions.compileSdk
+  defaultConfig {
+    minSdkVersion versions.minSdk
+    consumerProguardFiles 'consumer-proguard-rules.pro'
+  }
+  lintOptions {
+    disable 'GoogleAppIndexingWarning'
+    error 'ObsoleteSdkInt'
+    check 'Interoperability'
+  }
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/plumber-android-startup/gradle.properties
+++ b/plumber-android-startup/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=plumber-android-startup
+POM_NAME=LeakCanary for Plumber Core
+POM_PACKAGING=aar

--- a/plumber-android-startup/src/main/AndroidManifest.xml
+++ b/plumber-android-startup/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.squareup.leakcanary.plumber">
+    <application>
+        <provider
+                android:name="leakcanary.internal.PlumberInstaller"
+                android:authorities="${applicationId}.plumber-installer"
+                tools:node="remove"
+                android:exported="false"/>
+
+        <provider
+                android:name="androidx.startup.InitializationProvider"
+                android:authorities="${applicationId}.androidx-startup"
+                android:exported="false"
+                tools:node="merge">
+
+            <meta-data
+                    android:name="leakcanary.internal.PlumberInstallerAndroidXStartup"
+                    android:value="androidx.startup"/>
+        </provider>
+
+    </application>
+</manifest>

--- a/plumber-android-startup/src/main/java/leakcanary/internal/PlumberInstallerAndroidXStartup.kt
+++ b/plumber-android-startup/src/main/java/leakcanary/internal/PlumberInstallerAndroidXStartup.kt
@@ -1,0 +1,23 @@
+package  leakcanary.internal
+
+import android.app.Application
+import android.content.Context
+import androidx.startup.Initializer
+import leakcanary.AndroidLeakFixes
+import java.util.*
+
+object PlumberInstallerAndroidXStartupPPTX
+
+class PlumberInstallerAndroidXStartup : Initializer<PlumberInstallerAndroidXStartupPPTX> {
+    override fun dependencies(): List<Class<out Initializer<*>?>> {
+        return Collections.emptyList()
+    }
+
+    override fun create(context: Context): PlumberInstallerAndroidXStartupPPTX {
+        (context.applicationContext as? Application)?.let {
+            AndroidLeakFixes.applyFixes(it)
+        }
+
+        return PlumberInstallerAndroidXStartupPPTX
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ pluginManagement {
     }
 }
 include ':plumber-android'
+include ':plumber-android-startup'
 include ':leakcanary-android'
 include ':leakcanary-android-core'
 include ':leakcanary-android-instrumentation'


### PR DESCRIPTION
If you add module then ContextInstaller  Removed from Manifest

Closes #1890
