### PR TITLE
Use activity context for Toast.makeText

### DIFF
--- a/leakcanary/leakcanary-android-core/src/main/java/leakcanary/internal/RequestPermissionActivity.kt
+++ b/leakcanary/leakcanary-android-core/src/main/java/leakcanary/internal/RequestPermissionActivity.kt
@@ -56,7 +56,7 @@ internal class RequestPermissionActivity : Activity() {
     grantResults: IntArray
   ) {
     if (!hasTargetPermission()) {
-      Toast.makeText(application, R.string.leak_canary_permission_not_granted, LENGTH_LONG)
+      Toast.makeText(this, R.string.leak_canary_permission_not_granted, LENGTH_LONG)
         .show()
     }
     finish()


### PR DESCRIPTION
It is problematic to use application context for UI use case since Android 31. And it will cause StrictMode violation (see [detectIncorrectContextUse](https://developer.android.com/reference/android/os/StrictMode.VmPolicy.Builder#detectIncorrectContextUse())).