### PR TITLE
Write a log file per run of the Shark Explorer

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -43,6 +43,26 @@ laid out, labelled view is a `TreemapPresentation` or a `RadialPresentation`, an
 The one thing that isn't thread safe is a `Sequence` a `HeapGraph` hands out — iterating one reads
 through it — so a thread reading `graph.objects` needs its own rather than a shared one.
 
+## Every run writes a log file
+
+`installLogging()` in `shark-explorer-app` points `SharkLog` at stdout **and** at
+`~/.shark-explorer/logs/shark-explorer-<when-it-started>.log`, one file per run, the newest
+`SessionLog.KEEP_SESSION_COUNT` kept and the rest deleted as a run starts.
+
+**So ask for that file when someone reports something odd**, and read it before guessing. It holds the
+environment (JVM, OS, heap limit — a dump too large for the explorer runs out of exactly that), every
+step of opening the dump with its duration, and every read of it through `HeapDumpSession.read` with
+what was being read and how long it took. What that makes readable:
+
+- A read logged as started and never as done is where the app was killed, hung, or ran out of memory.
+- The last line being `Shark Explorer closed` is how a session that ended cleanly is told from one that
+  didn't.
+- Everything the window does silently — a path zoomed out because a node left the tree, a click landing
+  on an object the tree has no node for, a list that came back empty — says so there rather than nowhere.
+
+Which is also the rule for new code here: **anything the UI swallows or falls back from gets a
+`SharkLog.d` line saying so.** The file is only worth reading if it's complete.
+
 ## Gradle facts that aren't visible from these build scripts
 
 - **`shark-explorer-app` is excluded by name** from the repo-wide Java 8 target in the root
@@ -83,6 +103,10 @@ it, so run it before pushing.
   tests can't find cells by tag. Test layout and hit testing as pure functions in
   `shark-explorer-core`, and have UI tests drive coordinates with `performMouseInput` and assert on
   the details panel and breadcrumbs.
+- **`ExplorerAppTest` records `SharkLog` for every test**, not only for the two that assert on it. A log
+  line is built from state — an index into a path, a node id — so a line built from the wrong state
+  should fail the test that reaches it rather than wait for a session nobody can read. Which means a
+  test that leaves `SharkLog.logger` set breaks the ones after it, hence the `@After`.
 - **A click is a fraction of the view, never of the window.** `ExplorerAppTest.viewBounds` measures the
   view by its `contentDescription`, and every press helper is relative to that. Window fractions break
   the moment anything above the view changes height, which is a change to the top bar away.

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -66,6 +66,23 @@ asked, since the sizes say what's held how firmly without leaving anything out o
 What the reachability checkboxes do instead is colour: unchecked greys everything held that firmly.
 That's a repaint, not a rebuild, so it's instant and there is no strength it makes no sense to press.
 
+## A log file per run, in `core` rather than in `shark-log`
+
+Reports arrive as "it showed nothing" or "it hung", about a session that has ended. So every run writes
+what it did to `~/.shark-explorer/logs`, and the reads are logged with their durations: without them a
+report is a guess about which of half a dozen heap dump reads was slow, failed, or never came back.
+
+`SessionLog` lives in `shark-explorer-core` and not in `shark-log`, next to `SharkLog` itself, because
+`shark-log` is published with a tracked ABI and this would grow the public API of an artifact a great
+many apps depend on, to serve a desktop tool none of them run. `core` is published nowhere, so it costs
+nothing there. It takes a directory rather than choosing one, which is what keeps it Android-consumable
+and unit testable; the app picks the directory.
+
+A file per run rather than one file appended to: the question asked of a log here is always what one
+session did. Every write is flushed, because the session worth reading is the one that ended by
+crashing, and a buffered tail is the part that would have said why. The last line of a clean run is
+`Shark Explorer closed`, which is how a session that ended is told from one that was killed.
+
 ## Testing split
 
 Headless `runComposeUiTest` on the JVM covers the UI, so there's no emulator in the loop — a real

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerLogging.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerLogging.kt
@@ -1,0 +1,104 @@
+package shark.explorer.app
+
+import java.io.Closeable
+import java.io.File
+import shark.SharkLog
+import shark.explorer.SessionLog
+import shark.explorer.formatByteSize
+
+/**
+ * Sends everything Shark logs to stdout and to this run's own log file, and returns what closes it.
+ *
+ * The file is what makes a report of "it hung" or "it showed nothing" answerable: the log says which
+ * heap dump was open, what was read off it and how long each read took, which read failed and with
+ * what. See [SessionLog], and [LOG_DIRECTORY] for where the files are.
+ */
+internal fun installLogging(): Closeable {
+  val standardOut = StandardOutLogger()
+  val sessionLog = try {
+    SessionLog.openIn(LOG_DIRECTORY)
+  } catch (throwable: Throwable) {
+    // A log file is a side channel, so not being able to open one is no reason not to start: say so on
+    // stdout, where a run from a terminal will see it, and run with stdout alone.
+    standardOut.d(throwable, "Could not open a log file in $LOG_DIRECTORY, logging to stdout only")
+    null
+  }
+  SharkLog.logger = if (sessionLog == null) {
+    standardOut
+  } else {
+    Loggers(listOf(standardOut, sessionLog))
+  }
+  logEnvironment(sessionLog)
+  logUncaughtExceptions()
+  return Closeable {
+    // The line that tells a session that ended from one that was killed or ran out of memory.
+    SharkLog.d { "Shark Explorer closed" }
+    sessionLog?.close()
+  }
+}
+
+/**
+ * What every report needs and nobody thinks to include: which JVM this is, which OS, and above all how
+ * much heap it was given, since a heap dump too large for the explorer runs out of exactly that.
+ */
+private fun logEnvironment(sessionLog: SessionLog?) {
+  val runtime = Runtime.getRuntime()
+  SharkLog.d {
+    "Shark Explorer starting" + if (sessionLog == null) "" else ", logging to ${sessionLog.file}"
+  }
+  SharkLog.d {
+    "Java ${System.getProperty("java.version")} (${System.getProperty("java.vm.name")}) on " +
+      "${System.getProperty("os.name")} ${System.getProperty("os.version")} " +
+      "(${System.getProperty("os.arch")})"
+  }
+  SharkLog.d {
+    "Heap limit ${formatByteSize(runtime.maxMemory())}, " +
+      "${runtime.availableProcessors()} processors"
+  }
+}
+
+/**
+ * Logs what killed a thread, which is otherwise printed to stderr alone and therefore missing from the
+ * file a report attaches. How Compose reports a failure in a composition or in an effect, so this is
+ * what stands between a window that vanished and knowing why.
+ */
+private fun logUncaughtExceptions() {
+  val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+  Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+    SharkLog.d(throwable) { "Uncaught ${throwable.javaClass.name} on thread ${thread.name}" }
+    // Nothing to delegate to when there was no handler, and nothing missing either: printing the trace
+    // is what the JVM would have done, and [StandardOutLogger] has just done it.
+    previousHandler?.uncaughtException(thread, throwable)
+  }
+}
+
+/** Shark's diagnostics on stdout, which is where a run from a terminal expects them. */
+private class StandardOutLogger : SharkLog.Logger {
+
+  override fun d(message: String) = println(message)
+
+  override fun d(
+    throwable: Throwable,
+    message: String
+  ) {
+    println(message)
+    throwable.printStackTrace()
+  }
+}
+
+/** Every log to each of [loggers], in the order they were given. */
+private class Loggers(private val loggers: List<SharkLog.Logger>) : SharkLog.Logger {
+
+  override fun d(message: String) = loggers.forEach { it.d(message) }
+
+  override fun d(
+    throwable: Throwable,
+    message: String
+  ) = loggers.forEach { it.d(throwable, message) }
+}
+
+/**
+ * Where the log files go: under the user's home directory rather than beside the heap dump or in the
+ * working directory, so that every run writes to the same place however it was started.
+ */
+private val LOG_DIRECTORY = File(System.getProperty("user.home"), ".shark-explorer/logs")

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import shark.SharkLog
 import shark.explorer.CellSubject
 import shark.explorer.ExplorerScreen
 import shark.explorer.HeapDominatorTreemap
