### PR TITLE
Fix broken links and deprecated constructs in recipes.md

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -9,7 +9,7 @@ This page contains code recipes to customize LeakCanary to your needs. Read thro
 
 The default configuration of LeakCanary will automatically watch Activity, Fragment, Fragment View and ViewModel instances.
 
-In your application, you may have other objects with a lifecycle, such as services, Dagger components, etc. Use [AppWatcher.objectWatcher](/leakcanary/api/leakcanary-object-watcher-android/leakcanary/-app-watcher/object-watcher/) to watch instances that should be garbage collected:
+In your application, you may have other objects with a lifecycle, such as services, Dagger components, etc. Use [AppWatcher.objectWatcher](/leakcanary/api/leakcanary/-app-watcher/object-watcher/) to watch instances that should be garbage collected:
 
 ```kotlin
 class MyService : Service {
@@ -43,27 +43,25 @@ class DebugExampleApplication : ExampleApplication() {
 !!! info
     Create a debug application class in your `src/debug/java` folder. Don't forget to also register it in `src/debug/AndroidManifest.xml`.
 
-To customize the detection of retained objects at runtime, update [AppWatcher.config](/leakcanary/api/leakcanary-object-watcher-android/leakcanary/-app-watcher/config/):
+To customize the detection of retained objects at runtime, specify the watchers you wish to install via [AppWatcher.manualInstall()](/leakcanary/api/leakcanary/-app-watcher/manual-install/):
 
 ```kotlin
-AppWatcher.config = AppWatcher.config.copy(watchFragmentViews = false)
+val watchersToInstall = AppWatcher.appDefaultWatchers(this)
+  .filter { it !is FragmentAndViewModelWatcher }
+AppWatcher.manualInstall(
+  application = this,
+  watchersToInstall = watchersToInstall
+)
 ```
 
-To customize the heap dumping & analysis, update [LeakCanary.config](/leakcanary/api/leakcanary-android-core/leakcanary/-leak-canary/config/):
+To customize the heap dumping & analysis, update [LeakCanary.config](/leakcanary/api/leakcanary/-leak-canary/config/):
 
 ```kotlin
 LeakCanary.config = LeakCanary.config.copy(retainedVisibleThreshold = 3)
 ```
 
 !!! info "Java"
-    In Java, use [AppWatcher.Config.Builder](/leakcanary/api/leakcanary-object-watcher-android/leakcanary/-app-watcher/-config/-builder/) and [LeakCanary.Config.Builder](/leakcanary/api/leakcanary-android-core/leakcanary/-leak-canary/-config/-builder/) instead:
-
-    ```java
-    AppWatcher.Config config = AppWatcher.getConfig().newBuilder()
-       .watchFragmentViews(false)
-       .build();
-    AppWatcher.setConfig(config);
-    ```
+    In Java, use [LeakCanary.Config.Builder](/leakcanary/api/leakcanary/-leak-canary/-config/-builder/) instead:
 
     ```java
     LeakCanary.Config config = LeakCanary.getConfig().newBuilder()
@@ -170,7 +168,7 @@ res/
 
 ## Matching known library leaks
 
-Set [LeakCanary.Config.referenceMatchers](/leakcanary/api/leakcanary-android-core/leakcanary/-leak-canary/-config/reference-matchers/) to a list that builds on top of [AndroidReferenceMatchers.appDefaults](/leakcanary/api/shark-android/shark/-android-reference-matchers/app-defaults/):
+Set [LeakCanary.Config.referenceMatchers](/leakcanary/api/leakcanary/-leak-canary/-config/reference-matchers/) to a list that builds on top of [AndroidReferenceMatchers.appDefaults](/leakcanary/api/shark/-android-reference-matchers/-companion/app-defaults/):
 
 ```kotlin
 class DebugExampleApplication : ExampleApplication() {
@@ -249,7 +247,7 @@ dependencies {
 }
 ```
 
-You can call [LeakCanaryProcess.isInAnalyzerProcess](/leakcanary/api/leakcanary-android-process/leakcanary/-leak-canary-process/is-in-analyzer-process/) to check if your Application class is being created in the LeakCanary process. This is useful when configuring libraries like Firebase that may crash when running in an unexpected process.
+You can call [LeakCanaryProcess.isInAnalyzerProcess](/leakcanary/api/leakcanary/-leak-canary-process/is-in-analyzer-process/) to check if your Application class is being created in the LeakCanary process. This is useful when configuring libraries like Firebase that may crash when running in an unexpected process.
 
 ## Setting up LeakCanary for different product flavors
 
@@ -293,7 +291,7 @@ dependencies {
 
 ## Extracting metadata from the heap dump
 
-[LeakCanary.Config.metadataExtractor](/leakcanary/api/leakcanary-android-core/leakcanary/-leak-canary/-config/metadata-extractor/) extracts metadata from a heap dump. The metadata is then available in `HeapAnalysisSuccess.metadata`. `LeakCanary.Config.metadataExtractor` defaults to `AndroidMetadataExtractor` but you can replace it to extract additional metadata from the hprof.
+[LeakCanary.Config.metadataExtractor](/leakcanary/api/leakcanary/-leak-canary/-config/metadata-extractor/) extracts metadata from a heap dump. The metadata is then available in `HeapAnalysisSuccess.metadata`. `LeakCanary.Config.metadataExtractor` defaults to `AndroidMetadataExtractor` but you can replace it to extract additional metadata from the hprof.
 
 For example, if you want to include the app version name in your heap analysis reports, you need to first store it in memory (e.g. in a static field) and then you can retrieve it in `MetadataExtractor`.
 


### PR DESCRIPTION
The [recipes.md](https://square.github.io/leakcanary/recipes/) contains a number of broken links. It looks like the pathing to the API reference docs was changed but the recipes weren't updated.

I also found one reference to a deprecated construct, which has been mentioned in https://github.com/square/leakcanary/issues/2195. To resolve it, I brought some example documentation from the `AppWatcher.kt` source code over into the recipes.

To test these changes, I ran:

```bash
pip install mkdocs-material mkdocs-markdownextradata-plugin
mkdocs serve
```

Looks like the `/api` URLs are served by other means?