### PR TITLE
Use activity context to inflate leakcanary toast

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/ToastEventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/ToastEventListener.kt
@@ -51,8 +51,9 @@ object ToastEventListener : EventListener {
       )
       toast.setGravity(Gravity.CENTER_VERTICAL, 0, -iconSize)
       toast.duration = Toast.LENGTH_LONG
-      // Inflating with application context: https://github.com/square/leakcanary/issues/1385
-      val inflater = LayoutInflater.from(appContext)
+      // Need an activity context because StrictMode added new stupid checks:
+      // https://github.com/square/leakcanary/issues/2153
+      val inflater = LayoutInflater.from(resumedActivity)
       toast.view = inflater.inflate(R.layout.leak_canary_heap_dump_toast, null)
       toast.show()
 


### PR DESCRIPTION
Fixes #2153

Unfortunately this means reintroducing #1385, but at least people can now customize the event listeners and use their own custom toast listener instead.