### PR TITLE
Add length paramter to OnHprofRecordListener

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/screen/HeapDumpRenderer.kt
@@ -108,7 +108,7 @@ internal object HeapDumpRenderer {
     val classNames = mutableMapOf<Long, Long>()
     reader.readRecords(
       setOf(HprofRecord::class)
-    ) { position, record ->
+    ) { position, _, record ->
       lastPosition = position
       when (record) {
         is StringRecord -> {

--- a/shark-graph/src/test/java/shark/HprofWriterTest.kt
+++ b/shark-graph/src/test/java/shark/HprofWriterTest.kt
@@ -181,7 +181,7 @@ class HprofWriterTest {
   private fun DualSourceProvider.readAllRecords(): MutableList<HprofRecord> {
     val readRecords = mutableListOf<HprofRecord>()
     StreamingHprofReader.readerFor(this).asStreamingRecordReader()
-      .readRecords(setOf(HprofRecord::class)) { position, record ->
+      .readRecords(setOf(HprofRecord::class)) { position, length, record ->
         readRecords += record
       }
     return readRecords

--- a/shark-hprof/api/shark-hprof.api
+++ b/shark-hprof/api/shark-hprof.api
@@ -518,11 +518,11 @@ public final class shark/HprofWriter$Companion {
 
 public abstract interface class shark/OnHprofRecordListener {
 	public static final field Companion Lshark/OnHprofRecordListener$Companion;
-	public abstract fun onHprofRecord (JLshark/HprofRecord;)V
+	public abstract fun onHprofRecord (JJLshark/HprofRecord;)V
 }
 
 public final class shark/OnHprofRecordListener$Companion {
-	public final fun invoke (Lkotlin/jvm/functions/Function2;)Lshark/OnHprofRecordListener;
+	public final fun invoke (Lkotlin/jvm/functions/Function3;)Lshark/OnHprofRecordListener;
 }
 
 public abstract interface class shark/OnHprofRecordTagListener {

--- a/shark-hprof/src/main/java/shark/HprofDeobfuscator.kt
+++ b/shark-hprof/src/main/java/shark/HprofDeobfuscator.kt
@@ -64,7 +64,7 @@ class HprofDeobfuscator {
 
     val reader = StreamingHprofReader.readerFor(inputHprofFile).asStreamingRecordReader()
     reader.readRecords(setOf(HprofRecord::class)
-    ) { _, record ->
+    ) { _, _, record ->
       when (record) {
         is StringRecord -> {
           maxId = maxId.coerceAtLeast(record.id)
@@ -110,7 +110,7 @@ class HprofDeobfuscator {
       )
     ).use { writer ->
       reader.readRecords(setOf(HprofRecord::class),
-        OnHprofRecordListener { _,
+        OnHprofRecordListener { _, _,
           record ->
           // HprofWriter automatically emits HeapDumpEndRecord, because it flushes
           // all continuous heap dump sub records as one heap dump record.

--- a/shark-hprof/src/main/java/shark/HprofPrimitiveArrayStripper.kt
+++ b/shark-hprof/src/main/java/shark/HprofPrimitiveArrayStripper.kt
@@ -62,7 +62,7 @@ class HprofPrimitiveArrayStripper {
     )
       .use { writer ->
         reader.readRecords(setOf(HprofRecord::class),
-          OnHprofRecordListener { _,
+          OnHprofRecordListener { _, _,
             record ->
             // HprofWriter automatically emits HeapDumpEndRecord, because it flushes
             // all continuous heap dump sub records as one heap dump record.

--- a/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
+++ b/shark-hprof/src/main/java/shark/OnHprofRecordListener.kt
@@ -13,6 +13,10 @@ fun interface OnHprofRecordListener {
      * The position of the record in the underlying hprof file.
      */
     position: Long,
+    /**
+     * Length of the record
+     */
+    length: Long,
     record: HprofRecord
   )
 
@@ -29,7 +33,7 @@ fun interface OnHprofRecordListener {
      * }
      * ```
      */
-    inline operator fun invoke(crossinline block: (Long, HprofRecord) -> Unit): OnHprofRecordListener =
-      OnHprofRecordListener { position, record -> block(position, record) }
+    inline operator fun invoke(crossinline block: (Long, Long, HprofRecord) -> Unit): OnHprofRecordListener =
+      OnHprofRecordListener { position, length, record -> block(position, length, record) }
   }
 }

--- a/shark-hprof/src/main/java/shark/StreamingRecordReaderAdapter.kt
+++ b/shark-hprof/src/main/java/shark/StreamingRecordReaderAdapter.kt
@@ -67,148 +67,148 @@ class StreamingRecordReaderAdapter(private val streamingHprofReader: StreamingHp
         STRING_IN_UTF8 -> {
           val recordPosition = reader.bytesRead
           val record = reader.readStringRecord(length)
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, length, record)
         }
         LOAD_CLASS -> {
           val recordPosition = reader.bytesRead
           val record = reader.readLoadClassRecord()
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, length, record)
         }
         STACK_FRAME -> {
           val recordPosition = reader.bytesRead
           val record = reader.readStackFrameRecord()
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, length, record)
         }
         STACK_TRACE -> {
           val recordPosition = reader.bytesRead
           val record = reader.readStackTraceRecord()
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, length, record)
         }
         ROOT_UNKNOWN -> {
           val recordPosition = reader.bytesRead
           val record = reader.readUnknownGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(record))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(record))
         }
         ROOT_JNI_GLOBAL -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readJniGlobalGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
         ROOT_JNI_LOCAL -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readJniLocalGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_JAVA_FRAME -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readJavaFrameGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_NATIVE_STACK -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readNativeStackGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_STICKY_CLASS -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readStickyClassGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_THREAD_BLOCK -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readThreadBlockGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_MONITOR_USED -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readMonitorUsedGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_THREAD_OBJECT -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readThreadObjectGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_INTERNED_STRING -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readInternedStringGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_FINALIZING -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readFinalizingGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_DEBUGGER -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readDebuggerGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_REFERENCE_CLEANUP -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readReferenceCleanupGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_VM_INTERNAL -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readVmInternalGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_JNI_MONITOR -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readJniMonitorGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
 
         ROOT_UNREACHABLE -> {
           val recordPosition = reader.bytesRead
           val gcRootRecord = reader.readUnreachableGcRootRecord()
-          listener.onHprofRecord(recordPosition, GcRootRecord(gcRootRecord))
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, GcRootRecord(gcRootRecord))
         }
         CLASS_DUMP -> {
           val recordPosition = reader.bytesRead
           val record = reader.readClassDumpRecord()
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, record)
         }
         INSTANCE_DUMP -> {
           val recordPosition = reader.bytesRead
           val record = reader.readInstanceDumpRecord()
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, record)
         }
 
         OBJECT_ARRAY_DUMP -> {
           val recordPosition = reader.bytesRead
           val arrayRecord = reader.readObjectArrayDumpRecord()
-          listener.onHprofRecord(recordPosition, arrayRecord)
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, arrayRecord)
         }
 
         PRIMITIVE_ARRAY_DUMP -> {
           val recordPosition = reader.bytesRead
           val record = reader.readPrimitiveArrayDumpRecord()
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, record)
         }
 
         HEAP_DUMP_INFO -> {
           val recordPosition = reader.bytesRead
           val record = reader.readHeapDumpInfoRecord()
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, record)
         }
         HEAP_DUMP_END -> {
           val recordPosition = reader.bytesRead
           val record = HeapDumpEndRecord
-          listener.onHprofRecord(recordPosition, record)
+          listener.onHprofRecord(recordPosition, reader.bytesRead - recordPosition, record)
         }
         else -> error("Unexpected heap dump tag $tag at position ${reader.bytesRead}")
       }

--- a/shark-hprof/src/test/java/shark/HprofReaderPrimitiveArrayTest.kt
+++ b/shark-hprof/src/test/java/shark/HprofReaderPrimitiveArrayTest.kt
@@ -18,7 +18,7 @@ class HprofReaderPrimitiveArrayTest {
       hprof.reader.readHprofRecords(
         emptySet()
       ) // skip everything including primitive arrays
-      { _, _ -> }
+      { _, _, _ -> }
     }
   }
 
@@ -34,7 +34,7 @@ class HprofReaderPrimitiveArrayTest {
     Hprof.open(heapDump).use { hprof ->
       hprof.reader.readHprofRecords(
         setOf(HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord::class)
-      ) { _, record ->
+      ) { _, _, record ->
         if (record is HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.ByteArrayDump) {
           if (byteArray.contentEquals(record.array)) {
             myByteArrayIsInHeapDump = true

--- a/shark-hprof/src/test/java/shark/HprofReaderRecordTest.kt
+++ b/shark-hprof/src/test/java/shark/HprofReaderRecordTest.kt
@@ -1,0 +1,29 @@
+package shark
+
+import org.assertj.core.api.Assertions
+import org.junit.Rule
+import org.junit.Test
+
+class HprofReaderRecordTest {
+  @get:Rule
+  var heapDumpRule = HeapDumpRule()
+
+  @Test
+  fun reads_hprof_records_correctly() {
+    val heapDump = heapDumpRule.dumpHeap()
+
+    Hprof.open(heapDump).use { hprof ->
+      hprof.reader.readHprofRecords(
+        setOf(HprofRecord::class)
+      ) { _, length, record ->
+        if (record is HprofRecord.HeapDumpEndRecord) {
+          // Only HprofRecord.HeapDumpEndRecord length = 0
+          Assertions.assertThat(length == 0L).isTrue()
+        } else {
+          Assertions.assertThat(length > 0L).isTrue()
+        }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
Add length paramter to OnHprofRecordListener(Easy to analyze entire hprof file).
When analyzing hprof files byte by byte, it will be more convenient to output the length of the record.