### PR TITLE
Provide reference path on invalid object id error

### DIFF
--- a/config/hooks/pre-push
+++ b/config/hooks/pre-push
@@ -3,7 +3,7 @@
 echo "Running static analysis..."
 
 # Run static analysis tools
-./gradlew detekt
+./gradlew detekt --no-configuration-cache
 
 status=$?
 

--- a/shark-cli.sh
+++ b/shark-cli.sh
@@ -1,2 +1,2 @@
-./gradlew --quiet :shark:shark-cli:installDist
+./gradlew --quiet --no-configuration-cache :shark:shark-cli:installDist
 ./shark/shark-cli/build/install/shark-cli/bin/shark-cli "$@"

--- a/shark/shark/api/shark.api
+++ b/shark/shark/api/shark.api
@@ -752,3 +752,7 @@ public final class shark/internal/ReferencePathNode$RootNode$NormalRootNode : sh
 	public fun getGcRoot ()Lshark/GcRoot;
 }
 
+public final class shark/internal/ReferencePathNodeKt {
+	public static final fun invalidObjectIdErrorMessage (Lshark/HeapGraph;Lshark/internal/ReferencePathNode;)Ljava/lang/String;
+}
+

--- a/shark/shark/src/main/java/shark/internal/ReferencePathNode.kt
+++ b/shark/shark/src/main/java/shark/internal/ReferencePathNode.kt
@@ -1,8 +1,28 @@
 package shark.internal
 
 import shark.GcRoot
+import shark.HeapGraph
+import shark.HeapObject.HeapClass
+import shark.HeapObject.HeapInstance
+import shark.HeapObject.HeapObjectArray
+import shark.HeapObject.HeapPrimitiveArray
+import shark.LeakTrace
+import shark.LeakTrace.GcRootType
+import shark.LeakTraceObject
+import shark.LeakTraceObject.LeakingStatus.UNKNOWN
+import shark.LeakTraceObject.ObjectType.ARRAY
+import shark.LeakTraceObject.ObjectType.CLASS
+import shark.LeakTraceObject.ObjectType.INSTANCE
+import shark.LeakTraceReference
+import shark.LeakTraceReference.ReferenceType.ARRAY_ENTRY
+import shark.LeakTraceReference.ReferenceType.INSTANCE_FIELD
+import shark.LeakTraceReference.ReferenceType.LOCAL
+import shark.LeakTraceReference.ReferenceType.STATIC_FIELD
 import shark.LibraryLeakReferenceMatcher
 import shark.Reference.LazyDetails
+import shark.ReferenceLocationType
+import shark.internal.ReferencePathNode.ChildNode
+import shark.internal.ReferencePathNode.RootNode
 
 sealed class ReferencePathNode {
   abstract val objectId: Long
@@ -30,4 +50,76 @@ sealed class ReferencePathNode {
     val parent: ReferencePathNode,
     val lazyDetailsResolver: LazyDetails.Resolver,
   ) : ReferencePathNode()
+}
+
+fun HeapGraph.invalidObjectIdErrorMessage(node: ReferencePathNode): String {
+  // This should never happen (a heap should only have references to objects that exist)
+  // but when it does happen, let's at least display how we got there.
+  return when (node) {
+    is ChildNode -> {
+      val childPath = mutableListOf<ChildNode>()
+      var iteratingNode = node
+      while (iteratingNode is ChildNode) {
+        childPath.add(0, iteratingNode)
+        iteratingNode = iteratingNode.parent
+      }
+      val rootNode = iteratingNode as RootNode
+      val childPathWithDetails = childPath.map { it to it.lazyDetailsResolver.resolve() }
+      val leakTraceObjects = (listOf(rootNode) + childPath.dropLast(1)).map {
+        val heapObject = findObjectById(it.objectId)
+        val className = when (heapObject) {
+          is HeapClass -> heapObject.name
+          is HeapInstance -> heapObject.instanceClassName
+          is HeapObjectArray -> heapObject.arrayClassName
+          is HeapPrimitiveArray -> heapObject.arrayClassName
+        }
+        val objectType = when (heapObject) {
+          is HeapClass -> CLASS
+          is HeapObjectArray, is HeapPrimitiveArray -> ARRAY
+          else -> INSTANCE
+        }
+        LeakTraceObject(
+          type = objectType,
+          className = className,
+          labels = emptySet(),
+          leakingStatus = UNKNOWN,
+          leakingStatusReason = "",
+          retainedHeapByteSize = null,
+          retainedObjectCount = null
+        )
+      } + LeakTraceObject(
+        type = INSTANCE,
+        className = "UnknownObject${node.objectId}",
+        labels = emptySet(),
+        leakingStatus = UNKNOWN,
+        leakingStatusReason = "",
+        retainedHeapByteSize = null,
+        retainedObjectCount = null
+      )
+      val referencePath = childPathWithDetails.mapIndexed { index, (_, details) ->
+        LeakTraceReference(
+          originObject = leakTraceObjects[index],
+          referenceType = when (details.locationType) {
+            ReferenceLocationType.INSTANCE_FIELD -> INSTANCE_FIELD
+            ReferenceLocationType.STATIC_FIELD -> STATIC_FIELD
+            ReferenceLocationType.LOCAL -> LOCAL
+            ReferenceLocationType.ARRAY_ENTRY -> ARRAY_ENTRY
+          },
+          owningClassName = findObjectById(details.locationClassObjectId).asClass!!.name,
+          referenceName = details.name
+        )
+      }
+      val leakTrace = LeakTrace(
+        gcRootType = GcRootType.fromGcRoot(rootNode.gcRoot),
+        referencePath = referencePath,
+        leakingObject = leakTraceObjects.last()
+      )
+      return "Invalid object id reached through path:\n${leakTrace.toSimplePathString()}"
+    }
+
+    is RootNode -> {
+      val rootType = GcRootType.fromGcRoot(node.gcRoot)
+      "Invalid object id for root ${rootType.name}"
+    }
+  }
 }


