### PR TITLE
Two hppc cleanups: an Int overflow and an uninformative ceiling message

### DIFF
--- a/shark/shark-graph/src/main/java/shark/internal/hppc/HPPC.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/hppc/HPPC.kt
@@ -48,14 +48,7 @@ internal object HPPC {
     length = max(MIN_HASH_ARRAY_LENGTH.toLong(), nextHighestPowerOfTwo(length))
 
     if (length > MAX_HASH_ARRAY_LENGTH) {
-      throw RuntimeException(
-        String.format(
-          Locale.ROOT,
-          "Maximum array size exceeded for this load factor (elements: %d, load factor: %f)",
-          elements,
-          loadFactor
-        )
-      )
+      throw RuntimeException(tooManyElementsMessage(elements, loadFactor))
     }
 
     return length.toInt()
@@ -87,16 +80,32 @@ internal object HPPC {
     loadFactor: Double
   ): Int {
     if (arraySize == MAX_HASH_ARRAY_LENGTH) {
-      throw RuntimeException(
-        String.format(
-          Locale.ROOT,
-          "Maximum array size exceeded for this load factor (elements: %d, load factor: %f)",
-          elements,
-          loadFactor
-        )
-      )
+      throw RuntimeException(tooManyElementsMessage(elements, loadFactor))
     }
 
     return arraySize shl 1
+  }
+
+  /**
+   * These structures hash into a power of two sized array and address its slots with an [Int], so
+   * the array can't go past [MAX_HASH_ARRAY_LENGTH] slots, which at [loadFactor] is a hard cap on
+   * how many elements they can hold. Says so, because the alternative reads like a corrupt heap
+   * dump or like running out of memory, and it's neither.
+   */
+  private fun tooManyElementsMessage(
+    elements: Int,
+    loadFactor: Double
+  ): String {
+    return String.format(
+      Locale.ROOT,
+      "Cannot hold more than %d elements (a hash array of at most %d slots at load factor %f), " +
+        "asked to hold %d. This is a limit of Shark's hash structures rather than of the heap dump " +
+        "format, so a heap dump that needs more cannot be analyzed, whatever heap the analysis " +
+        "runs with.",
+      expandAtCount(MAX_HASH_ARRAY_LENGTH, loadFactor),
+      MAX_HASH_ARRAY_LENGTH,
+      loadFactor,
+      elements
+    )
   }
 }

