### PR TITLE
Fix LeakCanaryLeakDeobfuscationPluginTest on Windows environments

### DIFF
--- a/leakcanary/leakcanary-deobfuscation-gradle-plugin/src/test/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPluginTest.kt
+++ b/leakcanary/leakcanary-deobfuscation-gradle-plugin/src/test/java/com/squareup/leakcanary/deobfuscation/LeakCanaryLeakDeobfuscationPluginTest.kt
@@ -8,6 +8,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.util.Properties
 import java.util.zip.ZipFile
 
 class LeakCanaryLeakDeobfuscationPluginTest {
@@ -26,8 +27,10 @@ class LeakCanaryLeakDeobfuscationPluginTest {
       localPropertiesFile.copyTo(File(tempFolder.root, "local.properties"), overwrite = true)
     } else {
       System.getenv("ANDROID_HOME")?.let { androidHome ->
-        tempFolder.newFile("local.properties").apply {
-          writeText("sdk.dir=$androidHome")
+        tempFolder.newFile("local.properties").outputStream().use {
+          Properties()
+            .apply { this["sdk.dir"] = androidHome }
+            .store(it, null)
         }
       }
     }


### PR DESCRIPTION
`local.properties` file creation from `ANDROID_HOME` variables did not properly escaped Windows paths, leading to invalid values.

For instance, if the env variable is `X:\Android`, the resulting file would contain `sdk.dir=X:\Android` which is invalid.