### PR TITLE
Fixes CI (with minimal changes)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
             ./gradlew leakcanary:leakcanary-android-core:connectedCheck leakcanary:leakcanary-android:connectedCheck leakcanary:leakcanary-android-instrumentation:connectedCheck --no-build-cache --no-daemon --stacktrace
       - name: Upload results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.api-level }}-${{ matrix.arch }}-instrumentation-test-results
           path: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,10 @@ subprojects {
     }
   }
 
+  dependencies {
+    "detektPlugins"(rootProject.libs.detekt.formatting)
+  }
+
   extensions.configure<DetektExtension> {
     config = rootProject.files("config/detekt-config.yml")
     parallel = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ coroutines = "1.7.3"
 androidXTest = "1.1.0"
 androidXJunit = "1.1.3"
 workManager = "2.7.0"
+detekt = "1.23.8"
 androidMinSdk = "14"
 androidCompileSdk = "34"
 
@@ -30,7 +31,7 @@ gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", ve
 gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.8.10" }
 gradlePlugin-binaryCompatibility = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.13.1" }
 gradlePlugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.25.2" }
-gradlePlugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version = "1.6.0" }
+gradlePlugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 gradlePlugin-keeper = { module = "com.slack.keeper:keeper", version = "0.7.0" }
 gradlePlugin-sqldelight = { module = "app.cash.sqldelight:gradle-plugin", version = "2.0.0-alpha05" }
 
@@ -38,6 +39,8 @@ coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ve
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
 # We don't need the latest version of AndroidX (there are no bugs that impact what LeakCanary
 # relies on), we're sticking a bit older because most apps will be using a more recent version

