### PR TITLE
New instrumentation related APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,14 @@ buildscript {
           core: 'androidx.core:core:1.0.1',
           fragment: 'androidx.fragment:fragment:1.0.0',
           test: [
-              core: 'androidx.test:core:1.0.0',
-              espresso: 'androidx.test.espresso:espresso-core:3.1.0',
-              rules: 'androidx.test:rules:1.1.0',
+              core: 'androidx.test:core:1.4.0',
+              espresso: 'androidx.test.espresso:espresso-core:3.4.0',
+              rules: 'androidx.test:rules:1.4.0',
+              // Exposed transitively, avoid increasing
               runner: 'androidx.test:runner:1.1.0',
-              orchestrator: 'androidx.test:orchestrator:1.1.0',
+              orchestrator: 'androidx.test:orchestrator:1.4.1',
+              junit: 'androidx.test.ext:junit:1.1.3',
+              junit_ktx: 'androidx.test.ext:junit-ktx:1.1.3',
           ],
           work: [
             // Note: we use the Java artifact because the Kotlin one bundles coroutines.

--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -59,7 +59,7 @@ object LeakCanary {
      * be fixed.
      *
      * When the app becomes invisible, LeakCanary dumps the heap after
-     * [AppWatcher.Config.watchDurationMillis] ms.
+     * [AppWatcher.retainedDelayMillis] ms.
      *
      * The app is considered visible if it has at least one activity in started state.
      *

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpControl.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpControl.kt
@@ -42,6 +42,17 @@ internal object HeapDumpControl {
     }
   }
 
+  private const val leakAssertionsClassName = "leakcanary.LeakAssertions"
+
+  private val hasLeakAssertionsClass by lazy {
+    try {
+      Class.forName(leakAssertionsClassName)
+      true
+    } catch (e: Exception) {
+      false
+    }
+  }
+
   fun updateICanHasHeap() {
     iCanHasHeap()
   }
@@ -60,6 +71,13 @@ internal object HeapDumpControl {
     } else if (hasTestClass) {
       SilentNope {
         app.getString(R.string.leak_canary_heap_dump_disabled_running_tests, testClassName)
+      }
+    } else if (hasLeakAssertionsClass) {
+      SilentNope {
+        app.getString(
+          R.string.leak_canary_heap_dump_disabled_running_tests,
+          leakAssertionsClassName
+        )
       }
     } else if (!config.dumpHeapWhenDebugging && DebuggerControl.isDebuggerAttached) {
       mainHandler.postDelayed({

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -11,8 +11,8 @@ import com.squareup.leakcanary.core.R
 import java.util.UUID
 import leakcanary.AppWatcher
 import leakcanary.EventListener.Event.DumpingHeap
-import leakcanary.EventListener.Event.HeapDumpFailed
 import leakcanary.EventListener.Event.HeapDump
+import leakcanary.EventListener.Event.HeapDumpFailed
 import leakcanary.GcTrigger
 import leakcanary.KeyedWeakReference
 import leakcanary.LeakCanary.Config
@@ -69,7 +69,7 @@ internal class HeapDumpTrigger(
   private val applicationInvisibleLessThanWatchPeriod: Boolean
     get() {
       val applicationInvisibleAt = applicationInvisibleAt
-      return applicationInvisibleAt != -1L && SystemClock.uptimeMillis() - applicationInvisibleAt < AppWatcher.config.watchDurationMillis
+      return applicationInvisibleAt != -1L && SystemClock.uptimeMillis() - applicationInvisibleAt < AppWatcher.retainedDelayMillis
     }
 
   @Volatile
@@ -85,7 +85,7 @@ internal class HeapDumpTrigger(
       // Scheduling for after watchDuration so that any destroyed activity has time to become
       // watch and be part of this analysis.
       scheduleRetainedObjectCheck(
-        delayMillis = AppWatcher.config.watchDurationMillis
+        delayMillis = AppWatcher.retainedDelayMillis
       )
     }
   }
@@ -297,9 +297,8 @@ internal class HeapDumpTrigger(
           }
         }
       } else if (applicationInvisibleLessThanWatchPeriod) {
-        // TODO This is a bug, should use AppWatcher.retainedDelayMillis instead
         val wait =
-          AppWatcher.config.watchDurationMillis - (SystemClock.uptimeMillis() - applicationInvisibleAt)
+          AppWatcher.retainedDelayMillis - (SystemClock.uptimeMillis() - applicationInvisibleAt)
         if (nopeReason != null) {
           "would dump heap in $wait ms (app just became invisible) but $nopeReason"
         } else {

--- a/leakcanary-android-instrumentation/api/leakcanary-android-instrumentation.api
+++ b/leakcanary-android-instrumentation/api/leakcanary-android-instrumentation.api
@@ -1,3 +1,26 @@
+public final class leakcanary/AndroidDetectLeaksAssert : leakcanary/DetectLeaksAssert {
+	public fun <init> ()V
+	public fun <init> (Lleakcanary/HeapAnalysisReporter;)V
+	public synthetic fun <init> (Lleakcanary/HeapAnalysisReporter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun assertNoLeaks (Ljava/lang/String;)V
+}
+
+public final class leakcanary/DetectLeaksAfterTestSuccess : org/junit/rules/TestRule {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
+}
+
+public abstract interface class leakcanary/DetectLeaksAssert {
+	public static final field Companion Lleakcanary/DetectLeaksAssert$Companion;
+	public abstract fun assertNoLeaks (Ljava/lang/String;)V
+}
+
+public final class leakcanary/DetectLeaksAssert$Companion {
+	public final fun update (Lleakcanary/DetectLeaksAssert;)V
+}
+
 public final class leakcanary/FailAnnotatedTestOnLeakRunListener : leakcanary/FailTestOnLeakRunListener {
 	public fun <init> ()V
 }
@@ -17,6 +40,28 @@ public class leakcanary/FailTestOnLeakRunListener : org/junit/runner/notificatio
 	public fun testRunFinished (Lorg/junit/runner/Result;)V
 	public fun testRunStarted (Lorg/junit/runner/Description;)V
 	public fun testStarted (Lorg/junit/runner/Description;)V
+}
+
+public abstract interface class leakcanary/HeapAnalysisReporter {
+	public abstract fun reportHeapAnalysis (Lshark/HeapAnalysis;)V
+}
+
+public final class leakcanary/InstrumentationHeapAnalyzer {
+	public fun <init> (Lshark/LeakingObjectFinder;Ljava/util/List;ZLshark/MetadataExtractor;Ljava/util/List;Lshark/ProguardMapping;)V
+	public final fun analyze (Ljava/io/File;)Lshark/HeapAnalysis;
+	public final fun getComputeRetainedHeapSize ()Z
+	public final fun getLeakingObjectFinder ()Lshark/LeakingObjectFinder;
+	public final fun getMetadataExtractor ()Lshark/MetadataExtractor;
+	public final fun getObjectInspectors ()Ljava/util/List;
+	public final fun getProguardMapping ()Lshark/ProguardMapping;
+	public final fun getReferenceMatchers ()Ljava/util/List;
+}
+
+public final class leakcanary/InstrumentationHeapDumpFileProvider {
+	public fun <init> ()V
+	public fun <init> (Ljava/io/File;)V
+	public synthetic fun <init> (Ljava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun newHeapDumpFile ()Ljava/io/File;
 }
 
 public final class leakcanary/InstrumentationLeakDetector {
@@ -40,5 +85,65 @@ public final class leakcanary/InstrumentationLeakDetector$Result$AnalysisPerform
 public final class leakcanary/InstrumentationLeakDetector$Result$NoAnalysis : leakcanary/InstrumentationLeakDetector$Result {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun getReason ()Ljava/lang/String;
+}
+
+public final class leakcanary/LeakAssertions {
+	public static final field INSTANCE Lleakcanary/LeakAssertions;
+	public static final field NO_TAG Ljava/lang/String;
+	public final fun assertNoLeaks (Ljava/lang/String;)V
+	public static synthetic fun assertNoLeaks$default (Lleakcanary/LeakAssertions;Ljava/lang/String;ILjava/lang/Object;)V
+}
+
+public final class leakcanary/NoLeakAssertionFailedError : java/lang/AssertionError {
+	public static final field Companion Lleakcanary/NoLeakAssertionFailedError$Companion;
+	public fun <init> (Lshark/HeapAnalysisSuccess;)V
+	public final fun getHeapAnalysis ()Lshark/HeapAnalysisSuccess;
+}
+
+public final class leakcanary/NoLeakAssertionFailedError$Companion {
+	public final fun throwOnApplicationLeaks ()Lleakcanary/HeapAnalysisReporter;
+}
+
+public final class leakcanary/RetainedObjectsInstrumentationChecker {
+	public fun <init> ()V
+	public fun <init> (Landroid/app/Instrumentation;Lleakcanary/ObjectWatcher;J)V
+	public synthetic fun <init> (Landroid/app/Instrumentation;Lleakcanary/ObjectWatcher;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clearObjectsWatchedBeforeHeapDump ()V
+	public final fun shouldDumpHeapWaitingForRetainedObjects ()Lleakcanary/RetainedObjectsInstrumentationChecker$YesNo;
+}
+
+public abstract class leakcanary/RetainedObjectsInstrumentationChecker$YesNo {
+}
+
+public final class leakcanary/RetainedObjectsInstrumentationChecker$YesNo$No : leakcanary/RetainedObjectsInstrumentationChecker$YesNo {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getReason ()Ljava/lang/String;
+}
+
+public final class leakcanary/RetainedObjectsInstrumentationChecker$YesNo$Yes : leakcanary/RetainedObjectsInstrumentationChecker$YesNo {
+	public static final field INSTANCE Lleakcanary/RetainedObjectsInstrumentationChecker$YesNo$Yes;
+}
+
+public final class leakcanary/RetryingHeapAnalyzer {
+	public fun <init> (Lleakcanary/InstrumentationHeapAnalyzer;)V
+	public final fun analyze (Ljava/io/File;)Lshark/HeapAnalysis;
+}
+
+public abstract interface annotation class leakcanary/SkipLeakDetection : java/lang/annotation/Annotation {
+	public static final field Companion Lleakcanary/SkipLeakDetection$Companion;
+	public abstract fun assertionTags ()[Ljava/lang/String;
+	public abstract fun message ()Ljava/lang/String;
+}
+
+public final class leakcanary/SkipLeakDetection$Companion {
+	public final fun shouldSkipTest (Ljava/lang/String;Lleakcanary/SkipLeakDetection;Ljava/lang/String;)Z
+	public final fun shouldSkipTest (Lorg/junit/runner/Description;Ljava/lang/String;)Z
+}
+
+public final class leakcanary/TestDescriptionHolder : org/junit/rules/TestRule {
+	public static final field INSTANCE Lleakcanary/TestDescriptionHolder;
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
+	public final fun getTestDescription ()Lorg/junit/runner/Description;
+	public final fun isEvaluating ()Z
 }
 

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/AndroidDetectLeaksAssert.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/AndroidDetectLeaksAssert.kt
@@ -1,0 +1,67 @@
+package leakcanary
+
+import leakcanary.RetainedObjectsInstrumentationChecker.YesNo.No
+import leakcanary.internal.friendly.checkNotMainThread
+import leakcanary.internal.friendly.measureDurationMillis
+import shark.HeapAnalysisFailure
+import shark.HeapAnalysisSuccess
+import shark.SharkLog
+
+/**
+ * Default [DetectLeaksAssert] implementation. Uses public helpers so you should be able to
+ * create our own implementation if needed.
+ *
+ * Leak detection can be skipped by annotating tests with [SkipLeakDetection] which requires the
+ * [TestDescriptionHolder] test rule be applied and evaluating when [assertNoLeaks]
+ * is called.
+ *
+ * For improved leak detection, you should consider updating [LeakCanary.Config.leakingObjectFinder]
+ * to `FilteringLeakingObjectFinder(AndroidObjectInspectors.appLeakingObjectFilters)` when running
+ * in instrumentation tests. This changes leak detection from being incremental (based on
+ * [AppWatcher] to also scanning for all objects of known types in the heap).
+ */
+class AndroidDetectLeaksAssert(
+  private val heapAnalysisReporter: HeapAnalysisReporter = NoLeakAssertionFailedError.throwOnApplicationLeaks()
+) : DetectLeaksAssert {
+  override fun assertNoLeaks(tag: String) {
+    if (TestDescriptionHolder.isEvaluating()) {
+      val testDescription = TestDescriptionHolder.testDescription
+      if (SkipLeakDetection.shouldSkipTest(testDescription, tag)) {
+        return
+      }
+    }
+    checkNotMainThread()
+    val retainedObjectsChecker = RetainedObjectsInstrumentationChecker()
+    val yesNo = retainedObjectsChecker.shouldDumpHeapWaitingForRetainedObjects()
+    if (yesNo is No) {
+      SharkLog.d { "Test can keep going: no heap dump performed (${yesNo.reason})" }
+      return
+    }
+    val heapDumpFile = InstrumentationHeapDumpFileProvider().newHeapDumpFile()
+
+    val config = LeakCanary.config
+
+    val heapDumpDurationMillis = measureDurationMillis {
+      config.heapDumper.dumpHeap(heapDumpFile)
+    }
+
+    val heapAnalyzer = RetryingHeapAnalyzer(
+      InstrumentationHeapAnalyzer(
+        leakingObjectFinder = config.leakingObjectFinder,
+        referenceMatchers = config.referenceMatchers,
+        computeRetainedHeapSize = config.computeRetainedHeapSize,
+        metadataExtractor = config.metadataExtractor,
+        objectInspectors = config.objectInspectors,
+        proguardMapping = null
+      )
+    )
+    val heapAnalysis = heapAnalyzer.analyze(heapDumpFile).let {
+      when (it) {
+        is HeapAnalysisSuccess -> it.copy(dumpDurationMillis = heapDumpDurationMillis)
+        is HeapAnalysisFailure -> it.copy(dumpDurationMillis = heapDumpDurationMillis)
+      }
+    }
+    retainedObjectsChecker.clearObjectsWatchedBeforeHeapDump()
+    heapAnalysisReporter.reportHeapAnalysis(heapAnalysis)
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/DetectLeaksAfterTestSuccess.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/DetectLeaksAfterTestSuccess.kt
@@ -1,0 +1,28 @@
+package leakcanary
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * [TestRule] that invokes [LeakAssertions.assertNoLeaks] after the test
+ * successfully evaluates. Pay attention to where you set up this rule in the
+ * rule chain as you might detect different leaks (e.g. around vs wrapped by the
+ * activity rule). It's also possible to use this rule several times in a rule
+ * chain.
+ */
+class DetectLeaksAfterTestSuccess(
+  private val tag: String = DetectLeaksAfterTestSuccess::class.java.simpleName
+) : TestRule {
+  override fun apply(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      override fun evaluate() {
+        // If the test fails, evaluate() will throw and we won't run the analysis (which is good).
+        base.evaluate()
+        LeakAssertions.assertNoLeaks(tag)
+      }
+    }
+  }
+}
+
+

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/DetectLeaksAssert.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/DetectLeaksAssert.kt
@@ -1,0 +1,21 @@
+package leakcanary
+
+/**
+ * The interface for the implementation that [LeakAssertions.assertNoLeaks] delegates to.
+ * You can call [DetectLeaksAssert.update] to provide your own implementation.
+ *
+ * The default implementation is [AndroidDetectLeaksAssert].
+ */
+fun interface DetectLeaksAssert {
+
+  fun assertNoLeaks(tag: String)
+
+  companion object {
+    @Volatile
+    internal var delegate: DetectLeaksAssert = AndroidDetectLeaksAssert()
+
+    fun update(delegate: DetectLeaksAssert) {
+      DetectLeaksAssert.delegate = delegate
+    }
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/FailAnnotatedTestOnLeakRunListener.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/FailAnnotatedTestOnLeakRunListener.kt
@@ -4,12 +4,16 @@ import org.junit.runner.Description
 import org.junit.runner.notification.RunListener
 
 /**
+ * Deprecated because this relies on hacks built on top of AndroidX Test internals which keep
+ * changing. Use [LeakAssertions] instead.
+ *
  * A JUnit [RunListener] extending [FailTestOnLeakRunListener] to detecting memory
  * leaks in Android instrumentation tests only when the [FailTestOnLeak] annotation
  * is used.
  *
  * @see FailTestOnLeak
  */
+@Deprecated("Use LeakAssertions instead")
 class FailAnnotatedTestOnLeakRunListener : FailTestOnLeakRunListener() {
 
   override fun skipLeakDetectionReason(description: Description) =

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeak.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeak.kt
@@ -1,12 +1,16 @@
 package leakcanary
 
 /**
+ * Deprecated because this relies on hacks built on top of AndroidX Test internals which keep
+ * changing. Use [LeakAssertions] instead.
+ *
  * An [Annotation] class to be used in conjunction with [FailAnnotatedTestOnLeakRunListener]
  * for detecting memory leaks. When using [FailAnnotatedTestOnLeakRunListener], the tests
  * should be annotated with this class in order for the listener to detect memory leaks.
  *
  * @see FailAnnotatedTestOnLeakRunListener
  */
+@Deprecated("Use LeakAssertions instead")
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class FailTestOnLeak

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeakRunListener.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/FailTestOnLeakRunListener.kt
@@ -6,8 +6,11 @@ import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
 import leakcanary.InstrumentationLeakDetector.Result.AnalysisPerformed
 import leakcanary.internal.TestResultPublisher
+import leakcanary.internal.friendly.noOpDelegate
 import org.junit.runner.Description
 import org.junit.runner.Result
 import org.junit.runner.notification.Failure
@@ -16,11 +19,10 @@ import shark.HeapAnalysis
 import shark.HeapAnalysisFailure
 import shark.HeapAnalysisSuccess
 import shark.SharkLog
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit.SECONDS
-import leakcanary.internal.friendly.noOpDelegate
 
 /**
+ * Deprecated because this relies on hacks built on top of AndroidX Test internals which keep
+ * changing. Use [LeakAssertions] instead.
  *
  * A JUnit [RunListener] that uses [InstrumentationLeakDetector] to detect memory leaks in Android
  * instrumentation tests. It waits for the end of a test, and if the test succeeds then it will
@@ -31,6 +33,7 @@ import leakcanary.internal.friendly.noOpDelegate
  *
  * @see InstrumentationLeakDetector
  */
+@Deprecated("Use LeakAssertions instead")
 open class FailTestOnLeakRunListener : RunListener() {
   private var _currentTestDescription: Description? = null
   private val currentTestDescription: Description

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/HeapAnalysisReporter.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/HeapAnalysisReporter.kt
@@ -1,0 +1,10 @@
+package leakcanary
+
+import shark.HeapAnalysis
+
+/**
+ * Reports the results of a heap analysis created by [AndroidDetectLeaksAssert].
+ */
+fun interface HeapAnalysisReporter {
+  fun reportHeapAnalysis(heapAnalysis: HeapAnalysis)
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationHeapAnalyzer.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationHeapAnalyzer.kt
@@ -1,0 +1,73 @@
+package leakcanary
+
+import java.io.File
+import shark.ConstantMemoryMetricsDualSourceProvider
+import shark.FileSourceProvider
+import shark.HeapAnalysis
+import shark.HeapAnalysisException
+import shark.HeapAnalysisFailure
+import shark.HeapAnalysisSuccess
+import shark.HeapAnalyzer
+import shark.HprofHeapGraph
+import shark.HprofHeapGraph.Companion.openHeapGraph
+import shark.LeakingObjectFinder
+import shark.MetadataExtractor
+import shark.ObjectInspector
+import shark.OnAnalysisProgressListener
+import shark.ProguardMapping
+import shark.ReferenceMatcher
+
+/**
+ * Sets up [HeapAnalyzer] for instrumentation tests and delegates heap analysis.
+ */
+class InstrumentationHeapAnalyzer(
+  val leakingObjectFinder: LeakingObjectFinder,
+  val referenceMatchers: List<ReferenceMatcher>,
+  val computeRetainedHeapSize: Boolean,
+  val metadataExtractor: MetadataExtractor,
+  val objectInspectors: List<ObjectInspector>,
+  val proguardMapping: ProguardMapping?
+) {
+
+  fun analyze(heapDumpFile: File): HeapAnalysis {
+    val heapAnalyzer = HeapAnalyzer(OnAnalysisProgressListener.NO_OP)
+
+    val sourceProvider = ConstantMemoryMetricsDualSourceProvider(FileSourceProvider(heapDumpFile))
+
+    val closeableGraph = try {
+      sourceProvider.openHeapGraph(proguardMapping)
+    } catch (throwable: Throwable) {
+      return HeapAnalysisFailure(
+        heapDumpFile = heapDumpFile,
+        createdAtTimeMillis = System.currentTimeMillis(),
+        analysisDurationMillis = 0,
+        exception = HeapAnalysisException(throwable)
+      )
+    }
+    return closeableGraph
+      .use { graph ->
+        val result = heapAnalyzer.analyze(
+          heapDumpFile = heapDumpFile,
+          graph = graph,
+          leakingObjectFinder = leakingObjectFinder,
+          referenceMatchers = referenceMatchers,
+          computeRetainedHeapSize = computeRetainedHeapSize,
+          objectInspectors = objectInspectors,
+          metadataExtractor = metadataExtractor
+        )
+        if (result is HeapAnalysisSuccess) {
+          val lruCacheStats = (graph as HprofHeapGraph).lruCacheStats()
+          val randomAccessStats =
+            "RandomAccess[" +
+              "bytes=${sourceProvider.randomAccessByteReads}," +
+              "reads=${sourceProvider.randomAccessReadCount}," +
+              "travel=${sourceProvider.randomAccessByteTravel}," +
+              "range=${sourceProvider.byteTravelRange}," +
+              "size=${heapDumpFile.length()}" +
+              "]"
+          val stats = "$lruCacheStats $randomAccessStats"
+          result.copy(metadata = result.metadata + ("Stats" to stats))
+        } else result
+      }
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationHeapDumpFileProvider.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationHeapDumpFileProvider.kt
@@ -1,0 +1,26 @@
+package leakcanary
+
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Provides unique file names for each heap dump in instrumentation tests.
+ */
+class InstrumentationHeapDumpFileProvider(
+  private val heapDumpDirectory: File = getInstrumentation().targetContext.filesDir
+) {
+
+  /**
+   * Returns a file for where the heap should be dumped.
+   */
+  fun newHeapDumpFile(): File {
+    // File name is unique as analysis may run several times per test
+    val fileName =
+      SimpleDateFormat("'instrumentation_tests_'yyyy-MM-dd_HH-mm-ss_SSS'.hprof'", Locale.US)
+        .format(Date())
+    return File(heapDumpDirectory, fileName)
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -147,7 +147,7 @@ class InstrumentationLeakDetector {
     val heapDumpDurationMillis: Long
 
     try {
-      Debug.dumpHprofData(heapDumpFile.absolutePath)
+      LeakCanary.config.heapDumper.dumpHeap(heapDumpFile)
       heapDumpDurationMillis = SystemClock.uptimeMillis() - heapDumpUptimeMillis
     } catch (exception: Exception) {
       SharkLog.d(exception) { "Could not dump heap" }

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/InstrumentationLeakDetector.kt
@@ -97,7 +97,7 @@ class InstrumentationLeakDetector {
   @Suppress("ReturnCount")
   fun detectLeaks(): Result {
     val leakDetectionTime = SystemClock.uptimeMillis()
-    val watchDurationMillis = AppWatcher.config.watchDurationMillis
+    val watchDurationMillis = AppWatcher.retainedDelayMillis
     val instrumentation = getInstrumentation()
     val context = instrumentation.targetContext
     val refWatcher = AppWatcher.objectWatcher

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/LeakAssertions.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/LeakAssertions.kt
@@ -1,0 +1,30 @@
+package leakcanary
+
+object LeakAssertions {
+
+  /**
+   * Asserts that there are no leak in the heap at this point in time.
+   *
+   * This method should be called on the instrumentation thread.
+   *
+   * This method is may block the current thread for a significant amount of time,
+   * as it might need to dump the heap and analyze it.
+   *
+   * If leaks are found, this method is expected to throw an exception, which will fail the test.
+   *
+   * The specific details depend on what you configured in [DetectLeaksAssert.update].
+   *
+   * [tag] identifies the calling code, which can then be used for reporting purposes or to skip
+   * leak detection for specific tags in a subset of tests (see [SkipLeakDetection]).
+   */
+  fun assertNoLeaks(tag: String = NO_TAG) {
+    DetectLeaksAssert.delegate.assertNoLeaks(tag)
+  }
+
+  const val NO_TAG = ""
+}
+
+
+
+
+

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/NoLeakAssertionFailedError.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/NoLeakAssertionFailedError.kt
@@ -1,0 +1,49 @@
+package leakcanary
+
+import shark.HeapAnalysisFailure
+import shark.HeapAnalysisSuccess
+import shark.SharkLog
+
+/**
+ * Thrown when using the [NoLeakAssertionFailedError.throwOnApplicationLeaks] HeapAnalysisReporter
+ */
+class NoLeakAssertionFailedError(
+  val heapAnalysis: HeapAnalysisSuccess
+) : AssertionError(
+  "Application memory leaks were detected:\n$heapAnalysis"
+) {
+  companion object {
+    /**
+     * A [HeapAnalysisReporter] that throws a [NoLeakAssertionFailedError] when the heap analysis
+     * has application leaks.
+     */
+    fun throwOnApplicationLeaks(): HeapAnalysisReporter = HeapAnalysisReporter { heapAnalysis ->
+      when (heapAnalysis) {
+        is HeapAnalysisSuccess -> {
+          when {
+            heapAnalysis.applicationLeaks.isNotEmpty() -> {
+              throw NoLeakAssertionFailedError(heapAnalysis)
+            }
+            heapAnalysis.libraryLeaks.isNotEmpty() -> {
+              SharkLog.d {
+                "Test can keep going: heap analysis found 0 application leaks and ${heapAnalysis.libraryLeaks} library leaks:\n$heapAnalysis"
+              }
+            }
+            heapAnalysis.unreachableObjects.isNotEmpty() -> {
+              SharkLog.d {
+                "Test can keep going: heap analysis found 0 leaks and ${heapAnalysis.unreachableObjects.size} watched weakly reachable objects:\n" +
+                  heapAnalysis
+              }
+            }
+            else -> {
+              SharkLog.d { "Test can keep going: heap analysis found 0 leaks." }
+            }
+          }
+        }
+        is HeapAnalysisFailure -> {
+          throw heapAnalysis.exception
+        }
+      }
+    }
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/RetainedObjectsInstrumentationChecker.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/RetainedObjectsInstrumentationChecker.kt
@@ -1,0 +1,70 @@
+package leakcanary
+
+import android.app.Instrumentation
+import android.os.SystemClock
+import androidx.test.platform.app.InstrumentationRegistry
+import leakcanary.GcTrigger.Default
+import leakcanary.RetainedObjectsInstrumentationChecker.YesNo.No
+import leakcanary.RetainedObjectsInstrumentationChecker.YesNo.Yes
+
+class RetainedObjectsInstrumentationChecker(
+  private val instrumentation: Instrumentation = InstrumentationRegistry.getInstrumentation(),
+  private val objectWatcher: ObjectWatcher = AppWatcher.objectWatcher,
+  private val retainedDelayMillis: Long = AppWatcher.retainedDelayMillis
+) {
+
+  sealed class YesNo {
+    object Yes : YesNo()
+    class No(val reason: String) : YesNo()
+  }
+
+  @Suppress("ReturnCount")
+  fun shouldDumpHeapWaitingForRetainedObjects(): YesNo {
+    val leakDetectionTime = SystemClock.uptimeMillis()
+
+    if (!objectWatcher.hasWatchedObjects) {
+      return No("No watched objects.")
+    }
+
+    instrumentation.waitForIdleSync()
+    if (!objectWatcher.hasWatchedObjects) {
+      return No("No watched objects after waiting for idle sync.")
+    }
+
+    Default.runGc()
+    if (!objectWatcher.hasWatchedObjects) {
+      return No("No watched objects after triggering an explicit GC.")
+    }
+
+    // Waiting for any delayed UI post (e.g. scroll) to clear. This shouldn't be needed, but
+    // Android simply has way too many delayed posts that aren't canceled when views are detached.
+    SystemClock.sleep(2000)
+
+    if (!objectWatcher.hasWatchedObjects) {
+      return No("No watched objects after delayed UI post is cleared.")
+    }
+
+    // Aaand we wait some more.
+    // 4 seconds (2+2) is greater than the 3 seconds delay for
+    // FINISH_TOKEN in android.widget.Filter
+    SystemClock.sleep(2000)
+
+    val endOfWatchDelay = retainedDelayMillis - (SystemClock.uptimeMillis() - leakDetectionTime)
+    if (endOfWatchDelay > 0) {
+      SystemClock.sleep(endOfWatchDelay)
+    }
+
+    Default.runGc()
+
+    if (!objectWatcher.hasRetainedObjects) {
+      return No("No retained objects after waiting for retained delay.")
+    }
+    KeyedWeakReference.heapDumpUptimeMillis = SystemClock.uptimeMillis()
+    return Yes
+  }
+
+  fun clearObjectsWatchedBeforeHeapDump() {
+    val heapDumpUptimeMillis = KeyedWeakReference.heapDumpUptimeMillis
+    objectWatcher.clearObjectsWatchedBefore(heapDumpUptimeMillis)
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/RetryingHeapAnalyzer.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/RetryingHeapAnalyzer.kt
@@ -1,0 +1,52 @@
+package leakcanary
+
+import android.os.SystemClock
+import android.util.Log
+import java.io.File
+import shark.HeapAnalysis
+import shark.HeapAnalysisFailure
+import shark.HeapAnalysisSuccess
+import shark.SharkLog
+
+/**
+ * Wraps [InstrumentationHeapAnalyzer] and retries the analysis once if it fails.
+ */
+class RetryingHeapAnalyzer(
+  private val heapAnalyzer: InstrumentationHeapAnalyzer
+) {
+
+  fun analyze(heapDumpFile: File): HeapAnalysis {
+    // A copy that will be used in case of failure followed by success, to see if the file has changed.
+    val heapDumpCopyFile = File(heapDumpFile.parent, "copy-${heapDumpFile.name}")
+    heapDumpFile.copyTo(heapDumpCopyFile)
+    // Giving an extra 2 seconds to flush the hprof to the file system. We've seen several cases
+    // of corrupted hprof files and assume this could be a timing issue.
+    SystemClock.sleep(2000)
+
+    val heapAnalysis = heapAnalyzer.analyze(heapDumpFile)
+
+    return if (heapAnalysis is HeapAnalysisFailure) {
+      // Experience has shown that trying again often just works. Not sure why.
+      SharkLog.d(heapAnalysis.exception) {
+        "Heap Analysis failed, retrying in 10s in case the heap dump was not fully baked yet. " +
+          "Copy of original heap dump available at ${heapDumpCopyFile.absolutePath}"
+      }
+      SystemClock.sleep(10000)
+      heapAnalyzer.analyze(heapDumpFile).let {
+        when (it) {
+          is HeapAnalysisSuccess -> it.copy(
+            metadata = it.metadata + mapOf(
+              "previousFailureHeapDumpCopy" to heapDumpCopyFile.absolutePath,
+              "previousFailureStacktrace" to Log.getStackTraceString(heapAnalysis.exception)
+            )
+          )
+          is HeapAnalysisFailure -> it
+        }
+      }
+    } else {
+      // We don't need the copy after all.
+      heapDumpCopyFile.delete()
+      heapAnalysis
+    }
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/SkipLeakDetection.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/SkipLeakDetection.kt
@@ -1,0 +1,60 @@
+package leakcanary
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import leakcanary.SkipLeakDetection.Companion.shouldSkipTest
+import org.junit.runner.Description
+import shark.SharkLog
+
+/**
+ * Annotation for skipping leak detection in a UI test that calls
+ * [LeakAssertions.assertNoLeaks]. This annotation is useful to skip a leak detection in
+ * a test until the leaks are fixed.
+ *
+ * The check is performed by [shouldSkipTest] which is called by [AndroidDetectLeaksAssert],
+ * which requires that the [TestDescriptionHolder] rule be applied and
+ * evaluating when [LeakAssertions.assertNoLeaks] is called.
+ *
+ * [message] should contain an explanation of why leak detection is skipped, e.g. a reference to a
+ * filed issue.
+ *
+ * The optional [assertionTags] allows finer grained filtering based on the tag value passed to
+ * [LeakAssertions.assertNoLeaks]. If [assertionTags] is empty, then the test will
+ * skip leak detection entirely. If [assertionTags] is not empty, then the test will skip leak
+ * detection for any call to [LeakAssertions.assertNoLeaks] with a tag value contained in
+ * [assertionTags].
+ */
+@Retention(RUNTIME)
+@Target(CLASS, FUNCTION)
+annotation class SkipLeakDetection(val message: String, vararg val assertionTags: String) {
+  companion object {
+    fun shouldSkipTest(testDescription: Description, assertionTag: String): Boolean {
+      val skipAnnotation =
+        testDescription.getAnnotation(SkipLeakDetection::class.java)
+      return shouldSkipTest(testDescription.displayName, skipAnnotation, assertionTag)
+    }
+
+    fun shouldSkipTest(
+      testName: String,
+      skipAnnotation: SkipLeakDetection?,
+      assertionTag: String
+    ): Boolean {
+      if (skipAnnotation != null) {
+        val assertionTags = skipAnnotation.assertionTags
+        if (assertionTags.isEmpty()) {
+          SharkLog.d { "Skipping leak detection for $testName, message: ${skipAnnotation.message}" }
+          return true
+        } else if (assertionTag in assertionTags) {
+          SharkLog.d {
+            "Skipping [$assertionTag] leak detection for $testName, " +
+              "message: ${skipAnnotation.message}"
+          }
+          return true
+        }
+      }
+      return false
+    }
+  }
+}
+

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/TestDescriptionHolder.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/TestDescriptionHolder.kt
@@ -1,0 +1,47 @@
+package leakcanary
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * A [TestRule] that holds onto the test [Description] in a thread local while evaluating, making
+ * it possible to retrieve that test [Description] from the test thread via [testDescription].
+ */
+object TestDescriptionHolder : TestRule {
+
+  private val descriptionThreadLocal = ThreadLocal<Description>()
+
+  fun isEvaluating() = descriptionThreadLocal.get() != null
+
+  val testDescription: Description
+    get() {
+      return descriptionThreadLocal.get() ?: error(
+        "Test description is null, either you forgot to add the TestDescriptionHolder rule around" +
+          "the current code or you did not call testDescription from the test thread."
+      )
+    }
+
+  override fun apply(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      override fun evaluate() {
+        try {
+          val previousDescription = descriptionThreadLocal.get()
+          check(previousDescription == null) {
+            "Test description should be null not [$previousDescription] before the rule evaluates. " +
+              "Did you add the TestDescriptionHolder rule twice by mistake?"
+          }
+          descriptionThreadLocal.set(description)
+          base.evaluate()
+        } finally {
+          val currentDescription = descriptionThreadLocal.get()
+          check(currentDescription != null) {
+            "Test description should not be null after the rule evaluates. " +
+              "Did you add the TestDescriptionHolder rule twice by mistake?"
+          }
+          descriptionThreadLocal.remove()
+        }
+      }
+    }
+  }
+}

--- a/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/friendly/Friendly.kt
+++ b/leakcanary-android-instrumentation/src/main/java/leakcanary/internal/friendly/Friendly.kt
@@ -3,3 +3,8 @@
 package leakcanary.internal.friendly
 
 internal inline fun <reified T : Any> noOpDelegate(): T = leakcanary.internal.noOpDelegate()
+
+internal inline fun checkNotMainThread() = leakcanary.internal.checkNotMainThread()
+
+internal inline fun measureDurationMillis(block: () -> Unit) =
+  leakcanary.internal.measureDurationMillis(block)

--- a/leakcanary-android-sample/build.gradle
+++ b/leakcanary-android-sample/build.gradle
@@ -31,6 +31,8 @@ dependencies {
   androidTestImplementation deps.androidx.test.espresso
   androidTestImplementation deps.androidx.test.rules
   androidTestImplementation deps.androidx.test.runner
+  androidTestImplementation deps.androidx.test.junit
+  androidTestImplementation deps.androidx.test.junit_ktx
   androidTestUtil deps.androidx.test.orchestrator
 }
 
@@ -51,10 +53,10 @@ android {
     versionName "1.0"
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"
 
     // Run ./gradlew leakcanary-android-sample:connectedCheck -Porchestrator
     if (project.hasProperty('orchestrator')) {
+      testInstrumentationRunnerArguments clearPackageData: 'true'
       testOptions {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
       }

--- a/leakcanary-object-watcher-android/api/leakcanary-object-watcher-android.api
+++ b/leakcanary-object-watcher-android/api/leakcanary-object-watcher-android.api
@@ -10,6 +10,7 @@ public final class leakcanary/AppWatcher {
 	public static synthetic fun appDefaultWatchers$default (Lleakcanary/AppWatcher;Landroid/app/Application;Lleakcanary/ReachabilityWatcher;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun getConfig ()Lleakcanary/AppWatcher$Config;
 	public final fun getObjectWatcher ()Lleakcanary/ObjectWatcher;
+	public final fun getRetainedDelayMillis ()J
 	public final fun isInstalled ()Z
 	public final fun manualInstall (Landroid/app/Application;)V
 	public final fun manualInstall (Landroid/app/Application;J)V

--- a/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcher.kt
+++ b/leakcanary-object-watcher-android/src/main/java/leakcanary/AppWatcher.kt
@@ -20,7 +20,8 @@ object AppWatcher {
   private const val RETAINED_DELAY_NOT_SET = -1L
 
   @Volatile
-  private var retainedDelayMillis = RETAINED_DELAY_NOT_SET
+  var retainedDelayMillis = RETAINED_DELAY_NOT_SET
+    private set
 
   private var installCause: Exception? = null
 

--- a/shark-cli/src/main/java/shark/AnalyzeCommand.kt
+++ b/shark-cli/src/main/java/shark/AnalyzeCommand.kt
@@ -41,7 +41,8 @@ class AnalyzeCommand : CliktCommand(
         referenceMatchers = AndroidReferenceMatchers.appDefaults,
         computeRetainedHeapSize = true,
         objectInspectors = objectInspectors,
-        proguardMapping = proguardMapping
+        proguardMapping = proguardMapping,
+        metadataExtractor = AndroidMetadataExtractor
       )
       echo(heapAnalysis)
     }

--- a/shark-cli/src/main/java/shark/InteractiveCommand.kt
+++ b/shark-cli/src/main/java/shark/InteractiveCommand.kt
@@ -595,7 +595,8 @@ class InteractiveCommand : CliktCommand(
       leakingObjectFinder = leakingObjectFinder,
       referenceMatchers = AndroidReferenceMatchers.appDefaults,
       computeRetainedHeapSize = true,
-      objectInspectors = objectInspectors
+      objectInspectors = objectInspectors,
+      metadataExtractor = AndroidMetadataExtractor
     )
 
     if (leakingObjectId == null || heapAnalysis is HeapAnalysisFailure) {


### PR DESCRIPTION
This PR deprecates FailTestOnLeakRunListener, FailAnnotatedTestOnLeakRunListener, FailTestOnLeak and InstrumentationLeakDetector.

- `FailTestOnLeakRunListener` is replaced by the `DetectLeaksAfterTestSuccess` test rule.
- Test code and test utilities can also call `LeakAssertions.assertNoLeak()`, which by default throws an exception if leaks are found.
- Specific tests can make calls to `LeakAssertions.assertNoLeak()` a no-op by using the `@SkipLeakDetection` annotation (and setting up the TestDescriptionHolder test rule)
- The leak detection and reporting behavior can be customized with `DetectLeaksAssert.update()`