### PR TITLE
Fix NullPointerException shark throws due to mockito memory leaks

### DIFF
--- a/shark/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
+++ b/shark/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
@@ -51,6 +51,8 @@ enum class AndroidObjectInspectors : ObjectInspector {
 
         // This filter only cares for root view because we only need one view in a view hierarchy.
         if (isRootView) {
+          // View.mContext is expected to never be null, but it can be null in a context
+          // environment where the view was mocked by Mockito, so we handle that gracefully here.
           val mContext = heapObject["android.view.View", "mContext"]?.value?.asObject?.asInstance
           val activityContext = mContext?.unwrapActivityContext()
           val mContextIsDestroyedActivity = (activityContext != null &&

--- a/shark/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
+++ b/shark/shark-android/src/main/java/shark/AndroidObjectInspectors.kt
@@ -51,8 +51,8 @@ enum class AndroidObjectInspectors : ObjectInspector {
 
         // This filter only cares for root view because we only need one view in a view hierarchy.
         if (isRootView) {
-          val mContext = heapObject["android.view.View", "mContext"]!!.value.asObject!!.asInstance!!
-          val activityContext = mContext.unwrapActivityContext()
+          val mContext = heapObject["android.view.View", "mContext"]?.value?.asObject?.asInstance
+          val activityContext = mContext?.unwrapActivityContext()
           val mContextIsDestroyedActivity = (activityContext != null &&
             activityContext["android.app.Activity", "mDestroyed"]?.value?.asBoolean == true)
           if (mContextIsDestroyedActivity) {


### PR DESCRIPTION
This fixes a NPE that appeared when using shark to analyze memory leaks created by mockito.
Shark attempts to determine if a View is leaking by checking if its `mContext` references a destroyed Activity. The code previously assumed that `mContext` was always non-null.
However, in certain situations (those containing mocked views), `mContext` can be null.