### PR TITLE
Fix crash when java.lang.Object has multiple class load records in JVM heap dumps

### DIFF
--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -132,6 +132,9 @@ internal class HprofInMemoryIndex private constructor(
     while(classNamesIterator.hasNext()) {
       val (classId, classNameStringId) = classNamesIterator.next()
       if (hprofStringId == classNameStringId) {
+        if (classId !in classIndex) {
+          continue
+        }
         if (classId in stickyClassGcRootIds) {
           return classId
         } else {

--- a/shark/shark-graph/src/test/java/shark/HprofHeapGraphEdgeCasesTest.kt
+++ b/shark/shark-graph/src/test/java/shark/HprofHeapGraphEdgeCasesTest.kt
@@ -14,7 +14,7 @@ import shark.HprofRecord.LoadClassRecord
 import shark.HprofRecord.StringRecord
 import shark.internal.HprofInMemoryIndex
 
-class HprofHeapGraphTest {
+class HprofHeapGraphEdgeCasesTest {
 
   @get:Rule
   val testFolder = TemporaryFolder()

--- a/shark/shark-graph/src/test/java/shark/HprofHeapGraphTest.kt
+++ b/shark/shark-graph/src/test/java/shark/HprofHeapGraphTest.kt
@@ -12,6 +12,7 @@ import shark.HprofRecord.HeapDumpRecord.GcRootRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord
 import shark.HprofRecord.LoadClassRecord
 import shark.HprofRecord.StringRecord
+import shark.internal.HprofInMemoryIndex
 
 class HprofHeapGraphTest {
 
@@ -23,6 +24,158 @@ class HprofHeapGraphTest {
   @Before
   fun setUp() {
     hprofFile = testFolder.newFile("temp.hprof")
+  }
+
+  @Test
+  fun `When duplicating LoadClassRecord, HprofHeapGraph selects the class that has a ClassDumpRecord`() {
+    val objectClassIds = listOf<Long>(1, 2, 3)
+    val loadedClassId = 2L
+    HprofWriter.openWriterFor(
+      hprofFile = hprofFile,
+      hprofHeader = HprofHeader(
+        version = HprofVersion.JDK_6,
+        identifierByteSize = 8
+      )
+    ).use { writer ->
+      val objectClassNameRecord = StringRecord(1L, "java/lang/Object")
+      writer.write(objectClassNameRecord)
+      for (classId in objectClassIds) {
+        writer.write(
+          LoadClassRecord(
+            classSerialNumber = 1,
+            id = classId,
+            stackTraceSerialNumber = 1,
+            classNameStringId = objectClassNameRecord.id
+          )
+        )
+        writer.write(GcRootRecord(gcRoot = StickyClass(classId)))
+      }
+      writer.write(
+        ClassDumpRecord(
+          id = loadedClassId,
+          stackTraceSerialNumber = 1,
+          superclassId = 0,
+          classLoaderId = 0,
+          signersId = 0,
+          protectionDomainId = 0,
+          instanceSize = 0,
+          staticFields = emptyList(),
+          fields = emptyList()
+        )
+      )
+    }
+
+    hprofFile.openHeapGraph().use { graph ->
+      val objectClass = graph.findClassByName("java.lang.Object")!!
+      assertThat(objectClass.objectId).isEqualTo(loadedClassId)
+    }
+  }
+
+  @Test
+  fun `When duplicating LoadClassRecord, HprofInMemoryIndex#indexedClassSequence() contains only the class that has a ClassDumpRecord`() {
+    val objectClassIds = listOf<Long>(1, 2, 3)
+    val loadedClassId = 2L
+
+    HprofWriter.openWriterFor(
+      hprofFile,
+      HprofHeader(version = HprofVersion.JDK_6, identifierByteSize = 8)
+    ).use { writer ->
+      val objectClassNameRecord = StringRecord(1L, "java/lang/Object")
+      writer.write(objectClassNameRecord)
+      for (classId in objectClassIds) {
+        writer.write(
+          LoadClassRecord(
+            classSerialNumber = 1,
+            id = classId,
+            stackTraceSerialNumber = 1,
+            classNameStringId = objectClassNameRecord.id
+          )
+        )
+        writer.write(GcRootRecord(gcRoot = StickyClass(classId)))
+      }
+      writer.write(
+        ClassDumpRecord(
+          id = loadedClassId,
+          stackTraceSerialNumber = 1,
+          superclassId = 0,
+          classLoaderId = 0,
+          signersId = 0,
+          protectionDomainId = 0,
+          instanceSize = 0,
+          staticFields = emptyList(),
+          fields = emptyList()
+        )
+      )
+    }
+
+    val source = FileSourceProvider(hprofFile)
+    val header = source.openStreamingSource().use { HprofHeader.parseHeaderOf(it) }
+    val reader = StreamingHprofReader.readerFor(source, header)
+    val index = HprofInMemoryIndex.indexHprof(
+      reader = reader,
+      hprofHeader = header,
+      proguardMapping = null,
+      indexedGcRootTags = HprofIndex.defaultIndexedGcRootTags()
+    )
+
+    val objectClasses = index.indexedClassSequence()
+      .filter { (_, indexedClass) ->
+        indexedClass.superclassId == ValueHolder.NULL_REFERENCE
+      }
+      .toList()
+
+    assertThat(objectClasses).hasSize(1)
+    assertThat(objectClasses.single().first).isEqualTo(loadedClassId)
+  }
+
+  @Test
+  fun `When duplicating LoadClassRecord, HprofInMemoryIndex#classId() returns the class that has a ClassDumpRecord`() {
+    val objectClassIds = listOf<Long>(1, 2, 3)
+    val loadedClassId = 2L
+
+    HprofWriter.openWriterFor(
+      hprofFile,
+      HprofHeader(version = HprofVersion.JDK_6, identifierByteSize = 8)
+    ).use { writer ->
+      val objectClassNameRecord = StringRecord(1L, "java/lang/Object")
+      writer.write(objectClassNameRecord)
+      for (classId in objectClassIds) {
+        writer.write(
+          LoadClassRecord(
+            classSerialNumber = 1,
+            id = classId,
+            stackTraceSerialNumber = 1,
+            classNameStringId = objectClassNameRecord.id
+          )
+        )
+        writer.write(GcRootRecord(gcRoot = StickyClass(classId)))
+      }
+      writer.write(
+        ClassDumpRecord(
+          id = loadedClassId,
+          stackTraceSerialNumber = 1,
+          superclassId = 0,
+          classLoaderId = 0,
+          signersId = 0,
+          protectionDomainId = 0,
+          instanceSize = 0,
+          staticFields = emptyList(),
+          fields = emptyList()
+        )
+      )
+    }
+
+    val source = FileSourceProvider(hprofFile)
+    val header = source.openStreamingSource().use { HprofHeader.parseHeaderOf(it) }
+    val reader = StreamingHprofReader.readerFor(source, header)
+    val index = HprofInMemoryIndex.indexHprof(
+      reader = reader,
+      hprofHeader = header,
+      proguardMapping = null,
+      indexedGcRootTags = HprofIndex.defaultIndexedGcRootTags()
+    )
+
+    assertThat(index.classId("java.lang.Object")).isEqualTo(loadedClassId)
   }
 
   @Test


### PR DESCRIPTION
Investigation: https://androiddev.social/@py/112530850033176080