### PR TITLE
Fix ToastEventListener race condition that retains a finished Toast

### DIFF
--- a/leakcanary/leakcanary-android-core/src/main/java/leakcanary/ToastEventListener.kt
+++ b/leakcanary/leakcanary-android-core/src/main/java/leakcanary/ToastEventListener.kt
@@ -58,6 +58,7 @@ object ToastEventListener : EventListener {
       val inflater = LayoutInflater.from(resumedActivity)
       toast.view = inflater.inflate(R.layout.leak_canary_heap_dump_toast, null)
       toast.show()
+      toastCurrentlyShown = toast
 
       val toastIcon = toast.view!!.findViewById<View>(R.id.leak_canary_toast_icon)
       toastIcon.translationY = -iconSize.toFloat()
@@ -66,7 +67,6 @@ object ToastEventListener : EventListener {
         .translationY(0f)
         .setListener(object : AnimatorListenerAdapter() {
           override fun onAnimationEnd(animation: Animator) {
-            toastCurrentlyShown = toast
             waitingForToast.countDown()
           }
         })


### PR DESCRIPTION
## Problem

\`ToastEventListener.toastCurrentlyShown\` can be left permanently holding a finished \`Toast\`, leaking the Toast view and its associated \`Context\`.

### Root cause

\`showToastBlocking()\` blocks the heap-dump thread (via \`CountDownLatch\`) waiting for \`onAnimationEnd\`, but only up to a **5-second timeout**. If the timeout fires before the animation completes:

1. The heap dump proceeds normally.
2. On \`HeapDump\`, cleanup is posted: \`mainHandler.post { toastCurrentlyShown?.cancel(); toastCurrentlyShown = null }\`.
3. That cleanup runs on the main thread while \`toastCurrentlyShown\` is **still \`null\`** (animation not done) → cancel is a no-op, null stays null.
4. Then \`onAnimationEnd\` fires and sets \`toastCurrentlyShown = toast\` — the already-finished Toast.
5. No further event fires to clear it → **permanent retention**.

### Why the 2.9 fix (\`ade42f792\`) was incomplete

That fix added \`toastCurrentlyShown = null\` to the cleanup block, which correctly handles the common case (animation ends → heap dump starts → cleanup runs after \`onAnimationEnd\`). But it does not prevent step 4 above: \`onAnimationEnd\` firing *after* cleanup has already run still re-sets the field with no subsequent cleanup.

## Fix

Move \`toastCurrentlyShown = toast\` from \`onAnimationEnd\` to **immediately after \`toast.show()\`**, before the animation starts.

This ensures the field is always set before the heap-dump thread unblocks (in the normal path) **and** before the 5-second timeout fires (in the race path). The cleanup runnable therefore always sees a non-null reference and correctly cancels + nulls it, regardless of animation state.

\`onAnimationEnd\` still calls \`waitingForToast.countDown()\` to unblock the heap-dump thread in the normal (non-timeout) path — that behaviour is unchanged.

## Reproducing

The race is timing-dependent (requires the 5-second await to time out, e.g. under system load or animation being skipped), but it has been observed in production via LeakCanary itself — the leak appears as \`ToastEventListener.toastCurrentlyShown\` in heap dumps.

Fixes #2301
Fixes #2325

🤖 Generated with [Claude Code](https://claude.com/claude-code)