### PR TITLE
Add known library leak and fix for PermissionControllerManager

### DIFF
--- a/plumber/plumber-android-core/api/plumber-android-core.api
+++ b/plumber/plumber-android-core/api/plumber-android-core.api
@@ -9,6 +9,7 @@ public abstract class leakcanary/AndroidLeakFixes : java/lang/Enum {
 	public static final field IMM_FOCUSED_VIEW Lleakcanary/AndroidLeakFixes;
 	public static final field LAST_HOVERED_VIEW Lleakcanary/AndroidLeakFixes;
 	public static final field MEDIA_SESSION_LEGACY_HELPER Lleakcanary/AndroidLeakFixes;
+	public static final field PERMISSION_CONTROLLER_MANAGER Lleakcanary/AndroidLeakFixes;
 	public static final field SAMSUNG_CLIPBOARD_MANAGER Lleakcanary/AndroidLeakFixes;
 	public static final field SPELL_CHECKER Lleakcanary/AndroidLeakFixes;
 	public static final field TEXT_LINE_POOL Lleakcanary/AndroidLeakFixes;

--- a/plumber/plumber-android-core/src/main/java/leakcanary/AndroidLeakFixes.kt
+++ b/plumber/plumber-android-core/src/main/java/leakcanary/AndroidLeakFixes.kt
@@ -721,6 +721,9 @@ enum class AndroidLeakFixes {
   PERMISSION_CONTROLLER_MANAGER {
     @SuppressLint("WrongConstant")
     override fun apply(application: Application) {
+      if (SDK_INT < 29) {
+        return
+      }
       try {
         application.getSystemService("permission_controller")
       } catch (ignored: Exception) {

--- a/plumber/plumber-android-core/src/main/java/leakcanary/AndroidLeakFixes.kt
+++ b/plumber/plumber-android-core/src/main/java/leakcanary/AndroidLeakFixes.kt
@@ -707,6 +707,26 @@ enum class AndroidLeakFixes {
         SharkLog.d(ignored) { "Unable to fix SpellChecker leak" }
       }
     }
+  },
+
+  /**
+   * PermissionControllerManager stores the first context it's initialized with forever.
+   * Sometimes it's an Activity context which then leaks after Activity is destroyed.
+   *
+   * This fix makes sure the PermissionControllerManager is created with the application context.
+   *
+   * For Pixel devices the issue can be tracked here
+   * https://issuetracker.google.com/issues/318415056
+   */
+  PERMISSION_CONTROLLER_MANAGER {
+    @SuppressLint("WrongConstant")
+    override fun apply(application: Application) {
+      try {
+        application.getSystemService("permission_controller")
+      } catch (ignored: Exception) {
+        SharkLog.d(ignored) { "Unable to fix PermissionControllerManager leak" }
+      }
+    }
   }
 
   ;

--- a/shark/shark-android/api/shark-android.api
+++ b/shark/shark-android/api/shark-android.api
@@ -133,6 +133,7 @@ public abstract class shark/AndroidReferenceMatchers : java/lang/Enum {
 	public static final field OEM_SCENE_CALL_BLOCKER Lshark/AndroidReferenceMatchers;
 	public static final field ONE_PLUS Ljava/lang/String;
 	public static final field PERF_MONITOR_LAST_CALLBACK Lshark/AndroidReferenceMatchers;
+	public static final field PERMISSION_CONTROLLER_MANAGER Lshark/AndroidReferenceMatchers;
 	public static final field PERSONA_MANAGER Lshark/AndroidReferenceMatchers;
 	public static final field PLAYER_BASE Lshark/AndroidReferenceMatchers;
 	public static final field RAZER Ljava/lang/String;

--- a/shark/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -50,6 +50,21 @@ enum class AndroidReferenceMatchers {
 
   // ######## Android Framework known leaks ########
 
+  PERMISSION_CONTROLLER_MANAGER {
+    override fun add(
+      references: MutableList<ReferenceMatcher>
+    ) {
+      references += instanceFieldLeak(
+        "android.permission.PermissionControllerManager", "mContext",
+        description = "On some devices PermissionControllerManager " +
+        "may be initialized with Activity as its Context field. " +
+        "Fix: you can \"fix\" this leak by calling getSystemService(\"permission_controller\") " +
+        "on an application context. " +
+        "Tracked here: https://issuetracker.google.com/issues/318415056"
+      )
+    }
+  },
+
   IREQUEST_FINISH_CALLBACK {
     override fun add(
       references: MutableList<ReferenceMatcher>

--- a/shark/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -61,7 +61,9 @@ enum class AndroidReferenceMatchers {
         "Fix: you can \"fix\" this leak by calling getSystemService(\"permission_controller\") " +
         "on an application context. " +
         "Tracked here: https://issuetracker.google.com/issues/318415056"
-      )
+      ) {
+        sdkInt >= 29
+      }
     }
   },
 


### PR DESCRIPTION
Added a new known leak for PermissionControllerManager.
Filed as https://issuetracker.google.com/issues/318415056

Here's an example LeakCanary trace:
```
┬───
│ GC Root: System class
│
├─ android.permission.PermissionControllerManager class
│    Leaking: NO (a class is never leaking)
│    ↓ static PermissionControllerManager.sRemoteServices
│                                         ~~~~~~~~~~~~~~~
├─ android.util.ArrayMap instance
│    Leaking: UNKNOWN
│    Retaining 94.8 kB in 1434 objects
│    ↓ ArrayMap.mArray
│               ~~~~~~
├─ java.lang.Object[] array
│    Leaking: UNKNOWN
│    Retaining 94.7 kB in 1432 objects
│    ↓ Object[1]
│            ~~~
├─ android.permission.PermissionControllerManager$1 instance
│    Leaking: UNKNOWN
│    Retaining 94.7 kB in 1430 objects
│    Anonymous subclass of com.android.internal.infra.ServiceConnector$Impl
│    mContext instance of android.app.ContextImpl
│    ↓ PermissionControllerManager$1.this$0
│                                    ~~~~~~
├─ android.permission.PermissionControllerManager instance
│    Leaking: UNKNOWN
│    Retaining 88.5 kB in 1318 objects
│    mContext instance of ##REDACTED##.main.MainActivity with mDestroyed = true
│    ↓ PermissionControllerManager.mContext
│                                  ~~~~~~~~
╰→ ##REDACTED##.MainActivity instance
​     Leaking: YES (ObjectWatcher was watching this because ##REDACTED##.
​     MainActivity received Activity#onDestroy() callback and
​     Activity#mDestroyed is true)
​     Retaining 88.5 kB in 1317 objects
​     key = 654d01bc-05b0-4327-8462-f4a615798c68
​     watchDurationMillis = 147156
​     retainedDurationMillis = 142156
​     mApplication instance of ##REDACTED##
​     mBase instance of androidx.appcompat.view.ContextThemeWrapper
```