### PR TITLE
Move dependency declarations into a version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,73 +2,22 @@ import org.jetbrains.dokka.gradle.DokkaTask
 
 buildscript {
   ext.versions = [
-      'minSdk': 14,
-      'compileSdk': 31,
-      // We would like to use Kotlin 1.4 language features but keep Kotlin 1.3 library APIs
-      // The benefit is that depending clients do not have to upgrade to Kotlin 1.4
-      'kotlinCompiler': '1.4.21',
-      'kotlinLib': '1.3.72',
-      // 2.7.0 to ensure support for setExpedited().
-      'workManager': '2.7.0',
-  ]
-  ext.deps = [
-      assertj_core: 'org.assertj:assertj-core:3.9.1',
-      // We don't need the latest version of AndroidX (there are no bugs that impact what LeakCanary
-      // relies on), we're sticking a bit older because most apps will be using a more recent version
-      // and they'll automatically resolve to higher version without having to necessarily resort to a
-      // resolution strategy.
-      androidGradlePlugin: "com.android.tools.build:gradle:4.2.2",
-      dokkaPlugin: "org.jetbrains.dokka:dokka-gradle-plugin:1.6.0",
-      mavenPublishPlugin: "com.vanniktech:gradle-maven-publish-plugin:0.18.0",
-      androidx: [
-          annotation: 'androidx.annotation:annotation:1.0.2',
-          core: 'androidx.core:core:1.0.1',
-          fragment: 'androidx.fragment:fragment:1.0.0',
-          test: [
-              core: 'androidx.test:core:1.0.0',
-              espresso: 'androidx.test.espresso:espresso-core:3.1.0',
-              rules: 'androidx.test:rules:1.1.0',
-              runner: 'androidx.test:runner:1.1.0',
-              orchestrator: 'androidx.test:orchestrator:1.1.0',
-          ],
-          work: [
-            // Note: we use the Java artifact because the Kotlin one bundles coroutines.
-            runtime: "androidx.work:work-runtime:${versions.workManager}",
-            multiprocess: "androidx.work:work-multiprocess:${versions.workManager}",
-          ]
-      ],
-      android_support: 'com.android.support:support-v4:28.0.0',
-      clikt: 'com.github.ajalt:clikt:2.3.0',
-      curtains: 'com.squareup.curtains:curtains:1.2.2',
-      jline: 'jline:jline:2.14.6',
-      detekt: 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.6.0',
-      junit: 'junit:junit:4.12',
-      kotlin: [
-          binaryCompatibilityValidatorPlugin: "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0",
-          gradlePlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlinCompiler}",
-          stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlinLib}",
-          reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlinLib}"
-      ],
-      kotlin_statistics: 'org.nield:kotlin-statistics:1.2.1',
-      mockito: 'org.mockito:mockito-core:3.5.10',
-      mockito_kotlin: 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0',
-      okio: 'com.squareup.okio:okio:2.2.2',
-      okio_1x: 'com.squareup.okio:okio:1.14.0',
-      robolectric: 'org.robolectric:robolectric:4.0-alpha-3',
+    'minSdk'    : 14,
+    'compileSdk': 31,
   ]
   repositories {
     google()
     gradlePluginPortal()
-    // For binary compatibility validator.
-    maven { url "https://kotlin.bintray.com/kotlinx" }
+    mavenCentral()
   }
   dependencies {
-    classpath deps.kotlin.gradlePlugin
-    classpath deps.androidGradlePlugin
-    classpath deps.dokkaPlugin
-    classpath deps.mavenPublishPlugin
-    classpath deps.detekt
-    classpath deps.kotlin.binaryCompatibilityValidatorPlugin
+    classpath libs.kotlinPlugin
+    classpath libs.androidPlugin
+    classpath libs.dokkaPlugin
+    classpath libs.mavenPublishPlugin
+    classpath libs.detektPlugin
+    classpath libs.binaryCompatibilityValidatorPlugin
+    classpath libs.keeperPlugin
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@
 kotlinCompiler = "1.4.21"
 kotlinLib = "1.3.72"
 androidXTest = "1.1.0"
+androidXJunit = "1.1.3"
 workManager = "2.7.0"
 
 [libraries]
@@ -37,11 +38,14 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 # and they'll automatically resolve to higher version without having to necessarily resort to a
 # resolution strategy.
 androidX-fragment = { module = "androidx.fragment:fragment", version = "1.0.0" }
-androidX-test-core = { module = "androidx.test:core", version = "1.0.0" }
+androidX-test-core = { module = "androidx.test:core", version = "1.4.0" }
 androidX-test-rules = { module = "androidx.test:rules", version.ref = "androidXTest" }
-androidX-test-runner = { module = "androidx.test:runner", version.ref = "androidXTest" }
-androidX-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidXTest" }
-androidX-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.1.0" }
+# Exposed transitively, avoid increasing
+androidX-test-runner = { module = "androidx.test:runner", version = "1.1.0" }
+androidX-test-orchestrator = { module = "androidx.test:orchestrator", version = "1.4.1" }
+androidX-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.4.0" }
+androidX-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidXJunit" }
+androidX-test-junitKtx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidXJunit" }
 androidX-work-runtime = { module = "androidx.work:work-runtime", version.ref = "workManager" }
 androidX-work-multiprocess = { module = "androidx.work:work-multiprocess", version.ref = "workManager" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,59 @@
+# Copyright (C) 2021 Square, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[versions]
+# We would like to use Kotlin 1.4 language features but keep Kotlin 1.3 library APIs
+# The benefit is that depending clients do not have to upgrade to Kotlin 1.4
+kotlinCompiler = "1.4.21"
+kotlinLib = "1.3.72"
+androidXTest = "1.1.0"
+workManager = "2.7.0"
+
+[libraries]
+androidPlugin = { module = "com.android.tools.build:gradle", version = "4.2.2" }
+kotlinPlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinCompiler" }
+dokkaPlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.6.0" }
+binaryCompatibilityValidatorPlugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.8.0" }
+mavenPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.18.0" }
+detektPlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version = "1.6.0" }
+keeperPlugin = { module = "com.slack.keeper:keeper", version = "0.7.0" }
+
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinLib" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinLib" }
+
+# We don't need the latest version of AndroidX (there are no bugs that impact what LeakCanary
+# relies on), we're sticking a bit older because most apps will be using a more recent version
+# and they'll automatically resolve to higher version without having to necessarily resort to a
+# resolution strategy.
+androidX-fragment = { module = "androidx.fragment:fragment", version = "1.0.0" }
+androidX-test-core = { module = "androidx.test:core", version = "1.0.0" }
+androidX-test-rules = { module = "androidx.test:rules", version.ref = "androidXTest" }
+androidX-test-runner = { module = "androidx.test:runner", version.ref = "androidXTest" }
+androidX-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidXTest" }
+androidX-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.1.0" }
+androidX-work-runtime = { module = "androidx.work:work-runtime", version.ref = "workManager" }
+androidX-work-multiprocess = { module = "androidx.work:work-multiprocess", version.ref = "workManager" }
+
+androidSupport = { module = "com.android.support:support-v4", version = "28.0.0" }
+assertjCore = { module = "org.assertj:assertj-core", version = "3.9.1" }
+clikt = { module = "com.github.ajalt:clikt", version = "2.3.0" }
+curtains = { module = "com.squareup.curtains:curtains", version = "1.2.2" }
+jline = { module = "jline:jline", version = "2.14.6" }
+junit = { module = "junit:junit", version = "4.12" }
+kotlinStatistics = { module = "org.nield:kotlin-statistics", version = "1.2.1" }
+mockito = { module = "org.mockito:mockito-core", version = "3.5.10" }
+mockitoKotlin = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version = "2.2.0" }
+robolectric = { module = "org.robolectric:robolectric", version = "4.0-alpha-3" }
+okio2 = { module = "com.squareup.okio:okio", version = "2.2.2" }
+okio1 = { module = "com.squareup.okio:okio", version = "1.14.0" }

