### PR TITLE
Enable fading edges on `ListView`s

### DIFF
--- a/leakcanary-android-core/src/main/res/layout/leak_canary_heap_dumps_screen.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_heap_dumps_screen.xml
@@ -12,6 +12,7 @@
       android:listSelector="@drawable/leak_canary_list_selector"
       android:divider="@null"
       android:dividerHeight="0dp"
+      android:requiresFadingEdge="vertical"
       />
   <LinearLayout
       android:layout_width="match_parent"

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_hprof_explorer.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_hprof_explorer.xml
@@ -23,6 +23,7 @@
       android:layout_height="match_parent"
       android:divider="@null"
       android:dividerHeight="0dp"
+      android:requiresFadingEdge="vertical"
       android:visibility="invisible"
       />
 </LinearLayout>

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_leak_screen.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_leak_screen.xml
@@ -34,5 +34,6 @@
       android:listSelector="@drawable/leak_canary_list_selector"
       android:divider="@null"
       android:dividerHeight="0dp"
+      android:requiresFadingEdge="vertical"
       />
 </LinearLayout>

--- a/leakcanary-android-core/src/main/res/layout/leak_canary_list.xml
+++ b/leakcanary-android-core/src/main/res/layout/leak_canary_list.xml
@@ -10,5 +10,6 @@
       android:listSelector="@drawable/leak_canary_list_selector"
       android:divider="@null"
       android:dividerHeight="0dp"
+      android:requiresFadingEdge="vertical"
       />
 </FrameLayout>


### PR DESCRIPTION
Hi P.Y.,
I was wondering what's your stance on fading edges on ListView?

I can't find any reference to it in any PRs/issues so I thought I might as well try.
I know it was kind of a delicate API back in the days for performance reasons:

> Using fading edges may introduce noticeable performance degradations and should be used only when required by the application's visual design.

Source: https://github.com/aosp-mirror/platform_frameworks_base/commit/1ef3fdbe047c805ce33b2be463ea51dec5952729

IMO it adds some nice separation between what is scrollable and what is not. Also it doesn't seem that impacting on perfs (though I've nothing to back this up).
I've thought about using `View`'s elevation, but I don't think this is backported to API 14 and would require changing many view hierarchies.

Here is what it look like in the Heap Dump Screen:

| *Without* fading edge | *With* fading edge |
|---|---|
| ![Screenshot_20220424_234601](https://user-images.githubusercontent.com/1921278/164998315-98d7361c-9a25-4bee-a143-cc5a97527c78.png) | ![Screenshot_20220424_234521](https://user-images.githubusercontent.com/1921278/164998318-52397efd-8d2f-49ca-bc33-10734dd6a09d.png) |


