### PR TITLE
Fix randomly failing instrumentation tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,13 +88,7 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-load
           disable-animations: false
-          # Write hide_error_dialogs into the snapshot, so that a process crashing on a device
-          # restored from it cannot put up a dialog that holds window focus and fails every
-          # Espresso interaction. Defence in depth behind the AOSP image: this only takes effect
-          # once ActivityManager re-reads the setting, which it does on configuration change.
-          script: |
-            adb shell settings put global hide_error_dialogs 1 || true
-            echo "Generated AVD snapshot for caching."
+          script: echo "Generated AVD snapshot for caching."
       # Save the snapshot here rather than at the end of the job. The test step below force-kills
       # the emulator, which leaves the AVD directory in a state that is not safe to restore, and
       # cache entries are immutable: caching it once breaks every later run on the same key.
@@ -118,7 +112,12 @@ jobs:
             touch emulator.log
             chmod 777 emulator.log
             adb logcat >> emulator.log &
-            # Belt and braces, so neither of these can become a new source of failures.
+            # Stop a crashing process from putting up a dialog that holds window focus, which
+            # fails every Espresso interaction with RootViewWithoutFocusException. Defence in
+            # depth behind the AOSP image, and only on API 30+: ActivityTaskManagerService
+            # observes this setting and applies it right away, while older releases decide
+            # whether to show error dialogs from the configuration alone and ignore it.
+            # `|| true` so this cannot itself become a new source of failures.
             adb shell settings put global hide_error_dialogs 1 || true
             # Espresso fails every interaction with RootViewWithoutFocusException when some other
             # window holds focus, and names only the window it wanted rather than the one that has

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,24 +31,15 @@ jobs:
   instrumentation-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      # Bump to throw away every cached AVD snapshot. Cache entries are immutable, so a snapshot
-      # saved while the device was in a bad state keeps breaking every later run on the same key,
-      # and there is otherwise no way to recover from that from within the workflow.
-      AVD_CACHE_VERSION: 1
     strategy:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
         arch: [ x86_64 ]
         # AOSP images rather than google_apis: nothing here uses Google Play services, and the
-        # Google apps that only ship in google_apis are what made these tests flaky. They crash
-        # while the device boots, and the resulting "app has stopped" dialog holds window focus,
-        # so every Espresso interaction fails with RootViewWithoutFocusException. When that
-        # happens during the snapshot-generating run it gets frozen into the cached snapshot and
-        # restored on every later run. They also keep the guest short on memory, which makes the
-        # `adb shell input keyevent 82` that android-emulator-runner sends once the device reports
-        # sys.boot_completed get SIGKILLed, failing the job with exit code 137 before any test runs.
+        # Google apps that only ship in google_apis crash while the device boots. The resulting
+        # "app has stopped" dialog holds window focus, and then every Espresso interaction fails
+        # with RootViewWithoutFocusException until something dismisses it.
         target: [ default ]
         channel: [ stable ]
         api-level:
@@ -70,44 +61,26 @@ jobs:
           java-version: 17
           distribution: 'zulu'
       - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
-      - name: AVD cache
-        uses: actions/cache/restore@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.AVD_CACHE_VERSION }}-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: ${{ matrix.arch }}
-          force-avd-creation: true
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-load
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-      # Save the snapshot here rather than at the end of the job. The test step below force-kills
-      # the emulator, which leaves the AVD directory in a state that is not safe to restore, and
-      # cache entries are immutable: caching it once breaks every later run on the same key.
-      - name: Save AVD cache
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.AVD_CACHE_VERSION }}-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
+      # Create the AVD and boot it from scratch on every run, rather than restoring a cached
+      # snapshot. android-emulator-runner decides the device is ready when `getprop
+      # sys.boot_completed` returns 1 and then immediately sends `input keyevent 82` to dismiss the
+      # lock screen. `sys.boot_completed` is part of the state a snapshot captures, so on a restored
+      # device it already reads 1 while adbd and zygote are still coming back, and that keyevent
+      # races them: it loses often enough that this was the single largest source of red builds,
+      # SIGKILLed with exit code 137 before the test script started. Booting for real makes the
+      # readiness check mean something -- the poll then takes ~10s and several attempts -- and it
+      # also means no run inherits frozen state from another. The snapshot cache saved roughly 20
+      # seconds of wall clock and had by then caused three separate classes of failure: stale test
+      # APKs (#2801), an AVD directory saved from a force-killed emulator (#2855), and a crash
+      # dialog frozen mid-boot holding window focus.
       - name: Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
