### PR TITLE
Give the dock the name the windows already have

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -113,6 +113,91 @@ one line from the build script and the flag is gone from the run's JVM arguments
 icon is back. So `java.awt.Taskbar` has nothing to add here. `Window(icon = …)` does, but only for the
 Windows and Linux title bar — macOS ignores it.
 
+## What macOS calls the run, as against what it calls a window
+
+A run is one process and many windows, so the OS gets one name for all of them, and `main` sets it from
+`--title` before the first window: `apple.awt.application.name`. That reaches the menu bar next to the
+Apple logo, the app switcher, and every name macOS reports through an API. **It does not reach the
+dock** — nothing a process can do reaches the dock, see the next section. Three things about that line
+aren't visible from it.
+
+**It is read once, as AWT starts**, and the process registers with macOS under whatever it said then.
+Setting it after a window is up changes nothing — measured, not assumed — so it belongs between parsing
+the command line and `application { }`, which is the only gap there is.
+
+**It is the same name `-Xdock:name` sets.** That JVM argument only puts the name in an environment
+variable AWT reads at that same moment: a run given `-Xdock:name=X` and a run that sets the property to
+`X` in `main` produce LaunchServices records differing in nothing but their audit token and check-in
+time. So the run task passes no name and an IDE run configuration needs none either, and
+`java.awt.Taskbar` is no help — its API is icon, badge, menu and progress, and no name.
+
+**A packaged app ignores the property and keeps its bundle's name.** `Shark Explorer.app` launched with
+`--title="Packaged with a title"` logs that title and is still called `Shark Explorer` by macOS, because
+jpackage gives it a real bundle. A run from Gradle has no bundle of its own — it is `/…/bin/java`,
+bundle id `net.java.openjdk.java` — which is why it is called after whatever launched it until
+something names it.
+
+## The dock only reads a bundle's file name, so `runNamed` gives it one
+
+`-Xdock:name` has not named the dock since around macOS 10.9 — [JDK-8173753][dock-bug], still open,
+where the reported symptom is exactly what you get: the name reaches the menu bar and the dock goes on
+saying `java`. Confirmed here, three explorer runs whose LaunchServices, `NSRunningApplication` and
+WindowServer names were all different showed three dock tiles all called `java`. **So don't spend time
+looking for the property or the API call that fixes this. There isn't one.**
+
+What the dock reads is the file name of the bundle a process was launched from. Not `CFBundleName`:
+two bundles carrying the same `CFBundleName` and differing only in file name are two differently named
+tiles.
+
+`runNamed` is `run` with a bundle around it, generated per launch and named after `--title`:
+
+```bash
+./gradlew :shark:shark-explorer:shark-explorer-app:runNamed \
+  --args="--title=\"Hover previews\" shark/shark-android/src/test/resources/compose_leak.hprof"
+```
+
+- **It is a launcher script and an `Info.plist` around the classes `run` would have run**, not a
+  `jpackage` build. Packaging is a minute of jlink per code change, which would be a minute per look;
+  this is a compile.
+- **The script `exec`s the JVM** rather than starting it as a child. The JVM has to end up being the
+  process macOS launched from the bundle or it is a process of its own again, and the dock is back to
+  calling it java.
+- **`open` gives it no terminal**, so stdout goes to `build/named/<title>.out` — which is where a run
+  that died before it could open a log file says why. Everything after that is in the usual place, see
+  the logging section.
+- **Relaunching a title while a window of that title is open** is the one thing to avoid: the bundle is
+  rewritten in place, and that window is reading it.
+
+[dock-bug]: https://bugs.openjdk.org/browse/JDK-8173753
+
+## Reading these names without being able to see the screen
+
+```bash
+lsappinfo find pid=<pid>            # ASN:0x0-0x2338336-"Hover previews":
+```
+
+`NSRunningApplication.localizedName`, which the app switcher shows, and `kCGWindowOwnerName`, which the
+WindowServer holds, agree with it and are readable from `osascript -l JavaScript` through `ObjC.import`.
+None of them is what the dock displays, which is why all three can say one thing and the tile another.
+
+The dock tile names, and an app's menu bar, are readable **only with the Accessibility permission**, and
+they are the ones worth reading, since they are what someone looking at the screen sees:
+
+```bash
+osascript -e 'tell application "System Events" to tell process "Dock" \
+  to get name of UI elements of list 1'
+osascript -e 'tell application "System Events" to tell process "<the run>" \
+  to get name of menu bar items of menu bar 1'      # Apple, <the run>
+```
+
+Without that permission both fail with `-1719 not allowed assistive access`, and the only way to know
+what the dock says is to ask the person in front of it. It is granted per responsible process — for an
+agent, whichever app launched the session — in System Settings → Privacy & Security → Accessibility.
+Screen Recording is separate, and without it a screenshot of another process comes back as wallpaper.
+
+An icon can be checked without either: `NSWorkspace.iconForFile` on a bundle hands back what macOS
+resolved for it, and writing that to a PNG is a picture an agent can open.
+
 ## Build and test
 
 ```bash
@@ -132,13 +217,18 @@ and `leakcanary/leakcanary-android-instrumentation/src/androidTest/assets/large-
 the biggest one). All of them are from API 25 or earlier, so every bitmap in them carries its pixels —
 anything about a modern dump has to be tried on one taken off a device. See `notes/bitmaps.md`.
 
