### PR TITLE
Run instrumentation tests on every major API level from 24 to 36

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,21 @@ jobs:
         # with RootViewWithoutFocusException until something dismisses it.
         target: [ default ]
         channel: [ stable ]
+        # One emulator per major Android release, from androidMinSdk up to the newest system image
+        # that exists. The point releases in between (25, 27, 32) are left out: for everything
+        # LeakCanary reaches into they behave like the release they follow, so they cost a job and
+        # cover nothing the neighbouring level doesn't.
         api-level:
           - 24
           - 26
+          - 28
+          - 29
+          - 30
           - 31
           - 33
           - 34
+          - 35
+          - 36
     steps:
       - name: Enable KVM group perms
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,9 @@ Java 8 have to be able to use the artifacts.
 ```
 
 Instrumentation tests need a device or emulator and only cover `leakcanary-android`,
-`leakcanary-android-core` and `leakcanary-android-instrumentation`. CI runs them on API 24, 26, 31,
-33 and 34, so a change that only works on newer APIs will fail there rather than locally.
+`leakcanary-android-core` and `leakcanary-android-instrumentation`. CI runs them on one emulator per
+major Android release, from the minSdk to the newest API level with a system image, so a change that
+only works on some API levels will fail there rather than locally.
 
 ## Things that will bite you
 


### PR DESCRIPTION
The matrix covered 24, 26, 31, 33 and 34, leaving Android 9, 10, 11, 15 and 16 untested. This fills it in so there is one emulator per major release, from the minSdk to the newest system image that exists.

The levels missing here were not an oversight, they were excluded for reasons that no longer hold. API 29 was commented out as flaky, and 28 and 29 were later dropped in b72effd74 because they were the two slowest jobs, at 652s and 672s. Both of those turn out to be properties of the emulator setup rather than of the API level: booting the AVD for real instead of restoring a snapshot (#2872) removed the failure mode that made runs look flaky, and it also removed whatever made those two levels slow. This run:

| API | 24 | 26 | 28 | 29 | 30 | 31 | 33 | 34 | 35 | 36 |
| --- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
| | 4m46 | 5m08 | 5m24 | 4m22 | 5m16 | 5m40 | 5m39 | 5m58 | 6m38 | 5m41 |

API 29 is now the fastest job in the matrix and 28 is faster than three of the levels that displaced it. The jobs all run in parallel, so the slowest one sets the wall clock and the rest cost only runner minutes.

Every level ran the same suite — 1 + 25 + 24 tests across the three modules — so no level is quietly skipping anything.

The point releases (25, 27, 32) stay out. For everything LeakCanary reaches into they behave like the release they follow.

Supersedes the original 2024 diff on this branch, which added 29, 30, 31 and 34 to a matrix that started at API 16.