### PR TITLE
Add stale bot for "need more info" and "need heap dump" issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,4 @@
-name: Mark stale issues and pull requests
+name: Mark stale issues
 on:
   schedule:
     - cron: "30 1 * * *"
@@ -18,4 +18,4 @@ jobs:
           close-issue-message: 'This issue was closed because it did not provide enough information to make it actionable.'
           stale-issue-label: stale
           stale-pr-label: stale
-          any-of-labels: status: needs more info, status: needs heap dump
+          any-of-labels: 'status: needs more info, status: needs heap dump'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,21 @@
+name: Mark stale issues and pull requests
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: 'This issue is not actionable without the required information. Please comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it did not provide enough information to make it actionable.'
+          stale-issue-label: stale
+          stale-pr-label: stale
+          any-of-labels: status: needs more info, status: needs heap dump


### PR DESCRIPTION
This PR is an "answer" for this tweet: https://twitter.com/Piwai/status/1470922805151559682

This is an adatation of the action that we use in detekt: https://github.com/detekt/detekt/blob/main/.github/workflows/stale.yaml

The documentation of this action is here: https://github.com/marketplace/actions/close-stale-issues

All the values are configurable.

Right now what the bot does is to search for all the issues labeled as `status: need more info` or `status: needs heap dump`, check if there were any activity in the last 30 days and, if there wasn't comment and mark it as "stale" with a nice comment asking for the required information. If, after a week, there isn't any answer it will close the issue.

All of those values are configurable so just tell me if you want me to change any of those.