### PR TITLE
Set read/write permissions after creating the .hprof file

### DIFF
--- a/leakcanary/leakcanary-android-core/src/main/java/leakcanary/AndroidDebugHeapDumper.kt
+++ b/leakcanary/leakcanary-android-core/src/main/java/leakcanary/AndroidDebugHeapDumper.kt
@@ -12,5 +12,7 @@ import java.io.File
 object AndroidDebugHeapDumper : HeapDumper {
   override fun dumpHeap(heapDumpFile: File) {
     Debug.dumpHprofData(heapDumpFile.absolutePath)
+    heapDumpFile.setReadable(true)
+    heapDumpFile.setWritable(true)
   }
 }

--- a/leakcanary/leakcanary-android-release/src/main/java/leakcanary/internal/RealHeapAnalysisJob.kt
+++ b/leakcanary/leakcanary-android-release/src/main/java/leakcanary/internal/RealHeapAnalysisJob.kt
@@ -219,6 +219,9 @@ internal class RealHeapAnalysisJob(
   }
 
   private fun dumpHeap(heapDumpFile: File) {
+    heapDumpFile.setWritable(true)
+    heapDumpFile.setReadable(true)
+
     Debug.dumpHprofData(heapDumpFile.absolutePath)
 
     check(heapDumpFile.exists()) {


### PR DESCRIPTION
No easy steps to reproduce. We use additional tool to shield our apk, and it seems to only happen after the app is shielded. It fails on reading the file back, when inspecting the .hprof file in cache, I noticed that it has no permissions `--------` instead of `--rw----` which causes the analysis to fail. We see this behaviour for all libs (startup/release/integration). 

More info in #2579 