-**Launch with `--title` when starting the app for someone to look at.** Several explorers end up open
-at once — one per piece of work, often on the same heap dump — and the window title is all the OS gives
-you to tell them apart. `--title` goes in front of the heap dump name in every window of that run,
-including windows opened from it later, so name the run after the change it contains rather than
-leaving two identical `large-dump.hprof` windows on screen. `ExplorerArguments` is the whole command
-line, and it is strict: an unknown option is a message saying what to type, not a heap dump that can't
-be found.
+**Always pass `--title`, and name the run after the piece of work it is for.** Several explorers end up
+open at once — one per task, often on the same heap dump — and a name is all the OS gives you to tell
+them apart. `--title` goes in front of the heap dump name in every window of that run, including windows
+opened from it later, so that two identical `large-dump.hprof` windows never end up on screen.
+`ExplorerArguments` is the whole command line, and it is strict: an unknown option is a message saying
+what to type, not a heap dump that can't be found.
+
+**`run` while you work, `runNamed` when you hand a window over.** They take the same command line.
+`run` streams the log to the terminal and is a compile away, so it is the one for trying your own
+change — don't reach for `runNamed` for that. When the change is done and the app is being started for
+someone else to look at, use `runNamed`: it is the only one of the two the dock will name, and with
+several explorers open the dock is what they navigate by. See the dock section above.
 
 `check` runs detekt (config at `config/detekt-config.yml`); CI and the pre-push hook both enforce
 it, so run it before pushing.

--- a/shark/shark-explorer/shark-explorer-app/build.gradle.kts
+++ b/shark/shark-explorer/shark-explorer-app/build.gradle.kts
@@ -1,3 +1,6 @@
+import javax.inject.Inject
+import org.gradle.api.tasks.options.Option
+import org.gradle.process.ExecOperations
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 
@@ -41,9 +44,31 @@ tasks.withType<JavaExec>().matching { it.name == "run" }.configureEach {
   workingDir = rootProject.projectDir
 }
 
