### PR TITLE
Fix primitive array global index in indexedObjectOrNull

### DIFF
--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -237,7 +237,7 @@ internal class HprofInMemoryIndex private constructor(
       )
     }
     shiftedIndex -= objectArrayIndex.size
-    require(index < primitiveArrayIndex.size)
+    require(shiftedIndex < primitiveArrayIndex.size)
     val objectId = primitiveArrayIndex.keyAt(shiftedIndex)
     val array = primitiveArrayIndex.getAtIndex(shiftedIndex)
     return objectId to IndexedPrimitiveArray(
@@ -276,7 +276,7 @@ internal class HprofInMemoryIndex private constructor(
     index = primitiveArrayIndex.indexOf(objectId)
     if (index >= 0) {
       val array = primitiveArrayIndex.getAtIndex(index)
-      return classIndex.size + instanceIndex.size + index + primitiveArrayIndex.size to IndexedPrimitiveArray(
+      return classIndex.size + instanceIndex.size + objectArrayIndex.size + index to IndexedPrimitiveArray(
         position = array.readTruncatedLong(positionSize),
         primitiveType = PrimitiveType.values()[array.readByte()
           .toInt()],

--- a/shark/shark-graph/src/test/java/shark/HprofIndexParsingTest.kt
+++ b/shark/shark-graph/src/test/java/shark/HprofIndexParsingTest.kt
@@ -8,6 +8,7 @@ import shark.HprofRecord.HeapDumpRecord.GcRootRecord
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.ClassDumpRecord
 import shark.HprofRecord.LoadClassRecord
 import shark.HprofRecord.StringRecord
+import shark.internal.HprofInMemoryIndex
 
 class HprofIndexParsingTest {
 
@@ -61,5 +62,33 @@ class HprofIndexParsingTest {
       assertThat(class2Index).isEqualTo(instance1Index + 1)
       assertThat(instance2Index).isEqualTo(class2Index + 1)
     }
+  }
+
+  @Test fun `indexedObjectOrNull index round trips through objectAtIndex for primitive arrays`() {
+    // The global index returned by indexedObjectOrNull is the concatenation of class, instance,
+    // object array and primitive array indexes. The offset for primitive arrays must add the
+    // object array index size, which is only correct when objectArrayIndex.size and
+    // primitiveArrayIndex.size differ. Here we have 2 object arrays but 1 primitive array.
+    var primitiveArrayId = 0L
+    val source = dump {
+      val arrayClass = clazz("char[]")
+      objectArrayOf(arrayClass, instance(clazz("com.example.MyClass1")))
+      objectArrayOf(arrayClass, instance(clazz("com.example.MyClass2")))
+      primitiveArrayId = primitiveLongArray(longArrayOf(1L, 2L, 3L))
+    }
+
+    val header = source.openStreamingSource().use { HprofHeader.parseHeaderOf(it) }
+    val reader = StreamingHprofReader.readerFor(source, header)
+    val index = HprofInMemoryIndex.indexHprof(
+      reader = reader,
+      hprofHeader = header,
+      proguardMapping = null,
+      indexedGcRootTags = HprofIndex.defaultIndexedGcRootTags()
+    )
+
+    val globalIndex = index.indexedObjectOrNull(primitiveArrayId)!!.first
+    val (roundTrippedId, _) = index.objectAtIndex(globalIndex)
+
+    assertThat(roundTrippedId).isEqualTo(primitiveArrayId)
   }
 }


### PR DESCRIPTION
indexedObjectOrNull offset the primitive-array branch by primitiveArrayIndex.size instead of objectArrayIndex.size, returning a wrong global index whenever those sizes differ; objectAtIndex's require also compared the global index rather than the shifted one. Both are fixed and a round-trip test now covers indexedObjectOrNull -> objectAtIndex for primitive arrays.