### PR TITLE
Name a run of the explorer after what it was started for

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -124,13 +124,21 @@ Windows and Linux title bar — macOS ignores it.
 # Launch it. Paths are optional; without one, use the "Open heap dump…" button. One window per path,
 # and one per heap dump opened from the button — see `notes/decisions.md`.
 ./gradlew :shark:shark-explorer:shark-explorer-app:run \
-  --args="shark/shark-android/src/test/resources/compose_leak.hprof"
+  --args="--title=\"Hover previews\" shark/shark-android/src/test/resources/compose_leak.hprof"
 ```
 
 The repo has real Android heap dumps to try it on: `shark/shark-android/src/test/resources/*.hprof`
 and `leakcanary/leakcanary-android-instrumentation/src/androidTest/assets/large-dump.hprof` (39 MB,
 the biggest one). All of them are from API 25 or earlier, so every bitmap in them carries its pixels —
 anything about a modern dump has to be tried on one taken off a device. See `notes/bitmaps.md`.
+
+**Launch with `--title` when starting the app for someone to look at.** Several explorers end up open
+at once — one per piece of work, often on the same heap dump — and the window title is all the OS gives
+you to tell them apart. `--title` goes in front of the heap dump name in every window of that run,
+including windows opened from it later, so name the run after the change it contains rather than
+leaving two identical `large-dump.hprof` windows on screen. `ExplorerArguments` is the whole command
+line, and it is strict: an unknown option is a message saying what to type, not a heap dump that can't
+be found.
 
 `check` runs detekt (config at `config/detekt-config.yml`); CI and the pre-push hook both enforce
 it, so run it before pushing.

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerArguments.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerArguments.kt
@@ -1,0 +1,64 @@
+package shark.explorer.app
+
+import java.io.File
+
+/**
+ * What the command line asked this run to do: which heap dumps to open, and what to call its windows.
+ *
+ * Plain state parsed from the arguments, so what a command line means is unit tested rather than found
+ * out by launching the app.
+ */
+internal data class ExplorerArguments(
+  /** One window each, in the order they were named. Empty for a run that opens no heap dump. */
+  val heapDumpFiles: List<File>,
+  /**
+   * Put in front of every window title of this run, or null when the command line asked for none.
+   *
+   * Several explorers open at once look alike in the window list — same app, often the same heap dump,
+   * opened for different reasons — and a title is all the OS gives you to pick one by. So a run started
+   * for a piece of work can say which work it is: "the window titled *Hover previews* is the one with the
+   * change in it".
+   */
+  val titlePrefix: String?
+) {
+
+  companion object {
+
+    /**
+     * Reads a command line, or throws [IllegalArgumentException] naming what is wrong with it.
+     *
+     * Strict about options rather than lenient: an unknown one taken for a file name opens a window
+     * saying a heap dump called `--titel=Hover` could not be read, which is a typo reported as a
+     * missing heap dump.
+     */
+    fun parse(args: List<String>): ExplorerArguments {
+      var titlePrefix: String? = null
+      val heapDumpFiles = mutableListOf<File>()
+      val remaining = ArrayDeque(args)
+      while (remaining.isNotEmpty()) {
+        val argument = remaining.removeFirst()
+        titlePrefix = when {
+          // Both spellings, because a title has spaces in it and which one survives the shell, Gradle's
+          // `--args` and an IDE run configuration is not the same everywhere.
+          argument == TITLE_OPTION -> requireNotNull(remaining.removeFirstOrNull()) {
+            "$TITLE_OPTION needs a title after it. $USAGE"
+          }
+          argument.startsWith("$TITLE_OPTION=") -> argument.substringAfter('=')
+          argument.startsWith("-") -> throw IllegalArgumentException("Unknown option $argument. $USAGE")
+          else -> {
+            heapDumpFiles += File(argument)
+            titlePrefix
+          }
+        }
+      }
+      require(titlePrefix != "") { "$TITLE_OPTION was given nothing to call the windows. $USAGE" }
+      return ExplorerArguments(heapDumpFiles = heapDumpFiles, titlePrefix = titlePrefix)
+    }
+
+    private const val TITLE_OPTION = "--title"
+
+    /** Shown with whatever was wrong, so that the message says what to type instead. */
+    private const val USAGE =
+      "Usage: shark-explorer [$TITLE_OPTION=\"<window title prefix>\"] [<heap dump>…]"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerWindow.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerWindow.kt
@@ -23,7 +23,9 @@ internal class ExplorerWindow(
    * the same one, so a window opened from another lands beside it rather than exactly over it. Where
    * that is, is `cascadedPosition`.
    */
-  val cascade: Int = 0
+  val cascade: Int = 0,
+  /** What this run calls its windows, in front of the heap dump. See [ExplorerArguments.titlePrefix]. */
+  val titlePrefix: String? = null
 ) {
 
   /** Null in the window the app starts with when it was given no heap dump to open. */
@@ -37,22 +39,28 @@ internal class ExplorerWindow(
   var bitmapPixels: NativeBitmapPixels? by mutableStateOf(bitmapPixels)
 
   /**
-   * Which heap dump this window is, for the window list of the OS: several windows all called after the
-   * app tell you nothing about which one to switch to.
+   * Which heap dump this window is, and which run it belongs to, for the window list of the OS: several
+   * windows all called after the app tell you nothing about which one to switch to.
    */
-  val title: String get() = heapDumpFile?.name ?: APP_NAME
+  val title: String
+    get() = listOfNotNull(titlePrefix, heapDumpFile?.name ?: APP_NAME).joinToString(TITLE_SEPARATOR)
 }
 
 /**
  * A window per heap dump named on the command line, or one window with none — something has to carry
  * the button that opens the first one.
  */
-internal fun explorerWindows(heapDumpFiles: List<File>): SnapshotStateList<ExplorerWindow> =
+internal fun explorerWindows(arguments: ExplorerArguments): SnapshotStateList<ExplorerWindow> =
   mutableStateListOf<ExplorerWindow>().apply {
-    if (heapDumpFiles.isEmpty()) {
-      add(ExplorerWindow(null))
+    val titlePrefix = arguments.titlePrefix
+    if (arguments.heapDumpFiles.isEmpty()) {
+      add(ExplorerWindow(null, titlePrefix = titlePrefix))
     } else {
-      addAll(heapDumpFiles.mapIndexed { index, file -> ExplorerWindow(file, cascade = index) })
+      addAll(
+        arguments.heapDumpFiles.mapIndexed { index, file ->
+          ExplorerWindow(file, cascade = index, titlePrefix = titlePrefix)
+        }
+      )
     }
   }
 
@@ -71,7 +79,16 @@ internal fun MutableList<ExplorerWindow>.openHeapDump(
 ) {
   val isWindowOfItsOwn = window.heapDumpFile != null
   if (isWindowOfItsOwn) {
-    add(ExplorerWindow(heapDumpFile, bitmapPixels, cascade = freeCascade()))
+    // Named after the same run as the window it was opened from: every window of one explorer belongs to
+    // whatever that explorer was started for, however many heap dumps end up open in it.
+    add(
+      ExplorerWindow(
+        heapDumpFile,
+        bitmapPixels,
+        cascade = freeCascade(),
+        titlePrefix = window.titlePrefix
+      )
+    )
   } else {
     window.heapDumpFile = heapDumpFile
     window.bitmapPixels = bitmapPixels
@@ -83,6 +100,9 @@ internal fun MutableList<ExplorerWindow>.openHeapDump(
     "Opening ${heapDumpFile.name} in $where"
   }
 }
+
+/** Between what a run is called and which heap dump a window shows, as elsewhere in this window. */
+private const val TITLE_SEPARATOR = " · "
 
 /** The first step of the cascade no window is at, which is where the next window goes. */
 private fun List<ExplorerWindow>.freeCascade(): Int =

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -56,6 +56,10 @@ fun main(args: Array<String>) {
       SharkLog.d { invalidArguments.message.orEmpty() }
       return@use
     }
+    // What the arguments above were taken to mean, which is not obvious from them: a shell, Gradle's
+    // `--args` and a run configuration each split a quoted title differently, and a title split in two
+    // reads as one on the line above.
+    SharkLog.d { "Read that as $arguments" }
     // Heap dump paths on the command line open straight away, which is how this is usually run.
     explorerApplication(arguments)
   }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -48,14 +48,22 @@ fun main(args: Array<String>) {
   // back after it. See [installLogging].
   installLogging().use {
     SharkLog.d { "Started with ${if (args.isEmpty()) "no arguments" else args.joinToString(" ")}" }
+    val arguments = try {
+      ExplorerArguments.parse(args.toList())
+    } catch (invalidArguments: IllegalArgumentException) {
+      // Said on stdout and in the log rather than thrown, because a command line nobody can read is a
+      // message to whoever typed it and not a crash to report.
+      SharkLog.d { invalidArguments.message.orEmpty() }
+      return@use
+    }
     // Heap dump paths on the command line open straight away, which is how this is usually run.
-    explorerApplication(args.map(::File))
+    explorerApplication(arguments)
   }
 }
 
 /** One window per heap dump open, which is what [openHeapDump] keeps true as more are opened. */
-private fun explorerApplication(heapDumpFiles: List<File>) = application {
-  val windows = remember { explorerWindows(heapDumpFiles) }
+private fun explorerApplication(arguments: ExplorerArguments) = application {
+  val windows = remember { explorerWindows(arguments) }
   windows.forEach { window ->
     // Keyed on the window, so that closing one doesn't hand its size and position to the next one along.
     key(window) {

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerArgumentsTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerArgumentsTest.kt
@@ -1,0 +1,65 @@
+package shark.explorer.app
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+
+/** What a command line means, without launching anything: see [ExplorerArguments]. */
+class ExplorerArgumentsTest {
+
+  @Test fun `a run with no arguments opens nothing and calls its window nothing`() {
+    val arguments = ExplorerArguments.parse(emptyList())
+
+    assertThat(arguments.heapDumpFiles).isEmpty()
+    assertThat(arguments.titlePrefix).isNull()
+  }
+
+  @Test fun `every path is a heap dump to open`() {
+    val arguments = ExplorerArguments.parse(listOf(FIRST_PATH, SECOND_PATH))
+
+    assertThat(arguments.heapDumpFiles).containsExactly(File(FIRST_PATH), File(SECOND_PATH))
+  }
+
+  @Test fun `a title can be given with an equals sign or as the next argument`() {
+    // Two spellings because a title has spaces in it, and a shell, Gradle's `--args` and a run
+    // configuration don't all pass those through the same way.
+    val joined = ExplorerArguments.parse(listOf("--title=$TITLE", FIRST_PATH))
+    val separate = ExplorerArguments.parse(listOf("--title", TITLE, FIRST_PATH))
+
+    assertThat(joined).isEqualTo(separate)
+    assertThat(joined.titlePrefix).isEqualTo(TITLE)
+    assertThat(joined.heapDumpFiles).containsExactly(File(FIRST_PATH))
+  }
+
+  @Test fun `a title given after the heap dump still names the windows`() {
+    val arguments = ExplorerArguments.parse(listOf(FIRST_PATH, "--title=$TITLE"))
+
+    assertThat(arguments.titlePrefix).isEqualTo(TITLE)
+  }
+
+  @Test fun `a title with nothing after it says what to type instead`() {
+    // Both ways of leaving it out, since a shell that swallows an empty argument produces the first and a
+    // hand written command line the second.
+    assertThatThrownBy { ExplorerArguments.parse(listOf("--title")) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("--title=")
+    assertThatThrownBy { ExplorerArguments.parse(listOf("--title=")) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("--title=")
+  }
+
+  @Test fun `an option nobody knows is not a heap dump`() {
+    // A typo taken for a path opens a window saying a heap dump called `--titel` could not be read, which
+    // is the wrong thing to go looking for.
+    assertThatThrownBy { ExplorerArguments.parse(listOf("--titel=$TITLE")) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("--titel=$TITLE")
+  }
+
+  companion object {
+    private const val FIRST_PATH = "first.hprof"
+    private const val SECOND_PATH = "dumps/second.hprof"
+    private const val TITLE = "Hover previews"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
@@ -19,20 +19,20 @@ class ExplorerWindowTest {
   @get:Rule val logged = RecordedLog()
 
   @Test fun `an app started with no heap dump has one window to open one from`() {
-    val windows = explorerWindows(emptyList())
+    val windows = explorerWindows(noHeapDumps())
 
     assertThat(windows).hasSize(1)
     assertThat(windows.single().heapDumpFile).isNull()
   }
 
   @Test fun `every heap dump on the command line gets a window`() {
-    val windows = explorerWindows(listOf(FIRST_DUMP, SECOND_DUMP))
+    val windows = explorerWindows(opening(FIRST_DUMP, SECOND_DUMP))
 
     assertThat(windows.map { it.heapDumpFile }).containsExactly(FIRST_DUMP, SECOND_DUMP)
   }
 
   @Test fun `the first heap dump opens in the window that has none`() {
-    val windows = explorerWindows(emptyList())
+    val windows = explorerWindows(noHeapDumps())
 
     windows.openHeapDump(windows.single(), FIRST_DUMP)
 
@@ -43,7 +43,7 @@ class ExplorerWindowTest {
   }
 
   @Test fun `another heap dump opens in a window of its own`() {
-    val windows = explorerWindows(listOf(FIRST_DUMP))
+    val windows = explorerWindows(opening(FIRST_DUMP))
     val first = windows.single()
 
     windows.openHeapDump(first, SECOND_DUMP)
@@ -56,7 +56,7 @@ class ExplorerWindowTest {
   }
 
   @Test fun `the same heap dump twice is two windows`() {
-    val windows = explorerWindows(listOf(FIRST_DUMP))
+    val windows = explorerWindows(opening(FIRST_DUMP))
 
     windows.openHeapDump(windows.single(), FIRST_DUMP)
 
@@ -66,7 +66,7 @@ class ExplorerWindowTest {
   }
 
   @Test fun `no two windows open at the same place`() {
-    val windows = explorerWindows(listOf(FIRST_DUMP, SECOND_DUMP))
+    val windows = explorerWindows(opening(FIRST_DUMP, SECOND_DUMP))
 
     windows.openHeapDump(windows.first(), FIRST_DUMP)
 
@@ -76,7 +76,7 @@ class ExplorerWindowTest {
   }
 
   @Test fun `a window opens where a closed one was`() {
-    val windows = explorerWindows(listOf(FIRST_DUMP, SECOND_DUMP))
+    val windows = explorerWindows(opening(FIRST_DUMP, SECOND_DUMP))
     windows -= windows.first()
 
     windows.openHeapDump(windows.single(), FIRST_DUMP)
@@ -87,7 +87,7 @@ class ExplorerWindowTest {
   }
 
   @Test fun `a window is named after the heap dump it shows`() {
-    val windows = explorerWindows(listOf(FIRST_DUMP))
+    val windows = explorerWindows(opening(FIRST_DUMP))
 
     // Which is what tells one window from another in the window list of the OS, where every window of
     // an app is otherwise the app.
@@ -95,9 +95,39 @@ class ExplorerWindowTest {
     assertThat(ExplorerWindow(null).title).isEqualTo(APP_NAME)
   }
 
+  @Test fun `a run given a title says it in front of every window name`() {
+    val windows = explorerWindows(opening(FIRST_DUMP, titlePrefix = TITLE))
+
+    // Which is what tells one explorer from another, where a heap dump opened twice for two reasons is
+    // otherwise the same window twice.
+    assertThat(windows.single().title).isEqualTo("$TITLE · ${FIRST_DUMP.name}")
+    assertThat(explorerWindows(noHeapDumps(titlePrefix = TITLE)).single().title)
+      .isEqualTo("$TITLE · $APP_NAME")
+  }
+
+  @Test fun `a heap dump opened into a window of its own keeps the run's title`() {
+    val windows = explorerWindows(opening(FIRST_DUMP, titlePrefix = TITLE))
+
+    windows.openHeapDump(windows.single(), SECOND_DUMP)
+
+    // Every window of one explorer belongs to whatever that explorer was started for, however many heap
+    // dumps end up open in it.
+    assertThat(windows.map { it.title })
+      .containsExactly("$TITLE · ${FIRST_DUMP.name}", "$TITLE · ${SECOND_DUMP.name}")
+  }
+
+  private fun noHeapDumps(titlePrefix: String? = null) =
+    ExplorerArguments(heapDumpFiles = emptyList(), titlePrefix = titlePrefix)
+
+  private fun opening(
+    vararg heapDumpFiles: File,
+    titlePrefix: String? = null
+  ) = ExplorerArguments(heapDumpFiles = heapDumpFiles.toList(), titlePrefix = titlePrefix)
+
   companion object {
     /** Never opened, so these don't have to exist. */
     private val FIRST_DUMP = File("first.hprof")
     private val SECOND_DUMP = File("second.hprof")
+    private const val TITLE = "Hover previews"
   }
 }


### PR DESCRIPTION
Several Shark Explorer windows end up open at once — one per piece of work, often on the same heap dump — and the window title is all the OS gives you to tell them apart. Two windows called `large-dump.hprof` are the same window twice.

`--title="<something>"` on the command line now goes in front of the heap dump name in every window of that run, including windows opened from one of them later, so a run started to look at a change can say which change it is:

```bash
./gradlew :shark:shark-explorer:shark-explorer-app:run \
  --args="--title=\"Hover previews\" leakcanary/leakcanary-android-instrumentation/src/androidTest/assets/large-dump.hprof"
```
gives a window titled `Hover previews · large-dump.hprof`.

The command line is now a parsed `ExplorerArguments` rather than a list of paths, unit tested in `ExplorerArgumentsTest`, and strict about options: an unknown one is a message saying what to type, where before a typo opened a window saying a heap dump called `--titel` could not be read. Both `--title=X` and `--title X` work, because a shell, Gradle’s `--args` and an IDE run configuration each split a quoted title differently — and for the same reason the run logs what it took the command line to mean, not just the raw arguments.

Split out of https://github.com/square/leakcanary/pull/2910, where it was along for the ride.

🤖 Generated with [Claude Code](https://claude.com/claude-code)