### PR TITLE
Fix crash when showing toast on TV devices on API level 30.

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/tv/TvToast.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/tv/TvToast.kt
@@ -3,12 +3,16 @@ package leakcanary.internal.tv
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
+import android.os.Build
 import android.widget.TextView
 import android.widget.Toast
 import com.squareup.leakcanary.core.R
 
 /**
  * Toast helper for Android TV preconfigured with LeakCanary icon.
+ *
+ * The icon is only shown on API level 29 and below, as custom toast views are deprecated from API level 30 on (see
+ * [docs](https://developer.android.com/reference/android/widget/Toast#getView()))
  */
 internal object TvToast {
 
@@ -25,10 +29,16 @@ internal object TvToast {
     text: CharSequence
   ): Toast {
     val toast: Toast = Toast.makeText(activity, text, Toast.LENGTH_LONG)
-    val textView = toast.view.findViewById<TextView>(android.R.id.message)
-    textView.setCompoundDrawablesWithIntrinsicBounds(R.drawable.leak_canary_icon, 0, 0, 0)
-    textView.compoundDrawablePadding =
-      activity.resources.getDimensionPixelSize(R.dimen.leak_canary_toast_icon_tv_padding)
+
+    // Custom toast views are deprecated from API level 30 on, see
+    // https://developer.android.com/reference/android/widget/Toast#getView()
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+      val textView = toast.view.findViewById<TextView>(android.R.id.message)
+      textView.setCompoundDrawablesWithIntrinsicBounds(R.drawable.leak_canary_icon, 0, 0, 0)
+      textView.compoundDrawablePadding =
+        activity.resources.getDimensionPixelSize(R.dimen.leak_canary_toast_icon_tv_padding)
+    }
+
     return toast
   }
 }


### PR DESCRIPTION
Fixes #2161.

Custom toast views are deprecated from API level 30 on (see [docs](https://developer.android.com/reference/android/widget/Toast#getView())). `TvToast` tries to add an icon to the toast. On Android 30 this currently results in a crash.

This PR fixes this issue by not showing the LeakCanary icon on toasts from API level 30 on. There is probably a better solution for this that still maintains the custom icon, e.g. by using a Snackbar when the app is in foreground instead of a toast. However, as a first-time contributor I did not feel comfortable making that change. I think it's good to disable the icon for now so the crash is fixed at least, and then a better solution could be submitted as a follow-up.

I've verified this fix by testing before/after on a project I'm working on. It should be reproducible by running any Android TV project with at least one leak on an Android 30 emulator.