### PR TITLE
Fix the spinner and clean up the take-a-heap-dump screens

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -272,10 +272,22 @@ it, so run it before pushing.
 
 Anything that reaches a device — taking a heap dump, fetching bitmaps — can be tried for real with an
 emulator running and `leakcanary-android-sample` installed on it
-(`ANDROID_SERIAL=emulator-5554 ./gradlew :samples:leakcanary-android-sample:installDebug`). It has to be a
-debuggable app: `am dumpheap` refuses anything else, including every app of the system image, and so does
-a JDWP connection. An emulator older than API 35 is what exercises `shark-explorer-jdwp`, since a newer
-one is asked through a heap dump instead.
+(`ANDROID_SERIAL=emulator-5554 ./gradlew :samples:leakcanary-android-sample:installDebug`). An emulator
+older than API 35 is what exercises `shark-explorer-jdwp`, since a newer one is asked through a heap dump
+instead.
+
+**Two things let a process be dumped, and either is enough**: an app built debuggable, or a device whose
+whole build is — `ro.debuggable=1`, which is what a `userdebug` or `eng` image sets and what
+`ActivityManagerService.enforceDebuggable` skips its check on. So "only a debuggable app can be dumped"
+is right for a phone and wrong for a `userdebug` emulator, where every process on the device can be
+dumped and attached to. Measured on two emulators here: an API 36 `user` image refuses
+`am dumpheap` of `com.android.systemui` with `SecurityException: Process not debuggable` and lists one
+pid under `adb jdwp`; an API 29 `userdebug` one writes 16 MB of `com.android.permissioncontroller` and
+lists twenty. `AndroidDevice.dumpsAnyProcess` is that property, read from the `getprop` the explorer
+already runs.
+
+**A modern emulator image is a `user` build**, so being an emulator is not what makes a device
+permissive — check `ro.debuggable` rather than assuming.
 
 **None of that is covered by a test**, and it can't be: a JDI client talks to a real VM or to nothing.
 Drive it from a throwaway test against a running emulator, read the numbers, and delete the test — the

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DeviceDialog.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DeviceDialog.kt
@@ -1,9 +1,11 @@
 package shark.explorer.app
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -18,6 +20,12 @@ import androidx.compose.ui.unit.dp
  * Both of them ask `adb` the same first question — which devices are connected — and both spend most of
  * their time waiting on a command that takes seconds. See [TakeHeapDumpDialog] and
  * [BitmapsFromDeviceDialog].
