### PR TITLE
[2661] Fix BroadcastReceiver ANR at ScreenOffTrigger

### DIFF
--- a/leakcanary/leakcanary-android-release/api/leakcanary-android-release.api
+++ b/leakcanary/leakcanary-android-release/api/leakcanary-android-release.api
@@ -186,9 +186,13 @@ public final class leakcanary/SaveResourceIdsInterceptor : leakcanary/HeapAnalys
 }
 
 public final class leakcanary/ScreenOffTrigger {
-	public fun <init> (Landroid/app/Application;Lleakcanary/HeapAnalysisClient;Ljava/util/concurrent/Executor;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Landroid/app/Application;Lleakcanary/HeapAnalysisClient;Ljava/util/concurrent/Executor;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final field Companion Lleakcanary/ScreenOffTrigger$Companion;
+	public synthetic fun <init> (Landroid/app/Application;Lleakcanary/HeapAnalysisClient;Ljava/util/concurrent/Executor;Lkotlin/jvm/functions/Function1;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroid/app/Application;Lleakcanary/HeapAnalysisClient;Ljava/util/concurrent/Executor;Lkotlin/jvm/functions/Function1;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun start ()V
 	public final fun stop ()V
+}
+
+public final class leakcanary/ScreenOffTrigger$Companion {
 }
 

--- a/leakcanary/leakcanary-android-release/src/main/java/leakcanary/ScreenOffTrigger.kt
+++ b/leakcanary/leakcanary-android-release/src/main/java/leakcanary/ScreenOffTrigger.kt
@@ -42,20 +42,20 @@ class ScreenOffTrigger(
       context: Context,
       intent: Intent
     ) {
-      if (intent.action == ACTION_SCREEN_OFF) {
-        if (currentJob == null) {
-          val job =
-            analysisClient.newJob(JobContext(ScreenOffTrigger::class))
-          currentJob = job
-          analysisExecutor.execute {
+      analysisExecutor.execute {
+        if (intent.action == ACTION_SCREEN_OFF) {
+          if (currentJob == null) {
+            val job =
+              analysisClient.newJob(JobContext(ScreenOffTrigger::class))
+            currentJob = job
             val result = job.execute()
             currentJob = null
             analysisCallback(result)
           }
+        } else {
+          currentJob?.cancel("screen on again")
+          currentJob = null
         }
-      } else {
-        currentJob?.cancel("screen on again")
-        currentJob = null
       }
     }
   }


### PR DESCRIPTION
Resolves https://github.com/square/leakcanary/issues/2661

**Issue**

BroadcastReceiver#onReceive runs by default on the main thread. If onReceive doesn't complete in a timely manner, the system will report an Application Not Responding 

We've seen instances of this occurring frequently on internal builds

**Solution**

NOTE: Kudos to @pyricau for the guidance on adding a delay. 

Let the broadcast receiver complete immediately and schedule the executor with an initial delay to avoid issues with the broadcast receiver not completing

**Verification**

Verified that the the ANR no longer occurs and reporting still completes without issues on one of our main apps (internal release build)

This was heavily tested on internal builds