--- a/shark/shark-graph/src/main/java/shark/internal/hppc/LongDeque.kt
+++ b/shark/shark-graph/src/main/java/shark/internal/hppc/LongDeque.kt
@@ -54,7 +54,14 @@ internal class LongDeque(expectedElements: Int = 4) {
   }
 
   private fun grow() {
-    val grown = LongArray(elements.size * 2)
+    // Doubling in Int arithmetic would wrap negative at 2^30 elements, and LongArray() would then
+    // throw a NegativeArraySizeException that says nothing about what hit its limit.
+    val grownSize = elements.size.toLong() * 2
+    check(grownSize <= Int.MAX_VALUE) {
+      "Cannot hold more than ${elements.size} elements: growing doubles the backing array, and an " +
+        "array of $grownSize longs is past what an Int index can address"
+    }
+    val grown = LongArray(grownSize.toInt())
     // Unwrap the circular buffer into the new array, so that head becomes 0 again.
     val untilEnd = elements.size - head
     elements.copyInto(grown, destinationOffset = 0, startIndex = head)

--- a/shark/shark-graph/src/test/java/shark/LongScatterSetTest.kt
+++ b/shark/shark-graph/src/test/java/shark/LongScatterSetTest.kt
@@ -125,7 +125,20 @@ class LongScatterSetTest {
       .containsExactly((1..100L).toList())
   }
 
+  /**
+   * Sized one element past the ceiling, which is rejected before anything is allocated. Sizing it
+   * at the ceiling instead allocates 8.59 GB, so only the failing side is checked here.
+   */
+  @Test fun `a set sized past the hash array ceiling says what the ceiling is`() {
+    Assertions.assertThatThrownBy { LongScatterSet(MAX_ELEMENTS + 1) }
+      .hasMessageContaining("Cannot hold more than $MAX_ELEMENTS elements")
+      .hasMessageContaining("asked to hold ${MAX_ELEMENTS + 1}")
+  }
+
   companion object {
+    /** 2^30 slots, the largest power of two an [Int] addresses, at the 0.75 load factor. */
+    const val MAX_ELEMENTS = 805_306_368
+
     // Values SAME_MIX_PHI_1 and SAME_MIX_PHI_2 have same hash when calculated via HHPC.mixPhi()
     const val SAME_MIX_PHI_1 = 11L
     const val SAME_MIX_PHI_2 = 14_723_950_898L


### PR DESCRIPTION
The two small hppc items left over from the path finder memory work (#2888, #2895).

## `LongDeque.grow()` doubled in `Int` arithmetic

`elements.size * 2` wraps negative once the backing array holds 2^30 longs. Reproduced, on the code before this change, by filling a `LongDeque` to 2^30 elements and adding one more:

```
filled to size = 1073741824 in 3064 ms
next add triggers grow()
Exception in thread "main" java.lang.NegativeArraySizeException: -2147483648
	at shark.internal.hppc.LongDeque.grow(LongDeque.kt:57)
	at shark.internal.hppc.LongDeque.add(LongDeque.kt:26)
```

That needs an 8.6 GB backing array, so **nothing reaches it today** — the path finder's two queues are the only `LongDeque` instances and they hold the traversal frontier. The growth still can't succeed after this change, so what it buys is a message instead of a bare JDK error:

```
java.lang.IllegalStateException: Cannot hold more than 1073741824 elements: growing doubles the
backing array, and an array of 2147483648 longs is past what an Int index can address
	at shark.internal.hppc.LongDeque.grow(LongDeque.kt:60)
```

No test for it: demonstrating it needs the 8.6 GB allocation, which doesn't belong in the suite.

## `"Maximum array size exceeded for this load factor"` said nothing about heap dumps

Both throw sites in `HPPC` shared that message. It names neither the maximum, nor whose maximum it is, nor whether more memory would help — and the natural reaction to it is to raise `-Xmx` and try again, which cannot work. Now:

```
Cannot hold more than 805306368 elements (a hash array of at most 1073741824 slots at load factor
0.750000), asked to hold 805306369. This is a limit of Shark's hash structures rather than of the
heap dump format, so a heap dump that needs more cannot be analyzed, whatever heap the analysis
runs with.
```

The ceiling is verified against `LongScatterSet` from both sides: 805306368 elements allocates its 8.59 GB array and works, 805306369 throws. Only the failing side is a committed test, since it throws before allocating anything.

**A note on the guidance.** The brief suggested pointing at `shark-cli` off-device. I left that out: this is a hard `Int` cap, not a memory condition, and the only way to request more than 805306368 elements is `LeakShareCalculator`'s `objectsReachableWithoutGrowth`, sized at `instanceCount / 2` — so you need a heap dump with more than 1610612736 instances, which puts the reader off-device already. Sending them somewhere they are makes the message worse, so it says instead that no amount of heap helps. Happy to add it back if you'd rather.

## Changelog

No entry, for either. Both classes are `internal`, the `LongDeque` crash is unreachable from any consumer path and still fails after the change, and the message change is text on a path that needs a 1.6 billion instance heap dump. Nothing a consumer can observe changed.

## Verification

`./gradlew detekt` and `./gradlew build` both green on **JDK 17** (Temurin 17.0.19), with `ANDROID_HOME` set. `build` runs `checkKotlinAbi`, and no `api/*.api` file changed, as expected for two `internal` classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)