### PR TITLE
Add support for AndroidX internal SafeIterableMap

### DIFF
--- a/shark/src/main/java/shark/internal/AndroidReferenceReaders.kt
+++ b/shark/src/main/java/shark/internal/AndroidReferenceReaders.kt
@@ -3,10 +3,10 @@ package shark.internal
 import shark.HeapGraph
 import shark.HeapObject.HeapInstance
 import shark.ValueHolder.ReferenceHolder
-import shark.internal.ReferenceLocationType.ARRAY_ENTRY
 import shark.internal.ChainingInstanceReferenceReader.VirtualInstanceReferenceReader
 import shark.internal.ChainingInstanceReferenceReader.VirtualInstanceReferenceReader.OptionalFactory
 import shark.internal.Reference.LazyDetails
+import shark.internal.ReferenceLocationType.ARRAY_ENTRY
 import shark.internal.ReferenceLocationType.INSTANCE_FIELD
 
 internal enum class AndroidReferenceReaders : OptionalFactory {
@@ -93,5 +93,84 @@ internal enum class AndroidReferenceReaders : OptionalFactory {
         }
       }
     }
+  },
+
+  SAFE_ITERABLE_MAP {
+    override fun create(graph: HeapGraph): VirtualInstanceReferenceReader? {
+      println(graph.findClassByName(SAFE_ITERABLE_MAP_CLASS_NAME))
+      val mapClass =
+        graph.findClassByName(SAFE_ITERABLE_MAP_CLASS_NAME) ?: return null
+      // A subclass of SafeIterableMap with dual storage in a backing HashMap for fast get.
+      // Yes, that's a little weird.
+      val fastMapClass = graph.findClassByName(FAST_SAFE_ITERABLE_MAP_CLASS_NAME)
+
+      val mapClassId = mapClass.objectId
+      val fastMapClassId = fastMapClass?.objectId
+
+      return object : VirtualInstanceReferenceReader {
+        override fun matches(instance: HeapInstance) =
+          instance.instanceClassId.let { classId ->
+            classId == mapClassId || classId == fastMapClassId
+          }
+
+        override fun read(source: HeapInstance): Sequence<Reference> {
+          val start = source[SAFE_ITERABLE_MAP_CLASS_NAME, "mStart"]!!.valueAsInstance
+
+          val entries = generateSequence(start) { node ->
+            node[SAFE_ITERABLE_MAP_ENTRY_CLASS_NAME, "mNext"]!!.valueAsInstance
+          }
+
+          val locationClassObjectId = source.instanceClassId
+          return entries.flatMap { entry ->
+            // mkey is never null
+            val key = entry[SAFE_ITERABLE_MAP_ENTRY_CLASS_NAME, "mKey"]!!.value
+
+            val keyRef = Reference(
+              valueObjectId = key.asObjectId!!,
+              isLowPriority = false,
+              lazyDetailsResolver = {
+                LazyDetails(
+                  name = "key()",
+                  locationClassObjectId = locationClassObjectId,
+                  locationType = ARRAY_ENTRY,
+                  isVirtual = true,
+                  matchedLibraryLeak = null
+                )
+              }
+            )
+
+            // mValue is never null
+            val value = entry[SAFE_ITERABLE_MAP_ENTRY_CLASS_NAME, "mValue"]!!.value
+
+            val valueRef = Reference(
+              valueObjectId = value.asObjectId!!,
+              isLowPriority = false,
+              lazyDetailsResolver = {
+                val keyAsName =
+                  key.asObject?.asInstance?.readAsJavaString() ?: key.asObject?.toString() ?: "null"
+                LazyDetails(
+                  name = keyAsName,
+                  locationClassObjectId = locationClassObjectId,
+                  locationType = ARRAY_ENTRY,
+                  isVirtual = true,
+                  matchedLibraryLeak = null
+                )
+              }
+            )
+            sequenceOf(keyRef, valueRef)
+          }
+        }
+      }
+    }
+  };
+
+  companion object {
+    // Note: not supporting the support lib version of these, which is identical but with an
+    // "android" package prefix instead of "androidx".
+    private const val SAFE_ITERABLE_MAP_CLASS_NAME = "androidx.arch.core.internal.SafeIterableMap"
+    private const val FAST_SAFE_ITERABLE_MAP_CLASS_NAME =
+      "androidx.arch.core.internal.FastSafeIterableMap"
+    private const val SAFE_ITERABLE_MAP_ENTRY_CLASS_NAME =
+      "androidx.arch.core.internal.SafeIterableMap\$Entry"
   }
 }

--- a/shark/src/test/java/shark/internal/AndroidReferenceReadersHprofTest.kt
+++ b/shark/src/test/java/shark/internal/AndroidReferenceReadersHprofTest.kt
@@ -1,0 +1,31 @@
+package shark.internal
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.HeapAnalysisSuccess
+import shark.LeakTraceReference.ReferenceType.ARRAY_ENTRY
+import shark.checkForLeaks
+
+class AndroidReferenceReadersHprofTest {
+
+  @Test fun `safe iterable map traversed as dictionary`() {
+    val hprofFile = "safe_iterable_map.hprof".classpathFile()
+    val analysis = hprofFile.checkForLeaks<HeapAnalysisSuccess>()
+    val leakTrace = analysis.applicationLeaks.single().leakTraces.single()
+
+    val mapReference =
+      leakTrace.referencePath.single { it.owningClassSimpleName == "FastSafeIterableMap" }
+    assertThat(mapReference.referenceName).isEqualTo("key()")
+    assertThat(mapReference.referenceType).isEqualTo(ARRAY_ENTRY)
+  }
+}
+
+fun String.classpathFile(): File {
+  val classLoader = Thread.currentThread()
+    .contextClassLoader
+  val url = classLoader.getResource(this)!!
+  return File(url.path)
+}
+
+


### PR DESCRIPTION
Before:

```
│...
├─ com.example.leakcanary.MainActivity instance
│    ↓ ComponentActivity.mLifecycleRegistry
├─ androidx.lifecycle.LifecycleRegistry instance
│    ↓ LifecycleRegistry.mObserverMap
├─ androidx.arch.core.internal.FastSafeIterableMap instance
│    ↓ SafeIterableMap.mEnd
├─ androidx.arch.core.internal.SafeIterableMap$Entry instance
│    ↓ SafeIterableMap$Entry.mKey
├─ com.example.leakcanary.MainActivity$onCreate$MyObserver instance
│    ↓ MainActivity$onCreate$MyObserver.leaking
│...
```

After:

```
│...
├─ com.example.leakcanary.MainActivity instance
│    ↓ ComponentActivity.mLifecycleRegistry
├─ androidx.lifecycle.LifecycleRegistry instance
│    ↓ LifecycleRegistry.mObserverMap
├─ androidx.arch.core.internal.FastSafeIterableMap instance
│    ↓ FastSafeIterableMap[key()]
├─ com.example.leakcanary.MainActivity$onCreate$MyObserver instance
│    ↓ MainActivity$onCreate$MyObserver.leaking
│...
```