### PR TITLE
Fix leakcanary-app build on Windows environment

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidXTest = "1.5.0"
 androidXJunit = "1.1.5"
 workManager = "2.7.0"
 detekt = "1.23.8"
-hilt = "2.53"
+hilt = "2.54"
 androidMinSdk = "26"
 androidCompileSdk = "35"
 


### PR DESCRIPTION
The issue comes from KAPT failing to correctly escape generated proguard files, as you can see in this scan: https://scans.gradle.com/s/v2w3gkl3o7cm6/failures?focused-exception-line=0-2-4-6-8-10-0#1

Bumping Hilt to the next-compatible version.

Successful build scan: https://scans.gradle.com/s/ceznm7rwpstq2

KAPT, your end is approaching 👀