--- a/leakcanary/leakcanary-android-core/detekt-baseline.xml
+++ b/leakcanary/leakcanary-android-core/detekt-baseline.xml
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ChainWrapping:HeapDumpRenderer.kt$HeapDumpRenderer$&amp;&amp;</ID>
+    <ID>ChainWrapping:LeakCanaryTextView.kt$LeakCanaryTextView$+</ID>
+    <ID>ChainWrapping:SquigglySpanRenderer.kt$SquigglySpanRenderer.Companion$||</ID>
+    <ID>FinalNewline:HeapAnalysisTable.kt$leakcanary.internal.activity.db.HeapAnalysisTable.kt</ID>
+    <ID>FinalNewline:LeakTraceTable.kt$leakcanary.internal.activity.db.LeakTraceTable.kt</ID>
+    <ID>FinalNewline:LeakTraceWrapper.kt$leakcanary.internal.activity.screen.LeakTraceWrapper.kt</ID>
+    <ID>FinalNewline:LeakTraceWrapperTest.kt$leakcanary.internal.activity.screen.LeakTraceWrapperTest.kt</ID>
+    <ID>FinalNewline:LeaksDbHelper.kt$leakcanary.internal.activity.db.LeaksDbHelper.kt</ID>
+    <ID>FinalNewline:NotificationReceiver.kt$leakcanary.internal.NotificationReceiver.kt</ID>
+    <ID>FinalNewline:NotificationType.kt$leakcanary.internal.NotificationType.kt</ID>
+    <ID>FinalNewline:Screen.kt$leakcanary.internal.navigation.Screen.kt</ID>
+    <ID>FinalNewline:Serializables.kt$leakcanary.internal.Serializables.kt</ID>
+    <ID>FinalNewline:SimpleListAdapter.kt$leakcanary.internal.activity.ui.SimpleListAdapter.kt</ID>
+    <ID>FinalNewline:TimeFormatter.kt$leakcanary.internal.activity.ui.TimeFormatter.kt</ID>
+    <ID>FinalNewline:UiUtils.kt$leakcanary.internal.activity.ui.UiUtils.kt</ID>
+    <ID>MaximumLineLength:HeapDumpTrigger.kt$HeapDumpTrigger$ </ID>
+    <ID>MaximumLineLength:LeakActivity.kt$LeakActivity$ </ID>
+    <ID>MaximumLineLength:LeakScreen.kt$LeakScreen$ </ID>
+    <ID>MaximumLineLength:LogcatEventListener.kt$LogcatEventListener$ </ID>
+    <ID>MaximumLineLength:WorkManagerHeapAnalyzer.kt$WorkManagerHeapAnalyzer$ </ID>
+    <ID>MultiLineIfElse:AndroidDebugHeapAnalyzer.kt$AndroidDebugHeapAnalyzer$result</ID>
+    <ID>MultiLineIfElse:DisplayLeakAdapter.kt$DisplayLeakAdapter$"${ extra( className.substring( 0, packageEnd ) ) }.$styledClassName"</ID>
+    <ID>MultiLineIfElse:DisplayLeakAdapter.kt$DisplayLeakAdapter$END</ID>
+    <ID>MultiLineIfElse:DisplayLeakAdapter.kt$DisplayLeakAdapter$START</ID>
+    <ID>MultiLineIfElse:DisplayLeakAdapter.kt$DisplayLeakAdapter$leakTrace.leakingObject</ID>
+    <ID>MultiLineIfElse:DisplayLeakAdapter.kt$DisplayLeakAdapter$leakTrace.referencePath[elementIndex( position + 1 )].originObject</ID>
+    <ID>MultiLineIfElse:DisplayLeakAdapter.kt$DisplayLeakAdapter$styledClassName</ID>
+    <ID>MultiLineIfElse:HeapAnalysisFailureScreen.kt$HeapAnalysisFailureScreen$""</ID>
+    <ID>MultiLineIfElse:HeapDumpControl.kt$HeapDumpControl$Yup</ID>
+    <ID>MultiLineIfElse:LeakScreen.kt$LeakScreen$""</ID>
+    <ID>MultiLineIfElse:LeakScreen.kt$LeakScreen$"&lt;br>&lt;br>" + "A &lt;font color='#FFCC32'>Library Leak&lt;/font> is a leak caused by a known bug in 3rd party code that you do not have control over. " + "(&lt;a href=\"https://square.github.io/leakcanary/fundamentals-how-leakcanary-works/#4-categorizing-leaks\">Learn More&lt;/a>)&lt;br>&lt;br>" + "&lt;b>Leak pattern&lt;/b>: ${selectedLeak.pattern}&lt;br>&lt;br>" + "&lt;b>Description&lt;/b>: ${parseLinks(selectedLeak.description)}"</ID>
+    <ID>MultiLineIfElse:LeakTable.kt$LeakTable$cursor.getLong(0)</ID>
+    <ID>MultiLineIfElse:LeakTable.kt$LeakTable$throw IllegalStateException( "No id found for leak with signature '${leak.signature}'" )</ID>
+    <ID>MultiLineIfElse:LeakTraceWrapper.kt$LeakTraceWrapper$null</ID>
+    <ID>MultiLineIfElse:Notifications.kt$Notifications$Notification.Builder(context)</ID>
+    <ID>NoBlankLineBeforeRbrace:HeapDumpsScreen.kt$HeapDumpsScreen$ </ID>
+    <ID>NoBlankLineBeforeRbrace:LeakCanaryConfigTest.kt$LeakCanaryConfigTest$ </ID>
+    <ID>NoConsecutiveBlankLines:DisplayLeakConnectorView.kt$DisplayLeakConnectorView$ </ID>
+    <ID>NoConsecutiveBlankLines:InternalLeakCanary.kt$InternalLeakCanary$ </ID>
+    <ID>NoConsecutiveBlankLines:LeakCanary.kt$LeakCanary.Config.Builder$ </ID>
+    <ID>NoConsecutiveBlankLines:LeakCanaryAndroidInternalUtils.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:RenderHeapDumpScreen.kt$ </ID>
+    <ID>NoMultipleSpaces:LogcatEventListener.kt$LogcatEventListener$ </ID>
+    <ID>NoMultipleSpaces:NotificationEventListener.kt$NotificationEventListener$ </ID>
+    <ID>NoSemicolons:NotificationType.kt$NotificationType.LEAKCANARY_MAX$;</ID>
+    <ID>SpacingAroundComma:NotificationEventListener.kt$NotificationEventListener$,</ID>
+    <ID>SpacingAroundCurly:TvEventListener.kt$TvEventListener${</ID>
+    <ID>SpacingAroundKeyword:InternalLeakCanary.kt$InternalLeakCanary$for</ID>
+    <ID>SpacingAroundKeyword:LogcatEventListener.kt$LogcatEventListener$when</ID>
+    <ID>StringTemplate:DisplayLeakAdapter.kt$DisplayLeakAdapter$${leakingStatusReason}</ID>
+    <ID>StringTemplate:LeakScreen.kt$LeakScreen$${word}</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-android-instrumentation/detekt-baseline.xml
+++ b/leakcanary/leakcanary-android-instrumentation/detekt-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaximumLineLength:NoLeakAssertionFailedError.kt$NoLeakAssertionFailedError.Companion$ </ID>
+    <ID>MultiLineIfElse:InstrumentationHeapAnalyzer.kt$InstrumentationHeapAnalyzer$result</ID>
+    <ID>NoConsecutiveBlankLines:DetectLeaksAfterTestSuccess.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:LeakAssertions.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:SkipLeakDetection.kt$ </ID>
+    <ID>StringTemplate:AndroidDetectLeaksAssert.kt$AndroidDetectLeaksAssert$${classSimpleName}</ID>
+    <ID>StringTemplate:AndroidDetectLeaksAssert.kt$AndroidDetectLeaksAssert$${methodName}</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-android-release/detekt-baseline.xml
+++ b/leakcanary/leakcanary-android-release/detekt-baseline.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CommentSpacing:GoodAndroidVersionInterceptor.kt$GoodAndroidVersionInterceptor$// findObjectById() sometimes failing. See #1759</ID>
+    <ID>FinalNewline:BackgroundTrigger.kt$leakcanary.BackgroundTrigger.kt</ID>
+    <ID>FinalNewline:ConditionalInterceptor.kt$leakcanary.ConditionalInterceptor.kt</ID>
+    <ID>FinalNewline:Friendly.kt$leakcanary.internal.friendly.Friendly.kt</ID>
+    <ID>FinalNewline:GoodAndroidVersionInterceptor.kt$leakcanary.GoodAndroidVersionInterceptor.kt</ID>
+    <ID>FinalNewline:HeapAnalysisInterceptor.kt$leakcanary.HeapAnalysisInterceptor.kt</ID>
+    <ID>FinalNewline:HeapAnalysisJob.kt$leakcanary.HeapAnalysisJob.kt</ID>
+    <ID>FinalNewline:MinimumElapsedSinceStartInterceptor.kt$leakcanary.MinimumElapsedSinceStartInterceptor.kt</ID>
+    <ID>FinalNewline:MinimumMemoryInterceptor.kt$leakcanary.MinimumMemoryInterceptor.kt</ID>
+    <ID>FinalNewline:OncePerPeriodInterceptor.kt$leakcanary.OncePerPeriodInterceptor.kt</ID>
+    <ID>FinalNewline:SaveResourceIdsInterceptor.kt$leakcanary.SaveResourceIdsInterceptor.kt</ID>
+    <ID>MaximumLineLength:OncePerPeriodInterceptor.kt$OncePerPeriodInterceptor$ </ID>
+    <ID>MultiLineIfElse:RealHeapAnalysisJob.kt$RealHeapAnalysisJob$null</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-android-utils/detekt-baseline.xml
+++ b/leakcanary/leakcanary-android-utils/detekt-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:LogcatSharkLog.kt$leakcanary.LogcatSharkLog.kt</ID>
+    <ID>FinalNewline:Objects.kt$leakcanary.internal.Objects.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-app/detekt-baseline.xml
+++ b/leakcanary/leakcanary-app/detekt-baseline.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:Color.kt$org.leakcanary.ui.theme.Color.kt</ID>
+    <ID>FinalNewline:Theme.kt$org.leakcanary.ui.theme.Theme.kt</ID>
+    <ID>FinalNewline:Type.kt$org.leakcanary.ui.theme.Type.kt</ID>
+    <ID>MaximumLineLength:LeakScreen.kt$LeakViewModel$ </ID>
+    <ID>MultiLineIfElse:LeakTraceWrapper.kt$LeakTraceWrapper$null</ID>
+    <ID>NoBlankLineBeforeRbrace:ClientAppAnalysesScreen.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:TreeMapScreen.kt$ </ID>
+    <ID>ParameterListWrapping:DatabaseModule.kt$DatabaseModule$( app: Application, @WriteAheadLoggingEnabled wolEnabled: Boolean )</ID>
+    <ID>SpacingAroundKeyword:HeapRepository.kt$HeapRepository$if</ID>
+    <ID>StringTemplate:LeakScreen.kt$${leakingStatusReason}</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-core/detekt-baseline.xml
+++ b/leakcanary/leakcanary-core/detekt-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaximumLineLength:DumpingRepeatingScenarioObjectGrowthDetector.kt$DumpingRepeatingScenarioObjectGrowthDetector$ </ID>
+    <ID>MaximumLineLength:ObjectGrowthWarmupHeapDumperTest.kt$ObjectGrowthWarmupHeapDumperTest$ </ID>
+    <ID>NoConsecutiveBlankLines:DatetimeFormattedHeapDumpFileProvider.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:DumpingRepeatingScenarioObjectGrowthDetector.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:DumpingRepeatingScenarioObjectGrowthDetectorTest.kt$DumpingRepeatingScenarioObjectGrowthDetectorTest$ </ID>
+    <ID>NoConsecutiveBlankLines:ObjectGrowthWarmupHeapDumperTest.kt$ObjectGrowthWarmupHeapDumperTest$ </ID>
+    <ID>NoUnusedImports:HeapDumpFileProvider.kt$leakcanary.HeapDumpFileProvider.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-deobfuscation-gradle-plugin/detekt-baseline.xml
+++ b/leakcanary/leakcanary-deobfuscation-gradle-plugin/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>NoUnusedImports:LeakCanaryLeakDeobfuscationPlugin.kt$com.squareup.leakcanary.deobfuscation.LeakCanaryLeakDeobfuscationPlugin.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-jvm-test/detekt-baseline.xml
+++ b/leakcanary/leakcanary-jvm-test/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>NoConsecutiveBlankLines:HotSpotHeapDumper.kt$ </ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/leakcanary/leakcanary-test-core/detekt-baseline.xml
+++ b/leakcanary/leakcanary-test-core/detekt-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>StringTemplate:TestHeapDumpFileProvider.kt$TestHeapDumpFileProvider$${classSimpleName}</ID>
+    <ID>StringTemplate:TestHeapDumpFileProvider.kt$TestHeapDumpFileProvider$${escapedMethodName}</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/object-watcher/object-watcher-android-core/detekt-baseline.xml
+++ b/object-watcher/object-watcher-android-core/detekt-baseline.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:Applications.kt$leakcanary.internal.Applications.kt</ID>
+    <ID>FinalNewline:InstallableWatcher.kt$leakcanary.InstallableWatcher.kt</ID>
+    <ID>FinalNewline:LeakCanaryDelegate.kt$leakcanary.internal.LeakCanaryDelegate.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/object-watcher/object-watcher-android/detekt-baseline.xml
+++ b/object-watcher/object-watcher-android/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ParameterListWrapping:MainProcessAppWatcherInstaller.kt$MainProcessAppWatcherInstaller$( uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array&lt;out String>? )</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/object-watcher/object-watcher/detekt-baseline.xml
+++ b/object-watcher/object-watcher/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MultiLineIfElse:DeletableObjectReporter.kt$object : TrackedObjectReachability { override val isStronglyReachable: Boolean get() = false override val isRetained: Boolean get() = false }</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plumber/plumber-android-core/detekt-baseline.xml
+++ b/plumber/plumber-android-core/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>SafeCast:AndroidLeakFixes.kt$AndroidLeakFixes.Companion$if (it is HandlerThread) it else null</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/plumber/plumber-android/detekt-baseline.xml
+++ b/plumber/plumber-android/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ParameterListWrapping:PlumberInstaller.kt$PlumberInstaller$( uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array&lt;out String>? )</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/samples/leakcanary-android-sample/detekt-baseline.xml
+++ b/samples/leakcanary-android-sample/detekt-baseline.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:LeakingService.kt$com.example.leakcanary.LeakingService.kt</ID>
+    <ID>FinalNewline:LeakingSingleton.kt$com.example.leakcanary.LeakingSingleton.kt</ID>
+    <ID>FinalNewline:LeakingThread.kt$com.example.leakcanary.LeakingThread.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark-android/detekt-baseline.xml
+++ b/shark/shark-android/detekt-baseline.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ChainWrapping:AndroidObjectInspectorsTest.kt$AndroidObjectInspectorsTest$&amp;&amp;</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.ACCESSIBILITY_NODE_INFO__MORIGINALTEXT$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.ACTIVITY_CHOOSE_MODEL$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.ACTIVITY_MANAGER_MCONTEXT$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.APP_WIDGET_HOST_CALLBACKS$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.AUDIO_MANAGER$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.AUDIO_MANAGER__MCONTEXT_STATIC$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.BACKDROP_FRAME_RENDERER__MDECORVIEW$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.BLOCKING_QUEUE$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.CLIPBOARD_UI_MANAGER__SINSTANCE$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.CONNECTIVITY_MANAGER__SINSTANCE$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.DEVICE_POLICY_MANAGER__SETTINGS_OBSERVER$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.EDITTEXT_BLINK_MESSAGEQUEUE$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.INPUT_METHOD_MANAGER_IS_TERRIBLE$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.INSTRUMENTATION_RECOMMEND_ACTIVITY$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.LAYOUT_TRANSITION$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.MAPPER_CLIENT$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.MEDIA_SCANNER_CONNECTION$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.MEDIA_SESSION_LEGACY_HELPER__SINSTANCE$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.PERSONA_MANAGER$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.RESOURCES__MCONTEXT$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.SPAN_CONTROLLER$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.SPEECH_RECOGNIZER$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.SPELL_CHECKER$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.SPELL_CHECKER_SESSION$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.SYSTEM_SENSOR_MANAGER__MAPPCONTEXTIMPL$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.TEXT_LINE__SCACHED$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.USER_MANAGER__SINSTANCE$+</ID>
+    <ID>ChainWrapping:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.VIEW_CONFIGURATION__MCONTEXT$+</ID>
+    <ID>ChainWrapping:AndroidServices.kt$AndroidServices$&amp;&amp;</ID>
+    <ID>ChainWrapping:LegacyHprofTest.kt$LegacyHprofTest$&amp;&amp;</ID>
+    <ID>Filename:AndroidReferenceMatcher_XIAMI__RESOURCES_IMPL_Test.kt$shark.AndroidReferenceMatcher_XIAMI__RESOURCES_IMPL_Test.kt</ID>
+    <ID>FinalNewline:AndroidResourceIdNames.kt$shark.AndroidResourceIdNames.kt</ID>
+    <ID>FinalNewline:AndroidServices.kt$shark.AndroidServices.kt</ID>
+    <ID>FinalNewline:Resources.kt$shark.Resources.kt</ID>
+    <ID>MaximumLineLength:AndroidObjectInspectors.kt$AndroidObjectInspectors.CONTEXT_FIELD$ </ID>
+    <ID>MaximumLineLength:AndroidObjectInspectors.kt$AndroidObjectInspectors.CONTEXT_WRAPPER$ </ID>
+    <ID>MaximumLineLength:AndroidObjectInspectors.kt$AndroidObjectInspectors.OBJECT_ANIMATOR$ </ID>
+    <ID>MaximumLineLength:AndroidObjectInspectors.kt$AndroidObjectInspectors.VIEW$ </ID>
+    <ID>MaximumLineLength:AndroidObjectInspectors.kt$AndroidObjectInspectors.VIEW_ROOT_IMPL$ </ID>
+    <ID>MaximumLineLength:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.INPUT_METHOD_MANAGER_IS_TERRIBLE$ </ID>
+    <ID>MaximumLineLength:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.SPEN_GESTURE_MANAGER$ </ID>
+    <ID>MaximumLineLength:HprofRetainedHeapPerfTest.kt$HprofRetainedHeapPerfTest$ </ID>
+    <ID>MaximumLineLength:LegacyHprofTest.kt$LegacyHprofTest$ </ID>
+    <ID>MultiLineIfElse:AndroidExtensions.kt$null</ID>
+    <ID>MultiLineIfElse:AndroidObjectInspectors.kt$AndroidObjectInspectors.TOAST$false</ID>
+    <ID>MultiLineIfElse:AndroidObjectInspectors.kt$AndroidObjectInspectors.VIEW_ROOT_IMPL$""</ID>
+    <ID>MultiLineIfElse:HprofRetainedHeapPerfTest.kt$HprofRetainedHeapPerfTest$""</ID>
+    <ID>MultiLineIfElse:LegacyHprofTest.kt$LegacyHprofTest$throw IllegalStateException( "Unexpected, should have 1 leaking status ${reporter.leakingReasons} or one label ${reporter.labels}" )</ID>
+    <ID>NoConsecutiveBlankLines:AndroidReferenceMatchers.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:AndroidReferenceMatchers.kt$AndroidReferenceMatchers.ACTIVITY_CHOOSE_MODEL$ </ID>
+    <ID>SpacingAroundCurly:AndroidResourceIdNamesTest.kt$AndroidResourceIdNamesTest${</ID>
+    <ID>SpacingAroundKeyword:AndroidMetadataExtractor.kt$AndroidMetadataExtractor$when</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark-cli/detekt-baseline.xml
+++ b/shark/shark-cli/detekt-baseline.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:DeobfuscateHprofCommand.kt$shark.DeobfuscateHprofCommand.kt</ID>
+    <ID>FinalNewline:StripHprofCommand.kt$shark.StripHprofCommand.kt</ID>
+    <ID>MaximumLineLength:DumpProcessCommand.kt$DumpProcessCommand.Companion$ </ID>
+    <ID>MaximumLineLength:HeapGrowthCommand.kt$HeapGrowthCommand$ </ID>
+    <ID>MaximumLineLength:StripHprofCommand.kt$StripHprofCommand$ </ID>
+    <ID>MultiLineIfElse:InteractiveCommand.kt$InteractiveCommand$""</ID>
+    <ID>NoConsecutiveBlankLines:Neo4JCommand.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:Neo4JCommand.kt$Neo4JCommand.Companion$ </ID>
+    <ID>SpacingAroundParens:HeapGrowthCommand.kt$HeapGrowthCommand$(</ID>
+    <ID>StringTemplate:InteractiveCommand.kt$InteractiveCommand$${instanceCount}</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark-graph/detekt-baseline.xml
+++ b/shark/shark-graph/detekt-baseline.xml
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ChainWrapping:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$+</ID>
+    <ID>EqualsWithHashCodeExist:SortedBytesMapTest.kt$SortedBytesMapTest$Entry : Comparable</ID>
+    <ID>FinalNewline:ByteSubArray.kt$shark.internal.ByteSubArray.kt</ID>
+    <ID>FinalNewline:CloseableHeapGraph.kt$shark.CloseableHeapGraph.kt</ID>
+    <ID>FinalNewline:FieldValuesReader.kt$shark.internal.FieldValuesReader.kt</ID>
+    <ID>FinalNewline:HeapField.kt$shark.HeapField.kt</ID>
+    <ID>FinalNewline:IndexedObject.kt$shark.internal.IndexedObject.kt</ID>
+    <ID>FinalNewline:LruCache.kt$shark.internal.LruCache.kt</ID>
+    <ID>FinalNewline:SortedBytesMap.kt$shark.internal.SortedBytesMap.kt</ID>
+    <ID>MaximumLineLength:ByteArrayTimSort.kt$ByteArrayTimSort$ </ID>
+    <ID>MaximumLineLength:HeapObject.kt$HeapObject.HeapInstance$ </ID>
+    <ID>MaximumLineLength:HprofHeapGraphEdgeCasesTest.kt$HprofHeapGraphEdgeCasesTest$ </ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$INITIAL_TMP_STORAGE_LENGTH</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$break@outer</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$len.ushr(1)</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$mergeHi(base1, len1, base2, len2)</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$mergeLo(base1, len1, base2, len2)</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$min(newSize, (a.size / entrySize).ushr(1))</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$minCapacity</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$minGallop = 0</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$n--</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort$return</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$lastOfs = m + 1</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$left = mid + 1</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$ofs = m</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$ofs = maxOfs</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$return</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$return 1</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$right = mid</ID>
+    <ID>MultiLineIfElse:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$start++</ID>
+    <ID>MultiLineIfElse:HeapObject.kt$HeapObject.HeapClass$PrimitiveType.byteSizeByHprofType.getValue(it.type)</ID>
+    <ID>MultiLineIfElse:HeapObject.kt$HeapObject.HeapInstance$offset + count</ID>
+    <ID>MultiLineIfElse:HprofInMemoryIndex.kt$HprofInMemoryIndex$className</ID>
+    <ID>MultiLineIfElse:HprofInMemoryIndex.kt$HprofInMemoryIndex$this</ID>
+    <ID>MultiLineIfElse:UnsortedByteEntries.kt$UnsortedByteEntries$entries</ID>
+    <ID>NoConsecutiveBlankLines:HeapObject.kt$HeapObject.HeapObjectArray$ </ID>
+    <ID>NoConsecutiveBlankLines:HeapObject.kt$HeapObject.HeapPrimitiveArray$ </ID>
+    <ID>NoConsecutiveBlankLines:UnsortedByteEntries.kt$ </ID>
+    <ID>NoMultipleSpaces:ByteArrayTimSort.kt$ByteArrayTimSort$ </ID>
+    <ID>NoMultipleSpaces:ByteArrayTimSort.kt$ByteArrayTimSort.Companion$ </ID>
+    <ID>SpacingAroundCurly:HprofInMemoryIndex.kt$HprofInMemoryIndex.Builder${</ID>
+    <ID>SpacingAroundKeyword:HprofInMemoryIndex.kt$HprofInMemoryIndex$while</ID>
+    <ID>SpacingAroundOperators:HprofHeapGraph.kt$HprofHeapGraph$?:</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark-hprof-test/detekt-baseline.xml
+++ b/shark/shark-hprof-test/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:ProguardMappingHelper.kt$shark.ProguardMappingHelper.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark-hprof/detekt-baseline.xml
+++ b/shark/shark-hprof/detekt-baseline.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:ConstantMemoryMetricsDualSourceProvider.kt$shark.ConstantMemoryMetricsDualSourceProvider.kt</ID>
+    <ID>FinalNewline:GcRoot.kt$shark.GcRoot.kt</ID>
+    <ID>FinalNewline:ProguardMappingReader.kt$shark.ProguardMappingReader.kt</ID>
+    <ID>FinalNewline:ProguardMappingTest.kt$shark.ProguardMappingTest.kt</ID>
+    <ID>FinalNewline:RandomAccessHprofReader.kt$shark.RandomAccessHprofReader.kt</ID>
+    <ID>FinalNewline:ValueHolder.kt$shark.ValueHolder.kt</ID>
+    <ID>NoConsecutiveBlankLines:ConstantMemoryMetricsDualSourceProvider.kt$ConstantMemoryMetricsDualSourceProvider$ </ID>
+    <ID>NoConsecutiveBlankLines:FileSourceProvider.kt$ </ID>
+    <ID>NoMultipleSpaces:HprofReaderPrimitiveArrayTest.kt$HprofReaderPrimitiveArrayTest$ </ID>
+    <ID>NoUnusedImports:ThrowingCancelableFileSourceProvider.kt$shark.ThrowingCancelableFileSourceProvider.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark-log/detekt-baseline.xml
+++ b/shark/shark-log/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:SharkLogTest.kt$shark.SharkLogTest.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark-test/detekt-baseline.xml
+++ b/shark/shark-test/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:JvmTestHeapDumper.kt$shark.JvmTestHeapDumper.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/shark/shark/detekt-baseline.xml
+++ b/shark/shark/detekt-baseline.xml
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>FinalNewline:AppSingletonInspector.kt$shark.AppSingletonInspector.kt</ID>
+    <ID>FinalNewline:FieldIdReader.kt$shark.internal.FieldIdReader.kt</ID>
+    <ID>FinalNewline:HeapAnalysis.kt$shark.HeapAnalysis.kt</ID>
+    <ID>FinalNewline:HeapAnalysisException.kt$shark.HeapAnalysisException.kt</ID>
+    <ID>FinalNewline:HeapAnalysisStringRenderingTest.kt$shark.HeapAnalysisStringRenderingTest.kt</ID>
+    <ID>FinalNewline:HprofHeapGraphTest.kt$shark.HprofHeapGraphTest.kt</ID>
+    <ID>FinalNewline:KeyedWeakReferenceFinder.kt$shark.KeyedWeakReferenceFinder.kt</ID>
+    <ID>FinalNewline:LeakNodeStatus.kt$shark.LeakNodeStatus.kt</ID>
+    <ID>FinalNewline:LeakTraceObject.kt$shark.LeakTraceObject.kt</ID>
+    <ID>FinalNewline:ShallowSizeCalculatorTest.kt$shark.internal.ShallowSizeCalculatorTest.kt</ID>
+    <ID>FinalNewline:UnreachableObjectRenderingTest.kt$shark.UnreachableObjectRenderingTest.kt</ID>
+    <ID>MaximumLineLength:AndroidNativeSizeMapper.kt$AndroidNativeSizeMapper$ </ID>
+    <ID>MaximumLineLength:DominatorTree.kt$DominatorTree$ </ID>
+    <ID>MaximumLineLength:HeapAnalysis.kt$Leak$ </ID>
+    <ID>MaximumLineLength:KeyedWeakReferenceFinder.kt$KeyedWeakReferenceFinder$ </ID>
+    <ID>MaximumLineLength:ObjectDominators.kt$ObjectDominators$ </ID>
+    <ID>MaximumLineLength:RetainedSizeTest.kt$RetainedSizeTest$ </ID>
+    <ID>MultiLineIfElse:ClassReferenceReader.kt$ClassReferenceReader$mapOrNull</ID>
+    <ID>MultiLineIfElse:FieldInstanceReferenceReader.kt$FieldInstanceReferenceReader$mapOrNull</ID>
+    <ID>MultiLineIfElse:HeapAnalysis.kt$HeapAnalysisSuccess$""</ID>
+    <ID>MultiLineIfElse:HeapAnalysis.kt$HeapAnalysisSuccess$"\n" + applicationLeaks.joinToString( "\n\n" ) + "\n"</ID>
+    <ID>MultiLineIfElse:HeapAnalysis.kt$HeapAnalysisSuccess$"\n" + libraryLeaks.joinToString( "\n\n" ) + "\n"</ID>
+    <ID>MultiLineIfElse:HeapAnalysis.kt$HeapAnalysisSuccess$"\n" + metadata.map { "${it.key}: ${it.value}" }.joinToString( "\n" )</ID>
+    <ID>MultiLineIfElse:HeapAnalysis.kt$HeapAnalysisSuccess$"\n" + unreachableObjects.joinToString( "\n\n" ) + "\n"</ID>
+    <ID>MultiLineIfElse:HeapAnalyzer.kt$HeapAnalyzer$result</ID>
+    <ID>MultiLineIfElse:InternalSharedExpanderHelpers.kt$InternalSharedHashMapReferenceReader$null</ID>
+    <ID>MultiLineIfElse:InternalSharedExpanderHelpers.kt$InternalSharedWeakHashMapReferenceReader$null</ID>
+    <ID>MultiLineIfElse:ObjectDominators.kt$ObjectDominators$" \"${heapObject.readAsJavaString()}\""</ID>
+    <ID>MultiLineIfElse:ObjectDominators.kt$ObjectDominators$""</ID>
+    <ID>MultiLineIfElse:ObjectDominators.kt$ObjectDominators$when (val heapObject = graph.findObjectById(objectId)) { is HeapClass -> "class ${heapObject.name}" is HeapInstance -> heapObject.instanceClassName is HeapObjectArray -> heapObject.arrayClassName is HeapPrimitiveArray -> heapObject.arrayClassName }</ID>
+    <ID>MultiLineIfElse:RealLeakTracerFactory.kt$RealLeakTracerFactory$statusPair</ID>
+    <ID>MultiLineIfElse:RealLeakTracerFactory.kt$RealLeakTracerFactory.ShortestPath$null</ID>
+    <ID>NoBlankLineBeforeRbrace:HeapDumps.kt$ </ID>
+    <ID>NoBlankLineBeforeRbrace:UnreachableObjectRenderingTest.kt$UnreachableObjectRenderingTest$ </ID>
+    <ID>NoConsecutiveBlankLines:AndroidReferenceReadersHprofTest.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:DominatorTree.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:HeapAnalysisStringRenderingTest.kt$HeapAnalysisStringRenderingTest$ </ID>
+    <ID>NoConsecutiveBlankLines:HeapAnalyzer.kt$HeapAnalyzer$ </ID>
+    <ID>NoConsecutiveBlankLines:KeyedWeakReferenceMirror.kt$ </ID>
+    <ID>NoConsecutiveBlankLines:PrioritizingShortestPathFinder.kt$ </ID>
+    <ID>NoMultipleSpaces:HeapAnalyzer.kt$HeapAnalyzer$ </ID>
+    <ID>NoMultipleSpaces:JavaLocalReferenceReader.kt$JavaLocalReferenceReader$ </ID>
+    <ID>NoMultipleSpaces:ObjectDominators.kt$ObjectDominators$ </ID>
+    <ID>NoSemicolons:ApacheHarmonyInstanceRefReaders.kt$ApacheHarmonyInstanceRefReaders.HASH_SET$;</ID>
+    <ID>NoSemicolons:LeakNodeStatus.kt$LeakNodeStatus.UNKNOWN$;</ID>
+    <ID>NoSemicolons:LeakTraceObject.kt$LeakTraceObject.LeakingStatus.UNKNOWN$;</ID>
+    <ID>NoSemicolons:OpenJdkInstanceRefReaders.kt$OpenJdkInstanceRefReaders.HASH_SET$;</ID>
+    <ID>NoUnusedImports:AndroidReferenceReaders.kt$shark.AndroidReferenceReaders.kt</ID>
+    <ID>NoUnusedImports:OpenJdkInstanceRefReadersTest.kt$shark.OpenJdkInstanceRefReadersTest.kt</ID>
+    <ID>SpacingAroundCurly:JavaLocalReferenceReader.kt$JavaLocalReferenceReader$}</ID>
+    <ID>SpacingAroundKeyword:DelegatingObjectReferenceReader.kt$DelegatingObjectReferenceReader$when</ID>
+    <ID>SpacingAroundOperators:JavaLocalReferenceReader.kt$JavaLocalReferenceReader$?:</ID>
+    <ID>StringTemplate:ObjectGrowthDetector.kt$ObjectGrowthDetector$${owningClassSimpleName}</ID>
+    <ID>StringTemplate:ObjectGrowthDetector.kt$ObjectGrowthDetector$${refName}</ID>
+    <ID>StringTemplate:ShortestPathObjectNode.kt$ShortestPathObjectNode$${increase}</ID>
+  </CurrentIssues>
+</SmellBaseline>


### PR DESCRIPTION
Current `main` branch CI is broken:

1) `Error: Missing download info for actions/upload-artifact@v3`
2) ```> Could not resolve all files for configuration ':leakcanary:leakcanary-android-release:detekt'.
   > Could not find org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.1.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.7.1/kotlinx-html-jvm-0.7.1.pom
       - https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-html-jvm/0.7.1/kotlinx-html-jvm-0.7.1.pom
       - https://jcenter.bintray.com/org/jetbrains/kotlinx/kotlinx-html-jvm/0.7.1/kotlinx-html-jvm-0.7.1.pom
     Required by:
         project :leakcanary:leakcanary-android-release > io.gitlab.arturbosch.detekt:detekt-cli:1.6.0

In order to fix it, I'been forced to bump `detekt` to its latest version, and that introduced new issues with code style. To minimize the impact of this PR, I just limited to add all of them to `detekt-baseline.xml`