### PR TITLE
Lay the treemap out once when a heap dump opens

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -43,6 +43,12 @@ laid out, labelled view is a `TreemapPresentation` or a `RadialPresentation`, an
 The one thing that isn't thread safe is a `Sequence` a `HeapGraph` hands out — iterating one reads
 through it — so a thread reading `graph.objects` needs its own rather than a shared one.
 
+**A read that has been submitted can't be called off.** Cancelling the coroutine that asked for it, which
+is what a `LaunchedEffect` being relaunched does, only stops anything from waiting for the answer: the
+block is already queued on that one thread and runs to the end, since nothing inside a layout or a
+summary is a cancellation point. So dragging a window edge pays in full for every size it passes through,
+and the read that draws the size it lands on waits behind all of them.
+
 ## Every run writes a log file
 
 `installLogging()` in `shark-explorer-app` points `SharkLog` at stdout **and** at
@@ -132,10 +138,15 @@ it, so run it before pushing.
   tests can't find cells by tag. Test layout and hit testing as pure functions in
   `shark-explorer-core`, and have UI tests drive coordinates with `performMouseInput` and assert on
   the details panel and breadcrumbs.
-- **`ExplorerAppTest` records `SharkLog` for every test**, not only for the two that assert on it. A log
+- **The UI tests record `SharkLog` for every test**, not only for the ones asserting on it. A log
   line is built from state — an index into a path, a node id — so a line built from the wrong state