+          force-avd-creation: true
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-save
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-load -no-snapshot-save
           script: |
             touch emulator.log
             chmod 777 emulator.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,12 +31,25 @@ jobs:
   instrumentation-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Bump to throw away every cached AVD snapshot. Cache entries are immutable, so a snapshot
+      # saved while the device was in a bad state keeps breaking every later run on the same key,
+      # and there is otherwise no way to recover from that from within the workflow.
+      AVD_CACHE_VERSION: 1
     strategy:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
         arch: [ x86_64 ]
-        target: [ google_apis ]
+        # AOSP images rather than google_apis: nothing here uses Google Play services, and the
+        # Google apps that only ship in google_apis are what made these tests flaky. They crash
+        # while the device boots, and the resulting "app has stopped" dialog holds window focus,
+        # so every Espresso interaction fails with RootViewWithoutFocusException. When that
+        # happens during the snapshot-generating run it gets frozen into the cached snapshot and
+        # restored on every later run. They also keep the guest short on memory, which makes the
+        # `adb shell input keyevent 82` that android-emulator-runner sends once the device reports
+        # sys.boot_completed get SIGKILLed, failing the job with exit code 137 before any test runs.
+        target: [ default ]
         channel: [ stable ]
         api-level:
           - 24
@@ -64,7 +77,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-cached-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
+          key: avd-${{ env.AVD_CACHE_VERSION }}-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
@@ -75,7 +88,13 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot-load
           disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
+          # Write hide_error_dialogs into the snapshot, so that a process crashing on a device
+          # restored from it cannot put up a dialog that holds window focus and fails every
+          # Espresso interaction. Defence in depth behind the AOSP image: this only takes effect
+          # once ActivityManager re-reads the setting, which it does on configuration change.
+          script: |
+            adb shell settings put global hide_error_dialogs 1 || true
+            echo "Generated AVD snapshot for caching."
       # Save the snapshot here rather than at the end of the job. The test step below force-kills
       # the emulator, which leaves the AVD directory in a state that is not safe to restore, and
       # cache entries are immutable: caching it once breaks every later run on the same key.
@@ -86,7 +105,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-cached-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
+          key: avd-${{ env.AVD_CACHE_VERSION }}-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
       - name: Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -99,11 +118,17 @@ jobs:
             touch emulator.log
             chmod 777 emulator.log
             adb logcat >> emulator.log &
+            # Belt and braces, so neither of these can become a new source of failures.
+            adb shell settings put global hide_error_dialogs 1 || true
+            # Espresso fails every interaction with RootViewWithoutFocusException when some other
+            # window holds focus, and names only the window it wanted rather than the one that has
+            # focus. Recording the focused window up front says which one that is.
+            echo "Focused window before tests: $(adb shell dumpsys window | grep -E 'mCurrentFocus|mFocusedApp')"
             ./gradlew leakcanary:leakcanary-android-core:connectedCheck leakcanary:leakcanary-android:connectedCheck leakcanary:leakcanary-android-instrumentation:connectedCheck --no-build-cache --no-daemon --stacktrace
             # Force-kill the emulator before the action's post-step cleanup.