@@ -49,6 +50,7 @@ import shark.explorer.TreemapNavigation
 import shark.explorer.TreemapPresentation
 import shark.explorer.TreemapRect
 import shark.explorer.formatByteSize
+import shark.explorer.formatObjectCount
 
 /**
  * One open heap dump, read through whichever screen the breadcrumbs say: the dominator tree as a treemap
@@ -118,6 +120,8 @@ internal fun HeapDumpExplorer(
     radialLayout
   ) {
     if (viewportSize == IntSize.Zero) {
+      // Which is what a window showing a spinner and nothing else has been waiting for all along.
+      SharkLog.d { "Not laying the tree out yet: the view has no size" }
       return@LaunchedEffect
     }
     isLayingOut = true
@@ -127,10 +131,19 @@ internal fun HeapDumpExplorer(
       right = viewportSize.width.toDouble(),
       bottom = viewportSize.height.toDouble()
     )
-    view = session.read { explorer ->
+    view = session.read(
+      "the ${shape.displayName.lowercase()} rooted at ${hexObjectId(navigation.current)}, " +
+        "${viewportSize.width}×${viewportSize.height}"
+    ) { explorer ->
       val tree = explorer.tree
       // An object zoomed into may no longer be dominated by the one above it on the path.
       val reachablePath = navigation.retainingWhere { it in tree }
+      if (reachablePath.path.size < navigation.path.size) {
+        SharkLog.d {
+          "Rooted at ${reachablePath.path.size} of the ${navigation.path.size} nodes zoomed through: " +
+            "${hexObjectId(navigation.path[reachablePath.path.size])} is no node of the tree"
+        }
+      }
       ViewState(
         navigation = reachablePath,
         crumbs = reachablePath.path.map { objectId -> tree.crumb(objectId) },
@@ -144,6 +157,8 @@ internal fun HeapDumpExplorer(
         }
       )
     }
+    // What a view that came out looking empty or coarse actually drew.
+    SharkLog.d { "Laid out ${view.presentation.description()}" }
     // Settling for the path that could actually be shown isn't a move, so it replaces where the explorer
     // is rather than being somewhere the back arrow returns to. Only if it's still there: a move made
     // while this was being laid out is not something to overwrite.
@@ -162,7 +177,7 @@ internal fun HeapDumpExplorer(
     selection = if (currentRequest == null) {
       null
     } else {
-      session.read { explorer ->
+      session.read(currentRequest.description()) { explorer ->
         val tree = explorer.tree
         when (currentRequest) {
           is SelectionRequest.Object -> {
@@ -170,7 +185,14 @@ internal fun HeapDumpExplorer(
             when {
               group != null -> Selection.ObjectGroup(group)
               currentRequest.objectId in tree -> Selection.Object(tree.summarize(currentRequest.objectId))
-              else -> null
+              // Which is why the panel goes back to saying nothing is selected.
+              else -> {
+                SharkLog.d {
+                  "Nothing to describe for ${hexObjectId(currentRequest.objectId)}: " +
+                    "it is no node of the tree"
+                }
+                null
+              }
             }
           }
           is SelectionRequest.Group -> Selection.Group(
@@ -188,7 +210,9 @@ internal fun HeapDumpExplorer(
   val selectedObjectId = (selection as? Selection.Object)?.summary?.objectId
   LaunchedEffect(session, selectedObjectId) {
     dominator = selectedObjectId?.let { objectId ->
-      session.read { explorer -> explorer.tree.dominatorOf(objectId) }
+      session.read("the dominator of ${hexObjectId(objectId)}") { explorer ->
+        explorer.tree.dominatorOf(objectId)
+      }
     }
   }
 
@@ -196,7 +220,9 @@ internal fun HeapDumpExplorer(
   // heap dump that indexes which object points at which. So it lands after the rest of the panel.
   LaunchedEffect(session, selectedObjectId) {
     paths = selectedObjectId?.let { objectId ->
-      session.read { explorer -> explorer.tree.independentPathsTo(objectId) }
+      session.read("the paths holding ${hexObjectId(objectId)}") { explorer ->
+        explorer.tree.independentPathsTo(objectId)
+      }
     }
   }
 
@@ -209,7 +235,14 @@ internal fun HeapDumpExplorer(
     }
     isListing = true
     delay(FILTER_SETTLE_MILLIS)
-    objects = session.read { explorer -> explorer.tree.listObjects(objectFilter) }
+    objects = session.read("the objects matching $objectFilter") { explorer ->
+      explorer.tree.listObjects(objectFilter)
+    }
+    // What a list that came back looking empty or short was actually asked for.
+    SharkLog.d {
+      "Listed ${objects.entries.size} of the ${formatObjectCount(objects.matchCount)} matched, " +
+        "out of ${formatObjectCount(objects.totalCount)}"
+    }
     isListing = false
   }
 
@@ -217,7 +250,14 @@ internal fun HeapDumpExplorer(
   // of a list leads to is a heap dump read as well.
   LaunchedEffect(session, nodeToOpen) {
     val open = nodeToOpen ?: return@LaunchedEffect
-    val path = session.read { explorer -> explorer.tree.pathToOpen(open.nodeId) }
+    val path = session.read("where the map draws ${hexObjectId(open.nodeId)}") { explorer ->
+      explorer.tree.pathToOpen(open.nodeId)
+    }
+    if (open.nodeId != ROOT_NODE && path == listOf(ROOT_NODE)) {
+      // Clicking a field or a row led to an object the tree has no node for, so the map has nowhere to
+      // go and stays on the whole heap dump.
+      SharkLog.d { "${hexObjectId(open.nodeId)} is nowhere on the map: it is no node of the tree" }
+    }
     val zoomed = history.current.treeNavigation.zoomInto(path)
     history = history.goTo(
       if (open.showsPaths) {
@@ -359,11 +399,21 @@ internal fun HeapDumpExplorer(
           )
         },
         onToggleStar = {
-          val summary = selectedSummary ?: return@DetailsPanel
-          favourites = if (favourites.any { it.objectId == summary.objectId }) {
-            favourites.filterNot { it.objectId == summary.objectId }
+          val summary = selectedSummary
+          if (summary == null) {
+            // The star is only ever drawn beside a selected object, so this is the panel and the
+            // selection disagreeing rather than a click on nothing.
+            SharkLog.d { "Nothing to star: no object is selected" }
           } else {
-            favourites + Favourite.of(summary, dominator)
+            val wasStarred = favourites.any { it.objectId == summary.objectId }
+            SharkLog.d {
+              "${if (wasStarred) "Unstarred" else "Starred"} ${hexObjectId(summary.objectId)}"
+            }
+            favourites = if (wasStarred) {
+              favourites.filterNot { it.objectId == summary.objectId }
+            } else {
+              favourites + Favourite.of(summary, dominator)
+            }
           }
         },
         modifier = Modifier.width(DETAILS_WIDTH).fillMaxHeight()
@@ -566,6 +616,14 @@ internal sealed interface ViewPresentation {
   data class Radial(val presentation: RadialPresentation) : ViewPresentation
 }
 
+/** What a laid out view amounts to, for the log: one that drew nothing at all says so here. */
+private fun ViewPresentation.description(): String = when (this) {
+  is ViewPresentation.Treemap ->
+    "${presentation.cells.size} rectangles, ${presentation.truncatedNodeCount} nodes not expanded"
+  is ViewPresentation.Radial ->
+    "${presentation.cells.size} sectors, ${presentation.truncatedNodeCount} nodes not expanded"
+}
+
 internal class Crumb(
   val objectId: Long,
   val label: String
@@ -597,6 +655,12 @@ private sealed interface SelectionRequest {
       is CellSubject.Own -> Object(subject.node)
     }
   }
