### PR TITLE
[Ft] : Add a support to generate a fat jar

### DIFF
--- a/shark/shark-cli/build.gradle
+++ b/shark/shark-cli/build.gradle
@@ -15,6 +15,28 @@ tasks.withType(KotlinCompile).configureEach {
   kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
 }
 
+jar {
+  manifest {
+    attributes "Main-Class": "shark.MainKt"
+  }
+
+  // super strange issue where we need to excludes these meta
+  // otherwise it would lead to load shark.MainKt is not found
+  // see https://stackoverflow.com/a/56242000
+  exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
+
+  configurations.implementation.setCanBeResolved(true)
+  // to be use to exclude META-INF/*
+  duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+
+  // This line of code recursively collects and copies all of a project's files
+  // and adds them to the JAR itself. One can extend this task, to skip certain
+  // files or particular types at will
+  from {
+    configurations.implementation.collect { it.isDirectory() ? it : zipTree(it) }
+  }
+}
+
 dependencies {
   api projects.shark.sharkAndroid
 
@@ -25,7 +47,7 @@ dependencies {
 }
 
 application {
-  mainClassName = 'shark.MainKt'
+  mainClassName = "shark.MainKt"
 }
 
 def generatedVersionDir = "${buildDir}/generated-version"


### PR DESCRIPTION
## Background
I have a use case where I want to utilize a shark-cli to capture memory leaks in our CI infrastructure, where it would run on every single merge request.

However, in the current stages, either we install leakcanary-shark using Homebrew, or we embed the shark-cli along with the fat JARs within the infrastructure test code. Both approaches work; however, they have their drawbacks.

#### Homebrew Install
This approach would require us to download the dependencies in our runner and cache those dependencies. It involves both required external downloads and internal downloads. The latter would run very frequently with each MR request, resulting in costs associated with downloading and caching the dependencies.

#### Embedded shark-cli and Fat JARs
This approach works, but the number of JARs that would be embedded in our infrastructure tests would be substantial. This is not my preferred approach.

#### Proposal
To generate a single fat JAR, which we can embed in our infrastructure without incurring download costs or the need for extensive caching.

#### How to generate a jar

```
./gradlew generateVersionProperties && ./gradlew :shark:shark-cli:jar
```