### PR TITLE
Deduplicate StickyClass GC roots

### DIFF
--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -72,7 +72,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(8.2 MB +-5 % margin)
+    assertThat(retained).isEqualTo(4.9 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory through analysis steps of leak_asynctask_o`() {

--- a/shark-graph/src/test/java/shark/HprofIndexParsingTest.kt
+++ b/shark-graph/src/test/java/shark/HprofIndexParsingTest.kt
@@ -1,0 +1,43 @@
+package shark
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.GcRoot.StickyClass
+import shark.HprofHeapGraph.Companion.openHeapGraph
+import shark.HprofRecord.HeapDumpRecord.GcRootRecord
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord
+import shark.HprofRecord.LoadClassRecord
+import shark.HprofRecord.StringRecord
+
+class HprofIndexParsingTest {
+
+  private var lastId = 0L
+  private val id: Long
+    get() = ++lastId
+
+  @Test fun `duplicated StickyClass GC roots are deduplicated`() {
+    val className = StringRecord(id, "com.example.VeryStickyClass")
+    val loadClassRecord = LoadClassRecord(1, id, 1, className.id)
+    val classDump = ClassDumpRecord(
+      id = loadClassRecord.id,
+      stackTraceSerialNumber = 1,
+      superclassId = 0,
+      classLoaderId = 0,
+      signersId = 0,
+      protectionDomainId = 0,
+      instanceSize = 0,
+      staticFields = emptyList(),
+      fields = emptyList()
+    )
+    val stickyClassRecords = (1..5).map { GcRootRecord(StickyClass(loadClassRecord.id)) }
+    val bytes = (listOf(className, loadClassRecord, classDump) + stickyClassRecords).asHprofBytes()
+
+    val stickyClassRoots = bytes.openHeapGraph().use { graph: HeapGraph ->
+      graph.gcRoots.filterIsInstance(StickyClass::class.java)
+    }
+
+    assertThat(stickyClassRoots).hasSize(1)
+    assertThat(stickyClassRoots.first().id).isEqualTo(loadClassRecord.id)
+  }
+}


### PR DESCRIPTION
System classes are GC roots and tracked by GcRoot.StickyClass. We've seen heap dumps from API 23 emulators that included millions of sticky class roots, pointing several times to the same instances. As we keep the list of roots in memory, this wasted a lot of memory and slowed down the sorting of gc roots which happens right before path finding. This change fixes this by deduplicating StickyClass GC roots based on their ids.