### PR TITLE
Adding automatically detection of services in docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,5 +24,6 @@ D LeakCanary: LeakCanary is running and ready to detect leaks
     * destroyed `Fragment` instances
     * destroyed fragment `View` instances
     * cleared `ViewModel` instances
+    * destroyed `Service` instance
 
 What's next? Learn the [Fundamentals](fundamentals.md)!


### PR DESCRIPTION
I have seen that leak canary is also able to catch leaking services. Also, remembering seeing this in changelog here: 
https://square.github.io/leakcanary/changelog/#detecting-services-retained-after-serviceondestroy

Thought to add it docs section as well. Let me know if I wrong somewhere.