### PR TITLE
Expose thread dumps from JVM HPROF heap dumps

### DIFF
--- a/shark/shark-android/src/test/java/shark/AndroidThreadDumpTest.kt
+++ b/shark/shark-android/src/test/java/shark/AndroidThreadDumpTest.kt
@@ -1,0 +1,18 @@
+package shark
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.HprofHeapGraph.Companion.openHeapGraph
+
+class AndroidThreadDumpTest {
+
+  /**
+   * Android heap dumps don't contain stack trace records, so there's no thread dump to expose
+   * even though they do contain thread objects.
+   */
+  @Test fun `android heap dump has no threads`() {
+    "leak_asynctask_o.hprof".classpathFile().openHeapGraph().use { graph ->
+      assertThat(graph.threads.toList()).isEmpty()
+    }
+  }
+}

--- a/shark/shark-graph/api/shark-graph.api
+++ b/shark/shark-graph/api/shark-graph.api
@@ -41,6 +41,7 @@ public abstract interface class shark/HeapGraph {
 	public abstract fun getObjects ()Lkotlin/sequences/Sequence;
 	public abstract fun getPrimitiveArrayCount ()I
 	public abstract fun getPrimitiveArrays ()Lkotlin/sequences/Sequence;
+	public abstract fun getThreads ()Lkotlin/sequences/Sequence;
 	public abstract fun objectExists (J)Z
 }
 
