### PR TITLE
Hurricup/issue 2807

### DIFF
--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -395,7 +395,7 @@ internal class HprofInMemoryIndex private constructor(
       val keyBytes = if (longIdentifiers) 8 else 4
       val shardCount = ShardedSortedBytesMap.pickShardCount(
         entryCount = entryCount,
-        bytesPerEntry = bytesPerValue + keyBytes
+        bytesPerEntry = keyBytes + bytesPerValue
       )
       val perShard = (entryCount + shardCount - 1) / shardCount
       return Array(shardCount) {

--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -402,7 +402,7 @@ internal class HprofInMemoryIndex private constructor(
         UnsortedByteEntries(
           bytesPerValue = bytesPerValue,
           longIdentifiers = longIdentifiers,
-          initialCapacity = if (perShard == 0) 4 else perShard
+          initialCapacity = perShard
         )
       }
     }

--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -54,10 +54,10 @@ internal class HprofInMemoryIndex private constructor(
   private val positionSize: Int,
   private val hprofStringCache: LongObjectScatterMap<String>,
   private val classNames: LongLongScatterMap,
-  private val classIndex: SortedBytesMap,
-  private val instanceIndex: SortedBytesMap,
-  private val objectArrayIndex: SortedBytesMap,
-  private val primitiveArrayIndex: SortedBytesMap,
+  private val classIndex: ShardedSortedBytesMap,
+  private val instanceIndex: ShardedSortedBytesMap,
+  private val objectArrayIndex: ShardedSortedBytesMap,
+  private val primitiveArrayIndex: ShardedSortedBytesMap,
   private val gcRoots: List<GcRoot>,
   private val proguardMapping: ProguardMapping?,
   private val bytesForClassSize: Int,
@@ -325,7 +325,7 @@ internal class HprofInMemoryIndex private constructor(
   }
 
   private class Builder(
-    longIdentifiers: Boolean,
+    private val longIdentifiers: Boolean,
     maxPosition: Long,
     classCount: Int,
     instanceCount: Int,
@@ -364,26 +364,48 @@ internal class HprofInMemoryIndex private constructor(
 
     private var classFieldsIndex = 0
 
-    private val classIndex = UnsortedByteEntries(
+    private val classIndex = shardedUnsortedEntries(
       bytesPerValue = positionSize + identifierSize + 4 + bytesForClassSize + classFieldsIndexSize,
-      longIdentifiers = longIdentifiers,
-      initialCapacity = classCount
+      entryCount = classCount
     )
-    private val instanceIndex = UnsortedByteEntries(
+    private val classShardMask = classIndex.size - 1
+
+    private val instanceIndex = shardedUnsortedEntries(
       bytesPerValue = positionSize + identifierSize + bytesForInstanceSize,
-      longIdentifiers = longIdentifiers,
-      initialCapacity = instanceCount
+      entryCount = instanceCount
     )
-    private val objectArrayIndex = UnsortedByteEntries(
+    private val instanceShardMask = instanceIndex.size - 1
+
+    private val objectArrayIndex = shardedUnsortedEntries(
       bytesPerValue = positionSize + identifierSize + bytesForObjectArraySize,
-      longIdentifiers = longIdentifiers,
-      initialCapacity = objectArrayCount
+      entryCount = objectArrayCount
     )
-    private val primitiveArrayIndex = UnsortedByteEntries(
+    private val objectArrayShardMask = objectArrayIndex.size - 1
+
+    private val primitiveArrayIndex = shardedUnsortedEntries(
       bytesPerValue = positionSize + 1 + bytesForPrimitiveArraySize,
-      longIdentifiers = longIdentifiers,
-      initialCapacity = primitiveArrayCount
+      entryCount = primitiveArrayCount
     )
+    private val primitiveArrayShardMask = primitiveArrayIndex.size - 1
+
+    private fun shardedUnsortedEntries(
+      bytesPerValue: Int,
+      entryCount: Int
+    ): Array<UnsortedByteEntries> {
+      val keyBytes = if (longIdentifiers) 8 else 4
+      val shardCount = ShardedSortedBytesMap.pickShardCount(
+        entryCount = entryCount,
+        bytesPerEntry = bytesPerValue + keyBytes
+      )
+      val perShard = (entryCount + shardCount - 1) / shardCount
+      return Array(shardCount) {
+        UnsortedByteEntries(
+          bytesPerValue = bytesPerValue,
+          longIdentifiers = longIdentifiers,
+          initialCapacity = if (perShard == 0) 4 else perShard
+        )
+      }
+    }
 
     // Pre seeding gc roots with the sticky class gc roots we've already parsed.
     private val gcRoots: MutableList<GcRoot> = ArrayList<GcRoot>(stickyClassGcRootIds.size()).apply {
@@ -570,7 +592,7 @@ internal class HprofInMemoryIndex private constructor(
           val fieldsSize = (reader.bytesRead - bytesReadFieldStart).toInt()
           val recordSize = reader.bytesRead - bytesReadStart
 
-          classIndex.append(id)
+          classIndex[ShardedSortedBytesMap.shardOf(id, classShardMask)].append(id)
             .apply {
               writeTruncatedLong(bytesReadStart, positionSize)
               writeId(superclassId)
@@ -590,7 +612,7 @@ internal class HprofInMemoryIndex private constructor(
           val remainingBytesInInstance = reader.readInt()
           reader.skip(remainingBytesInInstance)
           val recordSize = reader.bytesRead - bytesReadStart
-          instanceIndex.append(id)
+          instanceIndex[ShardedSortedBytesMap.shardOf(id, instanceShardMask)].append(id)
             .apply {
               writeTruncatedLong(bytesReadStart, positionSize)
               writeId(classId)
@@ -607,7 +629,7 @@ internal class HprofInMemoryIndex private constructor(
           reader.skip(identifierSize * size)
           // record size - (ID+INT + INT + ID)
           val recordSize = reader.bytesRead - bytesReadStart
-          objectArrayIndex.append(id)
+          objectArrayIndex[ShardedSortedBytesMap.shardOf(id, objectArrayShardMask)].append(id)
             .apply {
               writeTruncatedLong(bytesReadStart, positionSize)
               writeId(arrayClassId)
@@ -622,7 +644,7 @@ internal class HprofInMemoryIndex private constructor(
           val type = PrimitiveType.primitiveTypeByHprofType.getValue(reader.readUnsignedByte())
           reader.skip(size * type.byteSize)
           val recordSize = reader.bytesRead - bytesReadStart
-          primitiveArrayIndex.append(id)
+          primitiveArrayIndex[ShardedSortedBytesMap.shardOf(id, primitiveArrayShardMask)].append(id)
             .apply {
               writeTruncatedLong(bytesReadStart, positionSize)
               writeByte(type.ordinal.toByte())
@@ -643,10 +665,18 @@ internal class HprofInMemoryIndex private constructor(
         "Read $classFieldsIndex into fields bytes instead of expected ${classFieldBytes.size}"
       }
 
-      val sortedInstanceIndex = instanceIndex.moveToSortedMap()
-      val sortedObjectArrayIndex = objectArrayIndex.moveToSortedMap()
-      val sortedPrimitiveArrayIndex = primitiveArrayIndex.moveToSortedMap()
-      val sortedClassIndex = classIndex.moveToSortedMap()
+      val sortedInstanceIndex = ShardedSortedBytesMap(Array(instanceIndex.size) {
+        instanceIndex[it].moveToSortedMap()
+      })
+      val sortedObjectArrayIndex = ShardedSortedBytesMap(Array(objectArrayIndex.size) {
+        objectArrayIndex[it].moveToSortedMap()
+      })
+      val sortedPrimitiveArrayIndex = ShardedSortedBytesMap(Array(primitiveArrayIndex.size) {
+        primitiveArrayIndex[it].moveToSortedMap()
+      })
+      val sortedClassIndex = ShardedSortedBytesMap(Array(classIndex.size) {
+        classIndex[it].moveToSortedMap()
+      })
       // Passing references to avoid copying the underlying data structures.
       return HprofInMemoryIndex(
         positionSize = positionSize,

--- a/shark/shark-graph/src/main/java/shark/internal/ShardedSortedBytesMap.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/ShardedSortedBytesMap.kt
@@ -1,0 +1,114 @@
+package shark.internal
+
+import shark.internal.hppc.LongObjectPair
+
+/**
+ * A [SortedBytesMap] split across N power-of-two shards keyed by [shardOf].
+ *
+ * A single [SortedBytesMap] is backed by one [ByteArray], which the JVM caps at ~2 GB.
+ * For very large heap dumps the per-record-type index can exceed that limit and the size
+ * calculation overflows [Int], throwing [NegativeArraySizeException]. Sharding by id keeps
+ * each backing array under the limit.
+ *
+ * The [Int] "global index" exposed via [indexOf], [getAtIndex], and [keyAt] is the
+ * shard-by-shard concatenation: indices `[0, shards[0].size)` refer to shard 0, the next
+ * block to shard 1, and so on. Within a shard, entries remain sorted by id; the global
+ * concatenation is not sorted by id across shards. Callers that treat the index as an
+ * opaque round-trip handle (e.g. `getAtIndex(indexOf(key))`) are unaffected.
+ *
+ * With a single shard, this is a thin pass-through over [SortedBytesMap].
+ */
+internal class ShardedSortedBytesMap(
+  private val shards: Array<SortedBytesMap>
+) {
+  init {
+    require(shards.isNotEmpty()) { "Must have at least one shard" }
+    require(shards.size and (shards.size - 1) == 0) {
+      "Shard count must be a power of two, was ${shards.size}"
+    }
+  }
+
+  private val shardMask: Int = shards.size - 1
+
+  // cumulativeSizes[i] = sum of shards[0 until i].size; cumulativeSizes[shards.size] = total.
+  private val cumulativeSizes: IntArray = IntArray(shards.size + 1).also {
+    for (i in shards.indices) {
+      it[i + 1] = it[i] + shards[i].size
+    }
+  }
+
+  val size: Int = cumulativeSizes[shards.size]
+
+  operator fun get(key: Long): ByteSubArray? = shards[shardOf(key)][key]
+
+  operator fun contains(key: Long): Boolean = key in shards[shardOf(key)]
+
+  /**
+   * Returns a non-negative global index if [key] is present, otherwise a negative number.
+   * Unlike [SortedBytesMap.indexOf], the negative return value is not a meaningful
+   * insertion point.
+   */
+  fun indexOf(key: Long): Int {
+    val shard = shardOf(key)
+    val local = shards[shard].indexOf(key)
+    if (local < 0) return -1
+    return cumulativeSizes[shard] + local
+  }
+
+  fun getAtIndex(keyIndex: Int): ByteSubArray {
+    val shard = findShard(keyIndex)
+    return shards[shard].getAtIndex(keyIndex - cumulativeSizes[shard])
+  }
+
+  fun keyAt(keyIndex: Int): Long {
+    val shard = findShard(keyIndex)
+    return shards[shard].keyAt(keyIndex - cumulativeSizes[shard])
+  }
+
+  fun entrySequence(): Sequence<LongObjectPair<ByteSubArray>> =
+    shards.asSequence().flatMap { it.entrySequence() }
+
+  private fun findShard(globalIndex: Int): Int {
+    require(globalIndex in 0 until size) {
+      "Index $globalIndex out of bounds [0, $size)"
+    }
+    // shards.size is small (typically 1, 2, 4, 8). A linear scan beats binary search here.
+    for (i in shards.indices) {
+      if (globalIndex < cumulativeSizes[i + 1]) return i
+    }
+    error("unreachable")
+  }
+
+  private fun shardOf(id: Long): Int = shardOf(id, shardMask)
+
+  companion object {
+    /**
+     * Smallest power-of-two `n` such that `entryCount * bytesPerEntry / n <= maxBytesPerShard`.
+     * Returns 1 when the predicted footprint already fits.
+     */
+    fun pickShardCount(
+      entryCount: Int,
+      bytesPerEntry: Int,
+      maxBytesPerShard: Long = DEFAULT_MAX_BYTES_PER_SHARD
+    ): Int {
+      val predicted = entryCount.toLong() * bytesPerEntry
+      var n = 1
+      while (predicted / n > maxBytesPerShard) n = n shl 1
+      return n
+    }
+
+    /**
+     * Routes an id to a shard. Mixes the upper half of the long into the lower half before
+     * masking so that pointer-like ids (often 8-byte aligned, low bits zero) still distribute
+     * across shards. Must match the routing used by the writer.
+     */
+    fun shardOf(id: Long, shardMask: Int): Int =
+      (((id ushr 3) xor (id ushr 32)).toInt()) and shardMask
+
+    /**
+     * 1 GB, well under the JVM's [Int.MAX_VALUE] byte-array ceiling so a shard has room
+     * to grow before [UnsortedByteEntries] doubles its backing array.
+     */
+    const val DEFAULT_MAX_BYTES_PER_SHARD: Long = 1L shl 30
+  }
+}

--- a/shark/shark-graph/src/test/java/shark/ShardedSortedBytesMapTest.kt
+++ b/shark/shark-graph/src/test/java/shark/ShardedSortedBytesMapTest.kt
@@ -1,0 +1,115 @@
+package shark
+
+import kotlin.random.Random
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.internal.ShardedSortedBytesMap
+import shark.internal.ShardedSortedBytesMap.Companion.pickShardCount
+import shark.internal.ShardedSortedBytesMap.Companion.shardOf
+import shark.internal.UnsortedByteEntries
+
+class ShardedSortedBytesMapTest {
+
+  @Test fun singleShardBehavesLikeSortedBytesMap() {
+    val ids = listOf(42L, 0L, 3L, Long.MAX_VALUE)
+    val map = buildSharded(shardCount = 1, ids = ids)
+
+    assertThat(map.size).isEqualTo(ids.size)
+    ids.forEach { assertThat(it in map).isTrue }
+    assertThat(map[12345L]).isNull()
+    assertThat(map.entrySequence().map { it.first }.toList())
+      .containsExactly(0L, 3L, 42L, Long.MAX_VALUE)
+  }
+
+  @Test fun multipleShardsContainAllKeys() {
+    val ids = (0L until 1000L).shuffled(Random(7L)).toList()
+    val map = buildSharded(shardCount = 4, ids = ids)
+
+    assertThat(map.size).isEqualTo(ids.size)
+    ids.forEach {
+      assertThat(it in map).`as`("key $it").isTrue
+      assertThat(map[it]).isNotNull
+    }
+    assertThat(map[Long.MIN_VALUE]).isNull()
+    assertThat(map[12345L]).isNull()
+  }
+
+  @Test fun indexOfRoundTripsThroughGetAtIndex() {
+    val ids = (0L until 500L step 7L).toList()
+    val map = buildSharded(shardCount = 8, ids = ids)
+
+    ids.forEach { id ->
+      val idx = map.indexOf(id)
+      assertThat(idx).`as`("indexOf($id)").isGreaterThanOrEqualTo(0)
+      assertThat(map.keyAt(idx)).`as`("keyAt(indexOf($id))").isEqualTo(id)
+      assertThat(map.getAtIndex(idx).readByte()).`as`("value at $id").isEqualTo((id and 0xff).toByte())
+    }
+  }
+
+  @Test fun indexOfReturnsNegativeForMissingKey() {
+    val map = buildSharded(shardCount = 4, ids = listOf(10L, 20L, 30L))
+
+    assertThat(map.indexOf(15L)).isLessThan(0)
+    assertThat(map.indexOf(99L)).isLessThan(0)
+  }
+
+  @Test fun entrySequenceVisitsEveryEntry() {
+    val ids = (0L until 200L).map { it * 13L }.shuffled(Random(1L))
+    val map = buildSharded(shardCount = 4, ids = ids)
+
+    val visited = map.entrySequence().map { it.first }.toList()
+    assertThat(visited).hasSize(ids.size)
+    assertThat(visited.toSet()).isEqualTo(ids.toSet())
+  }
+
+  @Test fun pickShardCountReturnsOneWhenUnderLimit() {
+    assertThat(pickShardCount(entryCount = 1_000_000, bytesPerEntry = 20)).isEqualTo(1)
+  }
+
+  @Test fun pickShardCountGrowsToFitOversizedIndex() {
+    // 2.5 GB predicted footprint at 1 GB per shard → needs 4 shards.
+    val maxBytesPerShard = 1L shl 30
+    val n = pickShardCount(entryCount = 125_000_000, bytesPerEntry = 20, maxBytesPerShard = maxBytesPerShard)
+    assertThat(n).isEqualTo(4)
+    assertThat(125_000_000L * 20 / n).isLessThanOrEqualTo(maxBytesPerShard)
+  }
+
+  @Test fun pickShardCountIsAlwaysPowerOfTwo() {
+    val cases = listOf(
+      Triple(1_000_000, 100, 1L shl 20),
+      Triple(10_000_000, 50, 1L shl 28),
+      Triple(200_000_000, 25, 1L shl 30),
+    )
+    cases.forEach { (count, perEntry, limit) ->
+      val n = pickShardCount(count, perEntry, limit)
+      assertThat(n and (n - 1)).`as`("n=$n is power of two").isZero
+      assertThat(count.toLong() * perEntry / n)
+        .`as`("$count*$perEntry / $n ≤ $limit").isLessThanOrEqualTo(limit)
+    }
+  }
+
+  @Test fun shardOfDistributesAlignedPointers() {
+    // Pointer-like ids: 8-byte aligned, ascending. Naive (id and mask) would put everything
+    // in shard 0; the mixer must spread them.
+    val mask = 7
+    val counts = IntArray(8)
+    var id = 0x7f00_0000L
+    repeat(8_000) {
+      counts[shardOf(id, mask)]++
+      id += 8L
+    }
+    counts.forEach { assertThat(it).isGreaterThan(0) }
+  }
+
+  /** Builds a sharded map where each entry's value is a single byte: `(id and 0xff)`. */
+  private fun buildSharded(shardCount: Int, ids: List<Long>): ShardedSortedBytesMap {
+    val mask = shardCount - 1
+    val shards = Array(shardCount) {
+      UnsortedByteEntries(bytesPerValue = 1, longIdentifiers = true)
+    }
+    ids.forEach { id ->
+      shards[shardOf(id, mask)].append(id).writeByte((id and 0xff).toByte())
+    }
+    return ShardedSortedBytesMap(Array(shardCount) { shards[it].moveToSortedMap() })
+  }
+}


### PR DESCRIPTION
  Fixes #2807: `NegativeArraySizeException` when opening very large heap dumps.                                                                                                                                                                                             
                                                                                                                                                                                                                                                                            
  For heap dumps with enough objects of a given record type that the per-type index would occupy more than ~2 GB of bytes, indexing fails before `HprofHeapGraph.openHeapGraph()` returns:                                                                                  
                                                                                                                                                                                                                                                                            
  java.lang.NegativeArraySizeException: -1473570498                                                                                                                                                                                                                         
      at shark.internal.UnsortedByteEntries.append(UnsortedByteEntries.kt:32)                                                                                                                                                                                               
      at shark.internal.HprofInMemoryIndex$Builder.onHprofRecord(HprofInMemoryIndex.kt:592)                                                                                                                                                                                 
                                                                                                                                                                                                                                                                            
  Root cause is a 32-bit `Int` overflow in `entryCount * bytesPerEntry`, which then gets passed to `ByteArray(...)`. A single Java `ByteArray` is capped at `Int.MAX_VALUE` bytes, so for a per-type index that exceeds that limit there is no single-array fix — the       
  storage has to be split.                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                            
  ## Approach                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                            
  Shard each per-record-type index across `N` power-of-two `SortedBytesMap` shards, keyed by id. Each shard's backing array stays under 1 GB, with growth headroom before the JVM ceiling.                                                                                  
                                                                                                                                                                                                                                                                            
  - `ShardedSortedBytesMap` wraps `Array<SortedBytesMap>` and exposes the same surface used by callers (`get`, `contains`, `size`, `indexOf`, `getAtIndex`, `keyAt`, `entrySequence`).                                                                                      
  - `pickShardCount(entryCount, bytesPerEntry)` derives `N` from the existing first-pass stats. When the predicted footprint already fits, it returns `N = 1` and behavior is identical to before — same code path, same memory.                                            
  - `shardOf(id)` mixes the upper 32 bits into the lower half before masking, so pointer-like 8-byte-aligned ids still distribute across shards.                                                                                                                            
  - Writes route to shards via the same `shardOf` used by reads; nothing else in `HprofInMemoryIndex` had to change.                                                                                                                                                        
                                                                                                                                                                                                                                                                            
  Sharding by id preserves the `indexOf(k) → getAtIndex` round-trip used internally. Within a shard, entries remain sorted by id; the global concatenation is not, but no caller depends on a global id-sorted iteration order across the whole index.                      
                                                                                                                                                                                                                                                                            
  ## Repro                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                            
  Reported with a ~12.7 GB JVM hprof from an IntelliJ-based IDE. Verified locally:                                                                                                                                                                                          
                                                                                                                                                                                                                                                                            
  classCount=238,802                                                                                                                                                                                                                                                        
  instanceCount=122,669,426        ← the bucket that was overflowing                                                                                                                                                                                                        
  objectArrayCount=15,134,930                                                                                                                                                                                                                                               
  primitiveArrayCount=31,280,395                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                            
  The instance index alone needs ~3 GB; `pickShardCount` selects `N = 4` (~750 MB per shard). `openHeapGraph()` completes in ~17s on this machine.                                                                                                                          
                                                                                                                                                                                                                                                                            
  ## What's not touched                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                            
  - `SortedBytesMap`, `UnsortedByteEntries`, `ByteSubArray`, `ByteArrayTimSort` — unchanged.                                                                                                                                                                                
  - `classFieldBytes` is a separate single-`ByteArray` allocation indexed by offset, not by id, so sharding-by-id doesn't apply. It hasn't been observed to overflow in real dumps; leaving it for a separate, narrower fix if it ever does.                                
  - Public API: all touched types are `internal`.                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                            
  - [x] New unit tests for `ShardedSortedBytesMap`: get/contains/indexOf/getAtIndex/keyAt/entrySequence with `N = 1, 4, 8`; `pickShardCount` thresholding and power-of-two invariant; `shardOf` distribution on aligned ids.                                                
  - [x] Existing `shark-graph` test suite (60+ tests) passes.                                                                                                                                                                                                               
  - [x] Existing `shark` test suite (141 tests) passes.                                                                                                                                                                                                                     
  - [x] Local smoke test: open the failing 12.7 GB hprof end-to-end without `NegativeArraySizeException`.                                                                                                                                                                   
                                                                                                                                                                                                                                                                            
  ## Commits                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                            
  1. Add `ShardedSortedBytesMap`                                                                                                                                                                                                                                            
  2. Add tests for `ShardedSortedBytesMap`                                                                                                                                                                                                                                  
  3. Shard per-record-type indexes in `HprofInMemoryIndex`                                                                                                                                                                                                                  