-            # On API 26 google_apis, the emulator process can hang for 20+ minutes after
-            # receiving adb emu kill, causing the job to hit its 30-minute timeout. Killing
-            # the qemu-system process here ensures the post-cleanup kill check exits immediately.
+            # On API 26, the emulator process can hang for 20+ minutes after receiving
+            # adb emu kill, causing the job to hit its 30-minute timeout. Killing the
+            # qemu-system process here ensures the post-cleanup kill check exits immediately.
             # The [m] bracket trick avoids pkill matching its own parent shell process
             # (whose cmdline contains the literal string "qemu-system" as an argument).
             pkill -9 -f "qemu-syste[m]" || true


### PR DESCRIPTION
The instrumentation jobs fail on unrelated PRs — e.g. [#2865](https://github.com/square/leakcanary/pull/2865), where API 26 failed on a docs-only change. Over the last 8 days: **9 spurious failures across 311 instrumentation jobs**, all on API 24 or 26.

Both failure modes come from restoring a cached AVD snapshot. Across the whole 120-run history I pulled artifacts for, all 28 emulator-side failures landed in a step that restored a snapshot, and none in a step that created the AVD and booted it — 10 × `adb` exit 137 before any test ran, 2 × `RootViewWithoutFocusException`, 16 × the emulator never coming up. That split is directional rather than conclusive on its own, because the create step only ran on a cache miss and so has a much smaller denominator. The mechanism below is the actual evidence.

## 1. `adb` exit code 137, two minutes in

```
[command] adb -s emulator-5554 shell getprop sys.boot_completed
1
Emulator booted.
[command] adb -s emulator-5554 shell input keyevent 82
##[error]The process 'adb' failed with exit code 137
```

android-emulator-runner treats the device as ready when `getprop sys.boot_completed` returns 1, then immediately sends `input keyevent 82` to dismiss the lock screen. **`sys.boot_completed` is part of the state a snapshot captures**, so on a restored device the first poll reads 1 while adbd and zygote are still coming back, and the keyevent races them. 137 is SIGKILL, 140 ms after the device claimed to be ready.

The same job on a real boot, for contrast:

| | cold boot | snapshot restore |
| --- | --- | --- |
| `sys.boot_completed` polls before ready | 11–15, over ~10–15s | 1, instant |
| `input keyevent 82` | succeeds | exit 137 |

This is the worse of the two: the script never starts, so the `pkill` guarding against the API 26 shutdown hang never runs either, and the job burns its full 30-minute timeout.

## 2. `RootViewWithoutFocusException` on every Espresso interaction

The activity is displayed and resumed — logcat shows `Displayed …LeakActivity: +772ms` — but never gets window focus, for four consecutive test processes over a full minute. So not a per-test race: something device-wide holds focus.

`emulator.log` from [that run](https://github.com/square/leakcanary/actions/runs/30414215189) contains two interleaved days, because `adb logcat` dumps the ring buffer captured inside the snapshot. At snapshot time:

```
07-28 19:08:13.196  I ActivityManager: Showing crash dialog for package com.google.android.apps.messaging u0
```

and after the restore, a day later, that same pid is still recorded as crashing:

```
07-29 01:31:54.046  I ActivityManager: Crashing app skipping ANR: ProcessRecord{… 3174:com.google.android.apps.messaging:rcs/u0a65}
```

A Google app crashed during the snapshot-generating boot and its "app has stopped" dialog was frozen into the snapshot, holding focus. Cache entries are immutable, so every later run replayed it — a failing run and a passing run restore the *same* entry, identical snapshot log window, crash in both. Each run was a coin flip on whether the dialog ended up with focus.

## Why now

[#2855](https://github.com/square/leakcanary/pull/2855) fixed a real and different poisoning — the AVD directory being saved from a force-killed emulator — and attributed `adb 137` to it. But it also changed the cache key, so fresh snapshots were generated on 07-28 19:07, and the first `adb 137` on that clean-provenance snapshot arrived 21 minutes later, with six more after. Corruption was fixed; what remained was the snapshot faithfully preserving bad state.

This is the third incident of that shape. [#2801](https://github.com/square/leakcanary/pull/2801) was stale test APKs in the snapshot causing `INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES`; #2855 was the force-killed directory; this one is a crash dialog plus a boot flag that lies.

## The fix

**Create the AVD and boot it on every run.** No cache, no snapshot. No run inherits state from another, and the readiness check means something.

This is not a slowdown, because a cold boot boots once where a cache miss booted twice — once to create the snapshot, once to restore it:

| job duration | API 24 | API 26 | API 31 | API 33 | API 34 |
| --- | --- | --- | --- | --- | --- |
| cache miss (create + restore) | 324s | 357s | 364s | 365s | 398s |
| cache hit (restore) | 313s | timeout | 347s | 307s | 378s |
| **cold boot, 3 runs** | **283–291s** | **299–314s** | **312–318s** | 328–342s | 309–383s |

Runner variance is wider than the difference on API 33 and 34, so read that as "no slower" rather than a speedup. API 24 and 26 — the two that were failing — are consistently faster.

**AOSP images rather than `google_apis`.** Nothing here uses Google Play services — no `play-services` dependency, no `com.google.android.gms` reference — and those apps are what crash and put the dialog up. Cold-booting a `google_apis` image would raise the dialog live rather than replay it, so this is needed independently.

Two smaller things:

- `hide_error_dialogs` before the tests, so a crashing process can't put up a focus-holding dialog. `ActivityTaskManagerService` observes it and applies it immediately, but only from Android 11 — before that the decision came from the configuration alone and the setting was ignored, so API 24 and 26 rely on the image change alone.
- The focused window logged up front. Espresso names the window it *wanted*, not the one holding focus, which is what made this slow to pin down. On a healthy device it reads `mCurrentFocus=Window{… com.android.launcher3/…QuickstepLauncher}` from API 31 on, and `mFocusedApp=Token{… com.android.launcher3/.Launcher}` on API 24 and 26.

Net: three steps and the cache gone — 26 lines of workflow configuration removed, 5 added.

## Test plan

- [x] Root cause read off CI artifacts, not inferred: the crash dialog inside the snapshot's log window, the crashing pid surviving the restore, and one cache entry behind both a passing and a failing run
- [x] `sys.boot_completed` race confirmed by poll count — 1 instant poll on a restore vs 11–15 over ~10–15s on a cold boot, with the keyevent failing only in the former. API 24 is the exception at 2 polls, but that is a genuine 12-second boot of a small old image, not stale state: there is no snapshot to load
- [x] Checked `HIDE_ERROR_DIALOGS` against AOSP rather than assuming: absent from `ActivityManagerService.shouldShowDialogs` in Oreo, read by `ActivityTaskManagerService.updateShouldShowDialogsLocked` behind a `ContentObserver` from Android 11
- [x] No Google Play services usage anywhere in the repo; `system-images;android-{24,26,31,33,34};default;x86_64` all exist
- [x] Diagnostic verified to actually resolve, not echo its own source: `Focused window before tests: mFocusedApp=Token{… com.android.launcher3/.Launcher}`
- [x] 15/15 green: all five API levels across three cold-boot runs, API 26 included, each finishing in ~3m20s and terminating without the shutdown hang

On sampling: the per-job flake rate was 2.9%, so 15 clean jobs would have happened about two thirds of the time even with no fix. Repeated green runs are a sanity check, not the argument — the argument is that both mechanisms need a snapshot to exist, and there is no longer a snapshot.

Two dead ends worth recording, since both were wrong in ways the artifacts eventually settled: `adb 137` is not memory pressure from the Google apps (it reproduced on a bare AOSP image), and the create-vs-restore failure counts do not argue for keeping the cache (create-path jobs also restored a snapshot for their test step, so both paths carried the race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
