### PR TITLE
Enable type-safe project accessors

### DIFF
--- a/leakcanary-android-core/build.gradle
+++ b/leakcanary-android-core/build.gradle
@@ -5,10 +5,10 @@ plugins {
 }
 
 dependencies {
-  api project(':shark-android')
-  api project(':leakcanary-object-watcher-android-core')
-  api project(':leakcanary-object-watcher-android-androidx')
-  api project(':leakcanary-object-watcher-android-support-fragments')
+  api projects.sharkAndroid
+  api projects.leakcanaryObjectWatcherAndroidCore
+  api projects.leakcanaryObjectWatcherAndroidAndroidx
+  api projects.leakcanaryObjectWatcherAndroidSupportFragments
   implementation libs.kotlin.stdlib
 
   // Optional dependency
@@ -24,7 +24,7 @@ dependencies {
   androidTestImplementation libs.androidX.test.rules
   androidTestImplementation libs.androidX.test.runner
   androidTestImplementation libs.assertjCore
-  androidTestImplementation project(':shark-hprof-test')
+  androidTestImplementation projects.sharkHprofTest
   androidTestUtil libs.androidX.test.orchestrator
 }
 

--- a/leakcanary-android-instrumentation/build.gradle
+++ b/leakcanary-android-instrumentation/build.gradle
@@ -5,15 +5,15 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-android-core')
+  api projects.leakcanaryAndroidCore
 
   implementation libs.androidX.test.runner
   implementation libs.kotlin.stdlib
 
   // AppWatcher auto installer for running tests
-  androidTestImplementation project(':leakcanary-object-watcher-android')
+  androidTestImplementation projects.leakcanaryObjectWatcherAndroid
   // Plumber auto installer for running tests
-  androidTestImplementation project(':plumber-android')
+  androidTestImplementation projects.plumberAndroid
   androidTestImplementation libs.androidX.test.core
   androidTestImplementation libs.androidX.test.espresso
   androidTestImplementation libs.androidX.test.rules

--- a/leakcanary-android-process/build.gradle
+++ b/leakcanary-android-process/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-  api project(':shark-log')
-  api project(':leakcanary-object-watcher-android-core')
+  api projects.sharkLog
+  api projects.leakcanaryObjectWatcherAndroidCore
 
   implementation libs.kotlin.stdlib
   implementation libs.androidX.work.multiprocess

--- a/leakcanary-android-release/build.gradle
+++ b/leakcanary-android-release/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-  api project(':shark-android')
-  api project(':leakcanary-android-utils')
+  api projects.sharkAndroid
+  api projects.leakcanaryAndroidUtils
 
   implementation libs.kotlin.stdlib
   implementation libs.okio2

--- a/leakcanary-android-sample/build.gradle
+++ b/leakcanary-android-sample/build.gradle
@@ -13,14 +13,14 @@ keeper {
 }
 
 dependencies {
-  debugImplementation project(':leakcanary-android')
-  // debugImplementation project(':leakcanary-android-startup')
+  debugImplementation projects.leakcanaryAndroid
+  // debugImplementation projects.leakcanaryAndroidStartup
 
   // Uncomment to use the :leakcanary process
-  // debugImplementation project(':leakcanary-android-process')
-  releaseImplementation project(':leakcanary-android-release')
+  // debugImplementation projects.leakcanaryAndroidProcess
+  releaseImplementation projects.leakcanaryAndroidRelease
   // Optional
-  releaseImplementation project(':leakcanary-object-watcher-android')
+  releaseImplementation projects.leakcanaryObjectWatcherAndroid
 
   implementation libs.kotlin.stdlib
   // Uncomment to use WorkManager
@@ -29,7 +29,7 @@ dependencies {
   testImplementation libs.junit
   testImplementation libs.robolectric
 
-  androidTestImplementation project(':leakcanary-android-instrumentation')
+  androidTestImplementation projects.leakcanaryAndroidInstrumentation
   androidTestImplementation libs.androidX.test.espresso
   androidTestImplementation libs.androidX.test.rules
   androidTestImplementation libs.androidX.test.runner

--- a/leakcanary-android-startup/build.gradle
+++ b/leakcanary-android-startup/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-android-core')
+  api projects.leakcanaryAndroidCore
   // AppWatcher AndroidX Startup installer
-  implementation project(':leakcanary-object-watcher-android-startup')
+  implementation projects.leakcanaryObjectWatcherAndroidStartup
   // Plumber AndroidX Startup installer
-  implementation project(':plumber-android-startup')
+  implementation projects.plumberAndroidStartup
 }
 
 android {

--- a/leakcanary-android-utils/build.gradle
+++ b/leakcanary-android-utils/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api project(':shark-log')
+  api projects.sharkLog
 
   implementation libs.kotlin.stdlib
 }

--- a/leakcanary-android/build.gradle
+++ b/leakcanary-android/build.gradle
@@ -5,17 +5,17 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-android-core')
+  api projects.leakcanaryAndroidCore
   // AppWatcher auto installer
-  api project(':leakcanary-object-watcher-android')
+  api projects.leakcanaryObjectWatcherAndroid
   // Plumber auto installer
-  implementation project(':plumber-android')
+  implementation projects.plumberAndroid
 
   androidTestImplementation libs.androidX.test.espresso
   androidTestImplementation libs.androidX.test.rules
   androidTestImplementation libs.androidX.test.runner
   androidTestImplementation libs.assertjCore
-  androidTestImplementation project(':shark-hprof-test')
+  androidTestImplementation projects.sharkHprofTest
 }
 
 android {

--- a/leakcanary-object-watcher-android-androidx/build.gradle
+++ b/leakcanary-object-watcher-android-androidx/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-object-watcher-android-core')
+  api projects.leakcanaryObjectWatcherAndroidCore
 
   implementation libs.kotlin.stdlib
   // Optional dependency

--- a/leakcanary-object-watcher-android-core/build.gradle
+++ b/leakcanary-object-watcher-android-core/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-object-watcher')
-  api project(':leakcanary-android-utils')
+  api projects.leakcanaryObjectWatcher
+  api projects.leakcanaryAndroidUtils
 
   implementation libs.curtains
   implementation libs.kotlin.stdlib

--- a/leakcanary-object-watcher-android-startup/build.gradle
+++ b/leakcanary-object-watcher-android-startup/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-object-watcher-android-core')
+  api projects.leakcanaryObjectWatcherAndroidCore
 
   implementation libs.androidX.startup
 }

--- a/leakcanary-object-watcher-android-support-fragments/build.gradle
+++ b/leakcanary-object-watcher-android-support-fragments/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-object-watcher-android-core')
+  api projects.leakcanaryObjectWatcherAndroidCore
 
   implementation libs.kotlin.stdlib
   // Optional dependency

--- a/leakcanary-object-watcher-android/build.gradle
+++ b/leakcanary-object-watcher-android/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api project(':leakcanary-object-watcher-android-core')
+  api projects.leakcanaryObjectWatcherAndroidCore
 }
 
 android {

--- a/leakcanary-object-watcher/build.gradle
+++ b/leakcanary-object-watcher/build.gradle
@@ -8,7 +8,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   implementation libs.kotlin.stdlib
-  api project(':shark-log')
+  api projects.sharkLog
 
   testImplementation libs.assertjCore
   testImplementation libs.junit

--- a/plumber-android-core/build.gradle
+++ b/plumber-android-core/build.gradle
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-  api project(':shark-log')
-  api project(':leakcanary-android-utils')
+  api projects.sharkLog
+  api projects.leakcanaryAndroidUtils
 
   implementation libs.kotlin.stdlib
   implementation libs.curtains

--- a/plumber-android-startup/build.gradle
+++ b/plumber-android-startup/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api project(':plumber-android-core')
+  api projects.plumberAndroidCore
 
   implementation libs.kotlin.stdlib
   implementation libs.androidX.startup

--- a/plumber-android/build.gradle
+++ b/plumber-android/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api project(':plumber-android-core')
+  api projects.plumberAndroidCore
 
   implementation libs.kotlin.stdlib
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,3 +24,5 @@ include ':shark-hprof-test'
 include ':shark-log'
 include ':shark-test'
 include ':leakcanary-deobfuscation-gradle-plugin'
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/shark-android/build.gradle
+++ b/shark-android/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  api project(':shark')
+  api projects.shark
 
   implementation libs.kotlin.stdlib
 
@@ -17,5 +17,5 @@ dependencies {
   testImplementation libs.mockito
   testImplementation libs.mockitoKotlin
   testImplementation libs.okio2
-  testImplementation project(':shark-test')
+  testImplementation projects.sharkTest
 }

--- a/shark-cli/build.gradle
+++ b/shark-cli/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(KotlinCompile).configureEach {
 }
 
 dependencies {
-  api project(':shark-android')
+  api projects.sharkAndroid
 
   implementation libs.clikt
   implementation libs.jline

--- a/shark-graph/build.gradle
+++ b/shark-graph/build.gradle
@@ -7,13 +7,13 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  api project(':shark-hprof')
+  api projects.sharkHprof
 
   implementation libs.kotlin.stdlib
   implementation libs.okio2
 
   testImplementation libs.assertjCore
   testImplementation libs.junit
-  testImplementation project(':shark-test')
-  testImplementation project(':shark-hprof-test')
+  testImplementation projects.sharkTest
+  testImplementation projects.sharkHprofTest
 }

--- a/shark-hprof-test/build.gradle
+++ b/shark-hprof-test/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation libs.junit
     implementation libs.okio2
 
-    implementation project(':shark-hprof')
+    implementation projects.sharkHprof
 }

--- a/shark-hprof/build.gradle
+++ b/shark-hprof/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  api project(':shark-log')
+  api projects.sharkLog
 
   implementation libs.kotlin.stdlib
   // compileOnly ensures this dependency is not exposed through this artifact's pom.xml in Maven Central.
@@ -21,5 +21,5 @@ dependencies {
 
   testImplementation libs.assertjCore
   testImplementation libs.junit
-  testImplementation project(':shark-test')
+  testImplementation projects.sharkTest
 }

--- a/shark/build.gradle
+++ b/shark/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  api project(':shark-graph')
+  api projects.sharkGraph
 
   implementation libs.kotlin.stdlib
   implementation libs.okio2
@@ -15,6 +15,6 @@ dependencies {
   testImplementation libs.assertjCore
   testImplementation libs.junit
   testImplementation libs.okio2
-  testImplementation project(':shark-test')
-  testImplementation project(':shark-hprof-test')
+  testImplementation projects.sharkTest
+  testImplementation projects.sharkHprofTest
 }


### PR DESCRIPTION
https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors

Ref https://github.com/square/okhttp/pull/7069.