### PR TITLE
Typo in startup module manifest

### DIFF
--- a/leakcanary-android-startup/src/main/AndroidManifest.xml
+++ b/leakcanary-android-startup/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="com.squareup.leakcanary.startup" />
+  <application/>
+</manifest>


### PR DESCRIPTION
Looks like need empty node to merge.

Not tested!  Fast fix from mobile

close #2279