### PR TITLE
Stop caching the AVD after the instrumentation tests have run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,15 +58,13 @@ jobs:
           distribution: 'zulu'
       - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
       - name: AVD cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         id: avd-cache
         with:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-cached-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}-${{ hashFiles('**/libs.versions.toml') }}
-          restore-keys: |
-            avd-cached-${{ matrix.api-level }}-${{ matrix.os }}-${{ matrix.target }}-
+          key: avd-cached-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
@@ -74,11 +72,21 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
-          # FORCE true here ensures if 'actions/cache' restored old avd, we wipe and start with a fresh image for the new dependency hash.
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-load
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
+      # Save the snapshot here rather than at the end of the job. The test step below force-kills
+      # the emulator, which leaves the AVD directory in a state that is not safe to restore, and
+      # cache entries are immutable: caching it once breaks every later run on the same key.
+      - name: Save AVD cache
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-cached-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
       - name: Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
The instrumentation test step force-kills qemu at the end of its script, to work around a 20 minute emulator shutdown hang on API 26. The AVD directory is then saved by the post step of `actions/cache`, so what ends up cached is whatever state the emulator was killed in.

Cache entries are immutable, so once a bad snapshot lands under a key, every later run that restores it fails identically:

```
Boot completed in 2996 ms
adb ... shell input keyevent 82
##[error]The process '.../adb' failed with exit code 137
Terminate Emulator → adb emu kill
Wait for emulator (pid 2759) 20 seconds to shutdown gracefully
... 28 minutes ...
##[error]The operation was canceled.
```

The action aborts on the `adb` failure and goes straight to teardown, so the test script never runs, and the emulator then hangs until the job hits `timeout-minutes: 30`. The `pkill` workaround lives inside that script, so it cannot help here — it only ever runs on the happy path, which is exactly how it poisoned the cache in the first place.

This happened on #2841: its cache entry was written at 21:29 by the last passing run and every run after that timed out. Deleting the entry by hand fixed it, and the same job then passed in 7m40s.

Two changes:

- Split `actions/cache` into `restore` + `save`, and save right after the snapshot is generated rather than at the end of the job. A post-test AVD is never cached.
- Drop the `libs.versions.toml` hash from the key. An AVD depends on the API level, architecture and target, not on the project's dependency versions — hashing them rebuilt all five AVDs (~1 GB each) on every dependency change, and scoped the bad entry to whichever branch created it, which is why this looked branch-specific. The old key also interpolated `matrix.os`, which this matrix does not define, leaving an empty segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)