### PR TITLE
Add a root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@ A memory leak detection library for Android, plus Shark, the heap analyzer under
 to Maven Central and consumed by a very large number of apps, so **the public API and the bytecode
 level are contracts**, not implementation details.
 
+Not equally, though. The `leakcanary*` modules are what apps depend on directly, and their public API
+is the contract that matters most: breaking backward compatibility there is a last resort. `shark*` is
+used far less, so a breaking change is on the table there when it buys a meaningful improvement. In
+both cases the ABI dump is what makes the break deliberate instead of a surprise, so propose it rather
+than assuming it's fine.
+
 This file records what an agent would get wrong from reading the source alone. Anything derivable by
 reading the code belongs in the code, not here — please keep it that way when editing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,22 +79,15 @@ before pushing rather than discovering it at push time.
 
 ## Changelog
 
-Entries go in `docs/changelog.md` under `## Unreleased`. Nothing in the repo documents the emoji
-legend, so:
+Entries go in `docs/changelog.md` under `## Unreleased`, each starting with one of the markers from
+the legend at the top of that file. Pick the marker from what the change *is*, not from how big it
+feels, and grep for a comparable existing entry rather than guessing.
 
-| | Means |
-| --- | --- |
-| 💥 | **A crash fix, and nothing else.** Something used to crash and no longer does. |
-| 🐛 | Bug fix |
-| 🔨 | Improvement or non-bug change |
-| 🐤 | A newly recognized leak in a library or manufacturer ROM |
-
-**Breaking changes and behavior changes get no emoji.** Write them as a plain bullet, or as a
-`### Breaking change: <summary>` heading with prose when they need explaining.
-
-The most common mistake is reaching for 💥 because a change feels impactful. That inverts the
-marker's meaning — it tells readers a crash was fixed when nothing crashed. Pick the emoji from what
-the change *is*, not how big it feels, and grep for a comparable existing entry rather than guessing.
+**💥 means a crash fix here, not a breaking change** — the opposite of the
+[gitmoji](https://gitmoji.dev/) convention, and the mistake that convention trips people into.
+Reaching for 💥 because a change feels impactful tells readers a crash was fixed when nothing
+crashed. Breaking changes are ⚠️; when one needs more than a bullet, write it as a
+`### Breaking change: <summary>` heading with prose.
 
 **The changelog is for changes that matter to the people consuming LeakCanary**, not a record of
 every diff. Refactors, internal cleanups and test-only changes usually don't need an entry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# LeakCanary — agent guide
+
+A memory leak detection library for Android, plus Shark, the heap analyzer underneath it. Published
+to Maven Central and consumed by a very large number of apps, so **the public API and the bytecode
+level are contracts**, not implementation details.
+
+This file records what an agent would get wrong from reading the source alone. Anything derivable by
+reading the code belongs in the code, not here — please keep it that way when editing.
+
+## Layout
+
+| Directory | What's in it |
+| --- | --- |
+| `shark/` | Heap dump parsing and analysis. Plain JVM, no Android dependency, except `shark-android` which adds Android specific reference readers and matchers. |
+| `object-watcher/` | Watches objects for retention. The lowest layer, usable on its own. |
+| `leakcanary/` | The Android library, plus `leakcanary-app*`, a standalone UI app that is not part of the library. |
+| `plumber/` | Fixes for known Android framework leaks, installed automatically. |
+| `samples/` | Sample app. |
+| `docs/` | The [documentation site](https://square.github.io/leakcanary/) content. |
+
+The group directories (`shark/`, `leakcanary/`, …) hold no code of their own — only modules do.
+
+## Build and test
+
+`docs/dev-env.md` is the contributor setup guide — code style, local deployment, examples of the
+synthetic heap dump DSL. Read it for anything this section doesn't cover.
+
+Built with **Java 17**, targeting **Java 8 bytecode** repo wide. Both matter: consumers still on
+Java 8 have to be able to use the artifacts.
+
+```bash
+./gradlew build                       # what CI runs
+./gradlew :shark:shark:test           # one module's unit tests
+./gradlew detekt                      # static analysis, also run by the pre-push hook
+./gradlew updateKotlinAbi             # after any public API change, see below
+./gradlew siteDokka                   # regenerate docs/api
+```
+
+Instrumentation tests need a device or emulator and only cover `leakcanary-android`,
+`leakcanary-android-core` and `leakcanary-android-instrumentation`. CI runs them on API 24, 26, 31,
+33 and 34, so a change that only works on newer APIs will fail there rather than locally.
+
+## Things that will bite you
+
+**Public API changes fail the build until the ABI dump is updated.** `checkKotlinAbi` compares the
+public ABI against the committed `api/*.api` files and runs as part of `check`, so `./gradlew build`
+catches it. When it fails, run `./gradlew updateKotlinAbi` and commit the changed `api/*.api` files —
+but read the diff first, because an unintended ABI change is exactly what this is meant to catch.
+Modules with no public API are exempt; they're listed in `modulesWithoutPublicApi` in the root
+`build.gradle.kts`.
+
+**There are two ABI validation mechanisms, deliberately sharing task names** so that one command
+covers the whole repo: the Kotlin Gradle plugin's `abiValidation()` for JVM modules, and an
+equivalent pair of tasks hand-rolled in the root `build.gradle.kts` for Android library modules,
+which KGP doesn't support yet ([KT-83410](https://youtrack.jetbrains.com/issue/KT-83410)).
+
+**So use `checkKotlinAbi`/`updateKotlinAbi`, never `checkLegacyAbi`/`updateLegacyAbi`.** The `Legacy`
+pair is what Kotlin's own ABI validation documentation calls these tasks, but here they come straight
+from KGP and therefore exist *only on the JVM modules* — they silently skip every Android library
+module, which is most of the published ones. A green `updateLegacyAbi` means less than half the repo
+was covered.
+
+**`docs/api/` is generated.** It's Dokka output committed to the repo, produced by
+`./gradlew siteDokka`. Never hand-edit those files; fix the KDoc in the source instead.
+
+**Some dependency versions are deliberately old.** The `compileOnly` AndroidX versions in
+`gradle/libs.versions.toml` are pinned to the *lowest* version LeakCanary supports, so that apps
+resolve to their own newer version without needing a resolution strategy. The inline comments say
+which ones and why. Don't bump them to fix a warning.
+
+**`HprofRetainedHeapPerfTest` and `HprofIOPerfTest` freeze exact numbers** — bytes read, and memory
+retained at each analysis step, within a margin. A change to how the analysis allocates or reads will
+fail them. That's the point: they exist to make memory and I/O regressions visible. Investigate
+before adjusting the expected values, and say in the PR why the new number is correct.
+
+**detekt runs on pre-push and in CI**, config at `config/detekt-config.yml`. The hook installs itself
+via the `assemble` and `clean` tasks, so a fresh clone gets it after the first build. Run `detekt`
+before pushing rather than discovering it at push time.
+
+## Changelog
+
+Entries go in `docs/changelog.md` under `## Unreleased`. Nothing in the repo documents the emoji
+legend, so:
+
+| | Means |
+| --- | --- |
+| 💥 | **A crash fix, and nothing else.** Something used to crash and no longer does. |
+| 🐛 | Bug fix |
+| 🔨 | Improvement or non-bug change |
+| 🐤 | A newly recognized leak in a library or manufacturer ROM |
+
+**Breaking changes and behavior changes get no emoji.** Write them as a plain bullet, or as a
+`### Breaking change: <summary>` heading with prose when they need explaining.
+
+The most common mistake is reaching for 💥 because a change feels impactful. That inverts the
+marker's meaning — it tells readers a crash was fixed when nothing crashed. Pick the emoji from what
+the change *is*, not how big it feels, and grep for a comparable existing entry rather than guessing.
+
+**The changelog is for changes that matter to the people consuming LeakCanary**, not a record of
+every diff. Refactors, internal cleanups and test-only changes usually don't need an entry.
+
+## Conventions
+
+- When a function's parameters don't fit on one line, put **each on its own line** — the existing
+  code is consistent about this and detekt won't tell you.
+- Commit subjects are imperative and describe the change, e.g. "Keep modules without a public API off
+  the documentation site". Explain *why* in the body when it isn't obvious.
+- Don't leave test-only or unused code in the committed tree. If scaffolding was needed to get
+  somewhere, remove it before the PR lands.
+- Test heap dumps are built with the `dump { }` DSL from `shark-hprof-test` (see `docs/dev-env.md`)
+  rather than committed as binary fixtures. Never hand-assemble hprof bytes. For a large realistic
+  dump, drive a real JVM via `HotSpotDiagnosticMXBean.dumpHeap`.
+- Tests use JUnit 4 and AssertJ. Note AssertJ is pinned at **3.9.1**, which predates a lot of the
+  assertions you may reach for — `hasSizeLessThanOrEqualTo` and friends don't exist.
+
+## Scoped guides
+
+Subdirectories may carry their own `AGENTS.md`, and the closest one to the file being edited wins,
+like `.gitignore`. Prefer putting guidance in the narrowest place it applies over growing this file —
+a module's quirks belong next to the module.
+
+Claude Code reads `CLAUDE.md` rather than `AGENTS.md`, so each `AGENTS.md` is paired with a
+`CLAUDE.md` containing `@AGENTS.md`. Add both when adding a scoped guide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds a root `AGENTS.md` so an agent picking up work here starts with the conventions that aren't visible in the source, plus a one-line `CLAUDE.md` importing it.

Kept deliberately short, and scoped to **what an agent would get wrong by reading the code alone**. Anything derivable from the source stayed out, and `docs/dev-env.md` remains the contributor setup guide — this links to it rather than restating it.

## What's in it

The section that earns its place is *Things that will bite you*:

- **`docs/api/` is generated Dokka output.** An agent asked to fix documentation will happily edit those files. Nothing in the tree says not to.
- **A public API change fails the build until `updateKotlinAbi` is run** — and the diff should be read first, since catching unintended ABI changes is the point.
- **Some dependency versions are pinned low on purpose**, so apps resolve to their own newer ones. They look like stale versions begging to be bumped.
- **`HprofRetainedHeapPerfTest` and `HprofIOPerfTest` freeze exact byte and memory numbers.** Left unexplained, a failure there reads as a flake to be adjusted away rather than a regression to investigate.

Plus the **changelog emoji legend**, which nothing in the repo documented:

| | Means |
| --- | --- |
| 💥 | A crash fix, and nothing else |
| 🐛 | Bug fix |
| 🔨 | Improvement or non-bug change |
| 🐤 | A newly recognized library or manufacturer leak |

with breaking and behavior changes getting no emoji. I checked this against the file rather than assuming: 20 of the 21 existing 💥 entries are genuine crash fixes, and all four markers are in active use.

The one outlier is [#2806](https://github.com/square/leakcanary/pull/2806) in Alpha 9 — `💥 Raise the minimum SDK to API 26 and remove the now obsolete AndroidLeakFixes`, which is a breaking change rather than a crash fix, and is exactly the failure mode the guidance describes. Left alone here since it's in a released section; happy to fix separately if you want.

## Structure

`AGENTS.md` is the [tool-agnostic convention](https://agents.md/) and supports nested files with the closest one winning, like `.gitignore` — so module-specific guidance can live next to the module rather than growing this file. Claude Code reads `CLAUDE.md` rather than `AGENTS.md`, so each guide is paired with a `CLAUDE.md` containing `@AGENTS.md`. I used the import rather than the `ln -s` symlink that's common elsewhere because it works on Windows.

## Also noticed

`docs/dev-env.md` has two stale bits, not touched here:

- It refers to **Travis CI**; the repo has been on GitHub Actions for a while.
- It documents `./gradlew uploadArchives -PSNAPSHOT_REPOSITORY_URL=...` for local deployment, which predates the vanniktech publish plugin.

## Test plan

- [x] `./gradlew detekt` — 0 findings, docs-only change doesn't affect the build
- [x] Every factual claim checked against the repo: CI's Java version and the modules and API levels its instrumentation job covers, the pre-push hook, the `siteDokka` output path, `modulesWithoutPublicApi`, the emoji distribution in `docs/changelog.md`, the `### Breaking change:` heading, the pinned AssertJ version, and the parameter-per-line style

🤖 Generated with [Claude Code](https://claude.com/claude-code)