+ *
+ * **The spinner has to be given a square**, which is why this is [Modifier.size] and not a height. A
+ * `CircularProgressIndicator` draws a circle of `size.width` and then spins it about the centre of
+ * whatever box it was handed, so in a box that is wider than it is tall those two points are different
+ * and the ring orbits that centre instead of turning on it — clipped to a sliver that wanders around,
+ * which is what constraining the height alone used to produce here.
  */
 @Composable
 internal fun Waiting(message: String) {
@@ -25,9 +33,51 @@ internal fun Waiting(message: String) {
     horizontalArrangement = Arrangement.spacedBy(12.dp),
     verticalAlignment = Alignment.CenterVertically
   ) {
-    CircularProgressIndicator(Modifier.heightIn(max = SPINNER_SIZE).padding(2.dp))
+    CircularProgressIndicator(Modifier.size(SPINNER_SIZE), strokeWidth = SPINNER_STROKE)
     Text(message, style = MaterialTheme.typography.bodyMedium)
   }
+}
+
+/**
+ * One thing to pick out of a list of them: what it is on the left, [detail] hard against the right.
+ *
+ * A row rather than a button, because thirty buttons stacked up read as thirty separate decisions where
+ * a list reads as one. Lining the details up down the right hand edge is the other half of that: a pid
+ * in a column is scanned, a pid trailing each name is read.
+ */
+@Composable
+internal fun PickerRow(
+  name: String,
+  detail: String? = null,
+  onClick: () -> Unit
+) {
+  Row(
+    Modifier.fillMaxWidth()
+      .clickable(onClick = onClick)
+      .padding(horizontal = ROW_INSET, vertical = 6.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Text(name, Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+    if (detail != null) {
+      Text(
+        detail,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+  }
+}
+
+/** What the rows under it have in common, for a list that runs on past what was being looked for. */
+@Composable
+internal fun SectionHeader(text: String) {
+  Text(
+    text,
+    Modifier.padding(start = ROW_INSET, top = 12.dp, bottom = 2.dp),
+    style = MaterialTheme.typography.labelMedium,
+    color = MaterialTheme.colorScheme.onSurfaceVariant
+  )
 }
 
 /**
@@ -40,5 +90,11 @@ internal const val LISTING_DEVICES = "Asking adb which devices are connected…"
 internal const val NO_DEVICES = "adb is not connected to any device."
 internal const val CLOSE = "Close"
 
-internal val DIALOG_MAX_HEIGHT = 400.dp
-private val SPINNER_SIZE = 20.dp
+internal val DIALOG_MAX_HEIGHT = 480.dp
+
+/** What everything a dialog lists lines up on, headings included, so the left edge is one edge. */
+internal val ROW_INSET = 8.dp
+
+/** A line of text tall, so that the row it is in is the height of that line and not of a spinner. */
+private val SPINNER_SIZE = 18.dp
+private val SPINNER_STROKE = 2.dp

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TakeHeapDumpDialog.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TakeHeapDumpDialog.kt
@@ -2,10 +2,12 @@ package shark.explorer.app
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
@@ -13,6 +15,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -112,8 +115,10 @@ internal fun TakeHeapDumpDialog(
     onDismissRequest = onDismiss,
     title = { Text(TAKE_HEAP_DUMP_TITLE) },
     text = {
+      // No scroll around the whole of this: each step scrolls its own list, so that what says where you
+      // are and what you are deciding stays put while thirty processes go past under it.
       Column(
-        Modifier.heightIn(max = DIALOG_MAX_HEIGHT).verticalScroll(rememberScrollState()),
+        Modifier.heightIn(max = DIALOG_MAX_HEIGHT),
         verticalArrangement = Arrangement.spacedBy(8.dp)
       ) {
         Text(TAKE_HEAP_DUMP_EXPLANATION, style = MaterialTheme.typography.bodySmall)
@@ -124,9 +129,11 @@ internal fun TakeHeapDumpDialog(
           is DumpStep.Working -> Waiting(currentStep.message)
           DumpStep.Devices -> Devices(
             devices = devices,
-            onPick = { device -> requestedDevice = device }
+            onPick = { device -> requestedDevice = device },
+            modifier = Modifier.weight(1f, fill = false)
           )
           is DumpStep.Processes -> Processes(
+            device = currentStep.device,
             processes = currentStep.processes,
             // Only worth offering where the dump can't carry the pixels itself: where it can, it does.
             offersBitmaps = !currentStep.device.canDumpBitmaps,
@@ -140,7 +147,8 @@ internal fun TakeHeapDumpDialog(
                 fetchesBitmaps = fetchesBitmaps && !currentStep.device.canDumpBitmaps
               )
             },
-            onBack = { step = DumpStep.Devices }
+            onBack = { step = DumpStep.Devices },
+            modifier = Modifier.weight(1f, fill = false)
           )
           is DumpStep.Failed -> Text(
             currentStep.message,
@@ -158,57 +166,106 @@ internal fun TakeHeapDumpDialog(
   )
 }
 
-/** One button per device, saying what a dump of it would and wouldn't have in it. */
+/** One row per device, and nothing else: which one it is, is the only question this screen asks. */
 @Composable
 private fun Devices(
   devices: List<AndroidDevice>,
-  onPick: (AndroidDevice) -> Unit
+  onPick: (AndroidDevice) -> Unit,
+  modifier: Modifier = Modifier
 ) {
   if (devices.isEmpty()) {
     Text(NO_DEVICES, style = MaterialTheme.typography.bodyMedium)
     return
   }
-  devices.forEach { device ->
-    Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-      TextButton(onClick = { onPick(device) }) {
-        Text(device.description)
-      }
-      Text(device.bitmapExplanation, style = MaterialTheme.typography.bodySmall)
+  Question(PICK_A_DEVICE)
+  Column(modifier.verticalScroll(rememberScrollState())) {
+    devices.forEach { device ->
+      PickerRow(name = device.description, onClick = { onPick(device) })
     }
   }
 }
 
 /**
- * One button per app process of the device picked, plus the way back to the device list.
+ * One row per app process of the device picked, under everything there is to decide before picking one.
  *
  * Picking a process starts the dump, so anything to decide about it has to be decided here — which is
- * why the bitmap checkbox is above the buttons rather than on a screen of its own.
+ * why the bitmap checkbox is above the list rather than on a screen of its own. The header is outside
+ * the scroll for the same reason: it says what will happen when a row is clicked, and a device runs
+ * enough processes to scroll it off.
+ *
+ * The system's own apps go under their own heading rather than in with the rest, because there are
+ * thirty of them to the one being looked for and on most devices none of them can be dumped at all.
  */
 @Composable
 private fun Processes(
+  device: AndroidDevice,
   processes: List<DeviceProcess>,
   offersBitmaps: Boolean,
   fetchesBitmaps: Boolean,
   onFetchesBitmapsChange: (Boolean) -> Unit,
   onPick: (DeviceProcess) -> Unit,
-  onBack: () -> Unit
+  onBack: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-  if (processes.isEmpty()) {
-    Text(NO_APP_PROCESSES, style = MaterialTheme.typography.bodyMedium)
-  } else {
-    Text(PICK_A_PROCESS, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
-    if (offersBitmaps) {
-      FetchBitmapsCheckbox(checked = fetchesBitmaps, onCheckedChange = onFetchesBitmapsChange)
+  Column(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    TextButton(onClick = onBack, contentPadding = PaddingValues(horizontal = ROW_INSET)) {
+      Text(BACK_TO_DEVICES, style = MaterialTheme.typography.bodySmall)
     }
-    processes.forEach { process ->
-      TextButton(onClick = { onPick(process) }) {
-        Text("${process.name} · pid ${process.processId}")
+    if (processes.isEmpty()) {
+      Text(NO_APP_PROCESSES, style = MaterialTheme.typography.bodyMedium)
+      return@Column
+    }
+    Question(PICK_A_PROCESS, device.dumpableProcesses)
+    if (offersBitmaps) {
+      FetchBitmapsCheckbox(
+        device = device,
+        checked = fetchesBitmaps,
+        onCheckedChange = onFetchesBitmapsChange
+      )
+    }
+    HorizontalDivider()
+    val (appProcesses, systemProcesses) = processes.partition { !it.isSystemApp }
+    Column(Modifier.weight(1f, fill = false).verticalScroll(rememberScrollState())) {
+      appProcesses.forEach { process -> ProcessRow(process, onPick) }
+      if (systemProcesses.isNotEmpty()) {
+        SectionHeader(SYSTEM_APPS)
+        systemProcesses.forEach { process -> ProcessRow(process, onPick) }
       }
     }
   }
-  HorizontalDivider()
-  TextButton(onClick = onBack) {
-    Text(BACK_TO_DEVICES)
+}
+
+@Composable
+private fun ProcessRow(
+  process: DeviceProcess,
+  onPick: (DeviceProcess) -> Unit
+) {
+  PickerRow(
+    name = process.name,
+    detail = "pid ${process.processId}",
+    onClick = { onPick(process) }
+  )
+}
+
+/** What this screen is asking, and whatever has to be known to answer it. */
+@Composable
+private fun Question(
+  question: String,
+  note: String? = null
+) {
+  Text(
+    question,
+    Modifier.padding(start = ROW_INSET),
+    style = MaterialTheme.typography.bodyMedium,
+    fontWeight = FontWeight.Bold
+  )
+  if (note != null) {
+    Text(
+      note,
+      Modifier.padding(start = ROW_INSET),
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
   }
 }
 
@@ -216,26 +273,42 @@ private fun Processes(
  * The offer to have the process compress its bitmaps for a debugger straight after the dump, for a
  * device whose dump can't carry them.
  *
- * It says what it costs, because it's minutes of a suspended app for a large one and there's no way to
- * tell from here how many bitmaps a process holds.
+ * On a surface of its own, because it is the one thing on this screen that isn't a process: left as
+ * plain rows it reads as another list item, and the list is what a click is about to land on.
+ *
+ * It says why it is being offered and what it costs, because it's minutes of a suspended app for a
+ * large one and there's no way to tell from here how many bitmaps a process holds.
  */
 @Composable
 private fun FetchBitmapsCheckbox(
+  device: AndroidDevice,
   checked: Boolean,
   onCheckedChange: (Boolean) -> Unit
 ) {
-  Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-    Row(
-      Modifier.fillMaxWidth()
-        .toggleable(value = checked, role = Role.Checkbox, onValueChange = onCheckedChange),
-      verticalAlignment = Alignment.CenterVertically
+  Surface(
+    Modifier.fillMaxWidth(),
+    shape = MaterialTheme.shapes.small,
+    color = MaterialTheme.colorScheme.surfaceVariant
+  ) {
+    Column(
+      Modifier.toggleable(value = checked, role = Role.Checkbox, onValueChange = onCheckedChange)
+        .padding(horizontal = 8.dp, vertical = 4.dp)
     ) {
-      // Null, so the row is the one thing a click lands on: a box that handles its own clicks and a
-      // label that doesn't is two targets for one answer.
-      Checkbox(checked = checked, onCheckedChange = null)
-      Text(FETCH_BITMAPS_WITH_DUMP, style = MaterialTheme.typography.bodyMedium)
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        // Null, so the block is the one thing a click lands on: a box that handles its own clicks and
+        // a label that doesn't is two targets for one answer.
+        Checkbox(checked = checked, onCheckedChange = null, modifier = Modifier.size(20.dp))
+        Text(FETCH_BITMAPS_WITH_DUMP, style = MaterialTheme.typography.bodyMedium)
+      }
+      Text(
+        device.fetchBitmapsExplanation,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
     }
-    Text(FETCH_BITMAPS_WITH_DUMP_EXPLANATION, style = MaterialTheme.typography.bodySmall)
   }
 }
 
@@ -293,25 +366,39 @@ private suspend fun DeviceHeapDumps.fetchedPixelsOrNull(
  */
 private fun DeviceHeapDumps.readyDevices(): List<AndroidDevice> = connectedDevices().filter { it.isReady }
 
-/** Whether a dump of this device will have the pixels of its bitmaps in it, which is most of the point. */
-private val AndroidDevice.bitmapExplanation: String
-  get() = if (canDumpBitmaps) {
-    "The dump will include the pixels of its bitmaps."
-  } else {
-    "API $sdkInt can't put the pixels of a bitmap in a heap dump, so the dump will have none — they " +
-      "have to be fetched off the process, either with the dump or once it's open."
+/**
+ * Which of this device's processes `am dumpheap` will actually agree to dump.
+ *
+ * Two things let it through and either is enough: an app built debuggable, or a device whose whole
+ * build is (`ro.debuggable=1`, which is what a `userdebug` or `eng` image sets). So "only a debuggable
+ * app can be dumped" is the answer for a retail phone and for a modern emulator image, and the wrong
+ * answer for the `userdebug` one someone reached for precisely so they could dump anything.
+ */
+private val AndroidDevice.dumpableProcesses: String
+  get() = when (isDebuggableBuild) {
+    true -> "This build is debuggable (ro.debuggable=1), so any of these can be dumped, the system's own included."
+    false -> "This build is not debuggable (ro.debuggable=0), so only an app built debuggable can be " +
+      "dumped: a release build and every app of the system will refuse."
+    null -> "An app built debuggable can be dumped, and so can anything at all on a device whose build " +
+      "is debuggable. This one didn't say which it is."
+  }
+
+/** Why the fetch is on offer at all, which is the device's Android version, and what it costs. */
+private val AndroidDevice.fetchBitmapsExplanation: String
+  get() {
+    val version = sdkInt?.let { "API $it" } ?: "This device's Android version"
+    return "$version can't put the pixels of a bitmap in a heap dump, so this one will have none. " +
+      "Fetching them attaches a debugger and has the app compress every bitmap, suspended throughout: " +
+      "seconds of fixed cost, plus a fraction of a second per bitmap."
   }
 
 internal const val TAKE_HEAP_DUMP = "Take heap dump…"
 internal const val TAKE_HEAP_DUMP_TITLE = "Take a heap dump off a device"
 internal const val TAKE_HEAP_DUMP_EXPLANATION =
-  "Dumping a heap freezes the app for a moment and pulls tens of megabytes over adb. Only a debuggable " +
-    "app can be dumped."
+  "Dumping a heap freezes the app for a moment and pulls tens of megabytes over adb."
+internal const val PICK_A_DEVICE = "Which device?"
 internal const val PICK_A_PROCESS = "Which process?"
 internal const val FETCH_BITMAPS_WITH_DUMP = "Fetch the pixels of its bitmaps too"
-internal const val FETCH_BITMAPS_WITH_DUMP_EXPLANATION =
-  "Slow: a debugger attaches to the app and has it compress every bitmap, a few seconds of fixed cost " +
-    "plus a fraction of a second per bitmap, and the app is suspended for all of it. The same fetch is " +
-    "offered once the dump is open, so tick this when there's time to get everything in one go."
 internal const val NO_APP_PROCESSES = "No app is running on this device."
+internal const val SYSTEM_APPS = "System apps"
 internal const val BACK_TO_DEVICES = "← Other devices"

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TakeHeapDumpTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TakeHeapDumpTest.kt
@@ -64,9 +64,64 @@ class TakeHeapDumpTest {
       setExplorerContent(DeviceHeapDumps(fakeAdb(deviceSdkInt = 30)))
 
       onNodeWithText(TAKE_HEAP_DUMP).performClick()
+      waitUntilAtLeastOneExists(hasText(OLD_DEVICE_DESCRIPTION), TIMEOUT_MILLIS)
+      // Not on the device list, which says nothing about bitmaps: it is on the screen where the fetch
+      // is offered, next to the checkbox it is the reason for.
+      assertThat(onAllNodesWithText("can't put", substring = true).fetchSemanticsNodes()).isEmpty()
+      onNodeWithText(OLD_DEVICE_DESCRIPTION).performClick()
 
       // The dump is still worth taking, and it's the one thing about it worth knowing in advance.
       waitUntilAtLeastOneExists(hasText("API 30 can't put", substring = true), TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `a user build says that only a debuggable app can be dumped`() {
+    runComposeUiTest {
+      setExplorerContent(DeviceHeapDumps(fakeAdb()))
+
+      onNodeWithText(TAKE_HEAP_DUMP).performClick()
+      waitUntilAtLeastOneExists(hasText(DEVICE_DESCRIPTION), TIMEOUT_MILLIS)
+      onNodeWithText(DEVICE_DESCRIPTION).performClick()
+
+      waitUntilAtLeastOneExists(hasText("ro.debuggable=0", substring = true), TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `a userdebug build says that any of its processes can be dumped`() {
+    runComposeUiTest {
+      // `ro.debuggable=1` is what `ActivityManagerService.enforceDebuggable` lets everything through
+      // on, so on this one the system's own apps can be dumped as well — which is the whole reason
+      // someone reaches for such an image, and the reason "only a debuggable app" is the wrong answer.
+      setExplorerContent(DeviceHeapDumps(fakeAdb(deviceIsDebuggable = true)))
+
+      onNodeWithText(TAKE_HEAP_DUMP).performClick()
+      waitUntilAtLeastOneExists(hasText(DEVICE_DESCRIPTION), TIMEOUT_MILLIS)
+      onNodeWithText(DEVICE_DESCRIPTION).performClick()
+
+      waitUntilAtLeastOneExists(hasText("ro.debuggable=1", substring = true), TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `the system's own processes are listed under their own heading`() {
+    runComposeUiTest {
+      setExplorerContent(
+        DeviceHeapDumps(
+          fakeAdb(
+            processLines = "PID NAME\n1 init\n914 com.android.systemui\n1201 com.example\n",
+            installedPackages = "package:com.example\npackage:com.android.systemui\n"
+          )
+        )
+      )
+
+      onNodeWithText(TAKE_HEAP_DUMP).performClick()
+      waitUntilAtLeastOneExists(hasText(DEVICE_DESCRIPTION), TIMEOUT_MILLIS)
+      onNodeWithText(DEVICE_DESCRIPTION).performClick()
+      waitUntilAtLeastOneExists(hasText(PROCESS_ROW), TIMEOUT_MILLIS)
+
+      // Thirty of the system's own to the one being looked for, so they are below a line rather than
+      // mixed in with it.
+      assertThat(onAllNodesWithText(SYSTEM_APPS).fetchSemanticsNodes()).hasSize(1)
+      assertThat(onAllNodesWithText("com.android.systemui").fetchSemanticsNodes()).hasSize(1)
     }
   }
 
@@ -170,7 +225,10 @@ class TakeHeapDumpTest {
     deviceSdkInt: Int = SDK_INT,
     processLines: String = "PID NAME\n1 init\n1201 com.example\n",
     // What a dump of that device would have in it: pixels only where `-b png` is understood.
-    dumpHasPixels: Boolean = true
+    dumpHasPixels: Boolean = true,
+    // A `user` build, which is what a retail phone and a modern emulator image both are.
+    deviceIsDebuggable: Boolean = false,
+    installedPackages: String = "package:com.example\n"
   ): RecordingAdb {
     val heapDumpFile = testFolder.newFile("pulled.hprof")
       .apply { writeBitmapHeapDump(hasPixels = dumpHasPixels) }
@@ -183,10 +241,11 @@ class TakeHeapDumpTest {
           [ro.build.fingerprint]: [$FINGERPRINT]
           [ro.product.model]: [$MODEL]
           [ro.build.version.sdk]: [$deviceSdkInt]
+          [ro.debuggable]: [${if (deviceIsDebuggable) 1 else 0}]
         """.trimIndent()
         command.contains("shell ps") -> processLines
         // What separates an app's process from a native service, which reads just like one.
-        command.contains("pm list packages") -> "package:com.example\n"
+        command.contains("pm list packages") -> installedPackages
         // A size that hasn't changed since the last look is what says the process has finished writing.
         command.contains("shell stat") -> dumpBytes.size.toString()
         command.contains(" pull ") -> {
@@ -226,7 +285,9 @@ class TakeHeapDumpTest {
 
     private const val SERIAL = "emulator-5554"
     private const val DEVICE_DESCRIPTION = "$MODEL · API $SDK_INT · $SERIAL"
-    private const val PROCESS_ROW = "com.example · pid 1201"
+
+    /** A row is the name and the pid in two columns, so the name is what a test clicks. */
+    private const val PROCESS_ROW = "com.example"
 
     /** Older than `am dumpheap -b png`, which is what makes a debugger the only way to the pixels. */
     private const val OLD_SDK_INT = 30

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Adb.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Adb.kt
@@ -144,10 +144,31 @@ class AndroidDevice(
   val state: String,
   val fingerprint: String?,
   val model: String?,
-  val sdkInt: Int?
+  val sdkInt: Int?,
+  /**
+   * `ro.debuggable`, which is what decides whether a process that isn't debuggable can be dumped.
+   *
+   * A `userdebug` or `eng` build sets it, and the framework then skips the check that would refuse:
+   * `ActivityManagerService.enforceDebuggable` throws `SecurityException: Process not debuggable` only
+   * where this is 0. Verified against a device of each: an API 29 `userdebug` emulator dumps
+   * `com.android.permissioncontroller`, and an API 36 `user` one refuses `com.android.systemui`.
+   *
+   * Null for a device that wasn't asked, which is one that isn't ready.
+   */
+  val isDebuggableBuild: Boolean?
 ) {
 
   val isReady: Boolean get() = state == READY_STATE
+
+  /**
+   * Whether every process of this device can be dumped, rather than only the apps built debuggable.
+   *
+   * The apps of a system image are not debuggable, and neither is a release build of one being worked
+   * on, so this is the difference between a device with two dumpable processes on it and one with all
+   * of them. Modern emulator images are `user` builds like a retail phone, so it is not the emulator
+   * question it looks like.
+   */
+  val dumpsAnyProcess: Boolean get() = isDebuggableBuild == true
 
   /**
    * Whether a heap dump taken of this device can carry the pixels of its bitmaps, which is what
@@ -201,7 +222,8 @@ internal fun Adb.connectedDevices(): List<AndroidDevice> =
       state = state,
       fingerprint = properties["ro.build.fingerprint"],
       model = properties["ro.product.model"],
-      sdkInt = properties["ro.build.version.sdk"]?.toIntOrNull()
+      sdkInt = properties["ro.build.version.sdk"]?.toIntOrNull(),
+      isDebuggableBuild = properties["ro.debuggable"]?.let { it == "1" }
     )
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DeviceHeapDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DeviceHeapDumps.kt
@@ -62,14 +62,16 @@ class DeviceHeapDumps(
    *
    * Every app process is offered rather than only the ones that can actually be dumped, because whether
    * a process is debuggable is something only `am dumpheap` knows, and it says so clearly when it isn't.
+   * [AndroidDevice.dumpsAnyProcess] is as close as anything gets in advance, and it is about the build
+   * rather than about the app.
    */
   fun appProcesses(device: AndroidDevice): List<DeviceProcess> {
     val packages = installedPackages(device)
     return runningProcesses(device)
       .filter { it.name.substringBefore(PROCESS_NAME_SEPARATOR) in packages }
       // The app being worked on first, because it is the one being looked for and there are thirty of the
-      // others: only a debuggable app can be dumped at all, and none of the system's own is.
-      .sortedWith(compareBy({ if (it.name.isSystemApp()) 1 else 0 }, { it.name }))
+      // system's own behind it — none of which is dumpable at all unless the build is debuggable.
+      .sortedWith(compareBy({ if (it.isSystemApp) 1 else 0 }, { it.name }))
   }
 
   /** Every package installed on [device], as `pm` lists them. */
@@ -234,8 +236,9 @@ class DeviceHeapDumps(
   /**
    * What `am dumpheap` said, with the one refusal that doesn't explain itself explained.
    *
-   * A process that isn't debuggable can't be dumped at all, and what the framework answers — a
-   * `SecurityException` — reads like something went wrong rather than like the answer being no.
+   * A process that isn't debuggable can't be dumped on a build that isn't, and what the framework
+   * answers — a `SecurityException` — reads like something went wrong rather than like the answer being
+   * no. Which of the two to fix is worth saying, since either one is enough.
    */
   private fun AdbOutput.orFailToDump(
     process: DeviceProcess,
@@ -246,7 +249,8 @@ class DeviceHeapDumps(
     val message = failure.message.orEmpty()
     if (NOT_DEBUGGABLE in message) {
       throw AdbFailureException(
-        "$message. Only a debuggable app can be asked for its heap, which a release build of one isn't."
+        "$message. A heap can only be asked for from an app built debuggable, which a release build " +
+          "isn't, or on a device whose build is (`ro.debuggable=1`), which this one's isn't."
       )
     }
     throw failure
@@ -277,11 +281,6 @@ class DeviceHeapDumps(
 
     /** What `pm list packages` puts in front of each package name. */
     private const val PACKAGE_LINE_PREFIX = "package:"
-
-    /** What the packages of the system and of Google's own apps start with. */
-    private val SYSTEM_PACKAGE_PREFIXES = listOf("android.", "com.android.", "com.google.android.")
-
-    private fun String.isSystemApp(): Boolean = SYSTEM_PACKAGE_PREFIXES.any { startsWith(it) }
   }
 }
 
@@ -312,7 +311,23 @@ fun interface BitmapDebugger {
 class DeviceProcess(
   val processId: Int,
   val name: String
-)
+) {
+
+  /**
+   * Whether this is one of the system image's own processes rather than an app someone installed.
+   *
+   * By the package name, which is all `ps` gives: the system's apps and Google's are the ones under
+   * these three, and there are thirty of them running to the one being worked on. None of them is built
+   * debuggable, so on a device that isn't either they are the ones that will refuse to be dumped.
+   */
+  val isSystemApp: Boolean get() = SYSTEM_PACKAGE_PREFIXES.any { name.startsWith(it) }
+
+  private companion object {
+    /** `com.google.process.gservices` and its like are the system's too, and match none of the others. */
+    val SYSTEM_PACKAGE_PREFIXES =
+      listOf("android.", "com.android.", "com.google.android.", "com.google.process.")
+  }
+}
 
 /** The pid and name of each line of `ps -A -o PID,NAME`, skipping its header. */
 internal fun parseProcessLines(output: String): List<DeviceProcess> = output.lines()

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/AdbTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/AdbTest.kt
@@ -14,6 +14,7 @@ class AdbTest {
       "-s emulator-5554 shell getprop" to """
         [ro.build.fingerprint]: [google/sdk_gphone64_arm64/emu64a:16/BP22.250325.006/13207872:user/release-keys]
         [ro.build.version.sdk]: [36]
+        [ro.debuggable]: [0]
         [ro.product.model]: [sdk_gphone64_arm64]
       """.trimIndent()
     )
@@ -27,6 +28,23 @@ class AdbTest {
     assertThat(device.model).isEqualTo("sdk_gphone64_arm64")
     assertThat(device.sdkInt).isEqualTo(36)
     assertThat(device.description).isEqualTo("sdk_gphone64_arm64 · API 36 · emulator-5554")
+    // A modern emulator image is a `user` build like a retail phone, so it dumps debuggable apps only.
+    assertThat(device.dumpsAnyProcess).isFalse()
+  }
+
+  @Test fun `a userdebug build dumps any process, not only a debuggable app`() {
+    // What `am dumpheap` goes by: `ActivityManagerService.enforceDebuggable` skips its check entirely
+    // when `ro.debuggable` is 1, which is what a userdebug or eng image sets.
+    val adb = FakeAdb(
+      "devices" to "List of devices attached\nemulator-5560\tdevice\n",
+      "-s emulator-5560 shell getprop" to """
+        [ro.build.type]: [userdebug]
+        [ro.build.version.sdk]: [29]
+        [ro.debuggable]: [1]
+      """.trimIndent()
+    )
+
+    assertThat(adb.connectedDevices().single().dumpsAnyProcess).isTrue()
   }
 
   @Test fun `a device that is not ready is not asked what it is`() {
@@ -144,7 +162,8 @@ class AdbTest {
     state = "device",
     fingerprint = fingerprint,
     model = model,
-    sdkInt = sdkInt
+    sdkInt = sdkInt,
+    isDebuggableBuild = false
   )
 
   private fun origin(

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/DeviceHeapDumpsTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/DeviceHeapDumpsTest.kt
@@ -207,7 +207,9 @@ class DeviceHeapDumpsTest {
     assertThatThrownBy { DeviceHeapDumps(adb).dumpHeap(device(), process()) }
       .isInstanceOf(AdbFailureException::class.java)
       .hasMessageContaining("Process not debuggable: com.example")
-      .hasMessageContaining("Only a debuggable app")
+      // Both ways past it, since either one is enough and the app is only one of them.
+      .hasMessageContaining("an app built debuggable")
+      .hasMessageContaining("ro.debuggable=1")
       // The twelve frames under it say nothing anyone at a window can act on.
       .hasMessageNotContaining("at com.android.server")
   }
@@ -299,7 +301,8 @@ class DeviceHeapDumpsTest {
     state = "device",
     fingerprint = "google/tokay/tokay:16/BP31.250610.004/13698546:user/release-keys",
     model = "Pixel 9",
-    sdkInt = sdkInt
+    sdkInt = sdkInt,
+    isDebuggableBuild = false
   )
 
   private fun process() = DeviceProcess(processId = 1201, name = "com.example")

--- a/shark/shark-explorer/shark-explorer-jdwp/src/test/java/shark/explorer/jdwp/JdwpBitmapsTest.kt
+++ b/shark/shark-explorer/shark-explorer-jdwp/src/test/java/shark/explorer/jdwp/JdwpBitmapsTest.kt
@@ -59,7 +59,8 @@ class JdwpBitmapsTest {
     state = "device",
     fingerprint = "google/sdk/sdk:10/QSR1/6427100:user/release-keys",
     model = "Pixel 4",
-    sdkInt = 29
+    sdkInt = 29,
+    isDebuggableBuild = false
   )
 
   private fun process() = DeviceProcess(processId = 1201, name = "com.example")


### PR DESCRIPTION
Reviewing the UX behind **Take heap dump…**, four things.

### The spinner every step of it shows was drawn outside its own box

`Waiting` constrained a `CircularProgressIndicator` with `heightIn(max = 20.dp)`, which bounds the height and leaves the width at the indicator's own 40dp. The indicator draws a circle of `size.width` and then spins it about the centre of whatever box it was handed, so in a box wider than it is tall those two points are different and the ring **orbits** that centre instead of turning on it — clipped to a sliver that wanders around the row.

Caught by rendering it headlessly frame by frame. Before, the arc leaves its layout bounds entirely; after, a probe of where the ink lands puts every frame inside the 18dp square, inset by the stroke.

It's a square now, with a stroke to match the text. That's both dialogs and every waiting step of each — listing devices, listing processes, dumping, waiting for the dump, pulling, and the whole fetch-the-pixels flow.

The other three `CircularProgressIndicator`s in the app were already given a square or left at their default, and measured fine.

### "Only a debuggable app can be dumped" was half the rule

The other half is the device. `ActivityManagerService.enforceDebuggable` skips its check entirely when `ro.debuggable` is 1, which is what a `userdebug` or `eng` image sets — so on such a device *every* process can be dumped, which is usually why someone reached for one.

Measured on two emulators rather than reasoned about:

| Emulator | `ro.debuggable` | `am dumpheap` of a system app | `adb jdwp` |
| --- | --- | --- | --- |
| API 36, `user` | 0 | `SecurityException: Process not debuggable: com.android.systemui` | 1 pid |
| API 29, `userdebug` | 1 | 16 MB of `com.android.permissioncontroller` written | 20 pids |

Worth noting a modern emulator image is a `user` build like a retail phone, so being an emulator is not what makes a device permissive.

`ro.debuggable` comes out of the `getprop` the explorer already runs, so this costs no extra call. The process screen says which of the two the device is, and the refusal, when one comes back, now names both ways past it instead of only the app.

### The device list no longer mentions bitmaps

It was two lines of Android version history per device, before anything had been picked. What a dump will and won't carry is now said where it's acted on: next to the checkbox offering to fetch the pixels, on the one screen that offers it.

### The process screen is a list rather than thirty buttons

Name on the left, pid lined up down the right, the system's own apps under their own heading — there are thirty of those to the one being looked for. The header (where you are, what's being asked, what it costs) is outside the scroll, so it stays put while the list goes past. The fetch checkbox sits on a surface of its own so it doesn't read as another row, and no longer ends by pointing at the fetch the window offers later.

### Testing

`shark-explorer-{core,jdwp,app}:check` and repo-wide `detekt` are green. New coverage: `ro.debuggable` read off `getprop`, the two builds saying different things, the system heading, and the device list staying silent about bitmaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)