### PR TITLE
Name the thread of the serialExecutor used in the Leak activity

### DIFF
--- a/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/Io.kt
+++ b/leakcanary-android-core/src/main/java/leakcanary/internal/activity/db/Io.kt
@@ -9,7 +9,8 @@ import java.util.concurrent.Executors
 
 internal object Io {
 
-  private val serialExecutor = Executors.newSingleThreadExecutor()
+  private val serialExecutor =
+    Executors.newSingleThreadExecutor { runnable -> Thread(runnable, "LeakCanary-Activity-DB") }
 
   fun interface OnIo {
     fun updateUi(updateUi: View.() -> Unit)


### PR DESCRIPTION
Naming the serialExecutor helps keep track of where threads are coming from within an app.

Otherwise, it is named as `pool-N-thread-1`, which is unhelpful when debugging.