+/** Shared by the Compose plugin's `run` and by `runNamed`, which launches the same classes itself. */
+val explorerMainClass = "shark.explorer.app.MainKt"
+
+/** The dock icon of a `run`, through `-Xdock:icon`, and of a `runNamed`, through its bundle. */
+val macOsIconFile = project.file("icons/shark-explorer-icon.icns")
+
+// Launching under a name the dock shows. `run` is the one to use while working; see AGENTS.md for why
+// this one is for handing a window over, and for what the dock does and doesn't take a name from.
+tasks.register<RunNamedExplorer>("runNamed") {
+  description = "Runs the explorer from an .app bundle named after --title, so the macOS dock says " +
+    "which run it is."
+  group = ApplicationPlugin.APPLICATION_GROUP
+  // The JVM Gradle itself is on, which is the one `run` would use: this module configures no toolchain.
+  javaExecutable.set(providers.systemProperty("java.home").map { "$it/bin/java" })
+  runtimeClasspath.from(sourceSets.main.get().runtimeClasspath)
+  mainClass.set(explorerMainClass)
+  iconFile.set(macOsIconFile)
+  bundleDirectory.set(layout.buildDirectory.dir("named"))
+  // Where `run` resolves a heap dump path from, so that the same command line means the same thing.
+  workingDirectory.set(rootProject.layout.projectDirectory)
+}
+
 compose.desktop {
   application {
-    mainClass = "shark.explorer.app.MainKt"
+    mainClass = explorerMainClass
 
     nativeDistributions {
       targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
@@ -57,7 +82,7 @@ compose.desktop {
       // launched: the Compose plugin turns this file into `-Xdock:icon` on the run task, and without
       // it the process shows the default Java icon.
       macOS {
-        iconFile.set(project.file("icons/shark-explorer-icon.icns"))
+        iconFile.set(macOsIconFile)
       }
       windows {
         iconFile.set(project.file("icons/shark-explorer-icon.ico"))
@@ -71,5 +96,149 @@ compose.desktop {
       // doesn't detect a use of, and it detects no use of one reached through `Bootstrap`.
       modules("jdk.jdi")
     }
+  }
+}
+
+/**
+ * Runs the explorer from a generated `.app` bundle whose file name is what `--title` calls the run,
+ * which is the only thing the macOS dock will name it after.
+ *
+ * The dock takes a process's name from the bundle it was launched from and ignores both `-Xdock:name`
+ * (JDK-8173753, open since macOS 10.9) and everything a process can set about itself. It ignores
+ * `CFBundleName` here too: two bundles carrying the same one, differing only in file name, are two
+ * differently named tiles.
+ *
+ * The bundle is a launcher script and an `Info.plist` around the classes `run` would have run, rather
+ * than a `jpackage` distribution, because jlink is a minute per code change and therefore a minute per
+ * look.
+ */
+abstract class RunNamedExplorer : DefaultTask() {
+
+  @get:Input
+  abstract val javaExecutable: Property<String>
+
+  @get:Classpath
+  abstract val runtimeClasspath: ConfigurableFileCollection
+
+  @get:Input
+  abstract val mainClass: Property<String>
+
+  @get:InputFile
+  @get:PathSensitive(PathSensitivity.NONE)
+  abstract val iconFile: RegularFileProperty
+
+  /** Holds one bundle per name, each rewritten by the next run that uses that name. */
+  @get:Internal
+  abstract val bundleDirectory: DirectoryProperty
+
+  @get:Internal
+  abstract val workingDirectory: DirectoryProperty
+
+  /** The explorer's own command line, spelled the way `run` takes it. */
+  @get:Input
+  @get:Optional
+  @get:Option(option = "args", description = "The explorer's command line, as `run` takes it.")
+  abstract val appArgs: Property<String>
+
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  @TaskAction
+  fun launch() {
+    val osName = System.getProperty("os.name")
+    if (!osName.startsWith("Mac")) {
+      throw GradleException("runNamed builds a macOS .app bundle, and this is $osName. Use `run`.")
+    }
+    val args = appArgs.getOrElse("").trim()
+    val name = bundleName(args)
+    val bundle = File(bundleDirectory.get().asFile, "$name.app")
+    // Rewritten rather than added to: the classpath and the command line are baked into it. Which is
+    // also why relaunching a name while a window of that name is still open is the thing not to do —
+    // that window is reading these files.
+    bundle.deleteRecursively()
+    val icon = File(bundle, "Contents/Resources/$ICON_FILE_NAME")
+    icon.parentFile.mkdirs()
+    iconFile.get().asFile.copyTo(icon)
+    File(bundle, "Contents/Info.plist").writeText(infoPlist())
+    // Everything the JVM says before the app can open a log file of its own, which is where a run that
+    // died on its way up says why: `open` gives a bundle no terminal to say it on.
+    val output = File(bundleDirectory.get().asFile, "$name.out")
+    val launcher = File(bundle, "Contents/MacOS/$EXECUTABLE_NAME")
+    launcher.parentFile.mkdirs()
+    launcher.writeText(launcherScript(args, output))
+    launcher.setExecutable(true)
+    execOperations.exec { commandLine("open", "-n", bundle.path) }
+    logger.lifecycle("Launched \"$name\". It logs to ~/.shark-explorer/logs, and to $output if it can't.")
+  }
+
+  /**
+   * What the bundle file is called, and therefore what the dock says: the run's title, or the app's own
+   * name for a command line that gave none.
+   *
+   * Read here with a regex rather than by the parser the app uses, which is in the app: a title the two
+   * read differently costs the bundle its name and nothing else, since every window title comes from
+   * the app's own reading of the same string.
+   */
+  private fun bundleName(args: String): String {
+    val title = TITLE.find(args)?.groupValues?.drop(1)?.firstOrNull { it.isNotEmpty() }
+    // The dock is reading a file name, which can hold neither of the characters a path is built from.
+    return title.orEmpty().replace(PATH_CHARACTERS, " ").trim().ifEmpty { DEFAULT_NAME }
+  }
+
+  private fun infoPlist(): String =
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>CFBundleExecutable</key><string>$EXECUTABLE_NAME</string>
+      <key>CFBundleIconFile</key><string>$ICON_FILE_NAME</string>
+      <key>CFBundleIdentifier</key><string>$BUNDLE_IDENTIFIER</string>
+      <key>CFBundlePackageType</key><string>APPL</string>
+    </dict>
+    </plist>
+    """.trimIndent() + "\n"
+
+  /**
+   * A script rather than a launcher binary, and `exec` rather than a child process: the JVM has to end
+   * up being the process macOS launched from the bundle, or it is a process of its own again and the
+   * dock is back to calling it java.
+   */
+  private fun launcherScript(
+    args: String,
+    output: File
+  ): String {
+    val classpath = runtimeClasspath.files.joinToString(":") { it.path }
+    return """
+      #!/bin/sh
+      # Written by the runNamed Gradle task, and rewritten by the next run of it.
+      cd ${workingDirectory.get().asFile.path.shellQuoted()} || exit 1
+      exec ${javaExecutable.get().shellQuoted()} \
+        -Dcompose.application.configure.swing.globals=true \
+        -cp ${classpath.shellQuoted()} \
+        ${mainClass.get()} $args >>${output.path.shellQuoted()} 2>&1
+    """.trimIndent() + "\n"
+  }
+
+  /**
+   * A path a shell reads as one word whatever is in it. The command line above is deliberately not put
+   * through this: it is split by the shell exactly as the shell that typed it would have split it.
+   */
+  private fun String.shellQuoted() = "'" + replace("'", "'\\''") + "'"
+
+  private companion object {
+    const val EXECUTABLE_NAME = "shark-explorer"
+    const val ICON_FILE_NAME = "shark-explorer-icon.icns"
+
+    /** Not the packaged app's, which names a real installed app rather than a bundle in a build folder. */
+    const val BUNDLE_IDENTIFIER = "shark.explorer.app.named"
+
+    /** What a run with no title is called, matching the window title of a window with no heap dump. */
+    const val DEFAULT_NAME = "Shark Explorer"
+
+    /** Both spellings of the option, since the app takes both. Quoted first: a title has spaces in it. */
+    val TITLE = Regex("""--title[=\s]+(?:"([^"]*)"|(\S+))""")
+
+    val PATH_CHARACTERS = Regex("[/:]")
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -60,9 +60,32 @@ fun main(args: Array<String>) {
     // `--args` and a run configuration each split a quoted title differently, and a title split in two
     // reads as one on the line above.
     SharkLog.d { "Read that as $arguments" }
+    nameThisRun(arguments.titlePrefix ?: APP_NAME)
     // Heap dump paths on the command line open straight away, which is how this is usually run.
     explorerApplication(arguments)
   }
+}
+
+/**
+ * Calls this process [name] wherever the OS names the process rather than one of its windows, which on
+ * macOS is the menu bar and the app switcher.
+ *
+ * A run is one process and several windows, so the one name it gets is what the run was started for —
+ * the `--title` its windows share — rather than which heap dump is open. Without this a run is called
+ * after whatever launched it, which is the same for every explorer on screen.
+ *
+ * Called before the first window, which is not a matter of taste: AWT reads this property as it starts
+ * and registers the process under whatever it says then, so setting it once a window is up changes
+ * nothing. It is the same name `-Xdock:name` sets — that JVM argument only puts it in an environment
+ * variable AWT reads at that same moment — which is why nothing that launches this has to pass one.
+ *
+ * The macOS dock is the one place this does not reach: it names a process after the bundle it was
+ * launched from and takes no notice of either. Naming that is the `runNamed` Gradle task's job.
+ */
+private fun nameThisRun(name: String) {
+  // Read on macOS only. Windows and Linux name a process after its window, which already says this.
+  System.setProperty("apple.awt.application.name", name)
+  SharkLog.d { "This run is called \"$name\" where the OS names the process rather than a window" }
 }
 
 /** One window per heap dump open, which is what [openHeapDump] keeps true as more are opened. */


### PR DESCRIPTION
A run of the explorer is `java` in the macOS dock whatever it was started for, so several runs are one name and one shark icon there. The window titles tell them apart; the dock, which is what you switch between them with, does not.

### Nothing the process can do about that

| tried | result |
| --- | --- |
| `-Xdock:name=X` on the run task | dock unchanged — [JDK-8173753](https://bugs.openjdk.org/browse/JDK-8173753), open since around macOS 10.9, symptom "the name reaches the menu bar and the dock still says java" |
| `System.setProperty("apple.awt.application.name", …)` before the first window | same name by another road: a run given either produces LaunchServices records differing in nothing but their audit token |
| the same, once a window is up | nothing — AWT reads it as it starts |
| `java.awt.Taskbar` | no name in its API: icon, badge, menu, progress |

Measured, not inferred: three runs whose LaunchServices, `NSRunningApplication` and WindowServer names were all different showed three dock tiles all called `java`.

### What the dock does read

The file name of the bundle a process was launched from — and not even its `CFBundleName`. Two bundles carrying the same `CFBundleName` and differing only in file name are two differently named tiles.

So `runNamed` launches from a bundle generated per launch and named after `--title`:

```bash
./gradlew :shark:shark-explorer:shark-explorer-app:runNamed \
  --args="--title=\"Hover previews\" leakcanary/leakcanary-android-instrumentation/src/androidTest/assets/large-dump.hprof"
```

- A launcher script and an `Info.plist` around the classes `run` would have run, **not a `jpackage` build** — jlink is a minute per code change, which would be a minute per look. `runNamed` is a compile: 6 seconds here.
- The script **`exec`s** the JVM. It has to end up being the process macOS launched from the bundle, or it is a process of its own again and the dock is back to calling it java.
- `open` gives it no terminal, so stdout goes to `build/named/<title>.out`, which is where a run that died before it could open a log file says why.
- The icon comes from the bundle: `NSWorkspace.iconForFile` on a generated bundle hands back the shark.

`run` stays the one to use while working — it streams the log and doesn't write a bundle — and `AGENTS.md` says which is for what: `run` for your own tests, `runNamed` when you are starting the app for someone else to look at.

### The three lines in `main` earn their place without the dock

`apple.awt.application.name` still names the run everywhere a process can name itself. A/B on the menu bar, read through the Accessibility API rather than by eye:

| | menu bar next to the Apple logo |
| --- | --- |
| before | `MainKt` |
| after | the `--title` string |

Verified by reading the dock's own UI (`System Events` → process `Dock`), which needs the Accessibility permission — `AGENTS.md` now records that, and how to check a name without it.