### PR TITLE
Enforce LeakActivity to fit system windows

### DIFF
--- a/leakcanary/leakcanary-android-core/src/main/res/layout/leak_canary_leak_activity.xml
+++ b/leakcanary/leakcanary-android-core/src/main/res/layout/leak_canary_leak_activity.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     >
   <FrameLayout
       android:id="@+id/leak_canary_main_container"


### PR DESCRIPTION
To ship new updates on Google Play Store, developers should target Android 15 (SDK 35). Most important behavior change at this version is the [egde-to-edge enforcement](https://developer.android.com/develop/ui/views/layout/edge-to-edge).

For LeakCanary it surfaces as content being cut from top and bottom of the screen, making the topmost leak non-accessible, so you have to add more leaks to debug your leaks.

This change adds an MVP support for manual edge-to-edge configuration. The proper support will require adding a bunch of libraries, and updating a lot of dependencies which is contrary to LeakCanary lean dependency approach.

Tested using sample app (recompiled locally with compileSdk/targetSdk set to 35).

| Before | After |
|--------|--------|
| <img width="540" alt="Screenshot_1761242076" src="https://github.com/user-attachments/assets/396770b4-9d87-4d18-96c7-cbbb10a3ecfa" /> | <img width="540" alt="Screenshot_1761242099" src="https://github.com/user-attachments/assets/3c5f6657-1280-4590-9fff-ded025e11e6c" /> |
| <img width="540" alt="Screenshot_1761242006" src="https://github.com/user-attachments/assets/64ff2f51-5304-4b4c-8037-93ec8caa37f0" /> | <img width="540" alt="Screenshot_1761242036" src="https://github.com/user-attachments/assets/b7b00a19-9fec-4d30-be9b-ba2ea85c4e3a" /> |
