### PR TITLE
Fix CI: force-kill emulator to prevent 20+ min hang after tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,9 @@ jobs:
             # On API 26 google_apis, the emulator process can hang for 20+ minutes after
             # receiving adb emu kill, causing the job to hit its 30-minute timeout. Killing
             # the qemu-system process here ensures the post-cleanup kill check exits immediately.
-            pkill -9 -f "qemu-system" || true
+            # The [m] bracket trick avoids pkill matching its own parent shell process
+            # (whose cmdline contains the literal string "qemu-system" as an argument).
+            pkill -9 -f "qemu-syste[m]" || true
       - name: Upload results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

On API 26 `google_apis`, the emulator process does not exit after receiving `adb emu kill`.
The `android-emulator-runner` post-step polls in a loop waiting for `kill -0 $pid` to fail.
The process never dies before the 30-minute job timeout, so the CI runner cancels the job
with `The operation was canceled.` — roughly 23 minutes after the tests actually finished.

This has happened consistently on API 26 (confirmed in runs for PR #2802 and earlier):

```
15:29:15 BUILD SUCCESSFUL in 5m 17s
15:29:15 ##[group]Terminate Emulator
15:29:15 adb emu kill → OK: killing emulator, bye bye
15:29:15 INFO | Wait for emulator (pid 2659) 20 seconds to shutdown gracefully before kill
  ...
15:52:05 ##[error]The operation was canceled.
```

## Fix

Add `pkill -9 -f "qemu-system" || true` at the end of the test script, before the
`android-emulator-runner` post-step cleanup runs. When the post-step then checks whether
the process is alive, it is already gone and the cleanup exits immediately.

The `|| true` makes it a no-op on API levels where the emulator shuts down cleanly.