### PR TITLE
Fix HeapGraph.findObjectByIndex(0) throwing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Please thank our [contributors](https://github.com/square/leakcanary/graphs/cont
 
 ## Unreleased
 
+* 💥 `HeapGraph.findObjectByIndex(0)` threw an `IllegalArgumentException` instead of returning the first object of the heap dump.
 * 🐛 [#2857](https://github.com/square/leakcanary/pull/2857) Retained fragments were reported as not leaking with androidx.fragment 1.1.0 and higher.
 * 💥 Opening the overflow menu in the LeakCanary activity crashed apps that wrap `Window.Callback`, because the framework decor action bar calls `Window.Callback.onMenuOpened()` with a `null` menu ([b/188568911](https://issuetracker.google.com/issues/188568911)) even though that parameter is annotated as non null, which Kotlin wrappers rightfully null check. The LeakCanary activity now hosts its own `Toolbar` instead of using the decor action bar, so `onMenuOpened()` is never called.
 * 🐛 [#1789](https://github.com/square/leakcanary/issues/1789) When running the analysis in a separate process (`leakcanary-android-process`), the `HeapAnalysisDone` event was dispatched in the `:leakcanary` process, so it never reached the `LeakCanary.Config.eventListeners` configured in the main process. The `:leakcanary` process now stores the analysis in LeakCanary's database and a chained WorkManager worker dispatches the event from the main process, which also means the event still gets dispatched if the main process dies while the analysis is running.

--- a/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/HprofInMemoryIndex.kt
@@ -338,7 +338,7 @@ internal class HprofInMemoryIndex private constructor(
   }
 
   fun objectAtIndex(index: Int): LongObjectPair<IndexedObject> {
-    require(index > 0)
+    require(index >= 0)
     if (index < classIndex.size) {
       val objectId = classIndex.keyAt(index)
       val array = classIndex.getAtIndex(index)

--- a/shark/shark-graph/src/test/java/shark/HprofIndexParsingTest.kt
+++ b/shark/shark-graph/src/test/java/shark/HprofIndexParsingTest.kt
@@ -64,6 +64,18 @@ class HprofIndexParsingTest {
     }
   }
 
+  @Test fun `findObjectByIndex supports index 0`() {
+    val bytes = dump {
+      instance(clazz("com.example.MyClass1"))
+    }
+
+    bytes.openHeapGraph().use { graph ->
+      val firstObject = graph.findObjectByIndex(0)
+
+      assertThat(firstObject.objectId).isEqualTo(graph.objects.first().objectId)
+    }
+  }
+
   @Test fun `indexedObjectOrNull index round trips through objectAtIndex for primitive arrays`() {
     // The global index returned by indexedObjectOrNull is the concatenation of class, instance,
     // object array and primitive array indexes. The offset for primitive arrays must add the


### PR DESCRIPTION
`HprofHeapGraph.findObjectByIndex` documents and range checks its argument as `0 until objectCount`:

```kotlin
require(objectIndex in 0 until objectCount) {
  "$objectIndex should be in range [0, $objectCount["
}
```

but the `HprofInMemoryIndex.objectAtIndex` it delegates to required `index > 0`, so asking for the first object of the heap dump threw an `IllegalArgumentException` instead.

Found while reviewing #2800, which carried this fix bundled with unrelated work. Its two other `HprofInMemoryIndex` off by one fixes have since landed on main independently, so this is the last one left.