+}
+
+/** What the panel is being filled in for, for the log. See [HeapDumpSession.read]. */
+private fun SelectionRequest.description(): String = when (this) {
+  is SelectionRequest.Object -> "what ${hexObjectId(objectId)} is"
+  is SelectionRequest.Group -> "what the $nodeCount objects under ${hexObjectId(parentObjectId)} are"
 }
 
 private const val ROOT_NODE = HeapDominatorTreemap.ROOT_OBJECT_ID

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpSession.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpSession.kt
@@ -4,9 +4,12 @@ import java.io.Closeable
 import java.io.File
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit.NANOSECONDS
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
+import shark.SharkLog
 import shark.explorer.HeapExplorer
 
 /**
@@ -29,8 +32,32 @@ class HeapDumpSession private constructor(
 
   val heapDumpFile: File get() = explorer.heapDumpFile
 
-  /** Runs [block] against the heap dump on the thread that owns it. */
-  suspend fun <T> read(block: (HeapExplorer) -> T): T = withContext(dispatcher) { block(explorer) }
+  /**
+   * Runs [block] against the heap dump on the thread that owns it, logging [description] as it starts
+   * and as it comes back.
+   *
+   * Every read of an open heap dump goes through here, so this is also the trace of what the window was
+   * doing: how long each read took says which one made it feel stuck, a read logged as started and
+   * never as done is where a session that was killed or ran out of memory was, and a read that throws
+   * is logged with what it was reading rather than with a stack trace alone.
+   *
+   * [description] therefore names what is being read, e.g. "the dominator of 0x12ab4000".
+   */
+  suspend fun <T> read(
+    description: String,
+    block: (HeapExplorer) -> T
+  ): T = withContext(dispatcher) {
+    SharkLog.d { "Reading $description" }
+    val startNanos = System.nanoTime()
+    try {
+      block(explorer).also {
+        SharkLog.d { "Read $description in ${millisSince(startNanos)} ms" }
+      }
+    } catch (throwable: Throwable) {
+      SharkLog.d(throwable) { "Failed to read $description after ${millisSince(startNanos)} ms" }
+      throw throwable
+    }
+  }
 
   /**
    * Closes the heap dump on its own thread, then releases the thread.
@@ -39,7 +66,21 @@ class HeapDumpSession private constructor(
    * behind whatever read is in flight rather than waited for.
    */
   override fun close() {
-    executor.execute { explorer.close() }
+    SharkLog.d { "Closing ${heapDumpFile.name}" }
+    try {
+      executor.execute {
+        try {
+          explorer.close()
+          SharkLog.d { "Closed ${heapDumpFile.name}" }
+        } catch (throwable: Throwable) {
+          // Nothing is waiting on this, so an exception here would otherwise reach an executor's
+          // uncaught handler and be printed by nobody.
+          SharkLog.d(throwable) { "Failed to close ${heapDumpFile.name}" }
+        }
+      }
+    } catch (rejected: RejectedExecutionException) {
+      SharkLog.d(rejected) { "${heapDumpFile.name} was already being closed" }
+    }
     executor.shutdown()
   }
 
@@ -64,5 +105,7 @@ class HeapDumpSession private constructor(
         throw throwable
       }
     }
