### PR TITLE
Remove timeout in executing programs 

### DIFF
--- a/shark/shark-cli/src/main/java/shark/SharkCliCommand.kt
+++ b/shark/shark-cli/src/main/java/shark/SharkCliCommand.kt
@@ -20,7 +20,6 @@ import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.Properties
-import java.util.concurrent.TimeUnit.SECONDS
 
 class SharkCliCommand : CliktCommand(
   name = "shark-cli",
@@ -183,7 +182,7 @@ class SharkCliCommand : CliktCommand(
       val process = ProcessBuilder(*arguments)
         .directory(directory)
         .start()
-        .also { it.waitFor(10, SECONDS) }
+        .also { it.waitFor() }
 
       // See https://github.com/square/leakcanary/issues/1711
       // On Windows, the process doesn't always exit; calling to readText() makes it finish, so


### PR DESCRIPTION
Fixes https://github.com/square/leakcanary/issues/2381
Wasn't sure about removing the timeout completely. But then I decided that if user will notice some unusual long operation than he'll stop it manually. If this is expected due to low speed connection than user will just wait.