### PR TITLE
Add read write permissions

### DIFF
--- a/leakcanary/leakcanary-android-core/src/main/java/leakcanary/AndroidDebugHeapDumper.kt
+++ b/leakcanary/leakcanary-android-core/src/main/java/leakcanary/AndroidDebugHeapDumper.kt
@@ -12,5 +12,9 @@ import java.io.File
 object AndroidDebugHeapDumper : HeapDumper {
   override fun dumpHeap(heapDumpFile: File) {
     Debug.dumpHprofData(heapDumpFile.absolutePath)
+
+    check(heapDumpFile.setReadable(true)) {
+      "File has no Read access."
+    }
   }
 }

--- a/leakcanary/leakcanary-android-release/src/main/java/leakcanary/internal/RealHeapAnalysisJob.kt
+++ b/leakcanary/leakcanary-android-release/src/main/java/leakcanary/internal/RealHeapAnalysisJob.kt
@@ -228,6 +228,10 @@ internal class RealHeapAnalysisJob(
     check(heapDumpFile.length() > 0L) {
       "File has length ${heapDumpFile.length()} after dump"
     }
+
+    check(heapDumpFile.setReadable(true)) {
+      "File has no Read access."
+    }
   }
 
   private fun stripHeapDump(


### PR DESCRIPTION
Not easy steps to reproduce. We use additional tool to shield our apk, and it seems to only happen after the app is shielded. It fails on reading the file back, when inspecting the `.hprof` file in cache, I noticed that it has no permissions `--------` instead of `--rw----` which causes the analysis to fail. We see this behaviour for all libs (startup/release/integration). 

More info in #2579 