### PR TITLE
shark: append explanation for binder stubs to labels

### DIFF
--- a/shark/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
+++ b/shark/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
@@ -871,7 +871,7 @@ enum class AndroidObjectInspectors : ObjectInspector {
   STUB {
     override fun inspect(reporter: ObjectReporter) {
       reporter.whenInstanceOf("android.os.Binder") { instance ->
-        labels + "${instance.instanceClassSimpleName} is a binder stub. Binder stubs will often be" +
+        labels += "${instance.instanceClassSimpleName} is a binder stub. Binder stubs will often be" +
           " retained long after the associated activity or service is destroyed, as by design stubs" +
           " are retained until the other side gets GCed. If ${instance.instanceClassSimpleName} is" +
           " not a *static* inner class then that's most likely the root cause of this leak. Make" +


### PR DESCRIPTION
I found this with some static analysis that warned that the string was unused.

Looking above, it looks like most of the other cases in this set `labels +=`, and I guess that was the intention here, to append to labels.