--- a/leakcanary-android-core/build.gradle
+++ b/leakcanary-android-core/build.gradle
@@ -10,20 +10,20 @@ dependencies {
   api project(':leakcanary-object-watcher-android-androidx')
   api project(':leakcanary-object-watcher-android-support-fragments')
   implementation project(':plumber-android')
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
 
   // Optional dependency
-  compileOnly deps.androidx.work.runtime
-  compileOnly deps.androidx.work.multiprocess
+  compileOnly libs.androidX.work.runtime
+  compileOnly libs.androidX.work.multiprocess
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
-  testImplementation deps.kotlin.reflect
-  testImplementation deps.mockito
-  testImplementation deps.mockito_kotlin
-  androidTestImplementation deps.androidx.test.espresso
-  androidTestImplementation deps.androidx.test.rules
-  androidTestImplementation deps.androidx.test.runner
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
+  testImplementation libs.kotlin.reflect
+  testImplementation libs.mockito
+  testImplementation libs.mockitoKotlin
+  androidTestImplementation libs.androidX.test.espresso
+  androidTestImplementation libs.androidX.test.rules
+  androidTestImplementation libs.androidX.test.runner
   androidTestImplementation project(':shark-hprof-test')
 }
 

--- a/leakcanary-android-instrumentation/build.gradle
+++ b/leakcanary-android-instrumentation/build.gradle
@@ -7,13 +7,13 @@ plugins {
 dependencies {
   api project(':leakcanary-android-core')
 
-  implementation deps.androidx.test.runner
-  implementation deps.kotlin.stdlib
+  implementation libs.androidX.test.runner
+  implementation libs.kotlin.stdlib
 
-  androidTestImplementation deps.androidx.test.core
-  androidTestImplementation deps.androidx.test.espresso
-  androidTestImplementation deps.androidx.test.rules
-  androidTestImplementation deps.androidx.fragment
+  androidTestImplementation libs.androidX.test.core
+  androidTestImplementation libs.androidX.test.espresso
+  androidTestImplementation libs.androidX.test.rules
+  androidTestImplementation libs.androidX.fragment
 }
 
 android {

--- a/leakcanary-android-process/build.gradle
+++ b/leakcanary-android-process/build.gradle
@@ -7,8 +7,8 @@ plugins {
 dependencies {
   api project(':leakcanary-android-core')
 
-  implementation deps.kotlin.stdlib
-  implementation deps.androidx.work.multiprocess
+  implementation libs.kotlin.stdlib
+  implementation libs.androidX.work.multiprocess
 }
 
 android {

--- a/leakcanary-android-release/build.gradle
+++ b/leakcanary-android-release/build.gradle
@@ -8,8 +8,8 @@ dependencies {
   api project(':shark-android')
   api project(':leakcanary-android-utils')
 
-  implementation deps.kotlin.stdlib
-  implementation deps.okio
+  implementation libs.kotlin.stdlib
+  implementation libs.okio2
 }
 
 def gitSha() {

--- a/leakcanary-android-sample/build.gradle
+++ b/leakcanary-android-sample/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   androidTestImplementation libs.androidX.test.rules
   androidTestImplementation libs.androidX.test.runner
   androidTestImplementation libs.androidX.test.junit
-  androidTestImplementation libs.androidX.test.junit_ktx
+  androidTestImplementation libs.androidX.test.junitKtx
   androidTestUtil libs.androidX.test.orchestrator
 }
 

--- a/leakcanary-android-sample/build.gradle
+++ b/leakcanary-android-sample/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id("org.jetbrains.kotlin.android")
   // Required to run obfuscated instrumentation tests:
   // ./gradlew leakcanary-android-sample:connectedCheck -Pminify
-  id("com.slack.keeper") version "0.7.0"
+  id("com.slack.keeper")
 }
 
 keeper {
@@ -20,18 +20,18 @@ dependencies {
   // Optional
   releaseImplementation project(':leakcanary-object-watcher-android')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
   // Uncomment to use WorkManager
-  // implementation deps.androidx.work.runtime
+  // implementation libs.androidX.work.runtime
 
-  testImplementation deps.junit
-  testImplementation deps.robolectric
+  testImplementation libs.junit
+  testImplementation libs.robolectric
 
   androidTestImplementation project(':leakcanary-android-instrumentation')
-  androidTestImplementation deps.androidx.test.espresso
-  androidTestImplementation deps.androidx.test.rules
-  androidTestImplementation deps.androidx.test.runner
-  androidTestUtil deps.androidx.test.orchestrator
+  androidTestImplementation libs.androidX.test.espresso
+  androidTestImplementation libs.androidX.test.rules
+  androidTestImplementation libs.androidX.test.runner
+  androidTestUtil libs.androidX.test.orchestrator
 }
 
 android {

--- a/leakcanary-android-utils/build.gradle
+++ b/leakcanary-android-utils/build.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api project(':shark-log')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
 }
 
 android {

--- a/leakcanary-android/build.gradle
+++ b/leakcanary-android/build.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api project(':leakcanary-android-core')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
 }
 
 android {

--- a/leakcanary-deobfuscation-gradle-plugin/build.gradle
+++ b/leakcanary-deobfuscation-gradle-plugin/build.gradle
@@ -19,13 +19,13 @@ gradlePlugin {
 }
 
 dependencies {
-  implementation deps.kotlin.stdlib
-  implementation deps.kotlin.gradlePlugin
-  implementation deps.androidGradlePlugin
+  implementation libs.kotlin.stdlib
+  implementation libs.kotlinPlugin
+  implementation libs.androidPlugin
   compileOnly gradleApi()
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/leakcanary-object-watcher-android-androidx/build.gradle
+++ b/leakcanary-object-watcher-android-androidx/build.gradle
@@ -7,9 +7,9 @@ plugins {
 dependencies {
   api project(':leakcanary-object-watcher-android')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
   // Optional dependency
-  compileOnly deps.androidx.fragment
+  compileOnly libs.androidX.fragment
 }
 
 android {

--- a/leakcanary-object-watcher-android-support-fragments/build.gradle
+++ b/leakcanary-object-watcher-android-support-fragments/build.gradle
@@ -7,9 +7,9 @@ plugins {
 dependencies {
   api project(':leakcanary-object-watcher-android')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
   // Optional dependency
-  compileOnly deps.android_support
+  compileOnly libs.androidSupport
 }
 
 android {

--- a/leakcanary-object-watcher-android/build.gradle
+++ b/leakcanary-object-watcher-android/build.gradle
@@ -8,12 +8,12 @@ dependencies {
   api project(':leakcanary-object-watcher')
   api project(':leakcanary-android-utils')
 
-  implementation deps.curtains
-  implementation deps.kotlin.stdlib
+  implementation libs.curtains
+  implementation libs.kotlin.stdlib
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
-  testImplementation deps.kotlin.reflect
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
+  testImplementation libs.kotlin.reflect
 }
 
 android {

--- a/leakcanary-object-watcher/build.gradle
+++ b/leakcanary-object-watcher/build.gradle
@@ -7,9 +7,9 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
   api project(':shark-log')
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
 }

--- a/plumber-android/build.gradle
+++ b/plumber-android/build.gradle
@@ -8,9 +8,9 @@ dependencies {
   api project(':shark-log')
   api project(':leakcanary-android-utils')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
   // Optional dependency
-  compileOnly deps.androidx.fragment
+  compileOnly libs.androidX.fragment
 }
 
 android {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,23 +1,3 @@
-pluginManagement {
-    repositories {
-        mavenCentral()
-        google()
-    }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "com.android.application") {
-                useModule("com.android.tools.build:gradle:${requested.version}")
-            }
-        }
-    }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "com.android.library") {
-                useModule("com.android.tools.build:gradle:${requested.version}")
-            }
-        }
-    }
-}
 include ':plumber-android'
 include ':leakcanary-android'
 include ':leakcanary-android-core'
@@ -39,3 +19,5 @@ include ':shark-hprof-test'
 include ':shark-log'
 include ':shark-test'
 include ':leakcanary-deobfuscation-gradle-plugin'
+
+enableFeaturePreview("VERSION_CATALOGS")

--- a/shark-android/build.gradle
+++ b/shark-android/build.gradle
@@ -9,13 +9,13 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
   api project(':shark')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
-  testImplementation deps.kotlin_statistics
-  testImplementation deps.mockito
-  testImplementation deps.mockito_kotlin
-  testImplementation deps.okio
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
+  testImplementation libs.kotlinStatistics
+  testImplementation libs.mockito
+  testImplementation libs.mockitoKotlin
+  testImplementation libs.okio2
   testImplementation project(':shark-test')
 }

--- a/shark-cli/build.gradle
+++ b/shark-cli/build.gradle
@@ -18,9 +18,9 @@ tasks.withType(KotlinCompile).configureEach {
 dependencies {
   api project(':shark-android')
 
-  implementation deps.clikt
-  implementation deps.jline
-  implementation deps.kotlin.stdlib
+  implementation libs.clikt
+  implementation libs.jline
+  implementation libs.kotlin.stdlib
 }
 
 application {

--- a/shark-graph/build.gradle
+++ b/shark-graph/build.gradle
@@ -9,11 +9,11 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
   api project(':shark-hprof')
 
-  implementation deps.kotlin.stdlib
-  implementation deps.okio
+  implementation libs.kotlin.stdlib
+  implementation libs.okio2
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
   testImplementation project(':shark-test')
   testImplementation project(':shark-hprof-test')
 }

--- a/shark-hprof-test/build.gradle
+++ b/shark-hprof-test/build.gradle
@@ -6,9 +6,9 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    implementation deps.kotlin.stdlib
-    implementation deps.junit
-    implementation deps.okio
+    implementation libs.kotlin.stdlib
+    implementation libs.junit
+    implementation libs.okio2
 
     implementation project(':shark-hprof')
 }

--- a/shark-hprof/build.gradle
+++ b/shark-hprof/build.gradle
@@ -9,17 +9,17 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
   api project(':shark-log')
 
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
   // compileOnly ensures this dependency is not exposed through this artifact's pom.xml in Maven Central.
   // Okio is a required dependency, but we're making it required on the "shark" artifact which is the main artifact that
   // should generally be used. The shark artifact depends on Okio 2.x (ensure compatibility with modern Okio). Depending on 1.x here
   // enables us to ensure binary compatibility with Okio 1.x and allow us to use the deprecated (error level) Okio APIs to keep that
   // compatibility.
   // See https://github.com/square/leakcanary/issues/1624
-  compileOnly deps.okio_1x
-  testImplementation deps.okio_1x
+  compileOnly libs.okio1
+  testImplementation libs.okio1
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
   testImplementation project(':shark-test')
 }

--- a/shark-log/build.gradle
+++ b/shark-log/build.gradle
@@ -7,8 +7,8 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  implementation deps.kotlin.stdlib
+  implementation libs.kotlin.stdlib
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
 }

--- a/shark-test/build.gradle
+++ b/shark-test/build.gradle
@@ -6,8 +6,8 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    implementation deps.kotlin.stdlib
-    implementation deps.assertj_core
-    implementation deps.junit
+    implementation libs.kotlin.stdlib
+    implementation libs.assertjCore
+    implementation libs.junit
 }
 

--- a/shark/build.gradle
+++ b/shark/build.gradle
@@ -9,11 +9,11 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
   api project(':shark-graph')
 
-  implementation deps.kotlin.stdlib
-  implementation deps.okio
+  implementation libs.kotlin.stdlib
+  implementation libs.okio2
 
-  testImplementation deps.assertj_core
-  testImplementation deps.junit
-  testImplementation deps.okio
+  testImplementation libs.assertjCore
+  testImplementation libs.junit
+  testImplementation libs.okio2
   testImplementation project(':shark-hprof-test')
 }


### PR DESCRIPTION
Migrate to version catalog, easy to convert gradle build scripts to kts.