### PR TITLE
Fix HeapAnalysisStringRenderingTest on Windows environments

### DIFF
--- a/shark/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
+++ b/shark/shark/src/test/java/shark/HeapAnalysisStringRenderingTest.kt
@@ -32,8 +32,7 @@ class HeapAnalysisStringRenderingTest {
       |====================================
       |STACKTRACE
       |
-      |java.lang.IllegalArgumentException: Source has no available bytes
-      |.*
+      |java.lang.IllegalArgumentException: Source has no available bytes.*?
       |====================================
       |METADATA
       |
@@ -41,7 +40,7 @@ class HeapAnalysisStringRenderingTest {
       |Build.MANUFACTURER: Unknown
       |LeakCanary version: Unknown
       |Analysis duration: \d* ms
-      |Heap dump file path: ${hprofFile.absolutePath}
+      |Heap dump file path: ${Regex.escape(hprofFile.absolutePath)}
       |Heap dump timestamp: \d*
       |===================================="""
   }
@@ -78,7 +77,7 @@ class HeapAnalysisStringRenderingTest {
       |Please include this in bug reports and Stack Overflow questions.
       |
       |Analysis duration: \d* ms
-      |Heap dump file path: ${hprofFile.absolutePath}
+      |Heap dump file path: ${Regex.escape(hprofFile.absolutePath)}
       |Heap dump timestamp: \d*
       |Heap dump duration: Unknown
       |===================================="""
@@ -108,7 +107,7 @@ class HeapAnalysisStringRenderingTest {
       |│ GC Root: System class
       |│
       |├─ GcRoot class
-      |.*
+      |.*?
       |====================================
       |0 LIBRARY LEAKS
       |
@@ -125,7 +124,7 @@ class HeapAnalysisStringRenderingTest {
       |Please include this in bug reports and Stack Overflow questions.
       |
       |Analysis duration: \d* ms
-      |Heap dump file path: ${hprofFile.absolutePath}
+      |Heap dump file path: ${Regex.escape(hprofFile.absolutePath)}
       |Heap dump timestamp: \d*
       |Heap dump duration: Unknown
       |===================================="""


### PR DESCRIPTION
- hprof absolute paths contains backslashes that must be escaped otherwise they are interpreted by the regex compiler
- stacktraces contains platform-dependent new-lines and must be part of the `.*`
- replace greedy quantifiers (`.*`) with lazy ones (`.*?`) for less unnecessary backtracking