### PR TITLE
Fix WorkerManager crash pre API 31

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerWorker.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapAnalyzerWorker.kt
@@ -1,9 +1,14 @@
 package leakcanary.internal
 
+import android.app.Notification
 import android.content.Context
 import androidx.work.Data
+import androidx.work.ForegroundInfo
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import androidx.work.impl.utils.futures.SettableFuture
+import com.google.common.util.concurrent.ListenableFuture
+import com.squareup.leakcanary.core.R
 import leakcanary.EventListener.Event
 
 internal class HeapAnalyzerWorker(appContext: Context, workerParams: WorkerParameters) :
@@ -17,6 +22,10 @@ internal class HeapAnalyzerWorker(appContext: Context, workerParams: WorkerParam
     return Result.success()
   }
 
+  override fun getForegroundInfoAsync(): ListenableFuture<ForegroundInfo> {
+    return applicationContext.heapAnalysisForegroundInfoAsync()
+  }
+
   companion object {
     private const val EVENT_BYTES = "EVENT_BYTES"
 
@@ -24,6 +33,24 @@ internal class HeapAnalyzerWorker(appContext: Context, workerParams: WorkerParam
       .putByteArray(EVENT_BYTES, toByteArray())
       .build()
 
-    inline fun <reified T> Data.asEvent(): T = Serializables.fromByteArray<T>(getByteArray(EVENT_BYTES)!!)!!
+    inline fun <reified T> Data.asEvent(): T =
+      Serializables.fromByteArray<T>(getByteArray(EVENT_BYTES)!!)!!
+
+    fun Context.heapAnalysisForegroundInfoAsync(): ListenableFuture<ForegroundInfo> {
+      val infoFuture = SettableFuture.create<ForegroundInfo>()
+      val builder = Notification.Builder(this)
+        .setContentTitle(getString(R.string.leak_canary_notification_analysing))
+        .setContentText("LeakCanary is working.")
+        .setProgress(100, 0, true)
+      val notification =
+        Notifications.buildNotification(this, builder, NotificationType.LEAKCANARY_LOW)
+      infoFuture.set(
+        ForegroundInfo(
+          R.id.leak_canary_notification_analyzing_heap,
+          notification
+        )
+      )
+      return infoFuture
+    }
   }
 }

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/RemoteHeapAnalyzerWorker.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/RemoteHeapAnalyzerWorker.kt
@@ -1,6 +1,7 @@
 package leakcanary.internal
 
 import android.content.Context
+import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import androidx.work.impl.utils.futures.SettableFuture
 import androidx.work.multiprocess.RemoteListenableWorker
@@ -8,6 +9,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import leakcanary.BackgroundThreadHeapAnalyzer.heapAnalyzerThreadHandler
 import leakcanary.EventListener.Event.HeapDump
 import leakcanary.internal.HeapAnalyzerWorker.Companion.asEvent
+import leakcanary.internal.HeapAnalyzerWorker.Companion.heapAnalysisForegroundInfoAsync
 import shark.SharkLog
 
 internal class RemoteHeapAnalyzerWorker(appContext: Context, workerParams: WorkerParameters) :
@@ -32,5 +34,9 @@ internal class RemoteHeapAnalyzerWorker(appContext: Context, workerParams: Worke
       }
     }
     return result
+  }
+
+  override fun getForegroundInfoAsync(): ListenableFuture<ForegroundInfo> {
+    return applicationContext.heapAnalysisForegroundInfoAsync()
   }
 }


### PR DESCRIPTION
setExpedited() isn't enough, we also needed to provide ForegroundInfo. The documentation doesn't make this very obvious, and there's no API enforcement.

Fixes #2268