### PR TITLE
Update kotlinx.coroutines to 1.7.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@
 # We would like to use Kotlin recent language features but keep Kotlin 1.3 library APIs
 # The benefit is that depending clients do not have to upgrade to Kotlin 1.4
 kotlin = "1.8.21"
-coroutines = "1.7.0"
+coroutines = "1.7.3"
 androidXTest = "1.1.0"
 androidXJunit = "1.1.3"
 workManager = "2.7.0"


### PR DESCRIPTION
Adding leakcanary to my project is causing all compose UI tests to fail with this error message:

```
java.lang.NoSuchMethodError: No static method runTest$default(Lkotlinx/coroutines/test/TestScope;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V in class Lkotlinx/coroutines/test/TestBuildersKt; or its super classes (declaration of 'kotlinx.coroutines.test.TestBuildersKt' appears in /data/app/~~4WNlhUfv0-7BOFlv6t-ZwQ==/eu.krzdabrowski.starter.basicfeature.test-Z8Fhx7B77jneF5dgjwsjTw==/base.apk!classes19.dex)
```

From what I understand, this was fixed in v1.7.1 and above: https://issuetracker.google.com/issues/281204431.