### PR TITLE
Improve ViewLocationHolder fix

### DIFF
--- a/plumber-android-core/build.gradle
+++ b/plumber-android-core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   api project(':leakcanary-android-utils')
 
   implementation libs.kotlin.stdlib
+  implementation libs.curtains
   // Optional dependency
   compileOnly libs.androidX.fragment
 }

--- a/plumber-android-core/src/main/java/leakcanary/internal/friendly/Friendly.kt
+++ b/plumber-android-core/src/main/java/leakcanary/internal/friendly/Friendly.kt
@@ -3,6 +3,11 @@
 
 package leakcanary.internal.friendly
 
+import android.os.Handler
+
 internal inline fun checkMainThread() = leakcanary.internal.checkMainThread()
 
 internal inline fun <reified T : Any> noOpDelegate(): T = leakcanary.internal.noOpDelegate()
+
+internal inline val mainHandler: Handler
+  get() = leakcanary.internal.mainHandler


### PR DESCRIPTION
This fixes the leak every time a window is removed, which can happen without any activity being destroyed (e.g. dialogs). Removed the onActivityDestroy() fix as activity destroy also leads to detaching the activity window.