### PR TITLE
Surface ObjectAnimator leaks

### DIFF
--- a/leakcanary-android-sample/src/main/java/com/example/leakcanary/MainActivity.kt
+++ b/leakcanary-android-sample/src/main/java/com/example/leakcanary/MainActivity.kt
@@ -15,6 +15,8 @@
  */
 package com.example.leakcanary
 
+import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.BroadcastReceiver
@@ -92,6 +94,17 @@ class MainActivity : Activity() {
         }
       }
       LeakyReschedulingRunnable(leaky).run()
+    }
+    findViewById<Button>(R.id.infinite_animator).setOnClickListener { view ->
+      ObjectAnimator.ofFloat(view, View.ALPHA, 0.1f, 0.2f).apply {
+        duration = 100
+        repeatMode = ValueAnimator.REVERSE
+        repeatCount = ValueAnimator.INFINITE
+        start()
+      }
+    }
+    findViewById<Button>(R.id.finish_activity).setOnClickListener { view ->
+      finish()
     }
   }
 

--- a/leakcanary-android-sample/src/main/res/layout/main_activity.xml
+++ b/leakcanary-android-sample/src/main/res/layout/main_activity.xml
@@ -71,5 +71,19 @@
     android:layout_height="wrap_content"
     android:text="Create Message leak"
     />
+  <Button
+    android:id="@+id/infinite_animator"
+    android:layout_width="wrap_content"
+    android:layout_gravity="center"
+    android:layout_height="wrap_content"
+    android:text="Create animator leak"
+    />
+  <Button
+    android:id="@+id/finish_activity"
+    android:layout_width="wrap_content"
+    android:layout_gravity="center"
+    android:layout_height="wrap_content"
+    android:text="Finish"
+    />
 
 </LinearLayout>

