### PR TITLE
Config defaults using `ServiceLoader`

### DIFF
--- a/leakcanary/leakcanary-android-core/src/test/java/leakcanary/LeakCanaryConfigTest.kt
+++ b/leakcanary/leakcanary-android-core/src/test/java/leakcanary/LeakCanaryConfigTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.memberProperties
+import shark.ObjectInspector
+import shark.ObjectReporter
 
 class LeakCanaryConfigTest {
 
@@ -22,4 +24,22 @@ class LeakCanaryConfigTest {
 
   private fun configProperties() = LeakCanary.Config::class.memberProperties
     .map { it.name }
+
+  @Test fun `LeakCanary Config loads extensions from classpath`() {
+    val config = LeakCanary.Config()
+
+    assertThat(config.objectInspectors.filterIsInstance<TestObjectInspector>()).size().isEqualTo(1)
+    assertThat(config.eventListeners.filterIsInstance<TestEventListener>()).size().isEqualTo(1)
+  }
+
+  class TestObjectInspector : ObjectInspector {
+    override fun inspect(reporter: ObjectReporter) {
+    }
+  }
+
+  class TestEventListener : EventListener {
+    override fun onEvent(event: EventListener.Event) {
+    }
+  }
+
 }

--- a/leakcanary/leakcanary-android-core/src/test/resources/META-INF/services/leakcanary.EventListener
+++ b/leakcanary/leakcanary-android-core/src/test/resources/META-INF/services/leakcanary.EventListener
@@ -1,0 +1,1 @@
+leakcanary.LeakCanaryConfigTest$TestEventListener

--- a/leakcanary/leakcanary-android-core/src/test/resources/META-INF/services/shark.ObjectInspector
+++ b/leakcanary/leakcanary-android-core/src/test/resources/META-INF/services/shark.ObjectInspector
@@ -1,0 +1,1 @@
+leakcanary.LeakCanaryConfigTest$TestObjectInspector

--- a/leakcanary/leakcanary-android-instrumentation/src/main/java/leakcanary/DetectLeaksAssert.kt
+++ b/leakcanary/leakcanary-android-instrumentation/src/main/java/leakcanary/DetectLeaksAssert.kt
@@ -1,10 +1,13 @@
 package leakcanary
 
+import java.util.ServiceLoader
+
 /**
  * The interface for the implementation that [LeakAssertions.assertNoLeaks] delegates to.
  * You can call [DetectLeaksAssert.update] to provide your own implementation.
  *
- * The default implementation is [AndroidDetectLeaksAssert].
+ * The default implementation is [AndroidDetectLeaksAssert] or to a discoverable [DetectLeaksAssert]
+ * through the classpath at `META-INF/services/leakcanary.DetectLeaksAssert`.
  */
 fun interface DetectLeaksAssert {
 
@@ -12,7 +15,9 @@ fun interface DetectLeaksAssert {
 
   companion object {
     @Volatile
-    internal var delegate: DetectLeaksAssert = AndroidDetectLeaksAssert()
+    internal var delegate: DetectLeaksAssert =
+      ServiceLoader.load(DetectLeaksAssert::class.java).singleOrNull()
+        ?: AndroidDetectLeaksAssert()
 
     fun update(delegate: DetectLeaksAssert) {
       DetectLeaksAssert.delegate = delegate


### PR DESCRIPTION
Add classpath support for loading `ObjectInspector` and `EventListener`, by leveraging `ServiceLoader`.

The use case for us is (for now) an internal tool allowing us to collect reports back to our CI.

The `META-INF/services` approach will allow us to dynamically register the collector without registering it explicitly on each test