### PR TITLE
Move Notifications to get triggered from NotificationEventListener

### DIFF
--- a/leakcanary-android-core/api/leakcanary-android-core.api
+++ b/leakcanary-android-core/api/leakcanary-android-core.api
@@ -36,6 +36,10 @@ public abstract class leakcanary/EventListener$Event : java/io/Serializable {
 	public final fun getUniqueId ()Ljava/lang/String;
 }
 
+public final class leakcanary/EventListener$Event$DismissNoRetainedOnTapNotification : leakcanary/EventListener$Event {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class leakcanary/EventListener$Event$DumpingHeap : leakcanary/EventListener$Event {
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -72,6 +76,16 @@ public final class leakcanary/EventListener$Event$HeapDumpFailed : leakcanary/Ev
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Z)V
 	public final fun getException ()Ljava/lang/Throwable;
 	public final fun getWillRetryLater ()Z
+}
+
+public final class leakcanary/EventListener$Event$ShowNoMoreRetainedObjectFoundNotification : leakcanary/EventListener$Event {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class leakcanary/EventListener$Event$ShowRetainedCountNotification : leakcanary/EventListener$Event {
+	public fun <init> (Ljava/lang/String;ILjava/lang/String;)V
+	public final fun getContentText ()Ljava/lang/String;
+	public final fun getObjectCount ()I
 }
 
 public abstract interface class leakcanary/HeapDumper {

--- a/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
@@ -86,6 +86,14 @@ fun interface EventListener {
         showIntent: Intent
       ) : HeapAnalysisDone<HeapAnalysisFailure>(uniqueId, heapAnalysis, showIntent)
     }
+
+    class NoRetainedObjectFound(
+      uniqueId: String,
+    ) : Event(uniqueId)
+
+    class HeapDumpReceived(
+      uniqueId: String,
+    ) : Event(uniqueId)
   }
 
   /**

--- a/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
@@ -91,10 +91,6 @@ fun interface EventListener {
       uniqueId: String,
     ) : Event(uniqueId)
 
-    class HeapDumpReceived(
-      uniqueId: String,
-    ) : Event(uniqueId)
-
     class ShowRetainedCount(
       uniqueId: String,
       val objectCount: Int,

--- a/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
@@ -87,11 +87,15 @@ fun interface EventListener {
       ) : HeapAnalysisDone<HeapAnalysisFailure>(uniqueId, heapAnalysis, showIntent)
     }
 
-    class NoMoreRetainedObjectFound(
+    class DismissNoRetainedOnTapNotification(
       uniqueId: String,
     ) : Event(uniqueId)
 
-    class ShowRetainedCount(
+    class ShowNoMoreRetainedObjectFoundNotification(
+      uniqueId: String,
+    ) : Event(uniqueId)
+
+    class ShowRetainedCountNotification(
       uniqueId: String,
       val objectCount: Int,
       val contentText: String

--- a/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
@@ -87,7 +87,7 @@ fun interface EventListener {
       ) : HeapAnalysisDone<HeapAnalysisFailure>(uniqueId, heapAnalysis, showIntent)
     }
 
-    class NoRetainedObjectFound(
+    class NoMoreRetainedObjectFound(
       uniqueId: String,
     ) : Event(uniqueId)
 

--- a/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/EventListener.kt
@@ -94,6 +94,12 @@ fun interface EventListener {
     class HeapDumpReceived(
       uniqueId: String,
     ) : Event(uniqueId)
+
+    class ShowRetainedCount(
+      uniqueId: String,
+      val objectCount: Int,
+      val contentText: String
+    ) : Event(uniqueId)
   }
 
   /**

--- a/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
@@ -42,7 +42,6 @@ object NotificationEventListener : EventListener {
     }
     when (event) {
       is DumpingHeap -> {
-        dismissRetainedCountNotification()
         val dumpingHeap = appContext.getString(R.string.leak_canary_notification_dumping)
         val builder = Notification.Builder(appContext)
           .setContentTitle(dumpingHeap)

--- a/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
@@ -87,7 +87,11 @@ object NotificationEventListener : EventListener {
         showHeapAnalysisResultNotification(contentTitle, pendingIntent)
       }
 
-      is Event.NoMoreRetainedObjectFound -> {
+      is Event.DismissNoRetainedOnTapNotification -> {
+        dismissNoRetainedOnTapNotification()
+      }
+
+      is Event.ShowNoMoreRetainedObjectFoundNotification -> {
         mainHandler.removeCallbacks(scheduleDismissNoRetainedOnTapNotification)
 
         @Suppress("DEPRECATION")
@@ -119,8 +123,8 @@ object NotificationEventListener : EventListener {
         )
       }
 
-      is Event.ShowRetainedCount -> {
-        dismissRetainedCountNotification()
+      is Event.ShowRetainedCountNotification -> {
+        mainHandler.removeCallbacks(scheduleDismissRetainedCountNotification)
 
         @Suppress("DEPRECATION")
         val builder = Notification.Builder(appContext)
@@ -133,7 +137,6 @@ object NotificationEventListener : EventListener {
         val notification =
           Notifications.buildNotification(appContext, builder, LEAKCANARY_LOW)
         notificationManager.notify(R.id.leak_canary_notification_retained_objects, notification)
-
       }
     }
   }

--- a/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
@@ -92,30 +92,8 @@ object NotificationEventListener : EventListener {
 
       is Event.ShowNoMoreRetainedObjectFoundNotification -> {
         mainHandler.removeCallbacks(scheduleDismissNoRetainedOnTapNotification)
-
-        @Suppress("DEPRECATION")
-        val builder = Notification.Builder(appContext)
-          .setContentTitle(
-            appContext.getString(R.string.leak_canary_notification_no_retained_object_title)
-          )
-          .setContentText(
-            appContext.getString(
-              R.string.leak_canary_notification_no_retained_object_content
-            )
-          )
-          .setAutoCancel(true)
-          .setContentIntent(
-            NotificationReceiver.pendingIntent(
-              appContext,
-              NotificationReceiver.Action.CANCEL_NOTIFICATION
-            )
-          )
-        val notification =
-          Notifications.buildNotification(appContext, builder, LEAKCANARY_LOW)
-        notificationManager.notify(
-          R.id.leak_canary_notification_no_retained_object_on_tap, notification
-        )
-
+        sendShowNoMoreRetainedObjectFoundNotification()
+        
         mainHandler.postDelayed(
           scheduleDismissNoRetainedOnTapNotification,
           DISMISS_NO_RETAINED_OBJECT_NOTIFICATION_MILLIS
@@ -124,20 +102,48 @@ object NotificationEventListener : EventListener {
 
       is Event.ShowRetainedCountNotification -> {
         mainHandler.removeCallbacks(scheduleDismissRetainedCountNotification)
-
-        @Suppress("DEPRECATION")
-        val builder = Notification.Builder(appContext)
-          .setContentTitle(
-            appContext.getString(R.string.leak_canary_notification_retained_title, event.objectCount)
-          )
-          .setContentText(event.contentText)
-          .setAutoCancel(true)
-          .setContentIntent(NotificationReceiver.pendingIntent(appContext, NotificationReceiver.Action.DUMP_HEAP))
-        val notification =
-          Notifications.buildNotification(appContext, builder, LEAKCANARY_LOW)
-        notificationManager.notify(R.id.leak_canary_notification_retained_objects, notification)
+        sendShowRetainedCountNotification(event.objectCount, event.contentText)
       }
     }
+  }
+
+  private fun sendShowNoMoreRetainedObjectFoundNotification() {
+    @Suppress("DEPRECATION")
+    val builder = Notification.Builder(appContext)
+      .setContentTitle(
+        appContext.getString(R.string.leak_canary_notification_no_retained_object_title)
+      )
+      .setContentText(
+        appContext.getString(
+          R.string.leak_canary_notification_no_retained_object_content
+        )
+      )
+      .setAutoCancel(true)
+      .setContentIntent(
+        NotificationReceiver.pendingIntent(
+          appContext,
+          NotificationReceiver.Action.CANCEL_NOTIFICATION
+        )
+      )
+    val notification =
+      Notifications.buildNotification(appContext, builder, LEAKCANARY_LOW)
+    notificationManager.notify(
+      R.id.leak_canary_notification_no_retained_object_on_tap, notification
+    )
+  }
+
+  private fun sendShowRetainedCountNotification(objectCount: Int, contentText: String) {
+    @Suppress("DEPRECATION")
+    val builder = Notification.Builder(appContext)
+      .setContentTitle(
+        appContext.getString(R.string.leak_canary_notification_retained_title, objectCount)
+      )
+      .setContentText(contentText)
+      .setAutoCancel(true)
+      .setContentIntent(NotificationReceiver.pendingIntent(appContext, NotificationReceiver.Action.DUMP_HEAP))
+    val notification =
+      Notifications.buildNotification(appContext, builder, LEAKCANARY_LOW)
+    notificationManager.notify(R.id.leak_canary_notification_retained_objects, notification)
   }
 
   private fun dismissNoRetainedOnTapNotification() {

--- a/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
@@ -87,10 +87,6 @@ object NotificationEventListener : EventListener {
         showHeapAnalysisResultNotification(contentTitle, pendingIntent)
       }
 
-      is Event.HeapDumpReceived -> {
-        dismissNoRetainedOnTapNotification()
-      }
-
       is Event.NoMoreRetainedObjectFound -> {
         mainHandler.removeCallbacks(scheduleDismissNoRetainedOnTapNotification)
 

--- a/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
@@ -5,24 +5,44 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
 import com.squareup.leakcanary.core.R
 import leakcanary.EventListener.Event
 import leakcanary.EventListener.Event.DumpingHeap
 import leakcanary.EventListener.Event.HeapAnalysisDone
 import leakcanary.EventListener.Event.HeapAnalysisDone.HeapAnalysisSucceeded
 import leakcanary.EventListener.Event.HeapAnalysisProgress
-import leakcanary.EventListener.Event.HeapDumpFailed
 import leakcanary.EventListener.Event.HeapDump
+import leakcanary.EventListener.Event.HeapDumpFailed
 import leakcanary.internal.InternalLeakCanary
+import leakcanary.internal.NotificationReceiver
 import leakcanary.internal.NotificationType.LEAKCANARY_LOW
 import leakcanary.internal.NotificationType.LEAKCANARY_MAX
 import leakcanary.internal.Notifications
+import leakcanary.internal.RetainInstanceEvent
+
+private const val BACKGROUND_THREAD_NAME = "Leakcanary-Notification-Event-listener"
+private const val DISMISS_NO_RETAINED_OBJECT_NOTIFICATION_MILLIS = 30_000L
 
 object NotificationEventListener : EventListener {
 
   private val appContext = InternalLeakCanary.application
   private val notificationManager =
     appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+  private val backgroundHandler: Handler
+  private val scheduleDismissNoRetainedOnTapNotification = {
+    dismissNoRetainedOnTapNotification()
+  }
+  private val scheduleDismissRetainedCountNotification = {
+    dismissRetainedCountNotification()
+  }
+
+  init {
+    val handlerThread = HandlerThread(BACKGROUND_THREAD_NAME)
+    handlerThread.start()
+    backgroundHandler = Handler(handlerThread.looper)
+  }
 
   override fun onEvent(event: Event) {
     // TODO Unify Notifications.buildNotification vs Notifications.showNotification
@@ -32,6 +52,7 @@ object NotificationEventListener : EventListener {
     }
     when (event) {
       is DumpingHeap -> {
+        dismissRetainedCountNotification()
         val dumpingHeap = appContext.getString(R.string.leak_canary_notification_dumping)
         val builder = Notification.Builder(appContext)
           .setContentTitle(dumpingHeap)
@@ -72,11 +93,76 @@ object NotificationEventListener : EventListener {
         } else {
           PendingIntent.FLAG_UPDATE_CURRENT
         }
-        val pendingIntent = PendingIntent.getActivity(appContext, 1,  event.showIntent, flags)
-        showHeapAnalysisResultNotification(contentTitle,pendingIntent)
+        val pendingIntent = PendingIntent.getActivity(appContext, 1, event.showIntent, flags)
+        showHeapAnalysisResultNotification(contentTitle, pendingIntent)
+      }
+
+      is Event.HeapDumpReceived -> {
+        dismissNoRetainedOnTapNotification()
+      }
+
+      is Event.NoRetainedObjectFound -> {
+        val builder = Notification.Builder(appContext)
+          .setContentTitle(
+            appContext.getString(R.string.leak_canary_notification_no_retained_object_title)
+          )
+          .setContentText(
+            appContext.getString(
+              R.string.leak_canary_notification_no_retained_object_content
+            )
+          )
+          .setAutoCancel(true)
+          .setContentIntent(
+            NotificationReceiver.pendingIntent(
+              appContext,
+              NotificationReceiver.Action.CANCEL_NOTIFICATION
+            )
+          )
+        val notification =
+          Notifications.buildNotification(appContext, builder, LEAKCANARY_LOW)
+        notificationManager.notify(
+          R.id.leak_canary_notification_no_retained_object_on_tap, notification
+        )
+
+        backgroundHandler.postDelayed(
+          scheduleDismissNoRetainedOnTapNotification,
+          DISMISS_NO_RETAINED_OBJECT_NOTIFICATION_MILLIS
+        )
       }
     }
   }
+
+  private fun dismissNoRetainedOnTapNotification() {
+    backgroundHandler.removeCallbacks(scheduleDismissNoRetainedOnTapNotification)
+    notificationManager.cancel(R.id.leak_canary_notification_no_retained_object_on_tap)
+  }
+
+  private fun dismissRetainedCountNotification() {
+    backgroundHandler.removeCallbacks(scheduleDismissRetainedCountNotification)
+    notificationManager.cancel(R.id.leak_canary_notification_retained_objects)
+  }
+
+  private fun showRetainedCountNotification(
+    objectCount: Int,
+    contentText: String
+  ) {
+    backgroundHandler.removeCallbacks(scheduleDismissRetainedCountNotification)
+    if (!Notifications.canShowNotification) {
+      return
+    }
+    @Suppress("DEPRECATION")
+    val builder = Notification.Builder(appContext)
+      .setContentTitle(
+        appContext.getString(R.string.leak_canary_notification_retained_title, objectCount)
+      )
+      .setContentText(contentText)
+      .setAutoCancel(true)
+      .setContentIntent(NotificationReceiver.pendingIntent(appContext, NotificationReceiver.Action.DUMP_HEAP))
+    val notification =
+      Notifications.buildNotification(appContext, builder, LEAKCANARY_LOW)
+    notificationManager.notify(R.id.leak_canary_notification_retained_objects, notification)
+  }
+
 
   private fun showHeapAnalysisResultNotification(contentTitle: String, showIntent: PendingIntent) {
     val contentText = appContext.getString(R.string.leak_canary_notification_message)

--- a/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/NotificationEventListener.kt
@@ -93,7 +93,7 @@ object NotificationEventListener : EventListener {
       is Event.ShowNoMoreRetainedObjectFoundNotification -> {
         mainHandler.removeCallbacks(scheduleDismissNoRetainedOnTapNotification)
         sendShowNoMoreRetainedObjectFoundNotification()
-        
+
         mainHandler.postDelayed(
           scheduleDismissNoRetainedOnTapNotification,
           DISMISS_NO_RETAINED_OBJECT_NOTIFICATION_MILLIS

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -1,20 +1,18 @@
 package leakcanary.internal
 
 import android.app.Application
-import android.app.NotificationManager
-import android.content.Context
 import android.content.res.Resources.NotFoundException
 import android.os.Handler
 import android.os.SystemClock
 import com.squareup.leakcanary.core.R
-import java.util.*
+import java.util.UUID
 import leakcanary.AppWatcher
 import leakcanary.EventListener
 import leakcanary.EventListener.Event.DumpingHeap
 import leakcanary.EventListener.Event.HeapDump
 import leakcanary.EventListener.Event.HeapDumpFailed
 import leakcanary.EventListener.Event.HeapDumpReceived
-import leakcanary.EventListener.Event.NoRetainedObjectFound
+import leakcanary.EventListener.Event.NoMoreRetainedObjectFound
 import leakcanary.GcTrigger
 import leakcanary.KeyedWeakReference
 import leakcanary.LeakCanary.Config
@@ -228,8 +226,7 @@ internal class HeapDumpTrigger(
       val retainedReferenceCount = objectWatcher.retainedObjectCount
       if (!forceDump && retainedReferenceCount == 0) {
         SharkLog.d { "Ignoring user request to dump heap: no retained objects remaining after GC" }
-        @Suppress("DEPRECATION")
-        InternalLeakCanary.sendEvent(NoRetainedObjectFound(currentEventUniqueId!!))
+        InternalLeakCanary.sendEvent(NoMoreRetainedObjectFound(currentEventUniqueId!!))
 
         lastDisplayedRetainedObjectCount = 0
         return@post
@@ -327,7 +324,7 @@ internal class HeapDumpTrigger(
   }
 
   private fun showNoMoreRetainedObjectNotification() {
-    InternalLeakCanary.sendEvent(NoRetainedObjectFound(currentEventUniqueId!!))
+    InternalLeakCanary.sendEvent(NoMoreRetainedObjectFound(currentEventUniqueId!!))
   }
 
   private fun showRetainedCountNotification(

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -11,7 +11,7 @@ import leakcanary.EventListener
 import leakcanary.EventListener.Event.DumpingHeap
 import leakcanary.EventListener.Event.HeapDump
 import leakcanary.EventListener.Event.HeapDumpFailed
-import leakcanary.EventListener.Event.NoMoreRetainedObjectFound
+import leakcanary.EventListener.Event.ShowNoMoreRetainedObjectFoundNotification
 import leakcanary.GcTrigger
 import leakcanary.KeyedWeakReference
 import leakcanary.LeakCanary.Config
@@ -220,11 +220,12 @@ internal class HeapDumpTrigger(
 
   fun onDumpHeapReceived(forceDump: Boolean) {
     backgroundHandler.post {
+      InternalLeakCanary.sendEvent(EventListener.Event.DismissNoRetainedOnTapNotification(currentEventUniqueId!!))
       gcTrigger.runGc()
       val retainedReferenceCount = objectWatcher.retainedObjectCount
       if (!forceDump && retainedReferenceCount == 0) {
         SharkLog.d { "Ignoring user request to dump heap: no retained objects remaining after GC" }
-        InternalLeakCanary.sendEvent(NoMoreRetainedObjectFound(currentEventUniqueId!!))
+        InternalLeakCanary.sendEvent(ShowNoMoreRetainedObjectFoundNotification(currentEventUniqueId!!))
 
         lastDisplayedRetainedObjectCount = 0
         return@post
@@ -322,7 +323,7 @@ internal class HeapDumpTrigger(
   }
 
   private fun showNoMoreRetainedObjectNotification() {
-    InternalLeakCanary.sendEvent(NoMoreRetainedObjectFound(currentEventUniqueId!!))
+    InternalLeakCanary.sendEvent(ShowNoMoreRetainedObjectFoundNotification(currentEventUniqueId!!))
   }
 
   private fun showRetainedCountNotification(
@@ -330,7 +331,7 @@ internal class HeapDumpTrigger(
     contentText: String
   ) {
     InternalLeakCanary.sendEvent(
-      EventListener.Event.ShowRetainedCount(
+      EventListener.Event.ShowRetainedCountNotification(
         uniqueId = currentEventUniqueId!!,
         objectCount = objectCount,
         contentText = contentText

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -11,7 +11,6 @@ import leakcanary.EventListener
 import leakcanary.EventListener.Event.DumpingHeap
 import leakcanary.EventListener.Event.HeapDump
 import leakcanary.EventListener.Event.HeapDumpFailed
-import leakcanary.EventListener.Event.HeapDumpReceived
 import leakcanary.EventListener.Event.NoMoreRetainedObjectFound
 import leakcanary.GcTrigger
 import leakcanary.KeyedWeakReference
@@ -221,7 +220,6 @@ internal class HeapDumpTrigger(
 
   fun onDumpHeapReceived(forceDump: Boolean) {
     backgroundHandler.post {
-      InternalLeakCanary.sendEvent(HeapDumpReceived(currentEventUniqueId!!))
       gcTrigger.runGc()
       val retainedReferenceCount = objectWatcher.retainedObjectCount
       if (!forceDump && retainedReferenceCount == 0) {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/HeapDumpTrigger.kt
@@ -8,6 +8,7 @@ import com.squareup.leakcanary.core.R
 import java.util.UUID
 import leakcanary.AppWatcher
 import leakcanary.EventListener
+import leakcanary.EventListener.Event.DismissNoRetainedOnTapNotification
 import leakcanary.EventListener.Event.DumpingHeap
 import leakcanary.EventListener.Event.HeapDump
 import leakcanary.EventListener.Event.HeapDumpFailed
@@ -220,7 +221,7 @@ internal class HeapDumpTrigger(
 
   fun onDumpHeapReceived(forceDump: Boolean) {
     backgroundHandler.post {
-      InternalLeakCanary.sendEvent(EventListener.Event.DismissNoRetainedOnTapNotification(currentEventUniqueId!!))
+      InternalLeakCanary.sendEvent(DismissNoRetainedOnTapNotification(currentEventUniqueId!!))
       gcTrigger.runGc()
       val retainedReferenceCount = objectWatcher.retainedObjectCount
       if (!forceDump && retainedReferenceCount == 0) {

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -137,10 +137,7 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
     val backgroundHandler = Handler(handlerThread.looper)
 
     heapDumpTrigger = HeapDumpTrigger(
-      application,
-      backgroundHandler,
-      AppWatcher.objectWatcher,
-      gcTrigger,
+      application, backgroundHandler, AppWatcher.objectWatcher, gcTrigger,
       configProvider
     )
     application.registerVisibilityListener { applicationVisible ->

--- a/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/InternalLeakCanary.kt
@@ -137,7 +137,10 @@ internal object InternalLeakCanary : (Application) -> Unit, OnObjectRetainedList
     val backgroundHandler = Handler(handlerThread.looper)
 
     heapDumpTrigger = HeapDumpTrigger(
-      application, backgroundHandler, AppWatcher.objectWatcher, gcTrigger,
+      application,
+      backgroundHandler,
+      AppWatcher.objectWatcher,
+      gcTrigger,
       configProvider
     )
     application.registerVisibilityListener { applicationVisible ->

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -119,7 +119,7 @@ class HprofRetainedHeapPerfTest {
     assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.02 MB +-5 % margin)
     assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.02 MB +-5 % margin)
     assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.02 MB +-5 % margin)
-    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.54 MB +-5 % margin)
+    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.77 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -112,14 +112,14 @@ class HprofRetainedHeapPerfTest {
       retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
-    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.91 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.10 MB +-5 % margin)
-    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
-    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.34 MB +-5 % margin)
+    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.62 MB +-5 % margin)
+    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.72 MB +-5 % margin)
+    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(7.12 MB +-5 % margin)
+    assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.12 MB +-5 % margin)
+    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.13 MB +-5 % margin)
+    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.13 MB +-5 % margin)
+    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(6.05 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -112,7 +112,7 @@ class HprofRetainedHeapPerfTest {
       retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
-    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.91 MB +-5 % margin)
+    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
     assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.10 MB +-5 % margin)
     assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
     assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -55,7 +55,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(4.83 MB +-5 % margin)
+    assertThat(retained).isEqualTo(5.07 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory when indexing leak_asynctask_m`() {
@@ -72,7 +72,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(4.7 MB +-5 % margin)
+    assertThat(retained).isEqualTo(4.9 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory through analysis steps of leak_asynctask_o`() {

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -113,7 +113,7 @@ class HprofRetainedHeapPerfTest {
     }
 
     assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.15 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.53 MB +-5 % margin)
     assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
     assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
     assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.39 MB +-5 % margin)

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -55,7 +55,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(4.17 MB +-5 % margin)
+    assertThat(retained).isEqualTo(4.83 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory when indexing leak_asynctask_m`() {
@@ -72,7 +72,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(4.29 MB +-5 % margin)
+    assertThat(retained).isEqualTo(4.7 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory through analysis steps of leak_asynctask_o`() {

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -114,12 +114,12 @@ class HprofRetainedHeapPerfTest {
 
     assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
     assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.53 MB +-5 % margin)
-    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
-    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(6.39 MB +-5 % margin)
-    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.34 MB +-5 % margin)
+    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.58 MB +-5 % margin)
+    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(7.02 MB +-5 % margin)
+    assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.02 MB +-5 % margin)
+    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.02 MB +-5 % margin)
+    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.02 MB +-5 % margin)
+    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.54 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -112,14 +112,14 @@ class HprofRetainedHeapPerfTest {
       retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
-//    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.91 MB +-5 % margin)
-//    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.1 MB +-5 % margin)
-//    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
-//    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(7.12 MB +-5 % margin)
-//    assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.12 MB +-5 % margin)
-//    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.13 MB +-5 % margin)
-//    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.13 MB +-5 % margin)
-//    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(6.05 MB +-5 % margin)
+    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.91 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.10 MB +-5 % margin)
+    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
+    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.34 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -113,7 +113,7 @@ class HprofRetainedHeapPerfTest {
     }
 
     assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.10 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.81 MB +-5 % margin)
     assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
     assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
     assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.39 MB +-5 % margin)

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -113,7 +113,7 @@ class HprofRetainedHeapPerfTest {
     }
 
     assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.81 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.15 MB +-5 % margin)
     assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
     assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
     assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.39 MB +-5 % margin)

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -55,7 +55,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(5.07 MB +-5 % margin)
+    assertThat(retained).isEqualTo(4.17 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory when indexing leak_asynctask_m`() {
@@ -72,7 +72,7 @@ class HprofRetainedHeapPerfTest {
 
     val retained = analysisRetained - baselineHeap.retainedHeap(ANALYSIS_THREAD).first
 
-    assertThat(retained).isEqualTo(4.9 MB +-5 % margin)
+    assertThat(retained).isEqualTo(4.29 MB +-5 % margin)
   }
 
   @Test fun `freeze retained memory through analysis steps of leak_asynctask_o`() {
@@ -112,14 +112,14 @@ class HprofRetainedHeapPerfTest {
       retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
-    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.62 MB +-5 % margin)
-    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.72 MB +-5 % margin)
-    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(7.12 MB +-5 % margin)
-    assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.12 MB +-5 % margin)
-    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.13 MB +-5 % margin)
-    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.13 MB +-5 % margin)
-    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(6.05 MB +-5 % margin)
+//    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.91 MB +-5 % margin)
+//    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.1 MB +-5 % margin)
+//    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
+//    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(7.12 MB +-5 % margin)
+//    assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.12 MB +-5 % margin)
+//    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.13 MB +-5 % margin)
+//    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.13 MB +-5 % margin)
+//    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(6.05 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {

--- a/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
+++ b/shark-android/src/test/java/shark/HprofRetainedHeapPerfTest.kt
@@ -112,14 +112,14 @@ class HprofRetainedHeapPerfTest {
       retainedPair.first - retainedBeforeAnalysis to retainedPair.second
     }
 
-    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(5.57 MB +-5 % margin)
-    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.62 MB +-5 % margin)
-    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.72 MB +-5 % margin)
-    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(7.12 MB +-5 % margin)
-    assertThat(retained after FINDING_DOMINATORS).isEqualTo(7.12 MB +-5 % margin)
-    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(7.13 MB +-5 % margin)
-    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(7.13 MB +-5 % margin)
-    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(6.05 MB +-5 % margin)
+    assertThat(retained after PARSING_HEAP_DUMP).isEqualTo(4.91 MB +-5 % margin)
+    assertThat(retained after EXTRACTING_METADATA).isEqualTo(5.10 MB +-5 % margin)
+    assertThat(retained after FINDING_RETAINED_OBJECTS).isEqualTo(5.15 MB +-5 % margin)
+    assertThat(retained after FINDING_PATHS_TO_RETAINED_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after FINDING_DOMINATORS).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after INSPECTING_OBJECTS).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after COMPUTING_NATIVE_RETAINED_SIZE).isEqualTo(6.39 MB +-5 % margin)
+    assertThat(retained after COMPUTING_RETAINED_SIZE).isEqualTo(5.34 MB +-5 % margin)
   }
 
   private fun indexRecordsOf(hprofFile: File): HprofIndex {


### PR DESCRIPTION
Fixes: https://github.com/square/leakcanary/issues/2394

**Change**
This PR moves the notifications triggering to the `NotificationEventListener`.

**Test Plan**
- [x] `./gradlew build --stacktrace`
- [x] Install leakcanary sample with: `./gradlew leakcanary-android-sample:installDebug` and ensure Notifications work as intended:
<img src="https://user-images.githubusercontent.com/6257696/178161866-a13ac9fc-7f3e-44c8-b400-7973caf5e474.png" width=300>
<img src="https://user-images.githubusercontent.com/6257696/178161898-9f1618bf-af0d-40e2-9d94-dcbdf1d11cc2.png" width=300>
