### PR TITLE
Fix ClassFieldsReader leaks during continuous analyzing.

### DIFF
--- a/shark-graph/src/main/java/shark/internal/ClassFieldsReader.kt
+++ b/shark-graph/src/main/java/shark/internal/ClassFieldsReader.kt
@@ -22,6 +22,7 @@ import shark.ValueHolder.LongHolder
 import shark.ValueHolder.ReferenceHolder
 import shark.ValueHolder.ShortHolder
 import shark.internal.IndexedObject.IndexedClass
+import kotlin.collections.ArrayList
 
 internal class ClassFieldsReader(
   private val identifierByteSize: Int,
@@ -76,15 +77,11 @@ internal class ClassFieldsReader(
     }
   }
 
-  private val readInFlightThreadLocal = object : ThreadLocal<ReadInFlight>() {
-    override fun initialValue() = ReadInFlight()
-  }
-
   private fun <R> read(
     initialPosition: Int,
     block: ReadInFlight.() -> R
   ): R {
-    val readInFlight = readInFlightThreadLocal.get()
+    val readInFlight = ReadInFlight()
     readInFlight.position = initialPosition
     return readInFlight.run(block)
   }

--- a/shark-graph/src/main/java/shark/internal/ClassFieldsReader.kt
+++ b/shark-graph/src/main/java/shark/internal/ClassFieldsReader.kt
@@ -22,7 +22,6 @@ import shark.ValueHolder.LongHolder
 import shark.ValueHolder.ReferenceHolder
 import shark.ValueHolder.ShortHolder
 import shark.internal.IndexedObject.IndexedClass
-import kotlin.collections.ArrayList
 
 internal class ClassFieldsReader(
   private val identifierByteSize: Int,


### PR DESCRIPTION
Instances of class [**ClassFieldsReader**](shark-graph/src/main/java/shark/internal/ClassFieldsReader.kt) will leaks when keep analyzing HPROF file with Shark. The instance is referred by an anonymous object inherited from ThreadLocal, which is an entry key of the thread local map that it will never be released until the thread was destroyed.

This is a sample from our analyzing stress test:

<img width="2130" alt="dump" src="https://user-images.githubusercontent.com/40159657/144426268-ef2eff57-ed11-4302-bfc4-e063d19e051e.png">

I have removed the thread local object and just create a new **ClassFieldsReader.ReadInFlight** instance if needed. The instant is lightweight enough that it is unnecessary to reuse it.