### PR TITLE
Add Motorola to OEMs causing a static context leak

### DIFF
--- a/shark/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
+++ b/shark/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt
@@ -1448,7 +1448,8 @@ enum class AndroidReferenceMatchers : ReferenceMatcher.ListBuilder {
         LENOVO,
         XIAOMI,
         TES,
-        REALME
+        REALME,
+        MOTOROLA
       )
       references += staticField("android.content.res.ResourcesImpl", "mAppContext").leak(
         description = """

--- a/shark/shark-android/src/test/java/shark/AndroidReferenceMatcher_XIAMI__RESOURCES_IMPL_Test.kt
+++ b/shark/shark-android/src/test/java/shark/AndroidReferenceMatcher_XIAMI__RESOURCES_IMPL_Test.kt
@@ -10,6 +10,7 @@ import shark.AndroidReferenceMatcher_XIAMI__RESOURCES_IMPL_Test.Companion.expect
 import shark.AndroidReferenceMatchers.Companion.HMD_GLOBAL
 import shark.AndroidReferenceMatchers.Companion.INFINIX
 import shark.AndroidReferenceMatchers.Companion.LENOVO
+import shark.AndroidReferenceMatchers.Companion.MOTOROLA
 import shark.AndroidReferenceMatchers.Companion.NVIDIA
 import shark.AndroidReferenceMatchers.Companion.XIAOMI
 import shark.HprofHeapGraph.Companion.openHeapGraph
@@ -55,6 +56,7 @@ class AndroidReferenceMatcher_XIAMI__RESOURCES_IMPL_Test(
       arrayOf(LENOVO, 30, HeapAnalysisSuccess::expectKnownLibraryLeak),
       arrayOf(INFINIX, 30, HeapAnalysisSuccess::expectKnownLibraryLeak),
       arrayOf(HMD_GLOBAL, 30, HeapAnalysisSuccess::expectKnownLibraryLeak),
+      arrayOf(MOTOROLA, 30, HeapAnalysisSuccess::expectKnownLibraryLeak),
     )
   }
 


### PR DESCRIPTION
Hello,

We encountered a memory leak caused by the static `mAppContext` field in `ResourcesImpl` on a Motorola device running Android 14.

```
┬───
│ GC Root: System class
│
├─ android.content.res.ResourcesImpl class
│    • Leaking: NO (a class is never leaking)
│    ↓ static ResourcesImpl.mAppContext
│                           ~~~~~~~~~~~
│
├─ android.app.ContextImpl instance
│    • Leaking: UNKNOWN
│    • Retaining 2.7 kB in 24 objects
│    • mOuterContext → com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService
│    ↓ ContextImpl.mOuterContext
│                  ~~~~~~~~~~~~~
│
╰→ com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService instance
     • Leaking: YES (Service not held by ActivityThread)
     • Retaining 789 B in 8 objects
     • mApplication → redacted
     • mBase → android.app.ContextImpl
```