### PR TITLE
Fix leakcanary-android instrumented tests

### DIFF
--- a/leakcanary/leakcanary-android/build.gradle.kts
+++ b/leakcanary/leakcanary-android/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   androidTestImplementation(libs.androidX.test.runner)
   androidTestImplementation(libs.assertjCore)
   androidTestImplementation(projects.shark.sharkHprofTest)
+  androidTestUtil(libs.androidX.test.orchestrator)
 }
 
 android {
@@ -32,9 +33,13 @@ android {
     // Avoid DeprecatedTargetSdkVersionDialog / INSTALL_FAILED_DEPRECATED_SDK_VERSION on API 28+
     targetSdk = libs.versions.androidCompileSdk.get().toInt()
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunnerArguments["clearPackageData"] = "true"
   }
   buildFeatures.buildConfig = false
   namespace = "com.squareup.leakcanary"
+  testOptions {
+    execution = "ANDROIDX_TEST_ORCHESTRATOR"
+  }
   lint {
     checkOnly += "Interoperability"
     disable += "GoogleAppIndexingWarning"


### PR DESCRIPTION
Add missing testInstrumentationRunnerArguments and orchestrator that prevents running the same test multiple times (expects "1 Heap Dump" title)