### PR TITLE
Migrate from deprecated getMappingFile() API and use getMappingFileProvider()

### DIFF
--- a/leakcanary-deobfuscation-gradle-plugin/src/main/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPlugin.kt
+++ b/leakcanary-deobfuscation-gradle-plugin/src/main/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPlugin.kt
@@ -74,8 +74,8 @@ class LeakCanaryLeakDeobfuscationPlugin : Plugin<Project> {
       CopyObfuscationMappingFileTask::class.java
     ) {
       it.variantName = variant.name
-      it.mappingFile = variant.mappingFile
-      it.mergeAssetsDirectory = variant.mergeAssetsProvider.get().outputDir.get().asFile
+      it.mappingFile.set(variant.mappingFileProvider.map { files -> files.firstOrNull() })
+      it.mergeAssetsDirectory.set(variant.mergeAssetsProvider.map { folders -> folders.outputDir.get().asFile })
 
       val mappingGeneratingTaskProvider =
         findTaskProviderOrNull(
@@ -138,7 +138,7 @@ class LeakCanaryLeakDeobfuscationPlugin : Plugin<Project> {
     throw GradleException(
       """
         LeakCanary deobfuscation plugin couldn't find any variant with minification enabled.
-        Please make sure that there is at least 1 minified variant in your project. 
+        Please make sure that there is at least 1 minified variant in your project.
       """
     )
   }

--- a/leakcanary-deobfuscation-gradle-plugin/src/test/java/com/squareup/leakcanary/deobfuscation/CopyObfuscationMappingFileTaskTest.kt
+++ b/leakcanary-deobfuscation-gradle-plugin/src/test/java/com/squareup/leakcanary/deobfuscation/CopyObfuscationMappingFileTaskTest.kt
@@ -32,7 +32,7 @@ class CopyObfuscationMappingFileTaskTest {
 
   @Test
   fun `should throw if mapping file is not specified`() {
-    task.mergeAssetsDirectory = tempFolder.newFolder("mergeAssetsDir")
+    task.mergeAssetsDirectory.set(tempFolder.newFolder("mergeAssetsDir"))
 
     assertThatExceptionOfType(GradleException::class.java)
       .isThrownBy { task.copyObfuscationMappingFile() }
@@ -40,7 +40,7 @@ class CopyObfuscationMappingFileTaskTest {
 
   @Test
   fun `should throw if merge assets dir is not specified`() {
-    task.mappingFile = tempFolder.newFile("mapping.txt")
+    task.mappingFile.set(tempFolder.newFile("mapping.txt"))
 
     assertThatExceptionOfType(GradleException::class.java)
       .isThrownBy { task.copyObfuscationMappingFile() }
@@ -48,33 +48,33 @@ class CopyObfuscationMappingFileTaskTest {
 
   @Test
   fun `existing mapping copied and merge assets dir generated if not exists`() {
-    task.mappingFile = tempFolder.newFile("mapping.txt")
-    task.mergeAssetsDirectory = File(tempFolder.root, "mergeAssetsDir")
+    task.mappingFile.set(tempFolder.newFile("mapping.txt"))
+    task.mergeAssetsDirectory.set(File(tempFolder.root, "mergeAssetsDir"))
 
-    assertThat(task.mergeAssetsDirectory!!.exists()).isFalse()
+    assertThat(task.mergeAssetsDirectory.get().exists()).isFalse()
 
     task.copyObfuscationMappingFile()
 
-    assertThat(task.mergeAssetsDirectory!!.exists()).isTrue()
+    assertThat(task.mergeAssetsDirectory.get().exists()).isTrue()
     assertThat(task.leakCanaryAssetsOutputFile.exists()).isTrue()
   }
 
   @Test
   fun `previous mapping overwritten`() {
-    task.mergeAssetsDirectory = tempFolder.newFolder("mergeAssetsDir")
+    task.mergeAssetsDirectory.set(tempFolder.newFolder("mergeAssetsDir"))
 
     // create first mapping file
-    task.mappingFile = tempFolder.newFile("firstMappingFile.txt")
+    task.mappingFile.set(tempFolder.newFile("firstMappingFile.txt")
       .apply {
         writeText("firstMappingFile")
-      }
+      })
     task.copyObfuscationMappingFile()
 
     // create second mapping file
-    task.mappingFile = tempFolder.newFile("secondMappingFile.txt")
+    task.mappingFile.set(tempFolder.newFile("secondMappingFile.txt")
       .apply {
         writeText("secondMappingFile")
-      }
+      })
     task.copyObfuscationMappingFile()
 
     assertThat(task.leakCanaryAssetsOutputFile.exists()).isTrue()


### PR DESCRIPTION
Fixes a [deprecation warning](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/api/BaseVariantImpl.java;l=507-520?q=mappingFileProvider) seen on every build due to the plugin's eager configuration of its tasks. 