### PR DESCRIPTION
Helped with https://github.com/square/leakcanary/issues/2567

```
./shark-cli.sh -h /Users/py/Downloads/2023-09-11_16-18-02_753.hprof   analyze
====================================
HEAP ANALYSIS FAILED

You can report this failure at https://github.com/square/leakcanary/issues
Please provide the stacktrace, metadata and the heap dump file.
====================================
STACKTRACE

java.lang.RuntimeException: Invalid object id reached through path:
┬───
│ GC Root: Thread object
│
├─ android.net.ConnectivityThread instance
│    ↓ Thread.contextClassLoader
├─ dalvik.system.PathClassLoader instance
│    ↓ ClassLoader.runtimeInternalObjects
├─ java.lang.Object[] array
│    ↓ Object[13501]
├─ androidx.core.google.shortcuts.builders.CapabilityBuilder[] class
│    ↓ static CapabilityBuilder.$class$componentType
╰→ UnknownObject336576656 instance
	at shark.PrioritizingShortestPathFinder.findPathsFromGcRoots(PrioritizingShortestPathFinder.kt:186)
	at shark.PrioritizingShortestPathFinder.findShortestPathsFromGcRoots(PrioritizingShortestPathFinder.kt:153)
	at shark.RealLeakTracerFactory.findLeaks(RealLeakTracerFactory.kt:94)
	at shark.RealLeakTracerFactory.createFor$lambda$0(RealLeakTracerFactory.kt:81)
	at shark.HeapAnalyzer.analyze(HeapAnalyzer.kt:179)
	at shark.HeapAnalyzer.analyze(HeapAnalyzer.kt:67)
	at shark.AnalyzeCommand$Companion.analyze(AnalyzeCommand.kt:36)
	at shark.AnalyzeCommand.run(AnalyzeCommand.kt:16)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:139)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:14)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:215)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:212)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:230)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:253)
	at shark.MainKt.main(Main.kt:13)
Caused by: java.lang.IllegalArgumentException: Object id 336576656 not found in heap dump.
	at shark.HprofHeapGraph.findObjectById(HprofHeapGraph.kt:134)
	at shark.PrioritizingShortestPathFinder.findPathsFromGcRoots(PrioritizingShortestPathFinder.kt:182)
	... 14 more
====================================
METADATA

Build.VERSION.SDK_INT: -1
Build.MANUFACTURER: Unknown
LeakCanary version: Unknown
Analysis duration: 2153 ms
Heap dump file path: /Users/py/Downloads/2023-09-11_16-18-02_753.hprof
Heap dump timestamp: 1704195781142
====================================
```