### PR TITLE
Install git hooks from a git worktree

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -389,7 +389,17 @@ abstract class AndroidAbiUpdateTask : DefaultTask() {
 //Git hook installation
 tasks.register<Copy>("installGitHooks") {
   from(File(rootProject.rootDir, "config/hooks"))
-  into({ File(rootProject.rootDir, ".git/hooks") })
+  // Not rootDir/.git/hooks: in a git worktree .git is a file, not a directory, and the hooks live
+  // in the main checkout. git rev-parse --git-common-dir resolves to the right place in both cases.
+  into({
+    val gitCommonDir = providers.exec {
+      commandLine("git", "rev-parse", "--git-common-dir")
+      workingDir = rootProject.rootDir
+    }.standardOutput.asText.get().trim()
+    // The path is relative to rootDir in a normal checkout and absolute in a worktree. resolve()
+    // handles both: it returns the argument as is when it's already rooted.
+    rootProject.rootDir.resolve(gitCommonDir).resolve("hooks")
+  })
   filePermissions {
     unix("rwxrwxrwx") // Make files executable
   }


### PR DESCRIPTION
`installGitHooks` copies into `rootDir/.git/hooks`, which doesn't exist in a git worktree: there `.git` is a *file* pointing at the main checkout. Every module's `assemble` and `clean` depend on `installGitHooks`, so no Gradle build can run from a worktree at all:

```
* What went wrong:
A problem was found with the configuration of task ':installGitHooks' (type 'Copy').
  - Type 'org.gradle.api.tasks.Copy' property 'destinationDir' is not writable because
    '<root>/.git/hooks' ancestor '<root>/.git' is not a directory.

    Reason: Expected '<root>/.git' to be a directory but it's a file.
```

`git rev-parse --git-common-dir` resolves to `.git` in a normal checkout and to the main checkout's `.git` in a worktree, which is where the hooks belong in both cases.

Found while reviewing #2800, which carried this fix bundled with unrelated work.
