### PR TITLE
Fix instrumentation tests: uninstall stale APKs before connectedCheck

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,9 +95,17 @@ jobs:
           arch: ${{ matrix.arch }}
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-save
           script: |
-            touch emulator.log                    # create log file
-            chmod 777 emulator.log                # allow writing to log file
-            adb logcat >> emulator.log &          # pipe all logcat messages into log file as a background process
+            # Uninstall existing packages to avoid INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES
+            # when a cached AVD snapshot has old APKs signed with different keys.
+            adb uninstall com.squareup.leakcanary || true
+            adb uninstall com.squareup.leakcanary.test || true
+            adb uninstall com.squareup.leakcanary.core || true
+            adb uninstall com.squareup.leakcanary.core.test || true
+            adb uninstall com.squareup.leakcanary.instrumentation || true
+            adb uninstall com.squareup.leakcanary.instrumentation.test || true
+            touch emulator.log
+            chmod 777 emulator.log
+            adb logcat >> emulator.log &
             ./gradlew leakcanary:leakcanary-android-core:connectedCheck leakcanary:leakcanary-android:connectedCheck leakcanary:leakcanary-android-instrumentation:connectedCheck --no-build-cache --no-daemon --stacktrace
       - name: Upload results
         if: ${{ always() }}


### PR DESCRIPTION
## Problem

All instrumentation test runs are failing with `INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES` across all API levels (16, 19, 21, 23, 26).

This happens because the CI uses a cached AVD snapshot (`actions/cache@v4`). When a snapshot is loaded that has LeakCanary APKs already installed (from a previous CI run), Android refuses to reinstall them if the signing certificate has changed (e.g. different GitHub Actions runner, different build environment).

The `fix-instru-tests` branch attempted the same fix but had a shell script syntax error (`Syntax error: end of file unexpected (expecting "done")`) likely due to YAML multiline block formatting issues with the `for` loop.

## Fix

Before running `connectedCheck`, explicitly uninstall all known LeakCanary packages using individual `adb uninstall` commands (with `|| true` so they don't fail when not installed). This avoids any shell loop syntax and works reliably in `/usr/bin/sh` (POSIX dash).

## Test plan

- [x] CI passes on all API levels (16, 19, 21, 23, 26)
- [x] `adb uninstall` exits cleanly even when package is not installed (due to `|| true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)