@@ -151,6 +152,48 @@ public final class shark/HeapObject$HeapPrimitiveArray : shark/HeapObject {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class shark/HeapStackFrame {
+	public static final field Companion Lshark/HeapStackFrame$Companion;
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getLineNumber ()I
+	public final fun getLineNumberKind ()Lshark/HeapStackFrame$LineNumberKind;
+	public final fun getLocals ()Ljava/util/List;
+	public final fun getMethodName ()Ljava/lang/String;
+	public final fun getSourceFileName ()Ljava/lang/String;
+	public final fun toStackTraceElement ()Ljava/lang/StackTraceElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapStackFrame$Companion {
+}
+
+public final class shark/HeapStackFrame$LineNumberKind : java/lang/Enum {
+	public static final field COMPILED_METHOD Lshark/HeapStackFrame$LineNumberKind;
+	public static final field HAS_LINE_NUMBER Lshark/HeapStackFrame$LineNumberKind;
+	public static final field NATIVE_METHOD Lshark/HeapStackFrame$LineNumberKind;
+	public static final field NO_LINE_INFO Lshark/HeapStackFrame$LineNumberKind;
+	public static final field UNKNOWN_LOCATION Lshark/HeapStackFrame$LineNumberKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lshark/HeapStackFrame$LineNumberKind;
+	public static fun values ()[Lshark/HeapStackFrame$LineNumberKind;
+}
+
+public final class shark/HeapThread {
+	public static final field Companion Lshark/HeapThread$Companion;
+	public static final field UNKNOWN_THREAD_NAME Ljava/lang/String;
+	public final fun getGraph ()Lshark/HeapGraph;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStackTrace ()Ljava/util/List;
+	public final fun getThreadInstance ()Lshark/HeapObject$HeapInstance;
+	public final fun getThreadObject ()Lshark/GcRoot$ThreadObject;
+	public final fun stackTraceAsString ()Ljava/lang/String;
+	public final fun toStackTrace ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class shark/HeapThread$Companion {
+}
+
 public final class shark/HeapValue {
 	public fun <init> (Lshark/HeapGraph;Lshark/ValueHolder;)V
 	public final fun getAsBoolean ()Ljava/lang/Boolean;
@@ -193,6 +236,7 @@ public final class shark/HprofHeapGraph : shark/CloseableHeapGraph {
 	public fun getObjects ()Lkotlin/sequences/Sequence;
 	public fun getPrimitiveArrayCount ()I
 	public fun getPrimitiveArrays ()Lkotlin/sequences/Sequence;
+	public fun getThreads ()Lkotlin/sequences/Sequence;
 	public final fun lruCacheStats ()Ljava/lang/String;
 	public fun objectExists (J)Z
 }

--- a/shark/shark-graph/src/main/java/shark/HeapGraph.kt
+++ b/shark/shark-graph/src/main/java/shark/HeapGraph.kt
@@ -35,6 +35,14 @@ interface HeapGraph {
   val gcRoots: List<GcRoot>
 
   /**
+   * The threads that were running when the heap dump was captured, with their stack traces,
+   * reconstructed from the thread object and stack trace records present in JVM HPROF heap dumps.
+   *
+   * Empty for Android heap dumps, which don't contain thread stack trace records.
+   */
+  val threads: Sequence<HeapThread>
+
+  /**
    * Sequence of all objects in the heap dump.
    *
    * This sequence does not trigger any IO reads.

--- a/shark/shark-graph/src/main/java/shark/HeapThread.kt
+++ b/shark/shark-graph/src/main/java/shark/HeapThread.kt
@@ -1,6 +1,5 @@
 package shark
 
-import kotlin.LazyThreadSafetyMode.NONE
 import shark.HeapObject.HeapInstance
 
 /**
@@ -14,7 +13,7 @@ class HeapThread internal constructor(
   /**
    * The [GcRoot.ThreadObject] this thread was reconstructed from.
    */
-  val gcRoot: GcRoot.ThreadObject,
+  val threadObject: GcRoot.ThreadObject,
   private val hprofGraph: HprofHeapGraph
 ) {
 
@@ -25,29 +24,26 @@ class HeapThread internal constructor(
     get() = hprofGraph
 
   /**
-   * The [HeapInstance] (a `java.lang.Thread` or subclass) backing this thread. Never null:
-   * [HeapGraph.threads] only yields threads whose object exists in the heap dump.
+   * The [HeapInstance] (a `java.lang.Thread` or subclass) backing this thread.
    */
-  val threadInstance: HeapInstance by lazy(NONE) {
-    hprofGraph.findObjectById(gcRoot.id) as HeapInstance
-  }
+  val threadInstance: HeapInstance
+    get() = hprofGraph.findObjectById(threadObject.id) as HeapInstance
 
   /**
    * The thread name, read from the backing `java.lang.Thread` instance. A live JVM thread always
    * has a non-null name, so this falls back to [UNKNOWN_THREAD_NAME] only when the name can't be
    * resolved from the heap object (e.g. a malformed dump or a non-standard Thread subtype).
    */
-  val name: String by lazy(NONE) {
-    threadInstance["java.lang.Thread", "name"]?.value?.readAsJavaString() ?: UNKNOWN_THREAD_NAME
-  }
+  val name: String
+    get() =
+      threadInstance["java.lang.Thread", "name"]?.value?.readAsJavaString() ?: UNKNOWN_THREAD_NAME
 
   /**
    * This thread's stack trace, deepest call last (same order as the HPROF stack trace record).
    * Empty when the heap dump has no stack trace for this thread.
    */
-  val stackTrace: List<HeapStackFrame> by lazy(NONE) {
-    hprofGraph.readThreadStackTrace(gcRoot)
-  }
+  val stackTrace: List<HeapStackFrame>
+    get() = hprofGraph.readThreadStackTrace(threadObject)
 
   /**
    * Converts [stackTrace] into a list of [StackTraceElement], so the stack can be handed to
@@ -64,8 +60,8 @@ class HeapThread internal constructor(
   fun stackTraceAsString(): String {
     return buildString {
       append('"').append(name).append('"')
-      stackTrace.forEach { frame ->
-        append("\n\tat ").append(frame)
+      toStackTrace().forEach { element ->
+        append("\n\tat ").append(element)
       }
     }
   }
@@ -132,13 +128,24 @@ class HeapStackFrame internal constructor(
   /**
    * Converts this frame into a [StackTraceElement]. [className] falls back to an empty string when
    * unresolved, since [StackTraceElement] requires a non-null declaring class.
+   *
+   * The line number is translated from the HPROF encoding to the [StackTraceElement] one: HPROF
+   * uses `-3` for native methods, but [StackTraceElement] uses `-2` (its `isNativeMethod` sentinel),
+   * and HPROF's `-2` (compiled method) has no [StackTraceElement] equivalent. Non-positive HPROF
+   * values other than native therefore map to `-1` so [StackTraceElement] renders `(SourceFile)` or
+   * `(Unknown Source)` rather than a misleading negative line number.
    */
   fun toStackTraceElement(): StackTraceElement {
+    val stackTraceElementLineNumber = when (lineNumberKind) {
+      LineNumberKind.HAS_LINE_NUMBER -> lineNumber
+      LineNumberKind.NATIVE_METHOD -> NATIVE_METHOD_STACK_TRACE_ELEMENT
+      else -> UNKNOWN_STACK_TRACE_ELEMENT
+    }
     return StackTraceElement(
       className ?: "",
       methodName,
       sourceFileName,
-      lineNumber
+      stackTraceElementLineNumber
     )
   }
 
@@ -170,5 +177,9 @@ class HeapStackFrame internal constructor(
     private const val UNKNOWN_LOCATION = -1
     private const val COMPILED_METHOD = -2
     private const val NATIVE_METHOD = -3
+
+    // StackTraceElement's own line number sentinels, which differ from HPROF's.
+    private const val NATIVE_METHOD_STACK_TRACE_ELEMENT = -2
+    private const val UNKNOWN_STACK_TRACE_ELEMENT = -1
   }
 }

--- a/shark/shark-graph/src/main/java/shark/HeapThread.kt
+++ b/shark/shark-graph/src/main/java/shark/HeapThread.kt
@@ -1,0 +1,174 @@
+package shark
+
+import kotlin.LazyThreadSafetyMode.NONE
+import shark.HeapObject.HeapInstance
+
+/**
+ * A thread that was running when the heap dump was captured, reconstructed from the thread object
+ * and stack trace records present in JVM HPROF heap dumps.
+ *
+ * Android heap dumps do not contain stack trace records, so [HeapGraph.threads] is empty for them
+ * and [stackTrace] is empty here.
+ */
+class HeapThread internal constructor(
+  /**
+   * The [GcRoot.ThreadObject] this thread was reconstructed from.
+   */
+  val gcRoot: GcRoot.ThreadObject,
+  private val hprofGraph: HprofHeapGraph
+) {
+
+  /**
+   * The [HeapGraph] this thread belongs to.
+   */
+  val graph: HeapGraph
+    get() = hprofGraph
+
+  /**
+   * The [HeapInstance] (a `java.lang.Thread` or subclass) backing this thread. Never null:
+   * [HeapGraph.threads] only yields threads whose object exists in the heap dump.
+   */
+  val threadInstance: HeapInstance by lazy(NONE) {
+    hprofGraph.findObjectById(gcRoot.id) as HeapInstance
+  }
+
+  /**
+   * The thread name, read from the backing `java.lang.Thread` instance. A live JVM thread always
+   * has a non-null name, so this falls back to [UNKNOWN_THREAD_NAME] only when the name can't be
+   * resolved from the heap object (e.g. a malformed dump or a non-standard Thread subtype).
+   */
+  val name: String by lazy(NONE) {
+    threadInstance["java.lang.Thread", "name"]?.value?.readAsJavaString() ?: UNKNOWN_THREAD_NAME
+  }
+
+  /**
+   * This thread's stack trace, deepest call last (same order as the HPROF stack trace record).
+   * Empty when the heap dump has no stack trace for this thread.
+   */
+  val stackTrace: List<HeapStackFrame> by lazy(NONE) {
+    hprofGraph.readThreadStackTrace(gcRoot)
+  }
+
+  /**
+   * Converts [stackTrace] into a list of [StackTraceElement], so the stack can be handed to
+   * tooling that consumes JVM stack traces (loggers, crash reporters, IDE stack parsers, etc).
+   */
+  fun toStackTrace(): List<StackTraceElement> {
+    return stackTrace.map { it.toStackTraceElement() }
+  }
+
+  /**
+   * Renders this thread as a JVM-thread-dump-style block: the thread name followed by one
+   * `\tat <frame>` line per stack frame.
+   */
+  fun stackTraceAsString(): String {
+    return buildString {
+      append('"').append(name).append('"')
+      stackTrace.forEach { frame ->
+        append("\n\tat ").append(frame)
+      }
+    }
+  }
+
+  override fun toString(): String = stackTraceAsString()
+
+  companion object {
+    const val UNKNOWN_THREAD_NAME = "UNKNOWN"
+  }
+}
+
+/**
+ * A single frame of a [HeapThread]'s [HeapThread.stackTrace].
+ */
+class HeapStackFrame internal constructor(
+  /**
+   * The name of the class that declared the method for this frame, or null when the frame's class
+   * serial number doesn't resolve to a known class (e.g. synthetic or native frames).
+   */
+  val className: String?,
+  /**
+   * The name of the method for this frame.
+   */
+  val methodName: String,
+  /**
+   * The source file name for this frame, or null when not available.
+   */
+  val sourceFileName: String?,
+  /**
+   * The raw HPROF line number. This encodes more than a line number: positive values are an
+   * actual line number, while `0`, `-1`, `-2` and `-3` are sentinels. Use [lineNumberKind] to
+   * interpret it.
+   *
+   * See the HPROF binary format manual
+   * (https://hg.openjdk.org/jdk6/jdk6/jdk/raw-file/tip/src/share/demo/jvmti/hprof/manual.html) and
+   * OpenJDK `heapDumper.cpp`.
+   */
+  val lineNumber: Int,
+  /**
+   * The objects held as local variables in this frame, reconstructed from the
+   * [GcRoot.JavaFrame] / [GcRoot.JniLocal] roots that point into this frame.
+   */
+  val locals: List<HeapObject>
+) {
+
+  /**
+   * Interprets the [lineNumber] sentinel encoding. When this is [LineNumberKind.HAS_LINE_NUMBER],
+   * [lineNumber] holds the actual line number; otherwise [lineNumber] is a sentinel.
+   */
+  val lineNumberKind: LineNumberKind
+    get() = when (lineNumber) {
+      NO_LINE_INFO -> LineNumberKind.NO_LINE_INFO
+      UNKNOWN_LOCATION -> LineNumberKind.UNKNOWN_LOCATION
+      COMPILED_METHOD -> LineNumberKind.COMPILED_METHOD
+      NATIVE_METHOD -> LineNumberKind.NATIVE_METHOD
+      else -> if (lineNumber > 0) {
+        LineNumberKind.HAS_LINE_NUMBER
+      } else {
+        // Any other negative value isn't part of the documented encoding.
+        LineNumberKind.UNKNOWN_LOCATION
+      }
+    }
+
+  /**
+   * Converts this frame into a [StackTraceElement]. [className] falls back to an empty string when
+   * unresolved, since [StackTraceElement] requires a non-null declaring class.
+   */
+  fun toStackTraceElement(): StackTraceElement {
+    return StackTraceElement(
+      className ?: "",
+      methodName,
+      sourceFileName,
+      lineNumber
+    )
+  }
+
+  override fun toString(): String = toStackTraceElement().toString()
+
+  /**
+   * The kind of location information carried by a stack frame's [lineNumber], per the HPROF
+   * `HPROF_FRAME` line number encoding.
+   */
+  enum class LineNumberKind {
+    /** [lineNumber] holds an actual, positive line number. */
+    HAS_LINE_NUMBER,
+
+    /** No line information is available (raw line number `0`). */
+    NO_LINE_INFO,
+
+    /** Unknown location (raw line number `-1`). */
+    UNKNOWN_LOCATION,
+
+    /** Compiled method (raw line number `-2`). */
+    COMPILED_METHOD,
+
+    /** Native method (raw line number `-3`). */
+    NATIVE_METHOD,
+  }
+
+  companion object {
+    private const val NO_LINE_INFO = 0
+    private const val UNKNOWN_LOCATION = -1
+    private const val COMPILED_METHOD = -2
+    private const val NATIVE_METHOD = -3
+  }
+}

--- a/shark/shark-graph/src/main/java/shark/HprofHeapGraph.kt
+++ b/shark/shark-graph/src/main/java/shark/HprofHeapGraph.kt
@@ -78,48 +78,16 @@ class HprofHeapGraph internal constructor(
           .map { HeapThread(it, this) }
       }
 
-  /**
-   * Maps a thread serial number to a map of frame number to the object ids that are local
-   * variables of that frame, reconstructed from [GcRoot.JavaFrame] and [GcRoot.JniLocal] roots.
-   * Built lazily and only once, since it requires a full scan of the gc roots.
-   */
-  private val localObjectIdsByThreadAndFrame: Map<Int, Map<Int, List<Long>>> by lazy {
-    val result = HashMap<Int, HashMap<Int, MutableList<Long>>>()
-    index.gcRoots().forEach { gcRoot ->
-      val threadSerialNumber: Int
-      val frameNumber: Int
-      when (gcRoot) {
-        is GcRoot.JavaFrame -> {
-          threadSerialNumber = gcRoot.threadSerialNumber
-          frameNumber = gcRoot.frameNumber
-        }
-        is GcRoot.JniLocal -> {
-          threadSerialNumber = gcRoot.threadSerialNumber
-          frameNumber = gcRoot.frameNumber
-        }
-        else -> return@forEach
-      }
-      result.getOrPut(threadSerialNumber) { HashMap() }
-        .getOrPut(frameNumber) { mutableListOf() }
-        .add(gcRoot.id)
-    }
-    result
-  }
-
-  internal fun readThreadStackTrace(gcRoot: GcRoot.ThreadObject): List<HeapStackFrame> {
-    val stackTrace = index.stackTrace(gcRoot.stackTraceSerialNumber) ?: return emptyList()
-    val localsByFrame = localObjectIdsByThreadAndFrame[gcRoot.threadSerialNumber]
-    return stackTrace.stackFrameIds.asList().mapIndexedNotNull { frameNumber, frameId ->
-      val frameRecord = index.stackFrame(frameId) ?: return@mapIndexedNotNull null
-      val locals = localsByFrame?.get(frameNumber)
-        ?.mapNotNull { findObjectByIdOrNull(it) }
-        ?: emptyList()
+  internal fun readThreadStackTrace(threadObject: GcRoot.ThreadObject): List<HeapStackFrame> {
+    // The index resolves everything but the local variables, which need the graph to turn object
+    // ids into heap objects.
+    return index.readThreadStackTrace(threadObject).map { frame ->
       HeapStackFrame(
-        className = index.classNameBySerial(frameRecord.classSerialNumber),
-        methodName = index.hprofStringOrNull(frameRecord.methodNameStringId) ?: "",
-        sourceFileName = index.hprofStringOrNull(frameRecord.sourceFileNameStringId),
-        lineNumber = frameRecord.lineNumber,
-        locals = locals
+        className = frame.className,
+        methodName = frame.methodName,
+        sourceFileName = frame.sourceFileName,
+        lineNumber = frame.lineNumber,
+        locals = frame.localObjectIds.mapNotNull { findObjectByIdOrNull(it) }
       )
     }
   }

--- a/shark/shark-graph/src/main/java/shark/HprofHeapGraph.kt
+++ b/shark/shark-graph/src/main/java/shark/HprofHeapGraph.kt
@@ -63,6 +63,67 @@ class HprofHeapGraph internal constructor(
   override val gcRoots: List<GcRoot>
     get() = index.gcRoots()
 
+  override val threads: Sequence<HeapThread>
+    get() =
+      // Android heap dumps contain thread objects but no stack trace records, so there's no thread
+      // dump to expose. Gate on stack trace presence to keep this empty for those dumps.
+      if (!index.hasStackTraces) {
+        emptySequence()
+      } else {
+        index.threadObjects()
+          .asSequence()
+          // GC roots can point to objects that don't exist in the heap dump; skip those so that
+          // HeapThread.threadInstance is always resolvable.
+          .filter { objectExists(it.id) }
+          .map { HeapThread(it, this) }
+      }
+
+  /**
+   * Maps a thread serial number to a map of frame number to the object ids that are local
+   * variables of that frame, reconstructed from [GcRoot.JavaFrame] and [GcRoot.JniLocal] roots.
+   * Built lazily and only once, since it requires a full scan of the gc roots.
+   */
+  private val localObjectIdsByThreadAndFrame: Map<Int, Map<Int, List<Long>>> by lazy {
+    val result = HashMap<Int, HashMap<Int, MutableList<Long>>>()
+    index.gcRoots().forEach { gcRoot ->
+      val threadSerialNumber: Int
+      val frameNumber: Int
+      when (gcRoot) {
+        is GcRoot.JavaFrame -> {
+          threadSerialNumber = gcRoot.threadSerialNumber
+          frameNumber = gcRoot.frameNumber
+        }
+        is GcRoot.JniLocal -> {
+          threadSerialNumber = gcRoot.threadSerialNumber
+          frameNumber = gcRoot.frameNumber
+        }
+        else -> return@forEach
+      }
+      result.getOrPut(threadSerialNumber) { HashMap() }
+        .getOrPut(frameNumber) { mutableListOf() }
+        .add(gcRoot.id)
+    }
+    result
+  }
+
+  internal fun readThreadStackTrace(gcRoot: GcRoot.ThreadObject): List<HeapStackFrame> {
+    val stackTrace = index.stackTrace(gcRoot.stackTraceSerialNumber) ?: return emptyList()
+    val localsByFrame = localObjectIdsByThreadAndFrame[gcRoot.threadSerialNumber]
+    return stackTrace.stackFrameIds.asList().mapIndexedNotNull { frameNumber, frameId ->
+      val frameRecord = index.stackFrame(frameId) ?: return@mapIndexedNotNull null
+      val locals = localsByFrame?.get(frameNumber)
+        ?.mapNotNull { findObjectByIdOrNull(it) }
+        ?: emptyList()
+      HeapStackFrame(
+        className = index.classNameBySerial(frameRecord.classSerialNumber),
+        methodName = index.hprofStringOrNull(frameRecord.methodNameStringId) ?: "",
+        sourceFileName = index.hprofStringOrNull(frameRecord.sourceFileNameStringId),
+        lineNumber = frameRecord.lineNumber,
+        locals = locals
+      )
+    }
+  }
+
   override val objects: Sequence<HeapObject>
     get() {
       var objectIndex = 0

--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -4,7 +4,10 @@ import java.util.EnumSet
 import kotlin.math.max
 import shark.GcRoot
 import shark.GcRoot.StickyClass
+import shark.GcRoot.ThreadObject
 import shark.HprofHeader
+import shark.HprofRecord.StackFrameRecord
+import shark.HprofRecord.StackTraceRecord
 import shark.HprofRecordReader
 import shark.HprofRecordTag
 import shark.HprofRecordTag.CLASS_DUMP
@@ -28,6 +31,8 @@ import shark.HprofRecordTag.ROOT_THREAD_OBJECT
 import shark.HprofRecordTag.ROOT_UNKNOWN
 import shark.HprofRecordTag.ROOT_UNREACHABLE
 import shark.HprofRecordTag.ROOT_VM_INTERNAL
+import shark.HprofRecordTag.STACK_FRAME
+import shark.HprofRecordTag.STACK_TRACE
 import shark.HprofRecordTag.STRING_IN_UTF8
 import shark.HprofVersion.ANDROID
 import shark.OnHprofRecordTagListener
@@ -68,7 +73,19 @@ internal class HprofInMemoryIndex private constructor(
   val classFieldsReader: ClassFieldsReader,
   private val classFieldsIndexSize: Int,
   private val stickyClassGcRootIds: LongScatterSet,
+  private val stackFrames: LongObjectScatterMap<StackFrameRecord>,
+  private val stackTraces: LongObjectScatterMap<StackTraceRecord>,
+  private val classSerialNameStringIds: LongLongScatterMap,
+  private val threadObjects: List<ThreadObject>,
 ) {
+
+  /**
+   * True if the heap dump contained stack frame records, i.e. a usable thread dump (JVM heap
+   * dumps). False for Android heap dumps: they do contain a (frame-less) stack trace record per
+   * thread, but no stack frames, so there's no thread dump to reconstruct.
+   */
+  val hasStackTraces: Boolean
+    get() = !stackFrames.isEmpty
 
   val classCount: Int
     get() = classIndex.size
@@ -209,6 +226,50 @@ internal class HprofInMemoryIndex private constructor(
     return gcRoots
   }
 
+  /**
+   * The [ThreadObject] gc roots, collected separately from [gcRoots] so that thread enumeration
+   * doesn't require scanning all roots. Empty when the heap dump has no thread objects.
+   */
+  fun threadObjects(): List<ThreadObject> {
+    return threadObjects
+  }
+
+  fun stackTrace(stackTraceSerialNumber: Int): StackTraceRecord? {
+    return stackTraces[stackTraceSerialNumber.toLong()]
+  }
+
+  fun stackFrame(stackFrameId: Long): StackFrameRecord? {
+    return stackFrames[stackFrameId]
+  }
+
+  /**
+   * Resolves an hprof string by id (e.g. a stack frame method or source file name), or null if
+   * the id is unknown (including the 0 id used when no string is available).
+   */
+  fun hprofStringOrNull(stringId: Long): String? {
+    return hprofStringCache[stringId]
+  }
+
+  /**
+   * Resolves the name of the class that declared a stack frame, from the frame's class serial
+   * number (as recorded by LOAD_CLASS records). Returns null when the serial number doesn't
+   * resolve to a known class. Mirrors [className] but keyed by class serial number rather than
+   * class object id.
+   */
+  fun classNameBySerial(classSerialNumber: Int): String? {
+    val slot = classSerialNameStringIds.getSlot(classSerialNumber.toLong())
+    if (slot == -1) {
+      return null
+    }
+    val classNameStringId = classSerialNameStringIds.getSlotValue(slot)
+    val classNameString = hprofStringById(classNameStringId)
+    return (proguardMapping?.deobfuscateClassName(classNameString) ?: classNameString).run {
+      if (useForwardSlashClassPackageSeparator) {
+        replace('/', '.')
+      } else this
+    }
+  }
+
   fun objectAtIndex(index: Int): LongObjectPair<IndexedObject> {
     require(index > 0)
     if (index < classIndex.size) {
@@ -337,6 +398,10 @@ internal class HprofInMemoryIndex private constructor(
     val bytesForPrimitiveArraySize: Int,
     val classFieldsTotalBytes: Int,
     val stickyClassGcRootIds: LongScatterSet,
+    private val hasStackTraces: Boolean,
+    private val neededClassSerials: LongScatterSet,
+    stackFrameCount: Int,
+    stackTraceCount: Int,
   ) : OnHprofRecordTagListener {
 
     private val identifierSize = if (longIdentifiers) 8 else 4
@@ -392,6 +457,18 @@ internal class HprofInMemoryIndex private constructor(
       }
     }
 
+    // Thread / stack trace data. These maps stay empty for heap dumps without stack records
+    // (e.g. Android heap dumps), so they cost nothing there.
+    private val stackFrames = LongObjectScatterMap<StackFrameRecord>().apply {
+      ensureCapacity(stackFrameCount)
+    }
+    private val stackTraces = LongObjectScatterMap<StackTraceRecord>().apply {
+      ensureCapacity(stackTraceCount)
+    }
+    // Only sized for the classes actually referenced by stack frames, not every class in the dump.
+    private val classSerialNameStringIds = LongLongScatterMap(expectedElements = neededClassSerials.size())
+    private val threadObjects = mutableListOf<ThreadObject>()
+
     private fun HprofRecordReader.copyToClassFields(byteCount: Int) {
       for (i in 1..byteCount) {
         classFieldBytes[classFieldsIndex++] = readByte()
@@ -412,13 +489,17 @@ internal class HprofInMemoryIndex private constructor(
           hprofStringCache[reader.readId()] = reader.readUtf8(length - identifierSize)
         }
         LOAD_CLASS -> {
-          // classSerialNumber
-          reader.skip(INT.byteSize)
+          val classSerialNumber = reader.readInt()
           val id = reader.readId()
           // stackTraceSerialNumber
           reader.skip(INT.byteSize)
           val classNameStringId = reader.readId()
           classNames[id] = classNameStringId
+          // Only record the class name by serial number for the handful of classes referenced by
+          // stack frames. Skipped entirely for dumps without stack traces (e.g. Android).
+          if (hasStackTraces && classSerialNumber.toLong() in neededClassSerials) {
+            classSerialNameStringIds[classSerialNumber.toLong()] = classNameStringId
+          }
         }
         ROOT_UNKNOWN -> {
           reader.readUnknownGcRootRecord().apply {
@@ -477,8 +558,17 @@ internal class HprofInMemoryIndex private constructor(
           reader.readThreadObjectGcRootRecord().apply {
             if (id != ValueHolder.NULL_REFERENCE) {
               gcRoots += this
+              threadObjects += this
             }
           }
+        }
+        STACK_FRAME -> {
+          val record = reader.readStackFrameRecord()
+          stackFrames[record.id] = record
+        }
+        STACK_TRACE -> {
+          val record = reader.readStackTraceRecord()
+          stackTraces[record.stackTraceSerialNumber.toLong()] = record
         }
         ROOT_INTERNED_STRING -> {
           reader.readInternedStringGcRootRecord().apply {
@@ -666,6 +756,10 @@ internal class HprofInMemoryIndex private constructor(
         classFieldsReader = ClassFieldsReader(identifierSize, classFieldBytes),
         classFieldsIndexSize = classFieldsIndexSize,
         stickyClassGcRootIds = stickyClassGcRootIds,
+        stackFrames = stackFrames,
+        stackTraces = stackTraces,
+        classSerialNameStringIds = classSerialNameStringIds,
+        threadObjects = threadObjects,
       )
     }
   }
@@ -700,6 +794,11 @@ internal class HprofInMemoryIndex private constructor(
       var primitiveArrayCount = 0
       var classFieldsTotalBytes = 0
       val stickyClassGcRootIds = LongScatterSet()
+      var stackFrameCount = 0
+      var stackTraceCount = 0
+      // The class serial numbers actually referenced by stack frames. Collected here so that the
+      // second pass only records class names for this (tiny) subset rather than every class.
+      val neededClassSerials = LongScatterSet()
 
       val bytesRead = reader.readRecords(
         EnumSet.of(
@@ -707,9 +806,11 @@ internal class HprofInMemoryIndex private constructor(
           INSTANCE_DUMP,
           OBJECT_ARRAY_DUMP,
           PRIMITIVE_ARRAY_DUMP,
-          ROOT_STICKY_CLASS
+          ROOT_STICKY_CLASS,
+          STACK_FRAME,
+          STACK_TRACE
         )
-      ) { tag, _, reader ->
+      ) { tag, length, reader ->
         val bytesReadStart = reader.bytesRead
         when (tag) {
           CLASS_DUMP -> {
@@ -746,6 +847,15 @@ internal class HprofInMemoryIndex private constructor(
               stickyClassGcRootIds += id
             }
           }
+          STACK_FRAME -> {
+            stackFrameCount++
+            // We need the class serial number to later resolve the frame's declaring class name.
+            neededClassSerials += reader.readStackFrameRecord().classSerialNumber.toLong()
+          }
+          STACK_TRACE -> {
+            stackTraceCount++
+            reader.skip(length)
+          }
           else -> {
             // Not interesting.
           }
@@ -769,7 +879,11 @@ internal class HprofInMemoryIndex private constructor(
         bytesForObjectArraySize = bytesForObjectArraySize,
         bytesForPrimitiveArraySize = bytesForPrimitiveArraySize,
         classFieldsTotalBytes = classFieldsTotalBytes,
-        stickyClassGcRootIds
+        stickyClassGcRootIds = stickyClassGcRootIds,
+        hasStackTraces = stackFrameCount > 0,
+        neededClassSerials = neededClassSerials,
+        stackFrameCount = stackFrameCount,
+        stackTraceCount = stackTraceCount,
       )
 
       val recordTypes = EnumSet.of(
@@ -778,7 +892,10 @@ internal class HprofInMemoryIndex private constructor(
         CLASS_DUMP,
         INSTANCE_DUMP,
         OBJECT_ARRAY_DUMP,
-        PRIMITIVE_ARRAY_DUMP
+        PRIMITIVE_ARRAY_DUMP,
+        // Always requested; absent (so never delivered) in heap dumps without thread data.
+        STACK_FRAME,
+        STACK_TRACE
       ) + HprofRecordTag.rootTags.intersect(indexedGcRootTags)
 
       reader.readRecords(recordTypes, indexBuilderListener)

--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -53,6 +53,19 @@ import shark.internal.hppc.LongScatterSet
 import shark.internal.hppc.to
 
 /**
+ * A stack frame of a thread's stack trace, as reconstructed by
+ * [HprofInMemoryIndex.readThreadStackTrace]. Strings and the declaring class name are already
+ * resolved; [localObjectIds] are left as ids for the graph layer to resolve to heap objects.
+ */
+internal class ThreadStackFrame(
+  val className: String?,
+  val methodName: String,
+  val sourceFileName: String?,
+  val lineNumber: Int,
+  val localObjectIds: List<Long>
+)
+
+/**
  * This class is not thread safe, should be used from a single thread.
  */
 internal class HprofInMemoryIndex private constructor(
@@ -234,19 +247,73 @@ internal class HprofInMemoryIndex private constructor(
     return threadObjects
   }
 
-  fun stackTrace(stackTraceSerialNumber: Int): StackTraceRecord? {
-    return stackTraces[stackTraceSerialNumber.toLong()]
+  /**
+   * Reconstructs the stack trace of [threadObject] from the stack trace and stack frame records in
+   * the heap dump, resolving method names, source files and declaring class names. Each frame also
+   * carries the object ids of its local variables (from [GcRoot.JavaFrame] / [GcRoot.JniLocal]
+   * roots); resolving those ids to heap objects is left to the caller, which holds the graph.
+   * Returns an empty list when the dump has no stack trace for this thread.
+   */
+  fun readThreadStackTrace(threadObject: ThreadObject): List<ThreadStackFrame> {
+    val stackTrace = stackTraces[threadObject.stackTraceSerialNumber.toLong()] ?: return emptyList()
+    val threadSerialNumber = threadObject.threadSerialNumber
+    return stackTrace.stackFrameIds.asList().mapIndexedNotNull { frameNumber, frameId ->
+      val frameRecord = stackFrames[frameId] ?: return@mapIndexedNotNull null
+      val localObjectIds =
+        localObjectIdsByThreadAndFrame[packThreadAndFrame(threadSerialNumber, frameNumber)]
+          ?: emptyList<Long>()
+      ThreadStackFrame(
+        className = classNameBySerial(frameRecord.classSerialNumber),
+        methodName = hprofStringOrNull(frameRecord.methodNameStringId) ?: "",
+        sourceFileName = hprofStringOrNull(frameRecord.sourceFileNameStringId),
+        lineNumber = frameRecord.lineNumber,
+        localObjectIds = localObjectIds
+      )
+    }
   }
 
-  fun stackFrame(stackFrameId: Long): StackFrameRecord? {
-    return stackFrames[stackFrameId]
+  /**
+   * Maps a packed (thread serial number, frame number) key (see [packThreadAndFrame]) to the object
+   * ids that are local variables of that frame, reconstructed from [GcRoot.JavaFrame] and
+   * [GcRoot.JniLocal] roots. Built lazily on the first thread stack trace read, since it requires a
+   * full scan of the gc roots.
+   */
+  private val localObjectIdsByThreadAndFrame: LongObjectScatterMap<MutableList<Long>> by lazy {
+    val result = LongObjectScatterMap<MutableList<Long>>()
+    gcRoots.forEach { gcRoot ->
+      val threadSerialNumber: Int
+      val frameNumber: Int
+      when (gcRoot) {
+        is GcRoot.JavaFrame -> {
+          threadSerialNumber = gcRoot.threadSerialNumber
+          frameNumber = gcRoot.frameNumber
+        }
+        is GcRoot.JniLocal -> {
+          threadSerialNumber = gcRoot.threadSerialNumber
+          frameNumber = gcRoot.frameNumber
+        }
+        else -> return@forEach
+      }
+      val key = packThreadAndFrame(threadSerialNumber, frameNumber)
+      val locals = result[key] ?: mutableListOf<Long>().also { result[key] = it }
+      locals.add(gcRoot.id)
+    }
+    result
+  }
+
+  /** Packs a thread serial number and a frame number into a single map key. */
+  private fun packThreadAndFrame(
+    threadSerialNumber: Int,
+    frameNumber: Int
+  ): Long {
+    return (threadSerialNumber.toLong() shl 32) or (frameNumber.toLong() and 0xFFFFFFFFL)
   }
 
   /**
    * Resolves an hprof string by id (e.g. a stack frame method or source file name), or null if
    * the id is unknown (including the 0 id used when no string is available).
    */
-  fun hprofStringOrNull(stringId: Long): String? {
+  private fun hprofStringOrNull(stringId: Long): String? {
     return hprofStringCache[stringId]
   }
 
@@ -256,7 +323,7 @@ internal class HprofInMemoryIndex private constructor(
    * resolve to a known class. Mirrors [className] but keyed by class serial number rather than
    * class object id.
    */
-  fun classNameBySerial(classSerialNumber: Int): String? {
+  private fun classNameBySerial(classSerialNumber: Int): String? {
     val slot = classSerialNameStringIds.getSlot(classSerialNumber.toLong())
     if (slot == -1) {
       return null

--- a/shark/shark-graph/src/test/java/shark/JvmThreadDumpStackTraceEqualityTest.kt
+++ b/shark/shark-graph/src/test/java/shark/JvmThreadDumpStackTraceEqualityTest.kt
@@ -1,0 +1,121 @@
+package shark
+
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.locks.LockSupport
+import kotlin.time.Duration.Companion.seconds
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.HprofHeapGraph.Companion.openHeapGraph
+
+/**
+ * Captures the live JVM stack trace of a worker thread parked at a known point, then dumps the
+ * heap and reconstructs that same thread's stack trace from the dump, and asserts the two agree
+ * from the worker method down — both as [StackTraceElement]s and as rendered strings.
+ *
+ * This lives in its own class (rather than in [JvmThreadDumpTest]) because it needs the worker to
+ * stay parked at a known point while both the live capture and the heap dump happen.
+ *
+ * The comparison starts at the worker method rather than the very top of the stack: the frames
+ * above it are JVM park internals that aren't guaranteed to be recorded identically by the live
+ * thread dump API and the HPROF format. Live [StackTraceElement]s are also normalized to drop the
+ * module name / version that the JVM attaches to `java.base` frames (e.g. `Thread.run`), since
+ * those can't be reconstructed from a heap dump. The worker is driven by a named [ParkingWorker]
+ * rather than a lambda so that every frame from the worker method down is a real declared method
+ * (a lambda shows up as a JVM hidden class whose name carries an environment-specific hash).
+ */
+class JvmThreadDumpStackTraceEqualityTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  private val threadName = "shark-thread-dump-equality-test"
+  private val workerMethodName = "blockHoldingSentinel"
+
+  private lateinit var workerThread: Thread
+  private lateinit var graph: CloseableHeapGraph
+  private lateinit var liveStackTrace: List<StackTraceElement>
+  private val parkedLatch = CountDownLatch(1)
+
+  @Volatile
+  private var keepRunning = true
+
+  /** Named Runnable so the worker's caller frame is a real method, not a lambda hidden class. */
+  private inner class ParkingWorker : Runnable {
+    override fun run() {
+      blockHoldingSentinel()
+    }
+  }
+
+  @Before fun setUp() {
+    workerThread = Thread(ParkingWorker(), threadName).apply {
+      isDaemon = true
+      start()
+    }
+    parkedLatch.await()
+    waitUntilParked(workerThread)
+
+    // Capture the live stack trace while the worker is parked, then dump the heap while it stays
+    // parked at the exact same point, so the two views observe the same stack.
+    liveStackTrace = workerThread.stackTrace.asList()
+
+    val hprofFile = File(testFolder.newFolder(), "jvm_heap.hprof")
+    JvmTestHeapDumper.dumpHeap(hprofFile.absolutePath)
+    graph = hprofFile.openHeapGraph()
+  }
+
+  @After fun tearDown() {
+    if (::graph.isInitialized) {
+      graph.close()
+    }
+    keepRunning = false
+    if (::workerThread.isInitialized) {
+      LockSupport.unpark(workerThread)
+      workerThread.join(1.seconds.inWholeMilliseconds)
+    }
+  }
+
+  private fun blockHoldingSentinel() {
+    parkedLatch.countDown()
+    while (keepRunning) {
+      LockSupport.park()
+    }
+  }
+
+  private fun waitUntilParked(thread: Thread) {
+    val deadline = System.currentTimeMillis() + 5.seconds.inWholeMilliseconds
+    while (thread.state != Thread.State.WAITING && System.currentTimeMillis() < deadline) {
+      Thread.sleep(1)
+    }
+  }
+
+  private fun dumpedThread() = graph.threads.single { it.name == threadName }
+
+  /** Everything from the worker method down, so we skip the volatile park internals on top. */
+  private fun List<StackTraceElement>.fromWorkerMethod(): List<StackTraceElement> {
+    return dropWhile { it.methodName != workerMethodName }
+  }
+
+  /** Rebuilds an element without module name / version, which a heap dump can't reconstruct. */
+  private fun StackTraceElement.withoutModule(): StackTraceElement {
+    return StackTraceElement(className, methodName, fileName, lineNumber)
+  }
+
+  @Test fun `reconstructed stack trace equals live stack trace from worker frame down`() {
+    val expected = liveStackTrace.fromWorkerMethod().map { it.withoutModule() }
+    val actual = dumpedThread().toStackTrace().fromWorkerMethod()
+
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test fun `reconstructed stack trace renders like live stack trace from worker frame down`() {
+    val expected = liveStackTrace.fromWorkerMethod().joinToString("\n") { it.withoutModule().toString() }
+    val actual = dumpedThread().toStackTrace().fromWorkerMethod().joinToString("\n")
+
+    assertThat(actual).isEqualTo(expected)
+  }
+}

--- a/shark/shark-graph/src/test/java/shark/JvmThreadDumpTest.kt
+++ b/shark/shark-graph/src/test/java/shark/JvmThreadDumpTest.kt
@@ -1,0 +1,114 @@
+package shark
+
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.locks.LockSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.HprofHeapGraph.Companion.openHeapGraph
+
+/**
+ * Dumps the heap of this live JVM while a known thread is parked inside a known method holding a
+ * sentinel local, then asserts that the reconstructed thread dump exposes that thread, its stack
+ * trace and its local variables. Each test asserts a single thing; the (expensive) heap dump is
+ * done once in [setUp].
+ */
+class JvmThreadDumpTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  /** A distinctive type so we can recognize the parked thread's local variable in the heap dump. */
+  class Sentinel
+
+  private val threadName = "shark-thread-dump-test"
+  private val workerMethodName = "blockHoldingSentinel"
+  private val sentinelClassName = Sentinel::class.java.name
+
+  private lateinit var workerThread: Thread
+  private lateinit var graph: CloseableHeapGraph
+  private val parkedLatch = CountDownLatch(1)
+
+  @Volatile
+  private var keepRunning = true
+
+  @Before fun setUp() {
+    workerThread = Thread({ blockHoldingSentinel() }, threadName).apply {
+      isDaemon = true
+      start()
+    }
+    // Wait until the worker reached blockHoldingSentinel (and thus has the sentinel local on its
+    // stack) before dumping the heap.
+    parkedLatch.await()
+
+    val hprofFile = File(testFolder.newFolder(), "jvm_heap.hprof")
+    JvmTestHeapDumper.dumpHeap(hprofFile.absolutePath)
+    graph = hprofFile.openHeapGraph()
+  }
+
+  @After fun tearDown() {
+    if (::graph.isInitialized) {
+      graph.close()
+    }
+    keepRunning = false
+    if (::workerThread.isInitialized) {
+      LockSupport.unpark(workerThread)
+      workerThread.join(SECONDS_TO_MILLIS)
+    }
+  }
+
+  @Suppress("UNUSED_VARIABLE")
+  private fun blockHoldingSentinel() {
+    val sentinel = Sentinel()
+    parkedLatch.countDown()
+    while (keepRunning) {
+      LockSupport.park()
+    }
+    // Reference the sentinel after the loop so it stays a live local while the thread is parked.
+    check(sentinel.hashCode() != 0 || true)
+  }
+
+  private fun dumpedThread() = graph.threads.single { it.name == threadName }
+
+  @Test fun `finds thread by name`() {
+    assertThat(graph.threads.map { it.name }.toList()).contains(threadName)
+  }
+
+  @Test fun `thread stack trace contains worker frame`() {
+    val workerFrame = dumpedThread().stackTrace.firstOrNull { it.methodName == workerMethodName }
+
+    assertThat(workerFrame).isNotNull
+    assertThat(workerFrame!!.className).isEqualTo(JvmThreadDumpTest::class.java.name)
+  }
+
+  @Test fun `frame exposes local variable`() {
+    val locals = dumpedThread().stackTrace.flatMap { it.locals }
+
+    val sentinelLocal = locals
+      .filterIsInstance<HeapObject.HeapInstance>()
+      .firstOrNull { it.instanceClassName == sentinelClassName }
+
+    assertThat(sentinelLocal).isNotNull
+  }
+
+  @Test fun `toStackTrace produces stack trace elements`() {
+    val elements = dumpedThread().toStackTrace()
+
+    assertThat(elements.map { it.methodName }).contains(workerMethodName)
+  }
+
+  @Test fun `stack trace as string renders jvm style`() {
+    val rendered = dumpedThread().stackTraceAsString()
+
+    assertThat(rendered).contains(threadName)
+    assertThat(rendered).contains("\tat ${JvmThreadDumpTest::class.java.name}.$workerMethodName")
+  }
+
+  companion object {
+    private const val SECONDS_TO_MILLIS = 1000L
+  }
+}

--- a/shark/shark-graph/src/test/java/shark/JvmThreadDumpTest.kt
+++ b/shark/shark-graph/src/test/java/shark/JvmThreadDumpTest.kt
@@ -3,6 +3,7 @@ package shark
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.LockSupport
+import kotlin.time.Duration.Companion.seconds
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -57,7 +58,7 @@ class JvmThreadDumpTest {
     keepRunning = false
     if (::workerThread.isInitialized) {
       LockSupport.unpark(workerThread)
-      workerThread.join(SECONDS_TO_MILLIS)
+      workerThread.join(1.seconds.inWholeMilliseconds)
     }
   }
 
@@ -106,9 +107,5 @@ class JvmThreadDumpTest {
 
     assertThat(rendered).contains(threadName)
     assertThat(rendered).contains("\tat ${JvmThreadDumpTest::class.java.name}.$workerMethodName")
-  }
-
-  companion object {
-    private const val SECONDS_TO_MILLIS = 1000L
   }
 }


### PR DESCRIPTION
## Summary

JVM HPROF heap dumps carry thread object and stack trace records that Shark parsed at the byte level but then discarded — there was no way to ask the graph "what were the live threads and their stack traces?". This adds a queryable `HeapGraph.threads` API that reconstructs the live threads, their stack traces and per-frame local variables from those records.

Requested in #2830 and tracked in #2842.

## Design

The feature is **presence-based, not version-based**: the index detects `STACK_FRAME` records during the counting (phase 1) pass and only captures thread data when they exist. Android heap dumps contain (frame-less) thread objects but no stack frames, so `threads` is empty for them and there is zero indexing overhead.

### Index layer — `HprofInMemoryIndex`
- Capture `STACK_FRAME` / `STACK_TRACE` records and `ThreadObject` roots (the latter into a dedicated list so thread enumeration doesn't rescan all roots).
- Resolve each frame's declaring class via a `classSerial → className` map that is sized only to the handful of classes actually referenced by frames — phase 1 collects the needed class serials, phase 2 fills only those. No per-class-in-heap cost.
- New internal accessors: `hasStackTraces`, `threadObjects()`, `stackTrace()`, `stackFrame()`, `hprofStringOrNull()`, `classNameBySerial()`.

### Public API — `shark-graph`
- `HeapGraph.threads: Sequence<HeapThread>` — empty for Android dumps.
- `HeapThread`: `name` (non-null, falls back to `UNKNOWN`), non-null `threadInstance`, `stackTrace`, `toStackTrace(): List<StackTraceElement>`, `stackTraceAsString()`.
- `HeapStackFrame`: `className` (nullable), `methodName`, `sourceFileName`, raw `lineNumber`, a `lineNumberKind` enum decoding the HPROF `HPROF_FRAME` line-number sentinels (`0` no line info, `-1` unknown, `-2` compiled, `-3` native), per-frame `locals` (from `JavaFrame` / `JniLocal` roots), and `toStackTraceElement()`.

## Tests
- `JvmThreadDumpTest` (shark-graph): dumps this live JVM's heap with a known daemon thread parked inside a named worker method holding a sentinel local, then asserts the reconstructed thread dump exposes that thread, its worker frame, the sentinel local, and the JVM-style rendering. One assertion per test; the heap is dumped once.
- `AndroidThreadDumpTest` (shark-android): opens an Android fixture and asserts `graph.threads` is empty.

All shark module test suites pass and detekt reports 0 code smells.

Closes #2842

🤖 Generated with [Claude Code](https://claude.com/claude-code)