### PR TITLE
Fix init crash

### DIFF
--- a/leakcanary-object-watcher-android-core/src/main/java/leakcanary/AppWatcher.kt
+++ b/leakcanary-object-watcher-android-core/src/main/java/leakcanary/AppWatcher.kt
@@ -102,7 +102,6 @@ object AppWatcher {
     check(retainedDelayMillis >= 0) {
       "retainedDelayMillis $retainedDelayMillis must be at least 0 ms"
     }
-    installCause = RuntimeException("manualInstall() first called here")
     this.retainedDelayMillis = retainedDelayMillis
     if (application.isDebuggableBuild) {
       LogcatSharkLog.install()
@@ -113,6 +112,8 @@ object AppWatcher {
     watchersToInstall.forEach {
       it.install()
     }
+    // Only install after we're fully done with init.
+    installCause = RuntimeException("manualInstall() first called here")
   }
 
   /**


### PR DESCRIPTION
Updating LeakCanary.config prior to installing AppWatcher will kickoff an async check for "can I dump", which could check while we're installing, so "is installed" could be true and yet LeakCanaryInternal.application isn't set, leading to a crash.