### PR TITLE
DNM Update keeper to 0.11.0

### DIFF
--- a/leakcanary-android-sample/build.gradle
+++ b/leakcanary-android-sample/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id("org.jetbrains.kotlin.android")
   // Required to run obfuscated instrumentation tests:
   // ./gradlew leakcanary-android-sample:connectedCheck -Pminify
-  id("com.slack.keeper") version "0.7.0"
+  id("com.slack.keeper") version "0.11.0"
 }
 
 keeper {


### PR DESCRIPTION
Tried to open up https://github.com/square/leakcanary/pull/2158/commits/e26b8c32e45655c069b128e19806cadc057325f5 as a separate PR 

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':leakcanary-android-sample'.
> Failed to notify project evaluation listener.
   > com.android.build.gradle.internal.CompileOptions.isCoreLibraryDesugaringEnabled()Z
```

cc @ZacSweers