### PR TITLE
Stop using WorkManager internals

### DIFF
--- a/leakcanary/leakcanary-android-core/src/main/java/leakcanary/internal/LazyImmediateFuture.kt
+++ b/leakcanary/leakcanary-android-core/src/main/java/leakcanary/internal/LazyImmediateFuture.kt
@@ -1,0 +1,34 @@
+package leakcanary.internal
+
+import com.google.common.util.concurrent.ListenableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+internal class LazyImmediateFuture<V>(
+  valueProvider: () -> V
+) : ListenableFuture<V> {
+
+  private val value by lazy {
+    valueProvider()
+  }
+
+  override fun cancel(mayInterruptIfRunning: Boolean) = false
+
+  override fun isCancelled() = false
+
+  override fun isDone() = true
+
+  override fun get() = value
+
+  override fun get(
+    timeout: Long,
+    unit: TimeUnit?
+  ): V = value
+
+  override fun addListener(
+    listener: Runnable,
+    executor: Executor
+  ) {
+    executor.execute(listener)
+  }
+}

--- a/leakcanary/leakcanary-android-core/src/main/java/leakcanary/internal/RemoteHeapAnalyzerWorker.kt
+++ b/leakcanary/leakcanary-android-core/src/main/java/leakcanary/internal/RemoteHeapAnalyzerWorker.kt
@@ -9,10 +9,13 @@ import com.google.common.util.concurrent.ListenableFuture
 import leakcanary.BackgroundThreadHeapAnalyzer.heapAnalyzerThreadHandler
 import leakcanary.EventListener.Event.HeapDump
 import leakcanary.internal.HeapAnalyzerWorker.Companion.asEvent
-import leakcanary.internal.HeapAnalyzerWorker.Companion.heapAnalysisForegroundInfoAsync
+import leakcanary.internal.HeapAnalyzerWorker.Companion.heapAnalysisForegroundInfo
 import shark.SharkLog
 
-internal class RemoteHeapAnalyzerWorker(appContext: Context, workerParams: WorkerParameters) :
+internal class RemoteHeapAnalyzerWorker(
+  appContext: Context,
+  workerParams: WorkerParameters
+) :
   RemoteListenableWorker(appContext, workerParams) {
 
   override fun startRemoteWork(): ListenableFuture<Result> {
@@ -37,6 +40,8 @@ internal class RemoteHeapAnalyzerWorker(appContext: Context, workerParams: Worke
   }
 
   override fun getForegroundInfoAsync(): ListenableFuture<ForegroundInfo> {
-    return applicationContext.heapAnalysisForegroundInfoAsync()
+    return LazyImmediateFuture {
+      applicationContext.heapAnalysisForegroundInfo()
+    }
   }
 }


### PR DESCRIPTION
Adding `LazyImmediateFuture` which removes the need to use `SettableFuture`.

Fixes #2650