+
+    private fun millisSince(startNanos: Long): Long = NANOSECONDS.toMillis(System.nanoTime() - startNanos)
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -36,20 +36,13 @@ import shark.explorer.formatByteSize
 import shark.explorer.formatObjectCount
 
 fun main(args: Array<String>) {
-  // Launched from a terminal, so Shark's own diagnostics and any failure to open a heap dump belong
-  // on stdout as well as in the window.
-  SharkLog.logger = object : SharkLog.Logger {
-    override fun d(message: String) = println(message)
-
-    override fun d(
-      throwable: Throwable,
-      message: String
-    ) {
-      println(message)
-      throwable.printStackTrace()
-    }
+  // Launched from a terminal, so Shark's own diagnostics and any failure to open a heap dump belong on
+  // stdout as well as in the window — and in a file, so that a session someone reports on can be read
+  // back after it. See [installLogging].
+  installLogging().use {
+    SharkLog.d { "Started with ${if (args.isEmpty()) "no arguments" else args.joinToString(" ")}" }
+    explorerApplication(args)
   }
-  explorerApplication(args)
 }
 
 private fun explorerApplication(args: Array<String>) = application {
@@ -85,7 +78,7 @@ fun ExplorerApp(
       val session = HeapDumpSession.open(file) { step ->
         state = HeapDumpState.Opening(file, step)
       }
-      val sizes = session.read { it.sizes }
+      val sizes = session.read("the sizes of ${file.name}") { it.sizes }
       HeapDumpState.Open(session, sizes).also {
         SharkLog.d { "${it.statusLine()} · ${sizes.strengthsText()}" }
       }
@@ -104,7 +97,16 @@ fun ExplorerApp(
   Column(Modifier.fillMaxSize()) {
     HeapDumpBar(
       state = currentState,
-      onOpenClick = { chooseHeapDumpFile()?.let { requestedFile = it } }
+      onOpenClick = {
+        val chosenFile = chooseHeapDumpFile()
+        if (chosenFile == null) {
+          // Which is why nothing happened, and the only way to tell that from a dialog that failed to
+          // open at all.
+          SharkLog.d { "No heap dump chosen" }
+        } else {
+          requestedFile = chosenFile
+        }
+      }
     )
     if (currentState is HeapDumpState.Open) {
       // Keyed on the session, so that opening another heap dump starts from the whole of it rather than

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -35,11 +35,15 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import shark.GcRoot.JniGlobal
+import shark.SharkLog
 import shark.ValueHolder.ReferenceHolder
 import shark.dump
 import shark.explorer.ExplorerScreen
@@ -60,6 +64,37 @@ class ExplorerAppTest {
 
   /** The object id of the array in [testHeapDump], recorded as the dump is written. */
   private var payloadObjectId = 0L
+
+  /**
+   * Everything Shark logged during this test, a line per log with the throwable it came with appended.
+   *
+   * Recorded for every test rather than only for the ones asserting on it, so that a log line built from
+   * the wrong state — an index into a path that has been shortened, say — fails the test that reaches it.
+   * The window's thread and the heap dump's both log, hence the concurrent list.
+   */
+  private val logged = CopyOnWriteArrayList<String>()
+
+  private var previousLogger: SharkLog.Logger? = null
+
+  @Before fun recordWhatIsLogged() {
+    previousLogger = SharkLog.logger
+    SharkLog.logger = object : SharkLog.Logger {
+      override fun d(message: String) {
+        logged += message
+      }
+
+      override fun d(
+        throwable: Throwable,
+        message: String
+      ) {
+        logged += "$message: $throwable"
+      }
+    }
+  }
+
+  @After fun stopRecordingWhatIsLogged() {
+    SharkLog.logger = previousLogger
+  }
 
   @Test fun `nothing is open until a heap dump is chosen`() {
     runComposeUiTest {
@@ -100,6 +135,35 @@ class ExplorerAppTest {
 
       waitUntilAtLeastOneExists(hasText("could not be opened", substring = true), OPEN_TIMEOUT_MILLIS)
     }
+  }
+
+  /**
+   * A window reporting a failure and a log saying nothing about it is a report nobody can answer, so what
+   * the window says has to be what the log says too. Where the log goes: [shark.explorer.SessionLog].
+   */
+  @Test fun `a file that is not a heap dump is logged with what went wrong`() {
+    runComposeUiTest {
+      val notAHeapDump = testFolder.newFile("not-a-heap-dump.txt").apply { writeText("nope") }
+      setContent { MaterialTheme { ExplorerApp(initialHeapDumpFile = notAHeapDump) } }
+
+      waitUntilAtLeastOneExists(hasText("could not be opened", substring = true), OPEN_TIMEOUT_MILLIS)
+    }
+
+    assertThat(logged).anyMatch { "Could not open" in it && "not-a-heap-dump.txt" in it }
+  }
+
+  /**
+   * What makes a session readable after it: which dump was opened, which step of opening it was running,
+   * and every read of it once it's open. See [HeapDumpSession.read].
+   */
+  @Test fun `opening a heap dump and reading it are logged`() {
+    runComposeUiTest { openHeapDump() }
+
+    assertThat(logged).anyMatch { it.startsWith("Opening heap dump") }
+    assertThat(logged).anyMatch { it.startsWith("Indexing") }
+    assertThat(logged).anyMatch { it.startsWith("Opened") }
+    assertThat(logged).anyMatch { it.startsWith("Read the sizes of") }
+    assertThat(logged).anyMatch { it.startsWith("Read the treemap rooted at") }
   }
 
   @Test fun `the whole heap dump is accounted for at the top`() {

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -42,6 +42,7 @@ import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.Sh
 import shark.ObjectDominators.DominatorNode
 import shark.ObjectReporter
 import shark.AndroidObjectInspectors
+import shark.SharkLog
 import shark.ValueHolder.BooleanHolder
 import shark.ValueHolder.ByteHolder
 import shark.ValueHolder.CharHolder
@@ -122,12 +123,21 @@ class HeapDominatorTreemap internal constructor(
   }
 
   /** Bytes retained by [node]: its own shallow size plus that of everything it dominates. */
-  override fun weight(node: Long): Long = group(node)?.retainedSize
-    ?: nodes.getValue(node).retainedSize
+  override fun weight(node: Long): Long = group(node)?.retainedSize ?: nodeOf(node).retainedSize
 
   override fun children(node: Long): List<Long> = when {
     node == root -> topLevel.ids
-    else -> group(node)?.childIds ?: nodes.getValue(node).dominatedObjectIds
+    else -> group(node)?.childIds ?: nodeOf(node).dominatedObjectIds
+  }
+
+  /**
+   * This tree's node for [nodeId], which every object of the heap dump has one of.
+   *
+   * Not [Map.getValue], whose "Key 21474836480 is missing in the map" is what asking this tree about an
+   * object of another heap dump reads as, three frames below whatever asked.
+   */
+  private fun nodeOf(nodeId: Long): DominatorNode = requireNotNull(nodes[nodeId]) {
+    "$nodeId is no node of this tree, which has ${nodes.size} of them. Ask contains() first."
   }
 
   /** Whether [objectId] is a node of this tree, which every object of the heap dump is. */
@@ -184,14 +194,14 @@ class HeapDominatorTreemap internal constructor(
     )
     // One pass, one read of each child: a production dump has six figures worth of them, and looking one
     // up twice — once for its strength and once for its class — was seconds of the wait to first paint.
-    nodes.getValue(root).dominatedObjectIds.forEach { objectId ->
+    nodeOf(root).dominatedObjectIds.forEach { objectId ->
       val heapObject = graph.findObjectById(objectId)
       val half = if (reachability.strengthOf(heapObject) == ReachabilityStrength.UNREACHABLE) {
         unreachable
       } else {
         reachable
       }
-      half.add(heapObject, nodes.getValue(objectId).retainedSize)
+      half.add(heapObject, nodeOf(objectId).retainedSize)
     }
     val groups = LinkedHashMap<Long, NodeGroup>()
     val ids = mutableListOf<Long>()
@@ -233,7 +243,7 @@ class HeapDominatorTreemap internal constructor(
       strength = half.strength,
       // Heaviest first, like the dominated ids a node hands out, so that these children stay ordered the
       // way the rest of the tree's are. Not through [weight], which would ask for the groups being built.
-      childIds = grouped.sortedByDescending { groups[it]?.retainedSize ?: nodes.getValue(it).retainedSize },
+      childIds = grouped.sortedByDescending { groups[it]?.retainedSize ?: nodeOf(it).retainedSize },
       retainedSize = half.retainedSize,
       objectCount = half.objectCount
     )
@@ -255,7 +265,10 @@ class HeapDominatorTreemap internal constructor(
       if (objectIds.size == 1) {
         ids += objectIds
       } else {
-        val heapClass = graph.findObjectById(classId).asClass!!
+        val heapClass = checkNotNull(graph.findObjectById(classId).asClass) {
+          "The class ${objectIds.size} objects were gathered under, ${hexObjectId(classId)}, is no " +
+            "class of the heap dump"
+        }
         val groupId = groupIds.next()
         groups[groupId] = NodeGroup(
           kind = ObjectGroupKind.CLASS,
@@ -264,7 +277,7 @@ class HeapDominatorTreemap internal constructor(
           simpleClassName = heapClass.simpleName,
           strength = half.strength,
           childIds = objectIds,
-          retainedSize = objectIds.sumOf { nodes.getValue(it).retainedSize },
+          retainedSize = objectIds.sumOf { nodeOf(it).retainedSize },
           objectCount = objectIds.size
         )
         ids += groupId
@@ -286,12 +299,24 @@ class HeapDominatorTreemap internal constructor(
   }
 
   /**
-   * The id of a class by name, looked up once per name: [HeapGraph.findClassByName] performs two linear
-   * scans over every string of the heap dump, and asking it per object of a production dump — once for
-   * every class object, once for every `byte[]` — took the best part of a minute.
+   * The id of a class by name, looked up once per name and remembered whether it was found or not:
+   * [HeapGraph.findClassByName] performs two linear scans over every string of the heap dump, and asking
+   * it per object of a production dump — once for every class object, once for every `byte[]` — took the
+   * best part of a minute.
    */
-  private fun classIdOf(className: String): Long? =
-    classIdByName.getOrPut(className) { graph.findClassByName(className)?.objectId }
+  private fun classIdOf(className: String): Long? {
+    if (className in classIdByName) {
+      return classIdByName[className]
+    }
+    val classId = graph.findClassByName(className)?.objectId
+    if (classId == null) {
+      // Which leaves every object of that class as a rectangle of its own under the root rather than
+      // gathered with its siblings, so it's worth a line saying so.
+      SharkLog.d { "No class named $className in the heap dump, so nothing groups by it" }
+    }
+    classIdByName[className] = classId
+    return classId
+  }
 
   private val classIdByName = mutableMapOf<String, Long?>()
 
@@ -340,7 +365,7 @@ class HeapDominatorTreemap internal constructor(
       "$objectId stands for a pile of objects rather than for one. Ask groupOrNull() first, and " +
         "describe it with what that returns."
     }
-    val node = nodes.getValue(objectId)
+    val node = nodeOf(objectId)
     val heapObject = if (objectId == root) null else graph.findObjectById(objectId)
     val fields = heapObject?.fieldsOf() ?: FieldList(emptyList(), totalCount = 0)
     return HeapObjectSummary(
@@ -507,6 +532,11 @@ class HeapDominatorTreemap internal constructor(
     val dominator = dominatorOf(objectId) ?: return IndependentPaths.NONE
     val targetIndex = referrerIndex.indexOf(objectId)
     if (targetIndex == ReferrerIndex.NOT_AN_OBJECT) {
+      // A node of the tree the heap dump has no object for: nothing to walk up from, and the tree and
+      // the dump disagreeing about what is in the dump.
+      SharkLog.d {
+        "No paths to ${hexObjectId(objectId)}: it is a node of the tree and no object of the heap dump"
+      }
       return IndependentPaths.NONE
     }
     val isBelowGroup = dominator.kind != DominatorKind.OBJECT
@@ -528,6 +558,14 @@ class HeapDominatorTreemap internal constructor(
     while (paths.size < MAX_INDEPENDENT_PATHS) {
       val found = search.findPath(isSource) ?: break
       paths += path(found, isBelowGroup)
+    }
+    if (paths.isEmpty()) {
+      // The tree attributes the object's bytes to that dominator, so there is a path from it by
+      // construction. Not finding one means the walk up the referrers and the walk down the tree were
+      // built through different references, which is the panel saying an object is held by nothing.
+      SharkLog.d {
+        "No path found from ${dominator.label} down to ${hexObjectId(objectId)}, though it dominates it"
+      }
     }
     return IndependentPaths(paths = paths, hasMore = paths.size == MAX_INDEPENDENT_PATHS)
   }
@@ -613,10 +651,24 @@ class HeapDominatorTreemap internal constructor(
    * Only the roots the tree followed, so that an object a local variable also happens to point at isn't
    * named after the local variable. See [TreeGcRootProvider].
    */
-  private fun gcRootLabelOf(objectId: Long): String = graph.gcRoots
-    .firstOrNull { it.id == objectId && reachability.isHeldThrough(objectId, it.reachabilityStrength()) }
-    ?.let { gcRootLabel(it) }
-    ?: UNCOLLECTED_LABEL
+  private fun gcRootLabelOf(objectId: Long): String {
+    val gcRoot = graph.gcRoots.firstOrNull {
+      it.id == objectId && reachability.isHeldThrough(objectId, it.reachabilityStrength())
+    }
+    if (gcRoot != null) {
+      return gcRootLabel(gcRoot)
+    }
+    val strength = strengthOf(objectId)
+    if (strength != ReachabilityStrength.UNREACHABLE) {
+      // Which is the paths screen calling an object garbage while the treemap draws it in the reachable
+      // half, and the two can only disagree if the roots the tree walked from aren't the roots here.
+      SharkLog.d {
+        "The path to ${hexObjectId(objectId)} starts at no GC root this tree was built from, though the " +
+          "object is reachable ($strength), so the path says uncollected garbage instead"
+      }
+    }
+    return UNCOLLECTED_LABEL
+  }
 
   /** How [referrerId] points at [objectId], which takes reading the referrer's references again. */
   private fun stepTo(
@@ -627,6 +679,15 @@ class HeapDominatorTreemap internal constructor(
       .firstOrNull { it.valueObjectId == objectId }
       ?.lazyDetailsResolver
       ?.resolve()
+    if (details == null) {
+      // The walk found this step through the referrer index, which was built with this same reader, so a
+      // step with no reference to name means the two disagree about the same pair of objects. Shows as a
+      // step naming the object and not how it's held.
+      SharkLog.d {
+        "No reference from ${hexObjectId(referrerId)} to ${hexObjectId(objectId)}, though the path to it " +
+          "was found through one"
+      }
+    }
     return step(
       objectId = objectId,
       reference = details?.let { resolved ->
@@ -1017,6 +1078,9 @@ class HeapDominatorTreemap internal constructor(
      * object. The root is [NULL_REFERENCE], neither.
      */
     private fun isGroupId(node: Long) = node < 0L
+
+    /** How an object id reads in a log line: hex, the way a heap dump records it. */
+    private fun hexObjectId(objectId: Long): String = "0x${objectId.toString(16)}"
 
     private const val BITMAP_CLASS_NAME = "android.graphics.Bitmap"
     private const val NULL_VALUE = "null"

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapExplorer.kt
@@ -2,6 +2,7 @@ package shark.explorer
 
 import java.io.Closeable
 import java.io.File
+import java.util.concurrent.TimeUnit.NANOSECONDS
 import shark.AndroidObjectSizeCalculator
 import shark.CloseableHeapGraph
 import shark.GcRoot
@@ -12,6 +13,7 @@ import shark.HeapGraph
 import shark.HprofHeapGraph.Companion.openHeapGraph
 import shark.HprofRecordTag
 import shark.MatchingGcRootProvider
+import shark.SharkLog
 
 /**
  * A heap dump, open and indexed, with its reachability worked out and its dominator [tree] built.
@@ -44,49 +46,92 @@ class HeapExplorer private constructor(
       heapDumpFile: File,
       onProgress: (String) -> Unit = {}
     ): HeapExplorer {
-      onProgress("Indexing ${heapDumpFile.name}")
+      SharkLog.d { "Opening heap dump $heapDumpFile, ${formatByteSize(heapDumpFile.length())}" }
+      val startNanos = System.nanoTime()
+      val steps = OpenSteps(onProgress)
       // Every GC root kind the hprof records, rather than HprofIndex.defaultIndexedGcRootTags():
       // those defaults drop the kinds that can't explain a leak, which on a real app dump is 180 K of
       // the 188 K roots — interned strings and the runtime's internals. An explorer has to say where
       // every object is held, so dropping a root kind means calling 45 K live objects garbage.
-      val graph = heapDumpFile.openHeapGraph(indexedGcRootTypes = HprofRecordTag.rootTags)
+      val graph = steps.run("Indexing ${heapDumpFile.name}") {
+        heapDumpFile.openHeapGraph(indexedGcRootTypes = HprofRecordTag.rootTags)
+      }
       try {
         val strengthReader = ReferenceStrengthReader(graph)
-        onProgress("Working out what owns what")
-        val ownerReferences = OwnerReferences.computeFor(graph)
-        onProgress("Working out what's reachable")
-        val reachability = HeapReachability.computeFor(
-          graph = graph,
-          strengthReader = strengthReader,
-          ownerReferences = ownerReferences,
-          gcRootProvider = MatchingGcRootProvider(emptyList()),
-          objectSizeCalculator = AndroidObjectSizeCalculator(graph)
-        )
-        onProgress("Working out what retains what")
+        val ownerReferences = steps.run("Working out what owns what") {
+          OwnerReferences.computeFor(graph)
+        }
+        val reachability = steps.run("Working out what's reachable") {
+          HeapReachability.computeFor(
+            graph = graph,
+            strengthReader = strengthReader,
+            ownerReferences = ownerReferences,
+            gcRootProvider = MatchingGcRootProvider(emptyList()),
+            objectSizeCalculator = AndroidObjectSizeCalculator(graph)
+          )
+        }
         val gcRootProvider = TreeGcRootProvider(reachability)
-        val dominatorTree = HeapDominatorTree.buildFor(
-          graph = graph,
-          referenceReader = WeakeningAwareReferenceReader(strengthReader, reachability, ownerReferences),
-          gcRootProvider = gcRootProvider
-        )
-        val nodes = dominatorTree.buildNodes(AndroidObjectSizeCalculator(graph))
-        val tree = HeapDominatorTreemap(
-          graph = graph,
-          reachability = reachability,
-          strengthReader = strengthReader,
-          ownerReferences = ownerReferences,
-          gcRootProvider = gcRootProvider,
-          dominatorTree = dominatorTree,
-          nodes = nodes
-        )
+        val tree = steps.run("Working out what retains what") {
+          val dominatorTree = HeapDominatorTree.buildFor(
+            graph = graph,
+            referenceReader = WeakeningAwareReferenceReader(strengthReader, reachability, ownerReferences),
+            gcRootProvider = gcRootProvider
+          )
+          HeapDominatorTreemap(
+            graph = graph,
+            reachability = reachability,
+            strengthReader = strengthReader,
+            ownerReferences = ownerReferences,
+            gcRootProvider = gcRootProvider,
+            dominatorTree = dominatorTree,
+            nodes = dominatorTree.buildNodes(AndroidObjectSizeCalculator(graph))
+          )
+        }
+        SharkLog.d {
+          val sizes = reachability.sizes
+          "Opened ${heapDumpFile.name} in ${millisSince(startNanos)} ms: " +
+            "${formatObjectCount(sizes.totalObjectCount)}, ${formatByteSize(sizes.totalByteCount)}, " +
+            "${formatByteSize(sizes.unreachableByteCount)} of it unreachable"
+        }
         return HeapExplorer(heapDumpFile, graph, reachability, tree)
       } catch (throwable: Throwable) {
-        graph.close()
+        // Closing on the way out must not replace what went wrong with a failure to close, which is
+        // what would be reported and is never the cause.
+        try {
+          graph.close()
+        } catch (closeFailure: Throwable) {
+          SharkLog.d(closeFailure) { "Failed to close $heapDumpFile after giving up on opening it" }
+        }
         throw throwable
       }
     }
   }
 }
+
+/**
+ * Runs the steps of opening a heap dump, telling the caller and the log which one is running and how
+ * long it took.
+ *
+ * Which step a session was in is the first thing to ask of its log when opening a dump never finished:
+ * a step logged as started and never as done is where the app was killed, or where it ran out of the
+ * heap a large dump needs.
+ */
+private class OpenSteps(private val onProgress: (String) -> Unit) {
+
+  fun <T> run(
+    description: String,
+    step: () -> T
+  ): T {
+    onProgress(description)
+    SharkLog.d { description }
+    val startNanos = System.nanoTime()
+    return step().also {
+      SharkLog.d { "$description: done in ${millisSince(startNanos)} ms" }
+    }
+  }
+}
+
+private fun millisSince(startNanos: Long): Long = NANOSECONDS.toMillis(System.nanoTime() - startNanos)
 
 /**
  * Where the dominator tree hangs the heap dump off: the GC roots that explain why what they point at is

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SessionLog.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SessionLog.kt
@@ -1,0 +1,163 @@
+package shark.explorer
+
+import java.io.Closeable
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.io.Writer
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import shark.SharkLog
+
+/**
+ * A [SharkLog.Logger] writing to a file of one run's own, with the files of the runs before it kept
+ * until there are more than [KEEP_SESSION_COUNT] of them.
+ *
+ * What this is for: someone reporting that the explorer did something odd, and reading back what it
+ * actually did rather than what anyone remembers of it — which heap dump, which reads, which one
+ * failed and with what. So every line says when it was written and from which thread, and every write
+ * is flushed, because the session worth reading is usually the one that ended by crashing and a
+ * buffered tail is the part that explains why.
+ *
+ * A file per run rather than one file appended to for ever: the question is always what one session
+ * did, and a week of sessions in one file is a file nobody reads.
+ */
+class SessionLog private constructor(
+  /** The file this run logs to. Worth showing the user, since it's what a bug report attaches. */
+  val file: File,
+  private val writer: Writer
+) : SharkLog.Logger, Closeable {
+
+  /** [SimpleDateFormat] isn't thread safe, so this is only ever touched under [write]'s lock. */
+  private val lineTimeFormat = SimpleDateFormat(LINE_TIME_PATTERN, Locale.US)
+
+  /** False once this stops being written to, by [close] or by a write that failed. */
+  private var isOpen = true
+
+  override fun d(message: String) = write(message, throwable = null)
+
+  override fun d(
+    throwable: Throwable,
+    message: String
+  ) = write(message, throwable)
+
+  private fun write(
+    message: String,
+    throwable: Throwable?
+  ) {
+    // Shark logs from whichever thread does the work — the window's, the heap dump's, an uncaught
+    // exception handler's — and one thread's line spliced into another's reads as a corrupted file.
+    synchronized(this) {
+      if (!isOpen) {
+        return
+      }
+      try {
+        writer.write("${lineTimeFormat.format(Date())} [${Thread.currentThread().name}] $message\n")
+        throwable?.let { writer.write(it.stackTraceText()) }
+        writer.flush()
+      } catch (failure: IOException) {
+        // Not logged through SharkLog, which is what this is the sink of, and only once: a line per
+        // log line saying the log isn't being written is worse than the log that is missing. Stderr
+        // because a run from a terminal is where anyone would notice.
+        isOpen = false
+        System.err.println("Stopped writing to the log file $file: $failure")
+      }
+    }
+  }
+
+  /**
+   * Stops writing and releases the file.
+   *
+   * Nothing is lost by never calling this — every line is already flushed — and whatever logs after it
+   * is dropped rather than throwing, because a logger that throws while the app is shutting down
+   * replaces the reason it is shutting down.
+   */
+  override fun close() {
+    synchronized(this) {
+      if (isOpen) {
+        isOpen = false
+        writer.close()
+      }
+    }
+  }
+
+  /**
+   * Deletes the oldest log files, keeping this run's and the [keepSessionCount] - 1 runs before it.
+   *
+   * Says what it deleted, and says when it couldn't: a log directory that grows past what it's meant
+   * to is only ever explained here.
+   */
+  private fun deleteOlderSessions(keepSessionCount: Int) {
+    val directory = file.parentFile
+    val logFiles = directory.listFiles { candidate: File -> candidate.isSessionLog() }
+    if (logFiles == null) {
+      d("Could not list $directory to delete the log files of older runs")
+      return
+    }
+    // Named after the time the run started, so oldest first is a sort by name.
+    logFiles.sortedBy { it.name }.dropLast(keepSessionCount).forEach { olderLog ->
+      if (olderLog.delete()) {
+        d("Deleted the log of an older run, $olderLog")
+      } else {
+        d("Could not delete the log of an older run, $olderLog")
+      }
+    }
+  }
+
+  companion object {
+    /**
+     * Opens the log file of this run in [directory], creating the directory if it isn't there, and
+     * deletes all but the newest [keepSessionCount] log files, this one included.
+     */
+    fun openIn(
+      directory: File,
+      keepSessionCount: Int = KEEP_SESSION_COUNT,
+      startedAt: Date = Date()
+    ): SessionLog {
+      require(keepSessionCount >= 1) {
+        "Expected to keep at least this run's log file, not $keepSessionCount of them"
+      }
+      directory.mkdirs()
+      check(directory.isDirectory) {
+        "Expected $directory to be a directory to write this run's log file to"
+      }
+      val fileName = FILE_NAME_PREFIX +
+        SimpleDateFormat(FILE_NAME_TIME_PATTERN, Locale.US).format(startedAt) +
+        FILE_NAME_SUFFIX
+      val file = File(directory, fileName)
+      // Appended to rather than truncated: two runs starting in the same millisecond isn't something
+      // that happens, and if it ever did, two sessions in one file beats one of them overwritten.
+      val writer = OutputStreamWriter(FileOutputStream(file, true), Charsets.UTF_8).buffered()
+      return SessionLog(file, writer).apply { deleteOlderSessions(keepSessionCount) }
+    }
+
+    /**
+     * How many runs' log files are kept. Enough that a session reported a few days late is still
+     * there, few enough that the directory stays something to read rather than to search.
+     */
+    const val KEEP_SESSION_COUNT = 20
+
+    private const val FILE_NAME_PREFIX = "shark-explorer-"
+
+    private const val FILE_NAME_SUFFIX = ".log"
+
+    /** Sorts oldest first as text, which is what makes finding the oldest files a sort by name. */
+    private const val FILE_NAME_TIME_PATTERN = "yyyy-MM-dd_HH-mm-ss_SSS"
+
+    /** No date: the file name has it, and every line of a session is better off short. */
+    private const val LINE_TIME_PATTERN = "HH:mm:ss.SSS"
+
+    private fun File.isSessionLog(): Boolean =
+      name.startsWith(FILE_NAME_PREFIX) && name.endsWith(FILE_NAME_SUFFIX)
+
+    private fun Throwable.stackTraceText(): String {
+      val text = StringWriter()
+      PrintWriter(text).use { printStackTrace(it) }
+      return text.toString()
+    }
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/SessionLogTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/SessionLogTest.kt
@@ -1,0 +1,113 @@
+package shark.explorer
+
+import java.io.File
+import java.util.Date
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SessionLogTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  private val logDirectory: File get() = File(testFolder.root, "logs")
+
+  @Test fun `a message is written with the time and the thread it came from`() {
+    val log = SessionLog.openIn(logDirectory)
+
+    log.d("Opening a heap dump")
+    log.close()
+
+    assertThat(log.file.readText())
+      .containsPattern("\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d ")
+      .contains("[${Thread.currentThread().name}]")
+      .contains("Opening a heap dump")
+  }
+
+  @Test fun `a throwable is written with its stack trace`() {
+    val log = SessionLog.openIn(logDirectory)
+
+    log.d(IllegalStateException("Not a heap dump"), "Could not open dump.hprof")
+    log.close()
+
+    assertThat(log.file.readText())
+      .contains("Could not open dump.hprof")
+      .contains("java.lang.IllegalStateException: Not a heap dump")
+      .contains("at shark.explorer.SessionLogTest")
+  }
+
+  @Test fun `every line is written before the log is closed`() {
+    val log = SessionLog.openIn(logDirectory)
+
+    log.d("A session that crashes right here")
+
+    assertThat(log.file.readText()).contains("A session that crashes right here")
+  }
+
+  @Test fun `each run writes to a file of its own`() {
+    val firstRun = SessionLog.openIn(logDirectory, startedAt = Date(0))
+    val secondRun = SessionLog.openIn(logDirectory, startedAt = Date(1000))
+
+    firstRun.d("The first run")
+    secondRun.d("The second run")
+    firstRun.close()
+    secondRun.close()
+
+    assertThat(firstRun.file).isNotEqualTo(secondRun.file)
+    assertThat(firstRun.file.readText()).contains("The first run").doesNotContain("The second run")
+    assertThat(secondRun.file.readText()).contains("The second run").doesNotContain("The first run")
+  }
+
+  @Test fun `the log files of older runs are deleted`() {
+    val runs = (1..5).map { run ->
+      SessionLog.openIn(logDirectory, keepSessionCount = 3, startedAt = Date(run * 1000L))
+        .apply { close() }
+    }
+
+    assertThat(logDirectory.listFiles()!!.map { it.name })
+      .containsExactlyInAnyOrderElementsOf(runs.takeLast(3).map { it.file.name })
+  }
+
+  @Test fun `deleting the log file of an older run is logged`() {
+    SessionLog.openIn(logDirectory, keepSessionCount = 1, startedAt = Date(0)).apply { close() }
+
+    val secondRun = SessionLog.openIn(logDirectory, keepSessionCount = 1, startedAt = Date(1000))
+    secondRun.close()
+
+    assertThat(secondRun.file.readText()).contains("Deleted the log of an older run")
+  }
+
+  @Test fun `a file that is not a log of this directory is left alone`() {
+    val heapDump = File(logDirectory.apply { mkdirs() }, "dump.hprof").apply { writeText("not a log") }
+
+    SessionLog.openIn(logDirectory, keepSessionCount = 1).close()
+
+    assertThat(heapDump).exists()
+  }
+
+  @Test fun `the log directory is created`() {
+    val log = SessionLog.openIn(File(logDirectory, "nested"))
+
+    log.close()
+
+    assertThat(log.file).exists()
+  }
+
+  @Test fun `logging after the log is closed neither throws nor writes`() {
+    val log = SessionLog.openIn(logDirectory)
+    log.d("Before closing")
+    log.close()
+
+    log.d("After closing")
+
+    assertThat(log.file.readText()).contains("Before closing").doesNotContain("After closing")
+  }
+
+  @Test fun `keeping no log file at all is refused`() {
+    assertThat(
+      runCatching { SessionLog.openIn(logDirectory, keepSessionCount = 0) }.exceptionOrNull()
+    ).isInstanceOf(IllegalArgumentException::class.java)
+  }
+}


### PR DESCRIPTION
When someone reports that the explorer "showed nothing" or "hung", there was nothing to read afterwards. The app logged to stdout, which a launched desktop app throws away, and the places where the UI quietly falls back logged nothing at all.

### One file per run

`installLogging()` points `SharkLog` at stdout **and** at `~/.shark-explorer/logs/shark-explorer-<when-it-started>.log`. A run keeps the newest 20 files and deletes the rest as it starts. Every write is flushed, because the session worth reading is the one that ended by crashing and a buffered tail is the part that would have said why.

A real run on `compose_leak.hprof`, the file verbatim:

```
08:23:18.850 [main] Shark Explorer starting, logging to /Users/py/.shark-explorer/logs/shark-explorer-2026-07-31_08-23-18_819.log
08:23:18.858 [main] Java 17.0.19 (OpenJDK 64-Bit Server VM) on Mac OS X 26.5.2 (aarch64)
08:23:18.861 [main] Heap limit 30 GB, 16 processors
08:23:18.862 [main] Started with shark/shark-android/src/test/resources/compose_leak.hprof
08:23:19.395 [heap-dump-compose_leak.hprof] Opening heap dump shark/shark-android/src/test/resources/compose_leak.hprof, 24 MB
08:23:19.395 [heap-dump-compose_leak.hprof] Indexing compose_leak.hprof
08:23:19.694 [heap-dump-compose_leak.hprof] Indexing compose_leak.hprof: done in 298 ms
08:23:19.710 [heap-dump-compose_leak.hprof] Working out what owns what
08:23:19.732 [heap-dump-compose_leak.hprof] Working out what owns what: done in 21 ms
08:23:19.733 [heap-dump-compose_leak.hprof] Working out what's reachable
08:23:20.470 [heap-dump-compose_leak.hprof] Working out what's reachable: done in 737 ms
08:23:20.472 [heap-dump-compose_leak.hprof] Working out what retains what
08:23:20.993 [heap-dump-compose_leak.hprof] Working out what retains what: done in 520 ms
08:23:20.993 [heap-dump-compose_leak.hprof] Opened compose_leak.hprof in 1597 ms: 258,993 objects, 15 MB, 464 KB of it unreachable
08:23:20.994 [heap-dump-compose_leak.hprof] Reading the sizes of compose_leak.hprof
08:23:20.995 [heap-dump-compose_leak.hprof] Read the sizes of compose_leak.hprof in 0 ms
08:23:20.996 [AWT-EventQueue-0] compose_leak.hprof · 15 MB in 258,993 objects · 15 MB strong, 464 KB unreachable
08:23:21.073 [heap-dump-compose_leak.hprof] Reading the treemap rooted at 0x0, 2240×1148
08:23:21.208 [heap-dump-compose_leak.hprof] Read the treemap rooted at 0x0, 2240×1148 in 134 ms
08:23:21.208 [heap-dump-compose_leak.hprof] Reading the treemap rooted at 0x0, 2240×1148
08:23:21.243 [heap-dump-compose_leak.hprof] Read the treemap rooted at 0x0, 2240×1148 in 35 ms
```

That file was written by a run I killed, which is why it has no `Shark Explorer closed` line — the marker that tells a session that ended from one that didn't. Its last four lines are also the first thing the log paid for: **the treemap is laid out twice on open**, same root, same viewport, the second read starting the millisecond the first returned, 134 ms thrown away. Pre-existing, out of scope here, and now tracked separately.

### What the sweep found in the UI

Anything the window did silently now says so: a zoomed path truncated because a node left the tree (with which node), a click landing on an object the tree has no node for, an object filter matching nothing, an open dialog cancelled, a star toggled with nothing selected. Reads are described in the terms of the thing being read — "the paths holding 0x1a2b3c", "the objects matching Bitmap" — so a report about the wrong panel points at the read behind it.

### Two fixes that fell out of it

- `HeapDominatorTreemap.classIdOf` memoized class name lookups that hit but not those that miss, so an object filter naming a class the dump doesn't have re-ran two linear scans of the string table **for every object**.
- Seven `nodes.getValue` calls threw `NoSuchElementException` with only a raw id. They now say what tree the id isn't in, how many nodes it has, and to ask `contains()` first.

### Tests

`SessionLogTest` covers the file behaviour on a `TemporaryFolder` — line format, stack traces, flush-before-close, a file per run, rotation, a non-log file left alone, logging after close. `ExplorerAppTest` now records `SharkLog` for **every** test rather than only the two that assert on it: a log line is built from state, so a line built from the wrong state fails the test that reaches it instead of waiting for a session nobody can read.

205 tests across both modules, detekt clean. Neither module is published, so there's no ABI to update and nothing here reaches a LeakCanary consumer — hence no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)