### PR TITLE
RandomAccess uses RandomAccessFile

### DIFF
--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -112,14 +112,14 @@ class HprofRetainedHeapPerfTest {
       retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
-    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.07 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.12 MB +-5 % margin)
-    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.22 MB +-5 % margin)
-    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.62 MB +-5 % margin)
-    assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.62 MB +-5 % margin)
-    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(6.63 MB +-5 % margin)
-    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(6.63 MB +-5 % margin)
-    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.55 MB +-5 % margin)
+    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.62 MB +-5 % margin)
+    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.72 MB +-5 % margin)
+    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(7.12 MB +-5 % margin)
+    assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.12 MB +-5 % margin)
+    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.13 MB +-5 % margin)
+    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.13 MB +-5 % margin)
+    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(6.05 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {


### PR DESCRIPTION
This changes the random access read impl from FileChannel.transferTo to RandomAccessFile.read. Experiments in #2333 showed that this new impl is 40% faster on API 23 due to lock contention, and otherwise 20% faster on API 24. FileChannelImpl.transferTo will use a java.nio.MemoryBlock$MemoryMappedBlock under the hood, which uses Libcore.os.mmap and then has a finalizer method that calls Libcore.os.munmap. This seemed to trigger a lot of contention locking between the Finalizer and the RefQueue daemons.