### PR TITLE
Open each heap dump in a window of its own

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -59,6 +59,9 @@ what was being read and how long it took. What that makes readable:
   didn't.
 - Everything the window does silently — a path zoomed out because a node left the tree, a click landing
   on an object the tree has no node for, a list that came back empty — says so there rather than nowhere.
+- A run is every window of it, and a window is a heap dump, so the reads of several dumps interleave.
+  The `[heap-dump-<file name>]` a line was written from is which dump it is about; lines from the
+  window's own thread name the file instead.
 
 Which is also the rule for new code here: **anything the UI swallows or falls back from gets a
 `SharkLog.d` line saying so.** The file is only worth reading if it's complete.
@@ -107,7 +110,8 @@ Windows and Linux title bar — macOS ignores it.
 ./gradlew :shark:shark-explorer:shark-explorer-app:test   # UI tests, headless, no emulator
 ./gradlew :shark:shark-explorer:shark-explorer-app:check   # test + detekt
 
-# Launch it. The path is optional; without one, use the "Open heap dump…" button.
+# Launch it. Paths are optional; without one, use the "Open heap dump…" button. One window per path,
+# and one per heap dump opened from the button — see `notes/decisions.md`.
 ./gradlew :shark:shark-explorer:shark-explorer-app:run \
   --args="shark/shark-android/src/test/resources/compose_leak.hprof"
 ```
@@ -132,6 +136,10 @@ it, so run it before pushing.
   line is built from state — an index into a path, a node id — so a line built from the wrong state
   should fail the test that reaches it rather than wait for a session nobody can read. Which means a
   test that leaves `SharkLog.logger` set breaks the ones after it, hence the `@After`.
+- **A `Window` needs a display, so nothing inside `application { }` is covered headless.** Which
+  window a heap dump opens in is plain state in `ExplorerWindow.kt`, unit tested by
+  `ExplorerWindowTest`. `ExplorerApp` is one window's worth of app and takes the heap dump it shows
+  as a parameter, so a UI test drives one window and nothing else.
 - **A click is a fraction of the view, never of the window.** `ExplorerAppTest.viewBounds` measures the
   view by its `contentDescription`, and every press helper is relative to that. Window fractions break
   the moment anything above the view changes height, which is a change to the top bar away.

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -83,6 +83,32 @@ session did. Every write is flushed, because the session worth reading is the on
 crashing, and a buffered tail is the part that would have said why. The last line of a clean run is
 `Shark Explorer closed`, which is how a session that ended is told from one that was killed.
 
+## One heap dump per window
+
+Opening a heap dump opens a window, so the windows on screen are the heap dumps open. A window never
+swaps the dump it shows for another: it costs seconds and a 100+ MB tree to open one, and the trail
+through it — where the map is zoomed, what's starred, what the panel is describing — is worth nothing
+for a different dump. Replacing meant the second dump erased the first, which is exactly what
+comparing two of them can't have.
+
+The one window that takes a heap dump into itself is the one showing none, which is what the app
+starts with when it was given no file: it's there to carry the button, and it has nothing to keep.
+
+What follows: `heapDumpFile` is a window's, not `ExplorerApp`'s, because the window title is the file
+name — several windows all called after the app say nothing about which one to switch to, and the OS
+window list is the only way between them. `explorerWindows` and `openHeapDump` are plain state so the
+rule is unit tested; the `application` block only draws a window per entry. Closing the last window
+quits.
+
+Where a window opens is ours to decide too, which `WindowPosition.PlatformDefault` was not doing:
+measured on macOS, every window it places is centred, so two windows landed on exactly the same pixels
+and the second looked like the first having been replaced — the very thing this is meant not to look
+like. `cascadedPosition` centres and then steps down and right, as many steps as the screen has room
+for before starting over.
+
+The memory cost is per window and it isn't small — a tree, a graph and an index each — so N windows on
+large dumps is N times the numbers in `dominator-tree.md`.
+
 ## Testing split
 
 Headless `runComposeUiTest` on the JVM covers the UI, so there's no emulator in the loop — a real

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerWindow.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerWindow.kt
@@ -1,0 +1,77 @@
+package shark.explorer.app
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import java.io.File
+import shark.SharkLog
+
+/**
+ * One window of the app, which is one heap dump.
+ *
+ * Plain state rather than a composable's, so that how many windows there are and which heap dump each
+ * one shows can be tested without a display: `explorerApplication` only draws a window per entry.
+ */
+internal class ExplorerWindow(
+  heapDumpFile: File?,
+  /**
+   * How many steps down and to the right of centre this window opens: no two windows on screen are at
+   * the same one, so a window opened from another lands beside it rather than exactly over it. Where
+   * that is, is `cascadedPosition`.
+   */
+  val cascade: Int = 0
+) {
+
+  /** Null in the window the app starts with when it was given no heap dump to open. */
+  var heapDumpFile: File? by mutableStateOf(heapDumpFile)
+
+  /**
+   * Which heap dump this window is, for the window list of the OS: several windows all called after the
+   * app tell you nothing about which one to switch to.
+   */
+  val title: String get() = heapDumpFile?.name ?: APP_NAME
+}
+
+/**
+ * A window per heap dump named on the command line, or one window with none — something has to carry
+ * the button that opens the first one.
+ */
+internal fun explorerWindows(heapDumpFiles: List<File>): SnapshotStateList<ExplorerWindow> =
+  mutableStateListOf<ExplorerWindow>().apply {
+    if (heapDumpFiles.isEmpty()) {
+      add(ExplorerWindow(null))
+    } else {
+      addAll(heapDumpFiles.mapIndexed { index, file -> ExplorerWindow(file, cascade = index) })
+    }
+  }
+
+/**
+ * Shows [heapDumpFile] in [window] if it has none yet, and in a window of its own if it has.
+ *
+ * A window showing a heap dump keeps it, so the windows on screen are the heap dumps open: comparing
+ * two dumps is looking at both, and closing a window closes one of them rather than the trail through
+ * several. The window that shows nothing has nothing to keep, so the first heap dump opens in it.
+ */
+internal fun MutableList<ExplorerWindow>.openHeapDump(
+  window: ExplorerWindow,
+  heapDumpFile: File
+) {
+  val isWindowOfItsOwn = window.heapDumpFile != null
+  if (isWindowOfItsOwn) {
+    add(ExplorerWindow(heapDumpFile, cascade = freeCascade()))
+  } else {
+    window.heapDumpFile = heapDumpFile
+  }
+  // One run's log covers every window of that run, and what tells the lines apart afterwards is the
+  // thread each was written from, so which window a heap dump went to is worth a line of its own.
+  SharkLog.d {
+    val where = if (isWindowOfItsOwn) "a window of its own" else "the window that had no heap dump"
+    "Opening ${heapDumpFile.name} in $where"
+  }
+}
+
+/** The first step of the cascade no window is at, which is where the next window goes. */
+private fun List<ExplorerWindow>.freeCascade(): Int =
+  generateSequence(0, Int::inc).first { step -> none { it.cascade == step } }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -25,10 +25,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import java.awt.FileDialog
 import java.awt.Frame
+import java.awt.GraphicsEnvironment
 import java.io.File
 import shark.SharkLog
 import shark.explorer.HeapSizes
@@ -42,37 +44,59 @@ fun main(args: Array<String>) {
   // back after it. See [installLogging].
   installLogging().use {
     SharkLog.d { "Started with ${if (args.isEmpty()) "no arguments" else args.joinToString(" ")}" }
-    explorerApplication(args)
+    // Heap dump paths on the command line open straight away, which is how this is usually run.
+    explorerApplication(args.map(::File))
   }
 }
 
-private fun explorerApplication(args: Array<String>) = application {
-  Window(
-    onCloseRequest = ::exitApplication,
-    title = "Shark Explorer",
-    // What Windows and Linux show in the title bar and the window list. macOS takes the dock icon
-    // from the process instead, which the build script sets.
-    icon = painterResource(APP_ICON),
-    state = rememberWindowState(width = 1440.dp, height = 900.dp)
-  ) {
-    MaterialTheme {
-      // A heap dump path on the command line opens straight away, which is how this is usually run.
-      ExplorerApp(initialHeapDumpFile = args.firstOrNull()?.let(::File))
+/** One window per heap dump open, which is what [openHeapDump] keeps true as more are opened. */
+private fun explorerApplication(heapDumpFiles: List<File>) = application {
+  val windows = remember { explorerWindows(heapDumpFiles) }
+  windows.forEach { window ->
+    // Keyed on the window, so that closing one doesn't hand its size and position to the next one along.
+    key(window) {
+      Window(
+        onCloseRequest = {
+          windows -= window
+          // The app is its windows, so there is nothing left to come back to.
+          if (windows.isEmpty()) {
+            exitApplication()
+          }
+        },
+        title = window.title,
+        // What Windows and Linux show in the title bar and the window list. macOS takes the dock icon
+        // from the process instead, which the build script sets.
+        icon = painterResource(APP_ICON),
+        state = rememberWindowState(
+          width = WINDOW_WIDTH,
+          height = WINDOW_HEIGHT,
+          position = cascadedPosition(window.cascade)
+        )
+      ) {
+        MaterialTheme {
+          ExplorerApp(
+            heapDumpFile = window.heapDumpFile,
+            onHeapDumpChosen = { file -> windows.openHeapDump(window, file) }
+          )
+        }
+      }
     }
   }
 }
 
 @Composable
 fun ExplorerApp(
-  initialHeapDumpFile: File? = null,
+  /** The one heap dump this window shows, null until one has been chosen for it. */
+  heapDumpFile: File?,
+  /** Where a heap dump chosen from the bar goes, which is a window: see [openHeapDump]. */
+  onHeapDumpChosen: (File) -> Unit,
   /** Overridden by tests, which have no display to put a file dialog on. */
   chooseHeapDumpFile: () -> File? = ::showHeapDumpFileDialog
 ) {
-  var requestedFile: File? by remember { mutableStateOf(initialHeapDumpFile) }
   var state: HeapDumpState by remember { mutableStateOf(HeapDumpState.None) }
 
-  LaunchedEffect(requestedFile) {
-    val file = requestedFile
+  LaunchedEffect(heapDumpFile) {
+    val file = heapDumpFile
     if (file == null) {
       state = HeapDumpState.None
       return@LaunchedEffect
@@ -93,7 +117,8 @@ fun ExplorerApp(
   }
 
   val currentState = state
-  // Opening another heap dump replaces this state, which is when the previous one has to be closed.
+  // Closing the window is what ends the session: it's the only thing that takes this heap dump off
+  // screen, since another one opens in a window of its own.
   DisposableEffect(currentState) {
     onDispose { (currentState as? HeapDumpState.Open)?.session?.close() }
   }
@@ -108,16 +133,12 @@ fun ExplorerApp(
           // open at all.
           SharkLog.d { "No heap dump chosen" }
         } else {
-          requestedFile = chosenFile
+          onHeapDumpChosen(chosenFile)
         }
       }
     )
     if (currentState is HeapDumpState.Open) {
-      // Keyed on the session, so that opening another heap dump starts from the whole of it rather than
-      // from wherever the previous one was being read.
-      key(currentState.session) {
-        HeapDumpExplorer(currentState.session, currentState.sizes, Modifier.weight(1f))
-      }
+      HeapDumpExplorer(currentState.session, currentState.sizes, Modifier.weight(1f))
     } else {
       Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
         Column(
@@ -203,6 +224,24 @@ private fun HeapDumpState.centerMessage(): String = when (this) {
 }
 
 /**
+ * Where a window opens: centred, then [cascade] steps down and to the right.
+ *
+ * Placing it is ours to do because macOS centres every window it is left to place itself, and a window
+ * landing exactly over the one it was opened from is what "the heap dump was replaced" looks like.
+ */
+private fun cascadedPosition(cascade: Int): WindowPosition {
+  // The screen minus whatever the OS keeps for itself, so a window doesn't open under the menu bar.
+  val screen = GraphicsEnvironment.getLocalGraphicsEnvironment().maximumWindowBounds
+  val centredX = ((screen.width.dp - WINDOW_WIDTH) / 2).coerceAtLeast(0.dp)
+  val centredY = ((screen.height.dp - WINDOW_HEIGHT) / 2).coerceAtLeast(0.dp)
+  // As many steps as there is room for below and to the right of centred, then over from the centre
+  // again: two windows sharing a spot beats one opening half off the screen.
+  val stepCount = (minOf(centredX, centredY) / CASCADE_STEP).toInt().coerceAtLeast(1)
+  val step = CASCADE_STEP * (cascade % stepCount)
+  return WindowPosition(x = screen.x.dp + centredX + step, y = screen.y.dp + centredY + step)
+}
+
+/**
  * The platform file picker, through AWT: Compose Multiplatform has none of its own, and this is the
  * native dialog on macOS and Windows.
  */
@@ -217,6 +256,15 @@ private fun showHeapDumpFileDialog(): File? {
 
 /** Rendered from `icons/shark-explorer-icon.svg`, and the same PNG a Linux package is built with. */
 private const val APP_ICON = "shark-explorer-icon.png"
+
+/** What a window with no heap dump in it is called, since it has no better name to go by. */
+internal const val APP_NAME = "Shark Explorer"
+
+private val WINDOW_WIDTH = 1440.dp
+private val WINDOW_HEIGHT = 900.dp
+
+/** How far a window opens from the one before it, which is about the height of a title bar. */
+private val CASCADE_STEP = 28.dp
 
 internal const val OPEN_HEAP_DUMP = "Open heap dump…"
 internal const val NO_HEAP_DUMP = "Open an Android heap dump to see what retains its memory."

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -1,6 +1,10 @@
 package shark.explorer.app
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -98,7 +102,7 @@ class ExplorerAppTest {
 
   @Test fun `nothing is open until a heap dump is chosen`() {
     runComposeUiTest {
-      setContent { MaterialTheme { ExplorerApp(chooseHeapDumpFile = { null }) } }
+      setExplorerContent()
 
       onNodeWithText(NO_HEAP_DUMP).assertIsDisplayed()
       onNodeWithText(OPEN_HEAP_DUMP).assertIsDisplayed()
@@ -117,7 +121,7 @@ class ExplorerAppTest {
   @Test fun `the chosen heap dump is opened`() {
     runComposeUiTest {
       val heapDumpFile = testHeapDump()
-      setContent { MaterialTheme { ExplorerApp(chooseHeapDumpFile = { heapDumpFile }) } }
+      setExplorerContent(chooseHeapDumpFile = { heapDumpFile })
 
       onNodeWithText(OPEN_HEAP_DUMP).performClick()
 
@@ -131,7 +135,7 @@ class ExplorerAppTest {
   @Test fun `a file that is not a heap dump is reported rather than crashing`() {
     runComposeUiTest {
       val notAHeapDump = testFolder.newFile("not-a-heap-dump.txt").apply { writeText("nope") }
-      setContent { MaterialTheme { ExplorerApp(initialHeapDumpFile = notAHeapDump) } }
+      setExplorerContent(notAHeapDump)
 
       waitUntilAtLeastOneExists(hasText("could not be opened", substring = true), OPEN_TIMEOUT_MILLIS)
     }
@@ -144,7 +148,7 @@ class ExplorerAppTest {
   @Test fun `a file that is not a heap dump is logged with what went wrong`() {
     runComposeUiTest {
       val notAHeapDump = testFolder.newFile("not-a-heap-dump.txt").apply { writeText("nope") }
-      setContent { MaterialTheme { ExplorerApp(initialHeapDumpFile = notAHeapDump) } }
+      setExplorerContent(notAHeapDump)
 
       waitUntilAtLeastOneExists(hasText("could not be opened", substring = true), OPEN_TIMEOUT_MILLIS)
     }
@@ -667,8 +671,22 @@ class ExplorerAppTest {
     }
   }
 
+  /**
+   * One window's worth of app, showing [heapDumpFile] and taking a chosen heap dump the way the window
+   * that has none does. Which window a chosen one lands in is `ExplorerWindowTest`'s.
+   */
+  private fun ComposeUiTest.setExplorerContent(
+    heapDumpFile: File? = null,
+    chooseHeapDumpFile: () -> File? = { null }
+  ) = setContent {
+    MaterialTheme {
+      var shown: File? by remember { mutableStateOf(heapDumpFile) }
+      ExplorerApp(shown, onHeapDumpChosen = { shown = it }, chooseHeapDumpFile = chooseHeapDumpFile)
+    }
+  }
+
   private fun ComposeUiTest.openHeapDump(heapDumpFile: File = testHeapDump()) {
-    setContent { MaterialTheme { ExplorerApp(initialHeapDumpFile = heapDumpFile) } }
+    setExplorerContent(heapDumpFile)
     waitUntilAtLeastOneExists(
       hasText(HeapDominatorTreemap.ROOT_LABEL, substring = true),
       OPEN_TIMEOUT_MILLIS

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
@@ -1,0 +1,127 @@
+package shark.explorer.app
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import shark.SharkLog
+
+/**
+ * How many windows the app has and which heap dump each one shows. No heap dump is read here: a window
+ * is a file and a title until [ExplorerApp] opens it.
+ */
+class ExplorerWindowTest {
+
+  /**
+   * What Shark logged during this test, recorded the way [ExplorerAppTest] records it and for the same
+   * reason: a log line is built lazily, so one built from the wrong state says nothing until a test runs
+   * with a logger installed.
+   */
+  private val logged = mutableListOf<String>()
+
+  private var previousLogger: SharkLog.Logger? = null
+
+  @Before fun recordWhatIsLogged() {
+    previousLogger = SharkLog.logger
+    SharkLog.logger = object : SharkLog.Logger {
+      override fun d(message: String) {
+        logged += message
+      }
+
+      override fun d(
+        throwable: Throwable,
+        message: String
+      ) {
+        logged += "$message: $throwable"
+      }
+    }
+  }
+
+  @After fun stopRecordingWhatIsLogged() {
+    SharkLog.logger = previousLogger
+  }
+
+  @Test fun `an app started with no heap dump has one window to open one from`() {
+    val windows = explorerWindows(emptyList())
+
+    assertThat(windows).hasSize(1)
+    assertThat(windows.single().heapDumpFile).isNull()
+  }
+
+  @Test fun `every heap dump on the command line gets a window`() {
+    val windows = explorerWindows(listOf(FIRST_DUMP, SECOND_DUMP))
+
+    assertThat(windows.map { it.heapDumpFile }).containsExactly(FIRST_DUMP, SECOND_DUMP)
+  }
+
+  @Test fun `the first heap dump opens in the window that has none`() {
+    val windows = explorerWindows(emptyList())
+
+    windows.openHeapDump(windows.single(), FIRST_DUMP)
+
+    assertThat(windows).hasSize(1)
+    assertThat(windows.single().heapDumpFile).isEqualTo(FIRST_DUMP)
+    // A run's log covers every window of that run, so which one a heap dump went to has to be in it.
+    assertThat(logged).anyMatch { FIRST_DUMP.name in it && "window that had no heap dump" in it }
+  }
+
+  @Test fun `another heap dump opens in a window of its own`() {
+    val windows = explorerWindows(listOf(FIRST_DUMP))
+    val first = windows.single()
+
+    windows.openHeapDump(first, SECOND_DUMP)
+
+    // The window it was opened from keeps what it was showing: two heap dumps are two windows, which is
+    // what looking at both of them at once takes.
+    assertThat(first.heapDumpFile).isEqualTo(FIRST_DUMP)
+    assertThat(windows.map { it.heapDumpFile }).containsExactly(FIRST_DUMP, SECOND_DUMP)
+    assertThat(logged).anyMatch { SECOND_DUMP.name in it && "a window of its own" in it }
+  }
+
+  @Test fun `the same heap dump twice is two windows`() {
+    val windows = explorerWindows(listOf(FIRST_DUMP))
+
+    windows.openHeapDump(windows.single(), FIRST_DUMP)
+
+    // Two independent reads of one dump rather than a jump to the window already showing it: the point
+    // of a second window is that it can be somewhere else in the same heap dump.
+    assertThat(windows).hasSize(2)
+  }
+
+  @Test fun `no two windows open at the same place`() {
+    val windows = explorerWindows(listOf(FIRST_DUMP, SECOND_DUMP))
+
+    windows.openHeapDump(windows.first(), FIRST_DUMP)
+
+    // A window landing exactly over the one it was opened from is what a heap dump being replaced looks
+    // like, which is the one thing a window per heap dump is meant not to look like.
+    assertThat(windows.map { it.cascade }).doesNotHaveDuplicates()
+  }
+
+  @Test fun `a window opens where a closed one was`() {
+    val windows = explorerWindows(listOf(FIRST_DUMP, SECOND_DUMP))
+    windows -= windows.first()
+
+    windows.openHeapDump(windows.single(), FIRST_DUMP)
+
+    // The cascade is where there is room rather than how many windows have ever been opened, so working
+    // through a directory of heap dumps one at a time doesn't walk them off the screen.
+    assertThat(windows.map { it.cascade }).containsExactly(1, 0)
+  }
+
+  @Test fun `a window is named after the heap dump it shows`() {
+    val windows = explorerWindows(listOf(FIRST_DUMP))
+
+    // Which is what tells one window from another in the window list of the OS, where every window of
+    // an app is otherwise the app.
+    assertThat(windows.single().title).isEqualTo(FIRST_DUMP.name)
+    assertThat(ExplorerWindow(null).title).isEqualTo(APP_NAME)
+  }
+
+  companion object {
+    /** Never opened, so these don't have to exist. */
+    private val FIRST_DUMP = File("first.hprof")
+    private val SECOND_DUMP = File("second.hprof")
+  }
+}


### PR DESCRIPTION
Opening a heap dump used to replace the one the window was showing, which made comparing two of them impossible: the second erased the first, along with wherever the map was zoomed to in it.

Now the windows on screen are the heap dumps open.

- A window keeps the heap dump it shows; another one opens beside it.
- Except in the window that shows nothing — the one the app starts with when it was given no file has nothing to keep, so the first heap dump opens there.
- Every path on the command line gets a window, rather than all but the first being ignored.
- Closing a window closes that heap dump's session; closing the last one quits.

Placing the window turned out to be ours to do rather than the platform's. `WindowPosition.PlatformDefault` centres every window on macOS, so I measured two windows landing on exactly the same pixels — which is what a heap dump being replaced looks like, the one thing this shouldn't look like. `cascadedPosition` centres and then steps 28 dp down and right per window, as many steps as the screen has room for before starting over. Each window is titled after its heap dump, since the OS window list is the only way between them.

Which window a heap dump opens in is plain state in `ExplorerWindow.kt`, because a `Window` needs a display and none of the UI tests have one. `ExplorerWindowTest` covers the rule; `ExplorerApp` is now one window's worth of app and takes the heap dump it shows as a parameter.

Verified by running the app on three heap dumps from `shark-android/src/test/resources`: three windows, three trees, cascaded 28 pt apart and all on screen. `:shark:shark-explorer:shark-explorer-app:check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)