### PR TITLE
Update api version for ignoring leak to 28 for InputMethodManager.mNextServedView

### DIFF
--- a/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -202,7 +202,7 @@ enum class AndroidReferenceMatchers {
       references += instanceFieldLeak(
         "android.view.inputmethod.InputMethodManager", "mNextServedView", description
       ) {
-        sdkInt in 15..27
+        sdkInt in 15..28
       }
 
       references += instanceFieldLeak(


### PR DESCRIPTION
 This leak is found happening in api 28. So updating to ignore it up to api 28.