### PR TITLE
Don't crash on old WorkManager

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/LeakCanary.kt
@@ -203,7 +203,7 @@ object LeakCanary {
       when {
           RemoteWorkManagerHeapAnalyzer.remoteLeakCanaryServiceInClasspath ->
             RemoteWorkManagerHeapAnalyzer
-          WorkManagerHeapAnalyzer.workManagerInClasspath -> WorkManagerHeapAnalyzer
+          WorkManagerHeapAnalyzer.validWorkManagerInClasspath -> WorkManagerHeapAnalyzer
           else -> BackgroundThreadHeapAnalyzer
       }
     ),


### PR DESCRIPTION
If we can't find putByteArray, we just won't use WorkManager

Fixes #2310