-  should fail the test that reaches it rather than wait for a session nobody can read. Which means a
-  test that leaves `SharkLog.logger` set breaks the ones after it, hence the `@After`.
+  should fail the test that reaches it rather than wait for a session nobody can read. The `RecordedLog`
+  rule does the recording, and is a rule rather than a `@Before` because putting the logger back is the
+  part that isn't optional: a test that leaves `SharkLog.logger` set breaks every test after it.
+- **What the log says is also how often something happened.** Every read of the heap dump is one line
+  through `HeapDumpSession.read`, so counting them is what holds the window to laying the tree out once
+  per view asked for, which is what `TreeLayoutTest` does. Those counts are sound because reads queue on
+  that one thread in order: anything queued behind the read a test waited for is already logged by then.
 - **A `Window` needs a display, so nothing inside `application { }` is covered headless.** Which
   window a heap dump opens in is plain state in `ExplorerWindow.kt`, unit tested by
   `ExplorerWindowTest`. `ExplorerApp` is one window's worth of app and takes the heap dump it shows

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -107,52 +107,50 @@ internal fun HeapDumpExplorer(
   val treemapLayout = rememberTreemapLayout()
   val radialLayout = rememberRadialLayout()
 
+  // Everything one laid out view follows from, as one value: a view is asked for, and the one that comes
+  // back is the answer to it. Null until the view has been measured, which is the one state there is
+  // nothing to lay out for.
+  val viewRequest = viewportSize.takeIf { it != IntSize.Zero }?.let { size ->
+    ViewRequest(
+      navigation = navigation,
+      viewportSize = size,
+      shape = shape,
+      treemapLayout = treemapLayout,
+      radialLayout = radialLayout
+    )
+  }
+
   // Resizing, zooming and switching shape all lay the tree out again, which reads the heap dump for
-  // every visible label. All of it ends up here, on the heap dump's thread. Keyed on the navigation
-  // rather than on the screen, so that reading a list of objects doesn't lay the map out again and the
-  // map is ready by the time the breadcrumbs lead back to it.
-  LaunchedEffect(
-    session,
-    navigation,
-    viewportSize,
-    shape,
-    treemapLayout,
-    radialLayout
-  ) {
-    if (viewportSize == IntSize.Zero) {
+  // every visible label. All of it ends up here, on the heap dump's thread. Keyed on the request rather
+  // than on the screen, so that reading a list of objects doesn't lay the map out again and the map is
+  // ready by the time the breadcrumbs lead back to it.
+  LaunchedEffect(session, viewRequest) {
+    if (viewRequest == null) {
       // Which is what a window showing a spinner and nothing else has been waiting for all along.
       SharkLog.d { "Not laying the tree out yet: the view has no size" }
       return@LaunchedEffect
     }
     isLayingOut = true
-    val viewport = TreemapRect(
-      left = 0.0,
-      top = 0.0,
-      right = viewportSize.width.toDouble(),
-      bottom = viewportSize.height.toDouble()
-    )
-    view = session.read(
-      "the ${shape.displayName.lowercase()} rooted at ${hexObjectId(navigation.current)}, " +
-        "${viewportSize.width}×${viewportSize.height}"
-    ) { explorer ->
+    view = session.read(viewRequest.description()) { explorer ->
       val tree = explorer.tree
+      val requested = viewRequest.navigation
       // An object zoomed into may no longer be dominated by the one above it on the path.
-      val reachablePath = navigation.retainingWhere { it in tree }
-      if (reachablePath.path.size < navigation.path.size) {
+      val reachablePath = requested.retainingWhere { it in tree }
+      if (reachablePath.path.size < requested.path.size) {
         SharkLog.d {
-          "Rooted at ${reachablePath.path.size} of the ${navigation.path.size} nodes zoomed through: " +
-            "${hexObjectId(navigation.path[reachablePath.path.size])} is no node of the tree"
+          "Rooted at ${reachablePath.path.size} of the ${requested.path.size} nodes zoomed through: " +
+            "${hexObjectId(requested.path[reachablePath.path.size])} is no node of the tree"
         }
       }
       ViewState(
         navigation = reachablePath,
         crumbs = reachablePath.path.map { objectId -> tree.crumb(objectId) },
-        presentation = when (shape) {
+        presentation = when (viewRequest.shape) {
           ViewShape.TREEMAP -> ViewPresentation.Treemap(
-            tree.present(treemapLayout, viewport, reachablePath.current)
+            tree.present(viewRequest.treemapLayout, viewRequest.viewport, reachablePath.current)
           )
           ViewShape.RADIAL -> ViewPresentation.Radial(
-            tree.presentRadial(radialLayout, viewport, reachablePath.current)
+            tree.presentRadial(viewRequest.radialLayout, viewRequest.viewport, reachablePath.current)
           )
         }
       )
@@ -162,7 +160,7 @@ internal fun HeapDumpExplorer(
     // Settling for the path that could actually be shown isn't a move, so it replaces where the explorer
     // is rather than being somewhere the back arrow returns to. Only if it's still there: a move made
     // while this was being laid out is not something to overwrite.
-    if (history.current.treeNavigation == navigation) {
+    if (history.current.treeNavigation == viewRequest.navigation) {
       history = history.replacingCurrent(history.current.withTreeNavigation(view.navigation))
     }
     isLayingOut = false
@@ -590,6 +588,39 @@ private fun HeapDominatorTreemap.crumb(objectId: Long): Crumb = Crumb(
     hexObjectId(objectId).takeIf { objectId > 0L }
   ).joinToString(CRUMB_SEPARATOR)
 )
+
+/**
+ * Everything one view of the tree follows from, which is therefore everything that lays it out again:
+ * where the map is, how big the view is, which shape it's drawn as, and the thresholds that shape is laid
+ * out to. A [ViewState] is the answer to one of these.
+ *
+ * One value rather than a key each on the effect that lays the tree out, because that effect has to work
+ * off exactly what it was keyed on. Keying it on the viewport while reading the viewport back out of the
+ * state is what laid every heap dump out twice as it opened: the run keyed on the size the view had before
+ * it was measured ran after the measurement, laid the whole tree out to the size it found there, and had
+ * that thrown away when the very measurement it had used relaunched it.
+ */
+private data class ViewRequest(
+  val navigation: TreemapNavigation<Long>,
+  /** In pixels, which is what the layouts and their thresholds work in. */
+  val viewportSize: IntSize,
+  val shape: ViewShape,
+  val treemapLayout: TreemapLayout<Long>,
+  val radialLayout: RadialLayout<Long>
+) {
+  val viewport: TreemapRect
+    get() = TreemapRect(
+      left = 0.0,
+      top = 0.0,
+      right = viewportSize.width.toDouble(),
+      bottom = viewportSize.height.toDouble()
+    )
+}
+
+/** What is being laid out, for the log. See [HeapDumpSession.read]. */
+private fun ViewRequest.description(): String =
+  "the ${shape.displayName.lowercase()} rooted at ${hexObjectId(navigation.current)}, " +
+    "${viewportSize.width}×${viewportSize.height}"
 
 /** Everything read off the heap dump's thread to draw one view of the tree. */
 internal class ViewState(

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -39,15 +39,11 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import java.io.File
-import java.util.concurrent.CopyOnWriteArrayList
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import shark.GcRoot.JniGlobal
-import shark.SharkLog
 import shark.ValueHolder.ReferenceHolder
 import shark.dump
 import shark.explorer.ExplorerScreen
@@ -69,36 +65,8 @@ class ExplorerAppTest {
   /** The object id of the array in [testHeapDump], recorded as the dump is written. */
   private var payloadObjectId = 0L
 
-  /**
-   * Everything Shark logged during this test, a line per log with the throwable it came with appended.
-   *
-   * Recorded for every test rather than only for the ones asserting on it, so that a log line built from
-   * the wrong state — an index into a path that has been shortened, say — fails the test that reaches it.
-   * The window's thread and the heap dump's both log, hence the concurrent list.
-   */
-  private val logged = CopyOnWriteArrayList<String>()
-
-  private var previousLogger: SharkLog.Logger? = null
-
-  @Before fun recordWhatIsLogged() {
-    previousLogger = SharkLog.logger
-    SharkLog.logger = object : SharkLog.Logger {
-      override fun d(message: String) {
-        logged += message
-      }
-
-      override fun d(
-        throwable: Throwable,
-        message: String
-      ) {
-        logged += "$message: $throwable"
-      }
-    }
-  }
-
-  @After fun stopRecordingWhatIsLogged() {
-    SharkLog.logger = previousLogger
-  }
+  /** Everything Shark logged during this test, which every test here records. See [RecordedLog]. */
+  @get:Rule val logged = RecordedLog()
 
   @Test fun `nothing is open until a heap dump is chosen`() {
     runComposeUiTest {

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
@@ -2,10 +2,8 @@ package shark.explorer.app
 
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
-import shark.SharkLog
 
 /**
  * How many windows the app has and which heap dump each one shows. No heap dump is read here: a window
@@ -14,33 +12,11 @@ import shark.SharkLog
 class ExplorerWindowTest {
 
   /**
-   * What Shark logged during this test, recorded the way [ExplorerAppTest] records it and for the same
-   * reason: a log line is built lazily, so one built from the wrong state says nothing until a test runs
-   * with a logger installed.
+   * What Shark logged during this test, recorded for the same reason every test here records it: a log line
+   * is built lazily, so one built from the wrong state says nothing until a test runs with a logger
+   * installed. See [RecordedLog].
    */
-  private val logged = mutableListOf<String>()
-
-  private var previousLogger: SharkLog.Logger? = null
-
-  @Before fun recordWhatIsLogged() {
-    previousLogger = SharkLog.logger
-    SharkLog.logger = object : SharkLog.Logger {
-      override fun d(message: String) {
-        logged += message
-      }
-
-      override fun d(
-        throwable: Throwable,
-        message: String
-      ) {
-        logged += "$message: $throwable"
-      }
-    }
-  }
-
-  @After fun stopRecordingWhatIsLogged() {
-    SharkLog.logger = previousLogger
-  }
+  @get:Rule val logged = RecordedLog()
 
   @Test fun `an app started with no heap dump has one window to open one from`() {
     val windows = explorerWindows(emptyList())

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/RecordedLog.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/RecordedLog.kt
@@ -1,0 +1,50 @@
+package shark.explorer.app
+
+import java.util.concurrent.CopyOnWriteArrayList
+import org.junit.rules.ExternalResource
+import shark.SharkLog
+
+/**
+ * Everything Shark logged during one test, a line per log with the throwable it came with appended, read
+ * as the list of lines it is.
+ *
+ * Recorded for every test of a class that takes this rule rather than only for the ones asserting on it: a
+ * log line is built from state — an index into a path that has been shortened, a node id — so a line built
+ * from the wrong state should fail the test that reaches it rather than wait for a session nobody can read.
+ *
+ * A rule rather than a `@Before` in each test class, because putting the logger back is the part that isn't
+ * optional: a test that leaves [SharkLog.logger] set breaks every test after it, whichever class those are
+ * in.
+ *
+ * The window's thread and the heap dump's both log, hence the concurrent list behind it.
+ */
+// Public rather than internal because JUnit reaches a `@Rule` through a public getter, which a property of
+// an internal type can't have.
+class RecordedLog private constructor(
+  private val lines: CopyOnWriteArrayList<String>
+) : ExternalResource(), List<String> by lines {
+
+  constructor() : this(CopyOnWriteArrayList())
+
+  private var previousLogger: SharkLog.Logger? = null
+
+  override fun before() {
+    previousLogger = SharkLog.logger
+    SharkLog.logger = object : SharkLog.Logger {
+      override fun d(message: String) {
+        lines += message
+      }
+
+      override fun d(
+        throwable: Throwable,
+        message: String
+      ) {
+        lines += "$message: $throwable"
+      }
+    }
+  }
+
+  override fun after() {
+    SharkLog.logger = previousLogger
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
@@ -1,0 +1,140 @@
+package shark.explorer.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+import shark.explorer.HeapDominatorTreemap
+
+/**
+ * How often the window lays the tree out, which is the most expensive thing it does: a layout reads the
+ * heap dump for every label it draws, a second and more of it on a large dump, all in front of a spinner.
+ *
+ * So one view asked for is one layout. Two for the same view is that cost paid twice for a result that gets
+ * thrown away, and none for a view that has changed is a window drawing something else. Counting the reads
+ * is what says which of those happened — [ExplorerAppTest] covers what the window shows, this covers what
+ * it did to show it.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TreeLayoutTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  /** Every layout is a line in here. See [RecordedLog] and [HeapDumpSession.read]. */
+  @get:Rule val logged = RecordedLog()
+
+  @Test fun `opening a heap dump lays the tree out once`() {
+    runComposeUiTest {
+      openHeapDump()
+
+      settleTheHeapDumpThread()
+    }
+
+    assertThat(treeLayoutsOf(ViewShape.TREEMAP)).hasSize(1)
+  }
+
+  /**
+   * The other half of it: laying out once is only right if what does need laying out again still does.
+   * Rings are laid out to different thresholds than rectangles, so they are a view of their own to read
+   * rather than the one already drawn.
+   */
+  @Test fun `switching shape lays the tree out once more`() {
+    runComposeUiTest {
+      openHeapDump()
+
+      shapeOption(ViewShape.RADIAL).performClick()
+      settleTheHeapDumpThread()
+    }
+
+    assertThat(treeLayoutsOf(ViewShape.RADIAL)).hasSize(1)
+    assertThat(treeLayoutsOf(ViewShape.TREEMAP)).hasSize(1)
+  }
+
+  /**
+   * Waits for a heap dump read that isn't a layout, which is what makes counting the layouts sound rather
+   * than a race: reads queue on the heap dump's one thread in the order they were asked for, so a layout
+   * queued behind the one that drew what the window is showing is in the log by the time this comes back.
+   *
+   * Pressing a cell is the read to wait for, because the details panel filling in is the one that shows.
+   */
+  private fun ComposeUiTest.settleTheHeapDumpThread() {
+    val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
+    onRoot().performMouseInput {
+      click(Offset(view.left + view.width * CELL_X, view.top + view.height * CELL_Y))
+    }
+    waitUntilAtLeastOneExists(hasText("Retained objects"), OPEN_TIMEOUT_MILLIS)
+  }
+
+  /** Every layout of the tree as [shape] the window has asked for, one line per read of the heap dump. */
+  private fun treeLayoutsOf(shape: ViewShape): List<String> =
+    logged.filter { it.startsWith("Reading the ${shape.displayName.lowercase()} rooted at") }
+
+  /** The radio button for [shape] above the view. */
+  private fun ComposeUiTest.shapeOption(shape: ViewShape): SemanticsNodeInteraction =
+    onNode(hasText(shape.displayName) and isSelectable())
+
+  private fun ComposeUiTest.openHeapDump() {
+    val heapDumpFile = heapDump()
+    setContent {
+      MaterialTheme {
+        var shown: File? by remember { mutableStateOf(heapDumpFile) }
+        ExplorerApp(shown, onHeapDumpChosen = { shown = it })
+      }
+    }
+    waitUntilAtLeastOneExists(
+      hasText(HeapDominatorTreemap.ROOT_LABEL, substring = true),
+      OPEN_TIMEOUT_MILLIS
+    )
+  }
+
+  /**
+   * A heap dump where one instance is the only path to a large object array, so that the two rectangles
+   * cover almost the whole view and a press in the middle of it lands on one of them whichever shape it
+   * is drawn as.
+   */
+  private fun heapDump(): File {
+    val file = testFolder.newFile("heap.hprof")
+    file.dump {
+      val holder = "com.example.Holder" instance {
+        field["payload"] =
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_LENGTH)))
+      }
+      gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+    }
+    return file
+  }
+
+  companion object {
+    /** Somewhere in the middle of the view, which is inside whatever it draws biggest. */
+    private const val CELL_X = 0.4f
+    private const val CELL_Y = 0.6f
+
+    private const val PAYLOAD_LENGTH = 4096
+
+    /** Opening a heap dump and laying the tree out both happen on another thread. */
+    private const val OPEN_TIMEOUT_MILLIS = 10_000L
+  }
+}


### PR DESCRIPTION
Opening a heap dump laid the treemap out twice, for the identical viewport, back to back, and threw the
first layout's work away. On the 39 MB `large-dump.hprof` that was a whole cold layout — 245 ms of reading
the dump for labels nothing ever drew — and the window sat on a spinner for 339 ms where it now sits for
263. On `compose_leak.hprof`, 200 ms down to 163.

## Why it happened

The effect in `HeapDumpExplorer` was keyed on `viewportSize` but read `viewportSize` back out of the
state, so the value it was keyed on and the value it laid out were not the same one:

1. The first composition runs before the view has been measured, so the effect is remembered with
   `IntSize.Zero` as its key.
2. Compose queues the effect body; `onSizeChanged` writes the real size during that same frame's layout
   pass.
3. The body therefore runs *after* the measurement, and its live read of `viewportSize` sees the real
   size — it lays the whole tree out to a size it was never keyed on.
4. That write then recomposes, the key it was launched with no longer matches, and the effect is cancelled
   and relaunched — with exactly the value the first run had already used.

Logging each key's identity across both runs is what shows it, rather than a guess about which one moved:

```
55.805 DIAG compose      viewport=0 x 0        navigation=1245659474 treemapLayout=32349681 density=DensityImpl(density=2.0, fontScale=1.0)
55.878 DIAG effect start  viewport=2240 x 1148  ← keyed on Zero, running with the measured size
55.879 Reading the treemap rooted at 0x0, 2240×1148
55.884 DIAG compose      viewport=2240 x 1148  navigation=1245659474 treemapLayout=32349681 density=DensityImpl(density=2.0, fontScale=1.0)
55.884 DIAG effect start  viewport=2240 x 1148  ← relaunched with the value run 1 had already used
56.036 Read the treemap rooted at 0x0, 2240×1148 in 156 ms
56.037 DIAG effect done   cause=LeftCompositionCancellationException: The coroutine scope left the composition
56.079 Read the treemap rooted at 0x0, 2240×1148 in 42 ms
56.079 Laid out 2237 rectangles, 0 nodes not expanded
```

Every other identity is unchanged across the two runs, which rules out the rest of the suspects:
`LocalDensity` is 2.0 from the first composition rather than arriving late, `sizes` landing a beat after
the window only recomposes, and `NavigationHistory` → `ExplorerScreen.Tree` → `TreemapNavigation` compare
by value all the way down, so the effect writing an equal navigation back to the state it is keyed on is a
no-op.

## The fix

Everything one view follows from is now one `ViewRequest` — where the map is, how big the view is, which
shape, and the thresholds that shape is laid out to. That value is what the effect is keyed on and all it
works off, so what it was asked for and what it lays out can't disagree. It is null until the view has
been measured, which is the one state there is nothing to lay out for.

No flag and no debounce: relaunching on a request that has genuinely changed is exactly what should still
happen, and it does.

## Before and after

`compose_leak.hprof`, before — same root, same viewport, second read starting the millisecond the first
returned, and no `Laid out` line for the first because the coroutine that asked for it was already
cancelled:

```
08:23:20.995 [heap-dump-compose_leak.hprof] Read the sizes of compose_leak.hprof in 0 ms
08:23:20.996 [AWT-EventQueue-0] compose_leak.hprof · 15 MB in 258,993 objects · 15 MB strong, 464 KB unreachable
08:23:21.073 [heap-dump-compose_leak.hprof] Reading the treemap rooted at 0x0, 2240×1148
08:23:21.208 [heap-dump-compose_leak.hprof] Read the treemap rooted at 0x0, 2240×1148 in 134 ms
08:23:21.208 [heap-dump-compose_leak.hprof] Reading the treemap rooted at 0x0, 2240×1148
08:23:21.243 [heap-dump-compose_leak.hprof] Read the treemap rooted at 0x0, 2240×1148 in 35 ms
```

After:

```
09:36:22.289 [heap-dump-compose_leak.hprof] Read the sizes of compose_leak.hprof in 0 ms
09:36:22.291 [AWT-EventQueue-0] compose_leak.hprof · 15 MB in 258,993 objects · 15 MB strong, 464 KB unreachable
09:36:22.371 [AWT-EventQueue-0] Not laying the tree out yet: the view has no size
09:36:22.378 [heap-dump-compose_leak.hprof] Reading the treemap rooted at 0x0, 2240×1148
09:36:22.541 [heap-dump-compose_leak.hprof] Read the treemap rooted at 0x0, 2240×1148 in 162 ms
09:36:22.541 [AWT-EventQueue-0] Laid out 2237 rectangles, 0 nodes not expanded
```

`large-dump.hprof` (39 MB), before:

```
09:39:20.244 [heap-dump-large-dump.hprof] Read the sizes of large-dump.hprof in 0 ms
09:39:20.245 [AWT-EventQueue-0] large-dump.hprof · 29 MB in 387,971 objects · 28 MB strong, 28 KB thread local, 1.4 KB soft, 261 B weak, 997 KB unreachable
09:39:20.318 [heap-dump-large-dump.hprof] Reading the treemap rooted at 0x0, 2240×1252
09:39:20.564 [heap-dump-large-dump.hprof] Read the treemap rooted at 0x0, 2240×1252 in 245 ms
09:39:20.564 [heap-dump-large-dump.hprof] Reading the treemap rooted at 0x0, 2240×1252
09:39:20.656 [heap-dump-large-dump.hprof] Read the treemap rooted at 0x0, 2240×1252 in 91 ms
09:39:20.657 [AWT-EventQueue-0] Laid out 4658 rectangles, 0 nodes not expanded
```

After:

```
09:37:24.042 [heap-dump-large-dump.hprof] Read the sizes of large-dump.hprof in 0 ms
09:37:24.043 [AWT-EventQueue-0] large-dump.hprof · 29 MB in 387,971 objects · 28 MB strong, 28 KB thread local, 1.4 KB soft, 261 B weak, 997 KB unreachable
09:37:24.117 [AWT-EventQueue-0] Not laying the tree out yet: the view has no size
09:37:24.123 [heap-dump-large-dump.hprof] Reading the treemap rooted at 0x0, 2240×1252
09:37:24.386 [heap-dump-large-dump.hprof] Read the treemap rooted at 0x0, 2240×1252 in 262 ms
09:37:24.386 [AWT-EventQueue-0] Laid out 4658 rectangles, 0 nodes not expanded
```

## While in there

- **A test class that counts the layouts.** `TreeLayoutTest` asserts exactly one `Reading the treemap
  rooted at …` for one open, and one layout more when the shape switches, since rings are laid out to
  different thresholds and so are a view of their own rather than the one already drawn. A fix that
  suppressed the second run instead of removing it would fail the first test, and one that stopped
  relaying out altogether would fail the second. Counting is sound because reads queue on the heap dump's
  one thread in order: the details panel the test clicks for comes back after anything queued behind the
  layout that drew the view.
- **`RecordedLog`.** The `SharkLog` recording every UI test relies on moved out of `ExplorerAppTest` into
  a rule of its own, which `TreeLayoutTest` and `ExplorerWindowTest` — which had a verbatim copy of that
  fixture — now take too. `ExplorerAppTest` is at detekt's `LargeClass` ceiling, and this was the fixture
  in it that isn't a test — putting the logger back is the part that isn't optional, which is what a rule
  is for.
- **`shark/shark-explorer/AGENTS.md`** gains the trap this ran into: a read that has been submitted can't
  be called off. Cancelling the coroutine only stops anything from waiting for the answer — the block is
  already queued on that one thread and runs to the end, since nothing inside a layout is a cancellation
  point. It's why the discarded read was paid for in full whether anything waited for it or not, and why
  dragging a window edge pays for every size it passes through. Worth fixing separately; it needs a
  cancellation point inside the layout in `shark-explorer-core`.

`notes/decisions.md` needed no correction — nothing in it describes the effect or its keys.

## Verification

`./gradlew :shark:shark-explorer:shark-explorer-app:check :shark:shark-explorer:shark-explorer-core:check`
is green, `TreeLayoutTest` included. Both of its tests fail with `Expected size: 1 but was: 2` when the
main source change alone is reverted, checked by doing exactly that and rerunning them.

Neither explorer module is published, so there is no ABI to update and no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

