### PR TITLE
Analyze with CodeQL on a JDK that can run Gradle 9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly, matching the cadence of the default setup this replaces.
+    - cron: '39 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: java-kotlin
+            build-mode: manual
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        if: matrix.build-mode == 'manual'
+        with:
+          java-version: 17
+          distribution: 'zulu'
+      - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+        if: matrix.build-mode == 'manual'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      # CodeQL's autobuild derives the JDK it runs Gradle on from the project's sourceCompatibility,
+      # which is Java 8 here, while Gradle 9 requires JDK 17+ to even start. Building the project
+      # ourselves keeps that JDK under our control.
+      #
+      # --no-build-cache forces compilation to actually happen: CodeQL builds its database by
+      # observing javac and kotlinc, so a build cache hit would leave it with nothing to extract.
+      - name: Build project
+        if: matrix.build-mode == 'manual'
+        run: ./gradlew assemble --no-build-cache --stacktrace
+      # The analysis below is memory hungry, so don't leave the Gradle daemon holding onto a heap.
+      - name: Stop Gradle daemon
+        if: matrix.build-mode == 'manual'
+        run: ./gradlew --stop
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
`CodeQL / Analyze (java-kotlin)` has failed on every push and PR since [#2841](https://github.com/square/leakcanary/pull/2841) (AGP 9 / Gradle 9 / Kotlin 2.4) merged. The last green run was on `c4b2f23`, the commit right before it.

CodeQL's autobuild picks the JDK it launches Gradle on from the project's `sourceCompatibility`, which is Java 8 across this repo. Gradle 9 needs JDK 17+ just to start, so the build dies before compiling anything ([run 30408587733](https://github.com/square/leakcanary/actions/runs/30408587733)):

```
[autobuild] > ./gradlew --no-daemon ... -Dorg.gradle.java.home=/usr/lib/jvm/temurin-8-jdk-amd64 clean
[autobuild] Gradle requires JVM 17 or later to run. Your build is currently configured to use JVM 8.
```

Setting `sourceCompatibility` higher isn't an option — the published artifacts need to stay Java 8 compatible — and autobuild ignores the runner's `JAVA_HOME`, so the only fix is to stop letting it choose. This replaces the repository's CodeQL *default setup* with an advanced setup workflow that builds the project itself on JDK 17, the same JDK the `Main` workflow uses.

Notes on the workflow:

- `--no-build-cache`: CodeQL builds its database by observing `javac` and `kotlinc`, so a build cache hit would leave it with an empty database instead of a failure. `org.gradle.caching=true` is set in `gradle.properties`, so this matters.
- `assemble` covers all 37 modules (112 compile tasks), Android and JVM alike.
- The `actions` language keeps analyzing with `build-mode: none`, matching what default setup was doing.
- CodeQL 2.26.0 added Kotlin 2.4.0 support and the runners are on 2.26.1, so the toolchain itself is fine — the JDK was the only blocker.

## Merging this needs one settings change

GitHub rejects advanced setup uploads while default setup is enabled, so **this workflow will fail on this PR until default setup is turned off**. Under Settings → Advanced Security → CodeQL analysis, use "Switch to advanced" and confirm "Disable CodeQL", then re-run the checks here. `main` isn't a protected branch, so nothing is blocked in the meantime — the failing check is noise, not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)