### PR TITLE
Use double quotes to allow variables in strings

### DIFF
--- a/docs/leakcanary-for-releases.md
+++ b/docs/leakcanary-for-releases.md
@@ -23,9 +23,9 @@ LeakCanary provides an artifact dedicated to detecting leaks in release builds:
 ```groovy
 dependencies {
   // LeakCanary for releases
-  releaseImplementation "com.squareup.leakcanary:leakcanary-android-release:${leakCanaryVersion}"
+  releaseImplementation 'com.squareup.leakcanary:leakcanary-android-release:{{ leak_canary.release }}'
   // Optional: detect retained objects. This helps but is not required.
-  releaseImplementation "com.squareup.leakcanary:leakcanary-object-watcher-android:${leakCanaryVersion}"
+  releaseImplementation 'com.squareup.leakcanary:leakcanary-object-watcher-android:{{ leak_canary.release }}'
 }
 ```
 

--- a/docs/leakcanary-for-releases.md
+++ b/docs/leakcanary-for-releases.md
@@ -23,9 +23,9 @@ LeakCanary provides an artifact dedicated to detecting leaks in release builds:
 ```groovy
 dependencies {
   // LeakCanary for releases
-  releaseImplementation 'com.squareup.leakcanary:leakcanary-android-release:${leakCanaryVersion}'
+  releaseImplementation "com.squareup.leakcanary:leakcanary-android-release:${leakCanaryVersion}"
   // Optional: detect retained objects. This helps but is not required.
-  releaseImplementation 'com.squareup.leakcanary:leakcanary-object-watcher-android:${leakCanaryVersion}'
+  releaseImplementation "com.squareup.leakcanary:leakcanary-object-watcher-android:${leakCanaryVersion}"
 }
 ```
 


### PR DESCRIPTION
This is a minor fix to be able to easily copy-paste the example config, it uses double quotes to be able to interpolate the variables.