### PR TITLE
Add missing GC root types to LeakTrace file

### DIFF
--- a/shark/shark/api/shark.api
+++ b/shark/shark/api/shark.api
@@ -423,15 +423,22 @@ public final class shark/LeakTrace$Companion {
 
 public final class shark/LeakTrace$GcRootType : java/lang/Enum {
 	public static final field Companion Lshark/LeakTrace$GcRootType$Companion;
+	public static final field DEBUGGER Lshark/LeakTrace$GcRootType;
+	public static final field FINALIZING Lshark/LeakTrace$GcRootType;
+	public static final field INTERNED_STRING Lshark/LeakTrace$GcRootType;
 	public static final field JAVA_FRAME Lshark/LeakTrace$GcRootType;
 	public static final field JNI_GLOBAL Lshark/LeakTrace$GcRootType;
 	public static final field JNI_LOCAL Lshark/LeakTrace$GcRootType;
 	public static final field JNI_MONITOR Lshark/LeakTrace$GcRootType;
 	public static final field MONITOR_USED Lshark/LeakTrace$GcRootType;
 	public static final field NATIVE_STACK Lshark/LeakTrace$GcRootType;
+	public static final field REFERENCE_CLEANUP Lshark/LeakTrace$GcRootType;
 	public static final field STICKY_CLASS Lshark/LeakTrace$GcRootType;
 	public static final field THREAD_BLOCK Lshark/LeakTrace$GcRootType;
 	public static final field THREAD_OBJECT Lshark/LeakTrace$GcRootType;
+	public static final field UNKNOWN Lshark/LeakTrace$GcRootType;
+	public static final field UNREACHABLE Lshark/LeakTrace$GcRootType;
+	public static final field VM_INTERNAL Lshark/LeakTrace$GcRootType;
 	public final fun getDescription ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lshark/LeakTrace$GcRootType;
 	public static fun values ()[Lshark/LeakTrace$GcRootType;

--- a/shark/shark/src/main/java/shark/LeakTrace.kt
+++ b/shark/shark/src/main/java/shark/LeakTrace.kt
@@ -136,6 +136,13 @@ data class LeakTrace(
     ),
     THREAD_OBJECT("Thread object"),
     JNI_MONITOR("Root JNI monitor"),
+    UNKNOWN("Unknown GC root type"),
+    INTERNED_STRING("Interned string"),
+    FINALIZING("Object awaiting finalization"),
+    DEBUGGER("Debugger reference"),
+    REFERENCE_CLEANUP("Reference cleanup"),
+    VM_INTERNAL("VM internal reference"),
+    UNREACHABLE("Unreachable object"),
     ;
 
     companion object {
@@ -149,7 +156,13 @@ data class LeakTrace(
         is GcRoot.MonitorUsed -> MONITOR_USED
         is GcRoot.ThreadObject -> THREAD_OBJECT
         is GcRoot.JniMonitor -> JNI_MONITOR
-        else -> throw IllegalStateException("Unexpected gc root $gcRoot")
+        is GcRoot.Unknown -> UNKNOWN
+        is GcRoot.InternedString -> INTERNED_STRING
+        is GcRoot.Finalizing -> FINALIZING
+        is GcRoot.Debugger -> DEBUGGER
+        is GcRoot.ReferenceCleanup -> REFERENCE_CLEANUP
+        is GcRoot.VmInternal -> VM_INTERNAL
+        is GcRoot.Unreachable -> UNREACHABLE
       }
     }
   }

--- a/shark/shark/src/main/java/shark/MatchingGcRootProvider.kt
+++ b/shark/shark/src/main/java/shark/MatchingGcRootProvider.kt
@@ -3,6 +3,13 @@ package shark
 import shark.GcRoot.JavaFrame
 import shark.GcRoot.JniGlobal
 import shark.GcRoot.ThreadObject
+import shark.GcRoot.Unknown
+import shark.GcRoot.InternedString
+import shark.GcRoot.Finalizing
+import shark.GcRoot.Debugger
+import shark.GcRoot.ReferenceCleanup
+import shark.GcRoot.VmInternal
+import shark.GcRoot.Unreachable
 import shark.HeapObject.HeapClass
 import shark.HeapObject.HeapInstance
 import shark.HeapObject.HeapObjectArray
@@ -39,7 +46,14 @@ class MatchingGcRootProvider(
       when (gcRoot) {
         // Note: in sortedGcRoots we already filter out any java frame that has an associated
         // thread. These are the remaining ones (shouldn't be any, this is just in case).
-        is JavaFrame -> {
+        is JavaFrame,
+        is Unknown,
+        is InternedString,
+        is Finalizing,
+        is Debugger,
+        is ReferenceCleanup,
+        is VmInternal,
+        is Unreachable -> {
           GcRootReference(
             gcRoot,
             isLowPriority = true,


### PR DESCRIPTION
Add mapping for 7 missing GC root types in LeakTrace to prevent crashes during trace formatting, and update the public API signatures in shark.api. These root types correspond to the subclasses defined in the GcRoot.kt file in the shark-hprof module. 