### PR TITLE
Disable `ANTI_ALIAS_FLAG` when rendering the "pixels"

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
@@ -260,7 +260,7 @@ internal object HeapDumpRenderer {
     canvas.drawBitmap(bitmap, source, destination, null)
     height -= legendHeight.toInt()
 
-    val pixelPaint = Paint()
+    val pixelPaint = Paint(Paint.ANTI_ALIAS_FLAG.inv())
     pixelPaint.style = FILL
 
     var recordIndex = 0


### PR DESCRIPTION
This is one of many possible options which fixes #2374 

- `Paint(Paint.ANTI_ALIAS_FLAG.inv())` on the constructor
- `pixelPaint.isAntiAlias = false` on the `Paint` instance
- `bitmap.setPixel(x, y, recordPositions[recordIndex].first)` instead of drawing on the `Canvas`