### PR TITLE
InputMethodManager.mServedView leak happens on API 28

### DIFF
--- a/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -208,7 +208,7 @@ enum class AndroidReferenceMatchers {
       references += instanceFieldLeak(
         "android.view.inputmethod.InputMethodManager", "mServedView", description
       ) {
-        sdkInt in 15..27
+        sdkInt in 15..28
       }
 
       references += instanceFieldLeak(


### PR DESCRIPTION
LeakTrace:

```
	
┬───
│ GC Root: System class
│
├─ android.view.inputmethod.InputMethodManager class
│    Leaking: NO (InputMethodManager↓ is not leaking and a class is never leaking)
│    ↓ static InputMethodManager.sInstance
├─ android.view.inputmethod.InputMethodManager instance
│    Leaking: NO (InputMethodManager is a singleton)
│    ↓ InputMethodManager.mServedView
│                         ~~~~~~~~~~~
├─ androidx.constraintlayout.widget.ConstraintLayout instance
│    Leaking: YES (View.mContext references a destroyed activity)
│    Retaining 5.0 MB in 65128 objects
│    View not part of a window view hierarchy
│    View.mAttachInfo is null (view detached)
│    View.mWindowAttachCount = 1
│    mContext instance of android.view.ContextThemeWrapper, wrapping activity com.squareup.ui.main.MainActivity with mDestroyed = true
│    ↓ View.mContext
```