--- a/shark-android/api/shark-android.api
+++ b/shark-android/api/shark-android.api
@@ -17,6 +17,7 @@ public final class shark/AndroidMetadataExtractor : shark/MetadataExtractor {
 public abstract class shark/AndroidObjectInspectors : java/lang/Enum, shark/ObjectInspector {
 	public static final field ACTIVITY Lshark/AndroidObjectInspectors;
 	public static final field ANDROIDX_FRAGMENT Lshark/AndroidObjectInspectors;
+	public static final field ANIMATOR Lshark/AndroidObjectInspectors;
 	public static final field APPLICATION Lshark/AndroidObjectInspectors;
 	public static final field APPLICATION_PACKAGE_MANAGER Lshark/AndroidObjectInspectors;
 	public static final field COMPOSITION_IMPL Lshark/AndroidObjectInspectors;
@@ -35,6 +36,7 @@ public abstract class shark/AndroidObjectInspectors : java/lang/Enum, shark/Obje
 	public static final field MESSAGE_QUEUE Lshark/AndroidObjectInspectors;
 	public static final field MORTAR_PRESENTER Lshark/AndroidObjectInspectors;
 	public static final field MORTAR_SCOPE Lshark/AndroidObjectInspectors;
+	public static final field OBJECT_ANIMATOR Lshark/AndroidObjectInspectors;
 	public static final field RECOMPOSER Lshark/AndroidObjectInspectors;
 	public static final field SERVICE Lshark/AndroidObjectInspectors;
 	public static final field SUPPORT_FRAGMENT Lshark/AndroidObjectInspectors;

--- a/shark/api/shark.api
+++ b/shark/api/shark.api
@@ -456,6 +456,11 @@ public final class shark/ReferencePattern$StaticFieldPattern : shark/ReferencePa
 public final class shark/ReferencePattern$StaticFieldPattern$Companion {
 }
 
+public final class shark/internal/InternalSharkCollectionsHelper {
+	public static final field INSTANCE Lshark/internal/InternalSharkCollectionsHelper;
+	public final fun arrayListValues (Lshark/HeapObject$HeapInstance;)Lkotlin/sequences/Sequence;
+}
+
 public final class shark/internal/ObjectDominators {
 	public fun <init> ()V
 	public final fun renderDominatorTree (Lshark/HeapGraph;Ljava/util/List;ILjava/lang/String;Z)Ljava/lang/String;

--- a/shark/src/main/java/shark/internal/InternalSharkCollectionsHelper.kt
+++ b/shark/src/main/java/shark/internal/InternalSharkCollectionsHelper.kt
@@ -1,0 +1,50 @@
+package shark.internal
+
+import shark.HeapObject
+import shark.HeapObject.HeapClass
+import shark.HeapObject.HeapInstance
+import shark.HeapObject.HeapObjectArray
+import shark.HeapObject.HeapPrimitiveArray
+
+/**
+ * INTERNAL
+ *
+ * This class is public to be accessible from other LeakCanary modules but shouldn't be
+ * called directly, the API may break at any point.
+ */
+object InternalSharkCollectionsHelper {
+
+  fun arrayListValues(heapInstance: HeapInstance): Sequence<String> {
+    val graph = heapInstance.graph
+    val arrayListReader = OpenJdkInstanceRefReaders.ARRAY_LIST.create(graph)
+      ?: ApacheHarmonyInstanceRefReaders.ARRAY_LIST.create(graph)
+      ?: return emptySequence()
+
+    if (!arrayListReader.matches(heapInstance)) {
+      return emptySequence()
+    }
+
+    return arrayListReader.read(heapInstance).map { reference ->
+      val arrayListValue = graph.findObjectById(reference.valueObjectId)
+      val details = reference.lazyDetailsResolver.resolve()
+      "[${details.name}] = ${className(arrayListValue)}"
+    }
+  }
+
+  private fun className(graphObject: HeapObject): String {
+    return when (graphObject) {
+      is HeapClass -> {
+        graphObject.name
+      }
+      is HeapInstance -> {
+        graphObject.instanceClassName
+      }
+      is HeapObjectArray -> {
+        graphObject.arrayClassName
+      }
+      is HeapPrimitiveArray -> {
+        graphObject.arrayClassName
+      }
+    }
+  }
+}


### PR DESCRIPTION
ObjectAnimator has an mTarget field that is a weak ref to the target. It's a weak ref as a misguided attempt to prevent leaks. Unfortunately, when an object animator runs forever, the mTarget weak ref will be checked every frame and the target reference held as a java local for a brief moment, which makes it really hard for the GC to collect the targeted object.

This changes fixes that by surfacing an additional low priority strong reference from ObjectAnimator to its target.

Additionally, this change adds object inspectors for animators that show useful state (such as listeners and running state).

```
┬───
│ GC Root: Thread object
│
├─ java.lang.Thread instance
│    Leaking: NO (the main thread always runs)
│    Thread name: 'main'
│    ↓ Thread.threadLocals
│             ~~~~~~~~~~~~
├─ java.lang.ThreadLocal$ThreadLocalMap instance
│    Leaking: UNKNOWN
│    Retaining 1.4 kB in 43 objects
│    ↓ ThreadLocal$ThreadLocalMap.table
│                                 ~~~~~
├─ java.lang.ThreadLocal$ThreadLocalMap$Entry[] array
│    Leaking: UNKNOWN
│    Retaining 1.3 kB in 42 objects
│    ↓ ThreadLocal$ThreadLocalMap$Entry[10]
│                                      ~~~~
├─ java.lang.ThreadLocal$ThreadLocalMap$Entry instance
│    Leaking: UNKNOWN
│    Retaining 28 B in 1 objects
│    ↓ ThreadLocal$ThreadLocalMap$Entry.value
│                                       ~~~~~
├─ android.animation.AnimationHandler instance
│    Leaking: UNKNOWN
│    Retaining 338.6 kB in 3421 objects
│    ↓ AnimationHandler.mAnimationCallbacks
│                       ~~~~~~~~~~~~~~~~~~~
├─ java.util.ArrayList instance
│    Leaking: UNKNOWN
│    Retaining 338.5 kB in 3417 objects
│    ↓ ArrayList[0]
│               ~~~
├─ android.animation.ObjectAnimator instance
│    Leaking: UNKNOWN
│    Retaining 338.4 kB in 3415 objects
│    mListeners = null
│    mPropertyName = null
│    mProperty.mName = alpha
│    mProperty.mType = java.lang.Float
│    mInitialized = true
│    mStarted = true
│    mRunning = true
│    mAnimationEndRequested = false
│    mDuration = 100
│    mStartDelay = 0
│    mRepeatCount = INFINITE (-1)
│    mRepeatMode = REVERSE (2)
│    ↓ ObjectAnimator.mTarget
│                     ~~~~~~~
╰→ android.widget.Button instance
     Leaking: YES (View.mContext references a destroyed activity)
```