### PR TITLE
Make the name on a rectangle the way to reach it

### DIFF
--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -216,6 +216,12 @@ rather than sliding when that would leave the view, because the card is a Materi
 the pointer ends up inside takes the hover off the map — which would close the card, and start over. Hence
 also the gap, and hence nothing in the card being clickable.
 
+**A rectangle that isn't one object gets the card too**, and needs it most. A pile is named on the map by a
+count and a simple class name — `400 × Sibling`, `300 smaller objects` — which is all a rectangle has room
+for, so the qualified class name, or which rectangle a leftover pile was left out of, fits nowhere but here.
+The card used to be drawn for `Selection.Object` alone, which meant pointing at the one kind of cell whose
+name is incomplete answered nothing at all.
+
 Both are kept, as two sets of details from the same code: one for what the map is on, one for what the
 pointer is on. Nothing is read when the pointer leaves, and nothing on the map screen is blanked as the
 next cell is read, so a sweep across the map doesn't flicker.

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -270,6 +270,12 @@ says, in a strip that couldn't hold a class name. **The whole heap dump is the t
 the same reason: the way back to the screen the window opens on belongs where the chain says the whole heap
 is, and a chain of the whole heap dump is that one row and nothing else.
 
+**The screen bar has a button of the same name, which is not a duplicate of that row.** The chain is drawn
+for the rectangle clicked, on the map screen only, so until something has been clicked, and from a list of
+objects, that row isn't there — and the way back to the top of the tree is the one move that has to be
+available whatever the window is showing. Hence a button beside the other screens rather than a second one
+above the map: leaving the map and going back to the top of it are the same kind of move.
+
 **The pointer's chain is drawn onto the end of the clicked one.** The rectangle under the pointer is inside
 the one the window is describing, so the chain holding it *is* this chain plus a few steps — and drawing it
 that way makes sweeping the pointer across the map read as the chain growing and shrinking, leaving the

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -66,7 +66,8 @@ for finalization and their `finalize()` hadn't run.
 Every legend row above the view says how firmly, how many bytes and how many objects — `Weak 0 B ·
 0 objects` — so a strength with nothing at it says so on its own. `NOTHING_WEAKER` then says why that's
 normal, since all four `java.lang.ref` strengths coming out empty reads as a broken computation until you
-know.
+know. It is one line, with the paragraph above on hover: it is true of most dumps, so it would otherwise be
+a paragraph sitting over the map for the whole session to answer a question asked once.
 
 Two more reference reader behaviours that surprise you when reading a treemap:
 

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -204,6 +204,14 @@ objects rather than one — a class group, or the siblings that didn't fit — i
 strength, cool slate when that strength is `STRONG`, so it reads as "not an object" without needing a
 colour of its own. All of it is in `CellColors.kt`, the one place the colours are named.
 
+**The siblings that didn't fit are filled with dots on top of that**, `pileDots` in `CellView.kt`. That
+rectangle is often the biggest thing on the map — a class group of 54,000 strings is one rectangle with
+one of these filling almost all of it — and at that size a flat block reads as one enormous object, which
+on a real dump means a bitmap. A texture says "many small things" before the label is read, and being an
+even texture rather than a drawing of each of them keeps the pile looking like the one thing a click can
+land on. It's a repeated `ImageShader` tile rather than a circle per dot, because the whole map is redrawn
+every time the pointer moves onto another rectangle.
+
 **Grey means one thing only: a strength switched off.** The checkboxes above the view are a `CellColoring`,
 and unchecking one greys out everything held that firmly rather than hiding it — the tree is the whole heap
 dump either way, so there is no strength it makes no sense to press, and toggling one is a repaint. Greying
@@ -266,8 +274,11 @@ into **along the whole chain**, and the chain beside the map is the way back out
 from resolving it that way rather than from the cell's own `parent`: an object that dominates nothing lands
 inside what holds it with itself selected, rather than filling the view with one rectangle and nothing to
 read; and it's the same code path whatever led there, so a class name clicked in the details panel and a
-rectangle clicked on the map land in the same place. A group isn't a node of the tree, so clicking one has
-nowhere to go: it describes what it stands for and leaves the map where it is.
+rectangle clicked on the map land in the same place. A group isn't a node of the tree, so what a click on
+one is walked to is its `parent` — the rectangle it was left out of, which is where those objects are, and
+rooted there the map has the room to draw the biggest of them one by one. The panels stay on the group,
+since the group is what was clicked. **Every rectangle moves the map**, in other words, and the group used
+to be the one that didn't.
 
 Keeping all of that pure functions in `shark-explorer-core` is what makes it testable — see
 `decisions.md` for how the UI tests are structured around this.

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -120,6 +120,15 @@ rectangle, not a tree node: it can't be subdivided or zoomed into, and clicking 
 objects it stands for. Same dump, same viewport, after the change: 1,190 cells, 28 groups, 7 levels
 deep, nothing truncated.
 
+**`maxChildrenPerNode` doesn't apply to the node the viewport is rooted at**, which gets
+`maxRootChildren` — half the cell budget — instead. A count that doesn't move when the room does makes
+zooming pointless, and the pile is the one thing zooming exists for: the `LongSparseArray[]` of drawable
+caches in `compose_leak.hprof` has 668 children, so it drew 200 and a pile of 468 whether it was a
+sliver of the whole-heap-dump map or the whole viewport, and clicking that pile landed on the picture it
+was clicked from. Rooted there it now draws 516 of them and a pile of 103, the ones still under the area
+floor. The whole-heap-dump map is unchanged — 1,726 cells, 93 rectangles at the top level — because at
+that root the area floor bites long before 200 does.
+
 A radial layout has one more bound: **rings**. Eight around the centre disk, the width of each derived
 from the viewport, so the picture always fills the circle and depth past that needs a zoom. Sectors
 take their parent's whole sweep divided by weight, and a ring band is where a node's own name fits, so

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -70,10 +70,11 @@ Two things follow, and both are behaviour rather than polish:
   (On the production dump only 4 own cells survive the 3×3 dp floor — an object's own bytes are usually a
   rounding error next to what it retains. The ones that don't survive are exactly the ones you don't need
   to see, and the one that does is a bitmap.)
-- **A container is pressed by its outline.** Its children cover every pixel of it, so `cellAt` takes an
-  `edgeGrab` — 4 dp — within which a subdivided cell wins over whatever shares that edge. Without it
-  there is no way to point at a container at all. Pointing at a *gap* in a subdivision, area left by
-  children too small to draw, still lands on the node holding it.
+- **A container is pressed by its name, or by its outline.** Its children cover every pixel of it, so
+  `cellAt` takes an `edgeGrab` — 4 dp — within which a subdivided cell wins over whatever shares that
+  edge, and the view checks the plate under a rectangle's name before that. Without either there is no
+  way to point at a container at all. Pointing at a *gap* in a subdivision, area left by children too
+  small to draw, still lands on the node holding it.
 
 And one consequence for the UI: a subdivided rectangle has nowhere to put its own name, so naming the
 levels falls to what is drawn beside the view — `RootPathPanel`, which draws the chain from the whole heap
@@ -94,6 +95,8 @@ Two things make that one level legible:
 - **The label goes over what's nested inside it**, on a translucent plate (`LABEL_PLATE_COLOR`). Text sits
   over fills, outlines and bitmaps it has no say over, so solid text on a washed out plate is readable
   against all of them while still letting what it covers show through. Drawn last, after the outlines.
+  That plate is a hit target as well as a background — see *Hit testing* below — so it is measured once,
+  into `MeasuredLabel`, and the rectangle painted and the rectangle pointed at are the same value.
 - **A child of the root is outlined heavily** (`ROOT_CHILD_BORDER_WIDTH`) and over every outline inside it,
   because the levels below cover their parent exactly: without it the boundary between two named blocks looks
   like every other edge on the map, and the map has no visible structure at the level it's named at.
@@ -242,6 +245,14 @@ own children, so `cellAt` takes an `edgeGrab`: within that distance of an edge, 
 whatever shares it, which is the line the view draws there. A gap in a subdivision still belongs to the
 node being subdivided. This is what a UI test clicks to reach a container — `clickContainerEdge` — since
 the label bands it used to press are gone.
+
+**And the name on a rectangle is a target of its own**, checked before the layout: `namedCellAt` in
+`TreemapView`, against the plates measured for drawing. A name is written over everything nested inside
+the rectangle it names, so the plate is the one piece of a subdivided rectangle still showing, and reading
+the map is reading those names — pointing at one meaning the descendant under the lettering was the view
+answering a question nobody asked. It lives in the app module rather than in `core` because only Compose
+can measure text, and the plate is clamped to the rectangle it names, so a name on a cell barely a line
+tall doesn't answer for the sibling below it. Everywhere else the innermost rectangle still wins.
 
 **A single click goes to the rectangle it landed on**, and it's handled on press rather than on tap:
 `detectTapGestures` holds `onTap` for the double click window whenever `onDoubleTap` is set, and with

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
@@ -9,13 +9,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageShader
 import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.math.roundToInt
 import shark.explorer.CellContent
 import shark.explorer.CellSubject
 import shark.explorer.LayoutCell
@@ -109,6 +120,36 @@ internal fun outlineOf(content: CellContent): Stroke = when {
 }
 
 /**
+ * What the siblings a rectangle had no room for are filled with: dots, over the flat colour every other
+ * cell gets.
+ *
+ * A pile of them can be a good part of the view, and one flat block that size reads as one enormous object
+ * — a bitmap, usually, since that is the only thing that ever is one. A texture says "many small things"
+ * before the label is read, and being an even texture over the whole rectangle rather than a drawing of
+ * each of them keeps the pile looking like the one thing a click can land on.
+ *
+ * One repeated tile rather than a circle per dot, because the whole map is redrawn every time the pointer
+ * moves onto another rectangle, and a pile that fills the view is tens of thousands of dots.
+ */
+internal fun pileDots(density: Density): Brush {
+  val side = with(density) { PILE_DOT_SPACING.toPx() }.roundToInt().coerceAtLeast(1)
+  val tile = ImageBitmap(side, side)
+  CanvasDrawScope().draw(
+    density = density,
+    layoutDirection = LayoutDirection.Ltr,
+    canvas = Canvas(tile),
+    size = Size(side.toFloat(), side.toFloat())
+  ) {
+    drawCircle(
+      color = PILE_DOT_COLOR,
+      radius = with(density) { PILE_DOT_RADIUS.toPx() },
+      center = Offset(side / 2f, side / 2f)
+    )
+  }
+  return ShaderBrush(ImageShader(tile, TileMode.Repeated, TileMode.Repeated))
+}
+
+/**
  * The layout thresholds in dp. The layouts work in pixels, so they have to be scaled or a cell that's
  * big enough to subdivide on one display is too small on another.
  */
@@ -161,4 +202,15 @@ internal const val HOVER_WIDTH = 2f
 internal const val PILE_BORDER_WIDTH = 2f
 internal val CLASS_GROUP_DASH_INTERVALS = floatArrayOf(5f, 4f)
 internal val LEFTOVER_DOT_INTERVALS = floatArrayOf(2f, 3f)
+
 internal val LABEL_STYLE = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Medium)
+
+/**
+ * How far apart the dots of [pileDots] are, and how big. Far enough apart to read as dots at a glance and
+ * small enough that the colour under them still says how firmly the pile is held.
+ */
+private val PILE_DOT_SPACING = 7.dp
+private val PILE_DOT_RADIUS = 1.1.dp
+
+/** The same near white as a name's plate, and for the same reason: it lightens without recolouring. */
+private val PILE_DOT_COLOR = Color(0x8CFFFFFF)

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -135,7 +135,8 @@ private fun ObjectGroupDetails(
   Detail("Objects", formatObjectCount(summary.objectCount))
 }
 
-private fun ObjectGroupSummary.title(): String = when (kind) {
+/** What a pile of objects is called wherever it is described: here, and on the card at the pointer. */
+internal fun ObjectGroupSummary.title(): String = when (kind) {
   ObjectGroupKind.UNREACHABLE -> HeapDominatorTreemap.UNREACHABLE_LABEL
   ObjectGroupKind.CLASS -> "${formatObjectCount(objectCount)} of one class"
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -312,7 +312,8 @@ internal const val CLASS_GROUP_EXPLANATION =
     "so the root's children can be read. Click it to see them one by one."
 
 private const val GROUP_EXPLANATION =
-  "Too small or too many to draw one by one. Click what holds them to see them."
+  "Too small or too many to draw one by one. Clicking them roots the map at what holds them, where the " +
+    "biggest of them get a rectangle each."
 
 /** What the pixels of the selected bitmap are, to anything that can't look at them. */
 internal const val BITMAP_DESCRIPTION = "The pixels of the selected bitmap."

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -312,8 +312,8 @@ internal const val CLASS_GROUP_EXPLANATION =
     "so the root's children can be read. Click it to see them one by one."
 
 private const val GROUP_EXPLANATION =
-  "Too small or too many to draw one by one. Clicking them roots the map at what holds them, where the " +
-    "biggest of them get a rectangle each."
+  "Too small or too many to draw one by one in the rectangle they belong to. Clicking them roots the " +
+    "map at what holds them, which gives it the whole view to draw them in."
 
 /** What the pixels of the selected bitmap are, to anything that can't look at them. */
 internal const val BITMAP_DESCRIPTION = "The pixels of the selected bitmap."

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -44,7 +44,6 @@ import shark.explorer.DeviceHeapDumps
 import shark.explorer.ExplorerScreen
 import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectKind
-import shark.explorer.HeapObjectSummary
 import shark.explorer.HeapSizes
 import shark.explorer.LayoutCell
 import shark.explorer.NativeBitmapPixels
@@ -502,7 +501,7 @@ internal fun HeapDumpExplorer(
               hovered = hovered?.cell,
               // What the pointer is on, for the card that follows it, and where the pointer is. Read
               // already: a card that appears empty and fills in a beat later reads as a flicker.
-              pointedSummary = (hoveredCellDetails?.selection as? Selection.Object)?.summary,
+              pointedSelection = hoveredCellDetails?.selection,
               pointerOffset = pointerOffset,
               viewSize = viewportSize,
               isLayingOut = isLayingOut,
@@ -650,7 +649,7 @@ private fun TreeScreen(
   selected: SelectedCell?,
   hovered: SelectedCell?,
   /** What the cell under the pointer is, once it has been read, and null while it hasn't. */
-  pointedSummary: HeapObjectSummary?,
+  pointedSelection: Selection?,
   /** Where the pointer is in the view, which is what the card naming that cell is placed by. */
   pointerOffset: Offset?,
   /** How big the view is, so that the card stays inside it. */
@@ -693,9 +692,9 @@ private fun TreeScreen(
     }
     // Beside the pointer, over the map, because what a rectangle is, is the question being asked by pointing
     // at it: an answer at the edge of the window is read by looking away from the rectangle it is about.
-    if (pointedSummary != null && pointerOffset != null) {
+    if (pointedSelection != null && pointerOffset != null) {
       PointerCard(
-        summary = pointedSummary,
+        selection = pointedSelection,
         coloring = coloring,
         modifier = Modifier
           .onSizeChanged { cardSize = it }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -134,21 +134,15 @@ internal fun HeapDumpExplorer(
   var showsBitmapsFromDevice by remember { mutableStateOf(false) }
   /** The objects starred so far, with everything the list shows about them read once. */
   var favourites by remember { mutableStateOf(emptyList<Favourite>()) }
-  /** A node something led to, until the path the treemap has it under is worked out. */
-  var nodeToOpen: Long? by remember { mutableStateOf(null) }
+  /** A move something led to, until the path the treemap has its destination under is worked out. */
+  var nodeToOpen: NodeToOpen? by remember { mutableStateOf(null) }
 
   /**
-   * Points the panels at a node, which every move does. Each screen says which node that is once it is
-   * arrived at, so this is called with [ExplorerScreen.describedNode] rather than deciding for itself.
+   * Points the panels at a node, which is what walking the history does. Each screen says which node that
+   * is, so this is called with [ExplorerScreen.describedNode] rather than deciding for itself — a move
+   * forwards carries what it is about along with it instead, see [NodeToOpen].
    */
-  val describe: (Long) -> Unit = { nodeId ->
-    clicked = DescribedCell(
-      // Never a group: what a move names is a node of the tree, and the one cell that isn't one stands for
-      // the siblings its parent didn't draw, which nothing leads to.
-      cell = SelectedCell(nodeId, isGroup = false),
-      request = SelectionRequest.Object(nodeId)
-    )
-  }
+  val describe: (Long) -> Unit = { nodeId -> clicked = DescribedCell.of(nodeId) }
 
   // Nothing is under the pointer while a screen other than the map is showing: the view isn't there, so
   // the rectangle it was on last is neither where the pointer is now nor what the screen is about.
@@ -369,7 +363,8 @@ internal fun HeapDumpExplorer(
   // Where the treemap draws a node takes walking up its dominators, so showing what a panel line or a row
   // of a list leads to is a heap dump read as well.
   LaunchedEffect(session, nodeToOpen) {
-    val openNodeId = nodeToOpen ?: return@LaunchedEffect
+    val move = nodeToOpen ?: return@LaunchedEffect
+    val openNodeId = move.nodeId
     val path = session.read("where the map draws ${nodeIdText(openNodeId)}") { explorer ->
       explorer.tree.pathToOpen(openNodeId)
     }
@@ -380,7 +375,7 @@ internal fun HeapDumpExplorer(
     }
     val zoomed = history.current.treeNavigation.zoomInto(path)
     history = history.goTo(ExplorerScreen.Tree(zoomed, openNodeId))
-    describe(openNodeId)
+    clicked = move.described
     nodeToOpen = null
   }
 
@@ -391,7 +386,7 @@ internal fun HeapDumpExplorer(
     pointerOffset = pointedAt?.offset
   }
   /**
-   * Where a click on the view goes, which is wherever was clicked.
+   * Where a click on the view goes, which is wherever was clicked. Every rectangle is a move.
    *
    * Through the same walk as a click on a line of a panel, so that the two land in the same place: an
    * object that dominates nothing is shown inside what holds it and described there, rather than as a view
@@ -399,17 +394,17 @@ internal fun HeapDumpExplorer(
    */
   val onClick: (LayoutCell<Long>) -> Unit = { cell ->
     val subject = cell.subject
-    if (subject is CellSubject.Group) {
-      // The siblings too small to draw are no node of the tree, so there is nowhere to go: clicking them
-      // says what they are and leaves the map where it is.
-      clicked = DescribedCell.of(cell)
-      history = history.replacingCurrent(ExplorerScreen.Tree(navigation, subject.parent))
+    nodeToOpen = if (subject is CellSubject.Group) {
+      // The siblings too small to draw are no node of the tree, so where a click on them goes is the
+      // rectangle they were left out of: rooted there, the map has the room to draw them one by one.
+      // The panels stay on the pile, because the pile is what was clicked.
+      NodeToOpen(subject.parent, DescribedCell.of(cell))
     } else {
-      nodeToOpen = DescribedCell.of(cell).cell.objectId
+      NodeToOpen.of(SelectedCell.of(subject).objectId)
     }
   }
   /** Shows a node on the map with it selected, and describes it, which is the object detail view. */
-  val onOpen: (Long) -> Unit = { nodeId -> nodeToOpen = nodeId }
+  val onOpen: (Long) -> Unit = { nodeId -> nodeToOpen = NodeToOpen.of(nodeId) }
   val onGoTo: (ExplorerScreen) -> Unit = { destination -> history = history.goTo(destination) }
 
   if (showsBitmapsFromDevice) {
@@ -434,6 +429,7 @@ internal fun HeapDumpExplorer(
     ScreenBar(
       starredCount = favourites.size,
       bitmapCounts = bitmapCounts,
+      onShowWholeHeapDump = { onOpen(ROOT_NODE) },
       onListObjects = {
         onGoTo(ExplorerScreen.Objects(navigation, ObjectListFilter(), screen.describedNode))
       },
@@ -611,11 +607,12 @@ private fun DescribedObject(selection: Selection?) {
   }
 }
 
-/** The screens an open heap dump can be read through that aren't the map, and how many are starred. */
+/** The screens an open heap dump can be read through, and how many objects are starred. */
 @Composable
 private fun ScreenBar(
   starredCount: Int,
   bitmapCounts: BitmapCounts,
+  onShowWholeHeapDump: () -> Unit,
   onListObjects: () -> Unit,
   onShowStarred: () -> Unit,
   onFetchBitmaps: () -> Unit
@@ -625,6 +622,12 @@ private fun ScreenBar(
     horizontalArrangement = Arrangement.spacedBy(4.dp),
     verticalAlignment = Alignment.CenterVertically
   ) {
+    // First, because it is the screen the others were opened from and the way back out to all of it: the
+    // map zoomed in far enough is several clicks and a guess away from the top, and the back arrow walks
+    // where the reader has been rather than out.
+    TextButton(onClick = onShowWholeHeapDump) {
+      Text(HeapDominatorTreemap.ROOT_LABEL)
+    }
     TextButton(onClick = onListObjects) {
       Text(ExplorerScreen.OBJECTS_LABEL)
     }
@@ -840,6 +843,30 @@ private data class DescribedCell(
       cell = SelectedCell.of(cell.subject),
       request = SelectionRequest.of(cell)
     )
+
+    /** A node of the tree, which is what a move arrives at and what every pane but the map leads to. */
+    fun of(nodeId: Long): DescribedCell = DescribedCell(
+      // Never a group: the one cell that isn't a node stands for the siblings its parent didn't draw,
+      // and nothing outside the map leads to one of those.
+      cell = SelectedCell(nodeId, isGroup = false),
+      request = SelectionRequest.Object(nodeId)
+    )
+  }
+}
+
+/**
+ * A move the map is about to make, waiting on the read that says where it draws [nodeId].
+ *
+ * [described] is what the panels are about once there, which is the destination itself for every move but
+ * a click on the siblings a rectangle had no room for: those are no node of the tree, so the map goes to
+ * the rectangle holding them while the panels stay on the pile that was clicked.
+ */
+private data class NodeToOpen(
+  val nodeId: Long,
+  val described: DescribedCell
+) {
+  companion object {
+    fun of(nodeId: Long) = NodeToOpen(nodeId, DescribedCell.of(nodeId))
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
@@ -156,11 +156,13 @@ private fun ObjectGroupSummary.retainedText(): String =
 internal const val PILE_OF_OBJECTS = "Not one object. Click it to reach the objects it stands for."
 
 /**
- * The other kind of pile: what a rectangle's subdivision had no room for. There is nothing to go into —
- * they were left out because they are too small to draw, so the promise [PILE_OF_OBJECTS] makes would be a
- * lie here. Clicking selects the pile, which is as far as it goes.
+ * The other kind of pile: what a rectangle's subdivision had no room for. It is no node of the tree, so
+ * there is nothing to go into and the promise [PILE_OF_OBJECTS] makes would be a lie here. What a click
+ * does instead is root the map at the rectangle they were left out of, which is where they have the room
+ * to be drawn — the biggest of them, at least.
  */
-internal const val LEFTOVER_OBJECTS = "Not one object, and too small or too many to draw one by one."
+internal const val LEFTOVER_OBJECTS =
+  "Not one object. Click it for what holds them, where the biggest of them are drawn."
 
 /**
  * Where a card of [cardSize] goes for a pointer at [pointer] in a view of [viewSize]: below and to the right

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
@@ -158,11 +158,11 @@ internal const val PILE_OF_OBJECTS = "Not one object. Click it to reach the obje
 /**
  * The other kind of pile: what a rectangle's subdivision had no room for. It is no node of the tree, so
  * there is nothing to go into and the promise [PILE_OF_OBJECTS] makes would be a lie here. What a click
- * does instead is root the map at the rectangle they were left out of, which is where they have the room
- * to be drawn — the biggest of them, at least.
+ * does instead is root the map at the rectangle they were left out of, which is where there is the room
+ * to draw them one by one. See `TreemapLayout.maxRootChildren`.
  */
 internal const val LEFTOVER_OBJECTS =
-  "Not one object. Click it for what holds them, where the biggest of them are drawn."
+  "Not one object. Click it for what holds them, where there is room to draw them one by one."
 
 /**
  * Where a card of [cardSize] goes for a pointer at [pointer] in a view of [viewSize]: below and to the right

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
@@ -22,23 +22,29 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import shark.explorer.HeapObjectSummary
+import shark.explorer.ObjectGroupSummary
+import shark.explorer.ReachabilityStrength
 import shark.explorer.formatByteSize
 import shark.explorer.formatObjectCount
 
 /**
- * Which object the pointer is on, in a card that follows it around the view.
+ * What the pointer is on, in a card that follows it around the view.
  *
  * Beside the pointer rather than in a pane, because this is the one thing the reader is asking as they sweep
  * across the map — what is this rectangle — and answering it at the edge of the window makes them look away
  * from the thing they're pointing at. The chain holding it is the slower question, and that is drawn onto the
  * end of the chain in the pane: see [RootPathPanel].
  *
+ * A rectangle that isn't one object gets the card too, and needs it most: a pile is named on the map by a
+ * count and a simple class name, and the fully qualified name saying which class that is fits nowhere else.
+ * See [Selection].
+ *
  * [placeCard] keeps it clear of the pointer and inside the view. Nothing here is clickable — the pointer is
  * on the map, and it leaving the map is what closes this.
  */
 @Composable
 internal fun PointerCard(
-  summary: HeapObjectSummary,
+  selection: Selection,
   coloring: CellColoring,
   modifier: Modifier = Modifier
 ) {
@@ -52,28 +58,82 @@ internal fun PointerCard(
       Modifier.padding(POINTER_CARD_PADDING),
       verticalArrangement = Arrangement.spacedBy(1.dp)
     ) {
-      // The same three lines a step of a chain names an object with, so that the card and the chain beside
-      // the map read as one answer rather than as two ways of saying which object this is.
-      ObjectIdentity(
-        className = summary.className,
-        typeName = summary.kind?.typeName,
-        objectId = summary.objectId
-      )
-      summary.headline?.let { headline ->
-        Text(headline, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
+      when (selection) {
+        is Selection.Object -> ObjectLines(selection.summary, coloring)
+        is Selection.ObjectGroup -> ObjectGroupLines(selection.summary, coloring)
+        is Selection.Group -> GroupLines(selection)
       }
-      Row(
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalAlignment = Alignment.CenterVertically
-      ) {
-        Box(Modifier.size(SWATCH_SIZE).background(legendColor(coloring, summary.strength)))
-        Text(summary.strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
-      }
-      // The same numbers the details panel gives a labelled row each, on two lines: a card that follows the
-      // pointer has to be read at a glance, and it covers the map for as long as it's up.
-      Text(summary.retainedText(), style = MaterialTheme.typography.bodySmall)
-      Text(summary.shallowText(), style = MaterialTheme.typography.bodySmall)
     }
+  }
+}
+
+@Composable
+private fun ObjectLines(
+  summary: HeapObjectSummary,
+  coloring: CellColoring
+) {
+  // The same three lines a step of a chain names an object with, so that the card and the chain beside
+  // the map read as one answer rather than as two ways of saying which object this is.
+  ObjectIdentity(
+    className = summary.className,
+    typeName = summary.kind?.typeName,
+    objectId = summary.objectId
+  )
+  summary.headline?.let { headline ->
+    Text(headline, style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
+  }
+  StrengthLine(summary.strength, coloring)
+  // The same numbers the details panel gives a labelled row each, on two lines: a card that follows the
+  // pointer has to be read at a glance, and it covers the map for as long as it's up.
+  Text(summary.retainedText(), style = MaterialTheme.typography.bodySmall)
+  Text(summary.shallowText(), style = MaterialTheme.typography.bodySmall)
+}
+
+/**
+ * Every instance of one class under the root, or the uncollected garbage.
+ *
+ * The fully qualified class name is the line the map can't draw: a rectangle has room for `42 × Bitmap`
+ * and no more, and which `Bitmap` that is, is the whole question a pile of them raises.
+ */
+@Composable
+private fun ObjectGroupLines(
+  summary: ObjectGroupSummary,
+  coloring: CellColoring
+) {
+  Text(summary.title(), style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
+  summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+  StrengthLine(summary.strength, coloring)
+  Text(summary.retainedText(), style = MaterialTheme.typography.bodySmall)
+  Text(PILE_OF_OBJECTS, style = MaterialTheme.typography.bodySmall)
+}
+
+/** The children of a rectangle that its subdivision had no room for. See [shark.explorer.CellSubject.Group]. */
+@Composable
+private fun GroupLines(selection: Selection.Group) {
+  Text(
+    "${selection.nodeCount} smaller objects",
+    style = MaterialTheme.typography.bodyMedium,
+    fontWeight = FontWeight.Bold
+  )
+  // Which rectangle they were left out of, since they have nothing else in common: that is the object to
+  // go to if any of them is worth finding.
+  Text("Held by ${selection.parentLabel}", style = MaterialTheme.typography.bodySmall)
+  Text("Retains ${formatByteSize(selection.byteCount)}", style = MaterialTheme.typography.bodySmall)
+  Text(LEFTOVER_OBJECTS, style = MaterialTheme.typography.bodySmall)
+}
+
+/** How firmly what the pointer is on is held, beside the colour the map drew it in. */
+@Composable
+private fun StrengthLine(
+  strength: ReachabilityStrength,
+  coloring: CellColoring
+) {
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Box(Modifier.size(SWATCH_SIZE).background(legendColor(coloring, strength)))
+    Text(strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
   }
 }
 
@@ -82,6 +142,25 @@ private fun HeapObjectSummary.retainedText(): String =
 
 private fun HeapObjectSummary.shallowText(): String =
   "${formatByteSize(shallowSize)} of its own, dominates ${formatObjectCount(dominatedObjectCount)}"
+
+private fun ObjectGroupSummary.retainedText(): String =
+  "Retains ${formatByteSize(retainedSize)} in ${formatObjectCount(objectCount)}"
+
+/**
+ * What a pile of objects has to say for itself in one line, because a rectangle full of them looks exactly
+ * like one object until something says otherwise. The details panel spells out which kind of pile it is.
+ *
+ * A pile of one class is a node of the tree, so clicking it goes into it and the objects are there. See
+ * [LEFTOVER_OBJECTS] for the pile that isn't.
+ */
+internal const val PILE_OF_OBJECTS = "Not one object. Click it to reach the objects it stands for."
+
+/**
+ * The other kind of pile: what a rectangle's subdivision had no room for. There is nothing to go into —
+ * they were left out because they are too small to draw, so the promise [PILE_OF_OBJECTS] makes would be a
+ * lie here. Clicking selects the pile, which is as far as it goes.
+ */
+internal const val LEFTOVER_OBJECTS = "Not one object, and too small or too many to draw one by one."
 
 /**
  * Where a card of [cardSize] goes for a pointer at [pointer] in a view of [viewSize]: below and to the right

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TreemapView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TreemapView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -30,6 +31,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import shark.explorer.CellContent
 import shark.explorer.CellSubject
 import shark.explorer.LayoutCell
 import shark.explorer.PresentedCell
@@ -65,16 +67,19 @@ internal fun TreemapView(
 ) {
   val textMeasurer = rememberTextMeasurer()
   val density = LocalDensity.current
+  // One tile shared by every pile on the map, since they are all filled with the same dots.
+  val dots = remember(density) { pileDots(density) }
   // Measuring a few hundred labels is the one part of drawing that isn't cheap, so it happens when
   // the presentation changes and never on a redraw.
-  val cells = remember(presentation, coloring, bitmapImages, textMeasurer, density) {
+  val cells = remember(presentation, coloring, bitmapImages, textMeasurer, density, dots) {
     val colors = CellColors.of(coloring, presentation.cells)
     presentation.cells.map { presented ->
       presented.measure(
         colors = colors,
         textMeasurer = textMeasurer,
         density = density,
-        image = presented.imageOf(bitmapImages)
+        image = presented.imageOf(bitmapImages),
+        dots = dots
       )
     }
   }
@@ -200,6 +205,8 @@ private class MeasuredCell(
   val topLeft: Offset,
   val size: Size,
   val color: Color,
+  /** The dots filling a pile of siblings its parent had no room for, and null for every other cell. */
+  val dots: Brush?,
   val borderColor: Color,
   val outline: Stroke,
   /** Whether this rectangle is one of the current root's own children, which are the named level. */
@@ -236,7 +243,8 @@ private fun PresentedCell<TreemapCell<Long>>.measure(
   colors: CellColors,
   textMeasurer: TextMeasurer,
   density: Density,
-  image: ImageBitmap?
+  image: ImageBitmap?,
+  dots: Brush
 ): MeasuredCell {
   val rect = cell.rect
   val labelPadding = with(density) { LABEL_PADDING.toPx() }
@@ -260,6 +268,7 @@ private fun PresentedCell<TreemapCell<Long>>.measure(
     topLeft = topLeft,
     size = size,
     color = colors.colorOf(this),
+    dots = dots.takeIf { content is CellContent.Leftover },
     borderColor = colors.borderOf(this),
     outline = outlineOf(content),
     isRootChild = isRootChild,
@@ -309,6 +318,10 @@ private fun TextLayoutResult.asLabel(
 
 private fun DrawScope.drawFill(cell: MeasuredCell) {
   drawRect(color = cell.color, topLeft = cell.topLeft, size = cell.size)
+  // Straight after its own fill rather than in a pass of its own: a pile is where the map stops dividing,
+  // so there is never a rectangle drawn inside one for the dots to end up under.
+  val dots = cell.dots ?: return
+  drawRect(brush = dots, topLeft = cell.topLeft, size = cell.size)
 }
 
 private fun DrawScope.drawImage(cell: MeasuredCell) {

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TreemapView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TreemapView.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -33,15 +34,16 @@ import shark.explorer.CellSubject
 import shark.explorer.LayoutCell
 import shark.explorer.PresentedCell
 import shark.explorer.TreemapCell
+import shark.explorer.TreemapLayoutResult
 import shark.explorer.TreemapPresentation
 
 /**
  * Draws an already laid out [TreemapPresentation], filling the available space.
  *
  * A press reports the rectangle under the pointer, which is what the window goes to, and moving over one
- * reports it as hovered, which is what the chain beside the view describes. Everything is drawn into a
- * single [Canvas], so there are no per-rectangle composables: see this module's `AGENTS.md` for what that
- * means for tests.
+ * reports it as hovered, which is what the chain beside the view describes. The names the map draws are
+ * rectangles of their own for both of those — see [namedCellAt]. Everything is drawn into a single [Canvas],
+ * so there are no per-rectangle composables: see this module's `AGENTS.md` for what that means for tests.
  *
  * Takes a presentation rather than a tree, because laying a treemap out reads the heap dump for every
  * visible label, and that has to have happened on the heap dump's own thread before we get here.
@@ -83,15 +85,15 @@ internal fun TreemapView(
   // Zooming, resizing and switching shape all move the rectangles rather than the pointer, and no pointer
   // event follows: without this the panels would keep describing whatever was under it before, until the
   // mouse next moved.
-  LaunchedEffect(presentation, edgeGrab) {
-    onHover(pointerOffset?.let { offset -> presentation.pointedAt(offset, edgeGrab) })
+  LaunchedEffect(presentation, cells, edgeGrab) {
+    onHover(pointerOffset?.let { offset -> presentation.pointedAt(offset, cells, edgeGrab) })
   }
   Box(modifier) {
     Canvas(
       Modifier.fillMaxSize()
         // Before the tap handler, so that the rectangle under the pointer is read wherever it is rather
         // than only where a gesture hasn't already claimed the events.
-        .pointerInput(presentation, edgeGrab) {
+        .pointerInput(presentation, cells, edgeGrab) {
           awaitPointerEventScope {
             while (true) {
               val event = awaitPointerEvent()
@@ -103,7 +105,7 @@ internal fun TreemapView(
                 PointerEventType.Move -> {
                   val position = event.changes.first().position
                   pointerOffset = position
-                  onHover(presentation.pointedAt(position, edgeGrab))
+                  onHover(presentation.pointedAt(position, cells, edgeGrab))
                 }
                 PointerEventType.Exit -> {
                   pointerOffset = null
@@ -113,11 +115,11 @@ internal fun TreemapView(
             }
           }
         }
-        .pointerInput(presentation, edgeGrab) {
+        .pointerInput(presentation, cells, edgeGrab) {
           detectTapGestures(
             // On press rather than on tap, which is immediate: with nothing waiting for a second click,
             // a tap handler would still hold every click for the double click window.
-            onPress = { offset -> presentation.cellAt(offset, edgeGrab)?.let(onClick) }
+            onPress = { offset -> presentation.cellAt(offset, cells, edgeGrab)?.let(onClick) }
           )
         }
     ) {
@@ -163,17 +165,37 @@ internal fun TreemapView(
 
 private fun TreemapPresentation.cellAt(
   offset: Offset,
+  /** This presentation's cells as measured for drawing, which is what says where the names ended up. */
+  cells: List<MeasuredCell>,
   edgeGrab: Double
-): TreemapCell<Long>? = layout.cellAt(offset.toTreemapPoint(), edgeGrab)
+): TreemapCell<Long>? = cells.namedCellAt(offset) ?: layout.cellAt(offset.toTreemapPoint(), edgeGrab)
 
 /** What the pointer is on at [offset], with the offset kept: the card following the pointer needs both. */
 private fun TreemapPresentation.pointedAt(
   offset: Offset,
+  cells: List<MeasuredCell>,
   edgeGrab: Double
-): PointedAt? = cellAt(offset, edgeGrab)?.let { PointedAt(cell = it, offset = offset) }
+): PointedAt? = cellAt(offset, cells, edgeGrab)?.let { PointedAt(cell = it, offset = offset) }
+
+/**
+ * The rectangle whose name is drawn at [offset], or null where no name is drawn.
+ *
+ * A rectangle's children cover every pixel of it, so the name the map gives it is drawn over them, and the
+ * plate under that name is the one piece of a subdivided rectangle that is still the rectangle itself. So
+ * pointing at a name means the thing named rather than whichever descendant happens to be under the
+ * lettering, and clicking one walks into the level the map is divided into rather than to the bottom of it.
+ * Everywhere else the innermost rectangle wins, as before: see [TreemapLayoutResult.cellAt].
+ *
+ * Last match first, which is topmost first: the names are painted in this order, so where two of them
+ * overlap the one drawn last is the one being pointed at.
+ */
+private fun List<MeasuredCell>.namedCellAt(offset: Offset): TreemapCell<Long>? =
+  lastOrNull { it.label?.plate?.contains(offset) == true }?.cell
 
 /** A rectangle with its label measured and its colour resolved, so that drawing does no work. */
 private class MeasuredCell(
+  /** The cell as laid out, which is what pointing at this rectangle reports. */
+  val cell: TreemapCell<Long>,
   val selects: SelectedCell,
   val topLeft: Offset,
   val size: Size,
@@ -182,14 +204,26 @@ private class MeasuredCell(
   val outline: Stroke,
   /** Whether this rectangle is one of the current root's own children, which are the named level. */
   val isRootChild: Boolean,
-  val labelColor: Color,
-  val labelOffset: Offset,
   /** Null when the rectangle is too small for a readable label, or when it isn't a named one. */
-  val label: TextLayoutResult?,
+  val label: MeasuredLabel?,
   /** The bitmap's pixels and where they go, for a cell that is a bitmap the dump has the pixels of. */
   val image: ImageBitmap?,
   val imageOffset: IntOffset,
   val imageSize: IntSize
+)
+
+/**
+ * A name drawn on a rectangle, and the plate it is drawn on.
+ *
+ * One value holding both what is painted and where, because the plate is a hit target as well as a
+ * background — see [namedCellAt] — and a plate the pointer answers to that isn't the plate on screen would
+ * be the view lying about where its own names are.
+ */
+private class MeasuredLabel(
+  val text: TextLayoutResult,
+  val color: Color,
+  val textTopLeft: Offset,
+  val plate: Rect
 )
 
 /** The pixels read for this cell, for a cell that stands for one bitmap. */
@@ -221,6 +255,7 @@ private fun PresentedCell<TreemapCell<Long>>.measure(
   val size = Size(rect.width.toFloat(), rect.height.toFloat())
   val bounds = image?.let { imageBounds(it, topLeft, size) }
   return MeasuredCell(
+    cell = cell,
     selects = SelectedCell.of(cell.subject),
     topLeft = topLeft,
     size = size,
@@ -228,8 +263,6 @@ private fun PresentedCell<TreemapCell<Long>>.measure(
     borderColor = colors.borderOf(this),
     outline = outlineOf(content),
     isRootChild = isRootChild,
-    labelColor = colors.label,
-    labelOffset = Offset(labelPadding, labelPadding),
     label = if (fitsALabel) {
       textMeasurer.measure(
         text = label,
@@ -237,6 +270,10 @@ private fun PresentedCell<TreemapCell<Long>>.measure(
         overflow = TextOverflow.Ellipsis,
         maxLines = 1,
         constraints = Constraints(maxWidth = labelWidth.toInt())
+      ).asLabel(
+        color = colors.label,
+        textTopLeft = topLeft + Offset(labelPadding, labelPadding),
+        cellBounds = Rect(offset = topLeft, size = size)
       )
     } else {
       null
@@ -246,6 +283,29 @@ private fun PresentedCell<TreemapCell<Long>>.measure(
     imageSize = bounds?.second ?: IntSize.Zero
   )
 }
+
+/** A measured name placed at [textTopLeft], with the plate it sits on around it. */
+private fun TextLayoutResult.asLabel(
+  color: Color,
+  textTopLeft: Offset,
+  /** The rectangle being named, which the plate stays inside. */
+  cellBounds: Rect
+) = MeasuredLabel(
+  text = this,
+  color = color,
+  textTopLeft = textTopLeft,
+  plate = Rect(
+    offset = textTopLeft - Offset(LABEL_PLATE_PADDING, LABEL_PLATE_PADDING),
+    size = Size(
+      size.width + 2 * LABEL_PLATE_PADDING,
+      size.height + 2 * LABEL_PLATE_PADDING
+    )
+  )
+    // A rectangle only a line of text tall has less room than the plate wants, and the overhang would be
+    // drawn on the sibling below it as well as answering the pointer for it. The lettering can still
+    // overflow, as it always could; what stands for the rectangle can't reach outside it.
+    .intersect(cellBounds)
+)
 
 private fun DrawScope.drawFill(cell: MeasuredCell) {
   drawRect(color = cell.color, topLeft = cell.topLeft, size = cell.size)
@@ -291,18 +351,11 @@ private fun DrawScope.drawSeparator(cell: MeasuredCell) {
  *
  * On a translucent plate rather than straight onto the map, because the text sits over rectangles, bitmaps
  * and outlines it has no say over: solid text on a washed out background is readable against all of them
- * while still letting what it covers show through.
+ * while still letting what it covers show through. That plate is also what pointing at the name points at,
+ * see [namedCellAt].
  */
 private fun DrawScope.drawLabel(cell: MeasuredCell) {
   val label = cell.label ?: return
-  val plate = cell.topLeft + cell.labelOffset
-  drawRect(
-    color = LABEL_PLATE_COLOR,
-    topLeft = Offset(plate.x - LABEL_PLATE_PADDING, plate.y - LABEL_PLATE_PADDING),
-    size = Size(
-      label.size.width + 2 * LABEL_PLATE_PADDING,
-      label.size.height + 2 * LABEL_PLATE_PADDING
-    )
-  )
-  drawText(textLayoutResult = label, color = cell.labelColor, topLeft = plate)
+  drawRect(color = LABEL_PLATE_COLOR, topLeft = label.plate.topLeft, size = label.plate.size)
+  drawText(textLayoutResult = label.text, color = label.color, topLeft = label.textTopLeft)
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ViewControls.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ViewControls.kt
@@ -71,7 +71,11 @@ internal fun ViewControls(
         )
       }
       if (REFERENCE_STRENGTHS.none { sizes.byteCountByStrength.getValue(it) > 0L }) {
-        Text(NOTHING_WEAKER, style = MaterialTheme.typography.bodySmall)
+        // The fact on one line, the paragraph saying why on hover: this sits above the map for as long as
+        // the heap dump is open, and the reader who has read it once is looking at the map underneath.
+        Hint(NOTHING_WEAKER_HINT) {
+          Text(NOTHING_WEAKER, style = MaterialTheme.typography.bodySmall, color = MUTED_TEXT)
+        }
       }
     }
   }
@@ -187,11 +191,14 @@ private val REFERENCE_STRENGTHS = ReachabilityStrength.values().toList() - setOf
 
 /**
  * Shown when every object a `java.lang.ref.Reference` points at is also reachable some stronger way,
- * which would otherwise read as a bug. Common but not a rule — see the notes on reachability.
+ * which is what the legend rows reading 0 B mean and would otherwise read as a bug.
  */
 internal const val NOTHING_WEAKER =
-  "Nothing in this heap dump is reachable only through a java.lang.ref.Reference. That's common, " +
-    "because the garbage collection before a dump clears the references whose referent nothing else " +
-    "was holding — but it isn't a given: a referent a thread got out of a reference and has since let " +
-    "go of is weakly reachable again until the next collection. Unreachable is a different thing " +
-    "again: objects nothing points at, which that collection didn't get to."
+  "Nothing in this heap dump is reachable only through a java.lang.ref.Reference."
+
+/** Why that is normal, which is a paragraph, and a paragraph is more than the bar above a map can hold. */
+internal const val NOTHING_WEAKER_HINT =
+  "$NOTHING_WEAKER That's common, because the garbage collection before a dump clears the references " +
+    "whose referent nothing else was holding — but it isn't a given: a referent a thread got out of a " +
+    "reference and has since let go of is weakly reachable again until the next collection. Unreachable " +
+    "is a different thing again: objects nothing points at, which that collection didn't get to."

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -6,9 +6,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
@@ -267,7 +269,7 @@ class ExplorerAppTest {
       waitUntilAtLeastOneExists(hasText("Object[] · ", substring = true), OPEN_TIMEOUT_MILLIS)
       assertThat(onAllNodesWithText("com.example.Holder").fetchSemanticsNodes()).isNotEmpty()
       // One chain, so one row for the whole heap dump it hangs below.
-      assertThat(onAllNodesWithText(HeapDominatorTreemap.ROOT_LABEL).fetchSemanticsNodes()).hasSize(1)
+      assertThat(onAllNodes(isWholeHeapDumpRow()).fetchSemanticsNodes()).hasSize(1)
     }
   }
 
@@ -398,7 +400,7 @@ class ExplorerAppTest {
       // stretch of what holds this object, and everything above and below it is where it was.
       waitUntilAtLeastOneExists(hasText("2 of 2 $WAYS_FROM_HERE"), OPEN_TIMEOUT_MILLIS)
       onNodeWithText(if (throughTheCache) "com.example.Tile" else "com.example.Cache").assertIsDisplayed()
-      onNodeWithText(HeapDominatorTreemap.ROOT_LABEL).assertIsDisplayed()
+      wholeHeapDumpRow().assertIsDisplayed()
     }
   }
 
@@ -661,6 +663,9 @@ class ExplorerAppTest {
       // bug until something explains it.
       strengthToggle(PHANTOM).assertTextContains(formatByteSize(0L), substring = true)
       onNodeWithText(NOTHING_WEAKER).assertIsDisplayed()
+      // The paragraph saying why that is normal waits for the pointer: it is above the map for as long as
+      // the heap dump is open, and read once it is in the way of the thing it is about.
+      onNodeWithText(NOTHING_WEAKER_HINT).assertDoesNotExist()
     }
   }
 
@@ -846,13 +851,22 @@ class ExplorerAppTest {
     }
   }
 
-  /** The row every chain hangs below, which is the one thing naming the whole heap dump that leads anywhere. */
-  private fun ComposeUiTest.wholeHeapDumpRow(): SemanticsNodeInteraction =
-    onNode(hasText(HeapDominatorTreemap.ROOT_LABEL) and hasClickAction())
+  /** The row every chain hangs below, which leads to the whole heap dump as the screen bar's button does. */
+  private fun ComposeUiTest.wholeHeapDumpRow(): SemanticsNodeInteraction = onNode(isWholeHeapDumpRow())
 
   /** A button on the row of screens an open heap dump can be read through. */
   private fun ComposeUiTest.screenButton(label: String): SemanticsNodeInteraction =
-    onNode(hasText(label) and hasClickAction())
+    onNode(hasText(label) and isButton())
+
+  /**
+   * What names the whole heap dump in the chain pane, which is a clickable line and not a button: the
+   * screen bar has a button of the same name, so the text alone matches two nodes.
+   */
+  private fun isWholeHeapDumpRow(): SemanticsMatcher =
+    hasText(HeapDominatorTreemap.ROOT_LABEL) and hasClickAction() and !isButton()
+
+  private fun isButton(): SemanticsMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
 
   /** The search box of the object list, the one thing in the window that takes typing. */
   private fun ComposeUiTest.searchBox(): SemanticsNodeInteraction = onNode(hasSetTextAction())

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/MapMovesTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/MapMovesTest.kt
@@ -1,0 +1,132 @@
+package shark.explorer.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.explorer.HeapDominatorTreemap
+
+/**
+ * Where a click on the map takes the map.
+ *
+ * Every rectangle is a way in, the one standing for the siblings a subdivision had no room for included.
+ * That one is no node of the tree, so there is nothing to root the map at but the rectangle they were left
+ * out of — which is exactly where they are, and rooted there the map has the room to draw them one by one.
+ *
+ * And the way back out, since a map zoomed in a few levels has nothing on screen saying where the top is
+ * until a rectangle has been clicked. [ExplorerAppTest] covers the rest of the window.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MapMovesTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  /** Every UI test here records what Shark logged. See [RecordedLog]. */
+  @get:Rule val logged = RecordedLog()
+
+  @Test fun `clicking the siblings that did not fit roots the map at what holds them`() {
+    explorerUiTest {
+      // Every sibling weighs the same, so the rectangle standing for the ones left out weighs as much as
+      // all of them together: it's the largest, and a squarified treemap puts that one in the top left.
+      openHeapDump(testFolder.manySiblingsHeapDump())
+
+      clickView(LEFTOVER_X, LEFTOVER_Y)
+
+      waitUntilZoomedIn()
+      // The panels stay on the pile rather than following the map to the array: the pile is what was
+      // clicked, and it is the one thing on the map that the array's own details don't cover.
+      onNodeWithText("Held by Object[]", substring = true).assertIsDisplayed()
+    }
+  }
+
+  @Test fun `the screen bar leads back out to the whole heap dump`() {
+    explorerUiTest {
+      openHeapDump(testFolder.manySiblingsHeapDump())
+      clickView(LEFTOVER_X, LEFTOVER_Y)
+      waitUntilZoomedIn()
+
+      onNode(hasText(HeapDominatorTreemap.ROOT_LABEL) and isButton()).performClick()
+
+      waitUntilZoomedOut()
+    }
+  }
+
+  /** Presses a point of the view given as a fraction of it, the view being one canvas. */
+  private fun ComposeUiTest.clickView(
+    xFraction: Float,
+    yFraction: Float
+  ) {
+    val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
+    onRoot().performMouseInput {
+      click(Offset(x = view.left + view.width * xFraction, y = view.top + view.height * yFraction))
+    }
+  }
+
+  /**
+   * Waits until the map has been laid out rooted somewhere other than the top of the tree, and until it is
+   * back at the top.
+   *
+   * Read off the log, because nothing on screen says where the map is rooted: the view is one canvas, and
+   * the panes beside it are about the rectangle clicked rather than about the node the map settled on.
+   */
+  private fun ComposeUiTest.waitUntilZoomedIn() {
+    waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
+      logged.any { it.startsWith(TREEMAP_LAID_OUT) && WHOLE_HEAP_DUMP_NODE !in it }
+    }
+  }
+
+  private fun ComposeUiTest.waitUntilZoomedOut() {
+    waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
+      logged.lastOrNull { it.startsWith(TREEMAP_LAID_OUT) }?.contains(WHOLE_HEAP_DUMP_NODE) == true
+    }
+  }
+
+  /** A button of the screen bar, as against the chain row of the same name. See [ExplorerAppTest]. */
+  private fun isButton(): SemanticsMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+
+  private fun ComposeUiTest.openHeapDump(heapDumpFile: File) {
+    setContent {
+      MaterialTheme {
+        var shown: File? by remember { mutableStateOf(heapDumpFile) }
+        ExplorerApp(shown, onHeapDumpChosen = { file, _ -> shown = file })
+      }
+    }
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+  }
+
+  companion object {
+    /**
+     * Well inside the largest rectangle of the second level, which is the one standing for the siblings
+     * that didn't fit: every sibling weighs the same, so the ones left out weigh as much as all of them.
+     */
+    private const val LEFTOVER_X = 0.05f
+    private const val LEFTOVER_Y = 0.45f
+
+    /** Opening a heap dump and laying the tree out both happen on another thread. */
+    private const val OPEN_TIMEOUT_MILLIS = 10_000L
+
+    private const val TREEMAP_LAID_OUT = "Read the treemap rooted at"
+    private const val WHOLE_HEAP_DUMP_NODE = "the whole heap dump"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/MapNamesTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/MapNamesTest.kt
@@ -1,0 +1,198 @@
+package shark.explorer.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+import shark.explorer.formatObjectCount
+import shark.explorer.hexObjectId
+
+/**
+ * What the names the map draws answer to.
+ *
+ * A rectangle's children cover every pixel of it, so the name written on it is the one part of it left to
+ * see — and therefore the one part left to point at. Pointing at a name means the rectangle it names and
+ * clicking one goes there, which is what makes a container reachable without hunting for the pixels of its
+ * edge.
+ *
+ * The names that stand for a pile of objects rather than for one, `400 × Sibling` and `300 smaller objects`,
+ * are the other half of it: a rectangle has room for the count and a simple class name and no more, so which
+ * pile it is has to be said at the pointer. [ExplorerAppTest] covers the rest of the window.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MapNamesTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  /** Every UI test here records what Shark logged. See [RecordedLog]. */
+  @get:Rule val logged = RecordedLog()
+
+  /** The object id of the array in [nestedHeapDump], recorded as the dump is written. */
+  private var payloadObjectId = 0L
+
+  /** And of the instance holding it, which is the rectangle the array is drawn inside. */
+  private var holderObjectId = 0L
+
+  @Test fun `pointing at a name says what it names rather than what is drawn inside it`() {
+    explorerUiTest {
+      openHeapDump(nestedHeapDump())
+
+      hoverName()
+
+      // The instance covers the view and the array covers the instance, so every pixel of the instance but
+      // the name written on it belongs to the array.
+      waitUntilAtLeastOneExists(hasText(hexObjectId(holderObjectId)), OPEN_TIMEOUT_MILLIS)
+      assertThat(onAllNodesWithText(hexObjectId(payloadObjectId)).fetchSemanticsNodes()).isEmpty()
+    }
+  }
+
+  @Test fun `clicking a name goes to what it names`() {
+    explorerUiTest {
+      openHeapDump(nestedHeapDump())
+
+      clickName()
+
+      // Rather than to the array drawn inside it, which is where a click anywhere else on it lands: the
+      // window is about the instance, so the panel beside the map lists the instance's own fields.
+      waitUntilAtLeastOneExists(hasText("payload = Object[]"), OPEN_TIMEOUT_MILLIS)
+      assertThat(onAllNodesWithText(hexObjectId(holderObjectId)).fetchSemanticsNodes()).isNotEmpty()
+    }
+  }
+
+  @Test fun `pointing at a class group says which class it gathers`() {
+    explorerUiTest {
+      // Every instance is a GC root of its own, so all of them land directly under the root and are
+      // gathered into one rectangle, which is the biggest thing on the map and so the one that is named.
+      openHeapDump(testFolder.crowdedRootHeapDump())
+
+      hoverName()
+
+      // The map has room for `400 × Sibling` and no more, and which Sibling that is, is the question a pile
+      // of them raises. So the qualified name is what the pointer gets.
+      waitUntilAtLeastOneExists(hasText(SIBLING_CLASS_NAME), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText("${formatObjectCount(SIBLING_COUNT)} of one class").assertIsDisplayed()
+      // And that it is a pile at all, because a rectangle full of objects looks exactly like one object.
+      onNodeWithText(PILE_OF_OBJECTS).assertIsDisplayed()
+    }
+  }
+
+  @Test fun `pointing at the rectangle standing for the siblings that did not fit says what they are`() {
+    explorerUiTest {
+      openHeapDump(testFolder.manySiblingsHeapDump())
+
+      hoverView(LEFTOVER_X, LEFTOVER_Y)
+
+      // They have nothing in common but the rectangle they were left out of, so that is the whole of what
+      // there is to say about them: how many, how much, and which rectangle to go to for any of them.
+      waitUntilAtLeastOneExists(hasText("smaller objects", substring = true), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText("Held by Object[]").assertIsDisplayed()
+      onNodeWithText(LEFTOVER_OBJECTS).assertIsDisplayed()
+    }
+  }
+
+  /** Moves the pointer onto the name of the largest of the root's children. See [nameAt]. */
+  private fun ComposeUiTest.hoverName() {
+    onRoot().performMouseInput { hover(nameAt()) }
+  }
+
+  /** And presses it, which is how a rectangle with something drawn inside it is walked into. */
+  private fun ComposeUiTest.clickName() {
+    onRoot().performMouseInput { click(nameAt()) }
+  }
+
+  /**
+   * Where the map writes the name of the largest of the root's children, which a squarified treemap puts
+   * in the top left corner.
+   *
+   * A few pixels in rather than at the very corner: the first [EDGE_GRAB] of a rectangle's edge belongs to
+   * it whatever is drawn there, so a point in the corner would reach the same rectangle whether its name is
+   * a target of its own or not. Density is 1 in a UI test, so these are pixels, and the plate a name sits
+   * on is a line of [LABEL_STYLE] text with a couple of them around it.
+   */
+  private fun ComposeUiTest.nameAt(): Offset {
+    val view = viewBounds()
+    return Offset(x = view.left + NAME_X, y = view.top + NAME_Y)
+  }
+
+  /** Moves the pointer onto a point of the view given as a fraction of it, the view being one canvas. */
+  private fun ComposeUiTest.hoverView(
+    xFraction: Float,
+    yFraction: Float
+  ) {
+    val view = viewBounds()
+    onRoot().performMouseInput {
+      hover(Offset(x = view.left + view.width * xFraction, y = view.top + view.height * yFraction))
+    }
+  }
+
+  /** Where the tree is drawn, which is the one part of the window a press has to land in. */
+  private fun ComposeUiTest.viewBounds() =
+    onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
+
+  private fun ComposeUiTest.openHeapDump(heapDumpFile: File) {
+    setContent {
+      MaterialTheme {
+        var shown: File? by remember { mutableStateOf(heapDumpFile) }
+        ExplorerApp(shown, onHeapDumpChosen = { file, _ -> shown = file })
+      }
+    }
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+  }
+
+  /**
+   * A heap dump where one instance is the only path to a large object array, so that the instance is the
+   * root's one child and the array covers all of it but the name the map writes on it.
+   */
+  private fun nestedHeapDump(): File {
+    val file = testFolder.newFile("nested.hprof")
+    file.dump {
+      val holder = "com.example.Holder" instance {
+        val payload =
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_LENGTH)))
+        payloadObjectId = payload.value
+        field["payload"] = payload
+      }
+      holderObjectId = holder.value
+      gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+    }
+    return file
+  }
+
+  companion object {
+    /** Where in a rectangle its name is: past the edge that belongs to it, inside the shortest label. */
+    private const val NAME_X = 12f
+    private const val NAME_Y = 9f
+
+    /**
+     * Well inside the largest rectangle of the second level, which is the one standing for the siblings
+     * that didn't fit: every sibling weighs the same, so the ones left out weigh as much as all of them.
+     */
+    private const val LEFTOVER_X = 0.05f
+    private const val LEFTOVER_Y = 0.45f
+
+    /** Opening a heap dump and laying the tree out both happen on another thread. */
+    private const val OPEN_TIMEOUT_MILLIS = 10_000L
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/RadialViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/RadialViewTest.kt
@@ -85,17 +85,18 @@ class RadialViewTest {
   @Test fun `clicking the sector standing for the siblings that did not fit reports a group`() {
     runComposeUiTest {
       // A ring holds far fewer sectors than a treemap holds rectangles, so this many children under
-      // one node is already past what is worth drawing one by one.
-      val presentation = mapTree(ROOT to (1L..50L).toList())
+      // one node is already past what is worth drawing one by one. Under a sector rather than under
+      // the node in the middle, which draws as many children as the first ring has room for.
+      val presentation = mapTree(ROOT to listOf(PARENT), PARENT to (1000L..1049L).toList())
         .present(RadialLayout(maxChildrenPerNode = 10))
       val clicked = mutableListOf<LayoutCell<Long>>()
       setContent { RadialUnderTest(presentation, onClick = { clicked += it }) }
 
-      onRoot().performMouseInput { click(presentation.middleOfGroupUnder(ROOT)) }
+      onRoot().performMouseInput { click(presentation.middleOfGroupUnder(PARENT)) }
 
       val group = clicked.single().subject as CellSubject.Group
       assertThat(group.nodeCount).isEqualTo(40)
-      assertThat(group.parent).isEqualTo(ROOT)
+      assertThat(group.parent).isEqualTo(PARENT)
     }
   }
 

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
@@ -171,6 +171,27 @@ class TreemapViewTest {
     }
   }
 
+  @Test fun `the rectangle standing for the siblings that did not fit is drawn as dots`() {
+    runComposeUiTest {
+      // It can be a good part of the view, and one flat block that size reads as one enormous object,
+      // which on a real heap dump means a bitmap. A texture says how many things are in there.
+      val presentation = mapTree(ROOT to (1L..500L).toList()).present()
+      setContent { TreemapUnderTest(presentation) }
+
+      val drawn = onRoot().captureToImage().toPixelMap()
+
+      // A patch of it wide enough to hold dots whichever way the pattern falls, and clear of both the
+      // dotted outline and the name written across the top. A fill on its own would be one colour.
+      val rect = presentation.groupUnder(ROOT).rect
+      val left = rect.left.toInt() + PATCH_INSET
+      val bottom = rect.bottom.toInt() - PATCH_INSET
+      val patch = (0 until PATCH_SIDE).flatMap { row ->
+        (0 until PATCH_SIDE).map { column -> drawn[left + column, bottom - row] }
+      }
+      assertThat(patch.toSet()).hasSizeGreaterThan(1)
+    }
+  }
+
   @Test fun `a bitmap's pixels are drawn on its rectangle`() {
     runComposeUiTest {
       val presentation = oneChild.present()
@@ -347,6 +368,10 @@ class TreemapViewTest {
     /** How far into a rectangle its name is, past its edge and short of the end of the shortest label. */
     private const val NAME_X = 12f
     private const val NAME_Y = 9f
+
+    /** A square of pixels a couple of dots across, taken well inside a rectangle's outline. */
+    private const val PATCH_SIDE = 16
+    private const val PATCH_INSET = 4
 
     /** A colour no cell is filled with, so that finding it is finding the image. */
     private val MAGENTA = Color(0xFFFF00FF)

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
@@ -91,6 +91,33 @@ class TreemapViewTest {
     }
   }
 
+  @Test fun `clicking the name on a rectangle opens what it names rather than what is inside it`() {
+    runComposeUiTest {
+      // PARENT is one of the root's own children, so the map names it, and CHILD covers every pixel of it:
+      // the name is drawn over CHILD, and pointing at it is how a container is reached without hunting for
+      // the pixels of its edge.
+      val presentation = mapTree(ROOT to listOf(PARENT), PARENT to listOf(CHILD)).present()
+      val clicked = mutableListOf<LayoutCell<Long>>()
+      setContent { TreemapUnderTest(presentation, onClick = { clicked += it }) }
+
+      onRoot().performMouseInput { click(presentation.nameOf(PARENT)) }
+
+      assertThat(clicked.map { it.node }).containsExactly(PARENT)
+    }
+  }
+
+  @Test fun `moving the pointer onto the name on a rectangle reports what it names`() {
+    runComposeUiTest {
+      val presentation = mapTree(ROOT to listOf(PARENT), PARENT to listOf(CHILD)).present()
+      val hovered = mutableListOf<LayoutCell<Long>?>()
+      setContent { TreemapUnderTest(presentation, onHover = { hovered += it }) }
+
+      onRoot().performMouseInput { hover(presentation.nameOf(PARENT)) }
+
+      assertThat(hovered.last()?.node).isEqualTo(PARENT)
+    }
+  }
+
   @Test fun `a root without children fills the view on its own`() {
     runComposeUiTest {
       val presentation = leafRoot.present()
@@ -288,6 +315,19 @@ class TreemapViewTest {
 
   private fun TreemapPresentation.centerOf(node: Long): Offset = center(nodeCellOf(node).rect)
 
+  /**
+   * A point on the plate the map draws one of the root's children's name on, which is a target of its own.
+   *
+   * In the lettering rather than at the corner of the rectangle: the first [EDGE_GRAB] of a rectangle's
+   * edge already belongs to it whatever is drawn there, so a point there would pass whether the name is a
+   * target or not. Density is 1 in a UI test, so these are pixels, and the plate is a line of
+   * [LABEL_STYLE] text with a couple of them around it.
+   */
+  private fun TreemapPresentation.nameOf(node: Long): Offset {
+    val rect = nodeCellOf(node).rect
+    return Offset(rect.left.toFloat() + NAME_X, rect.top.toFloat() + NAME_Y)
+  }
+
   private fun TreemapPresentation.centerOfGroupUnder(parent: Long): Offset =
     center(groupUnder(parent).rect)
 
@@ -303,6 +343,10 @@ class TreemapViewTest {
     private const val OTHER_PARENT = 3L
 
     private val VIEWPORT = TreemapRect(left = 0.0, top = 0.0, right = 600.0, bottom = 400.0)
+
+    /** How far into a rectangle its name is, past its edge and short of the end of the shortest label. */
+    private const val NAME_X = 12f
+    private const val NAME_Y = 9f
 
     /** A colour no cell is filled with, so that finding it is finding the image. */
     private val MAGENTA = Color(0xFFFF00FF)

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
@@ -52,6 +52,14 @@ class TreemapViewTest {
 
   private val leafRoot = mapTree(ROOT to emptyList())
 
+  /**
+   * One rectangle filling the view, holding more children than it has room to draw one by one.
+   *
+   * Under a rectangle and not under the root, because the node the view is rooted at draws as many
+   * children as it can fit: a pile is what a rectangle inside the view leaves out.
+   */
+  private val manyChildren = mapTree(ROOT to listOf(PARENT), PARENT to (1000L..1499L).toList())
+
   @Test fun `clicking a rectangle reports it`() {
     runComposeUiTest {
       val presentation = oneChild.present()
@@ -132,16 +140,17 @@ class TreemapViewTest {
 
   @Test fun `clicking the rectangle standing for the siblings that did not fit reports a group`() {
     runComposeUiTest {
-      // More children than a node draws one by one, so the smallest ones end up in one rectangle.
-      val presentation = mapTree(ROOT to (1L..500L).toList()).present()
+      // More children than a rectangle draws one by one, so the smallest ones end up in one of their
+      // own. Under a rectangle rather than under the whole view, which draws all it has room for.
+      val presentation = manyChildren.present()
       val clicked = mutableListOf<LayoutCell<Long>>()
       setContent { TreemapUnderTest(presentation, onClick = { clicked += it }) }
 
-      onRoot().performMouseInput { click(presentation.centerOfGroupUnder(ROOT)) }
+      onRoot().performMouseInput { click(presentation.centerOfGroupUnder(PARENT)) }
 
       val group = clicked.single().group
       assertThat(group.nodeCount).isEqualTo(300)
-      assertThat(group.parent).isEqualTo(ROOT)
+      assertThat(group.parent).isEqualTo(PARENT)
     }
   }
 
@@ -175,14 +184,14 @@ class TreemapViewTest {
     runComposeUiTest {
       // It can be a good part of the view, and one flat block that size reads as one enormous object,
       // which on a real heap dump means a bitmap. A texture says how many things are in there.
-      val presentation = mapTree(ROOT to (1L..500L).toList()).present()
+      val presentation = manyChildren.present()
       setContent { TreemapUnderTest(presentation) }
 
       val drawn = onRoot().captureToImage().toPixelMap()
 
       // A patch of it wide enough to hold dots whichever way the pattern falls, and clear of both the
       // dotted outline and the name written across the top. A fill on its own would be one colour.
-      val rect = presentation.groupUnder(ROOT).rect
+      val rect = presentation.groupUnder(PARENT).rect
       val left = rect.left.toInt() + PATCH_INSET
       val bottom = rect.bottom.toInt() - PATCH_INSET
       val patch = (0 until PATCH_SIDE).flatMap { row ->

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RadialLayout.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RadialLayout.kt
@@ -85,9 +85,10 @@ class RadialLayoutResult<N>(
  *
  * Depth is adaptive the way it is in a treemap, only measured along a ring rather than as an area: a
  * node is subdivided while its sector is at least [minSubdivideArcLength] long, children shorter than
- * [minDrawArcLength], past [maxChildrenPerNode] or outside the [maxCells] budget become one
- * [CellSubject.Group], and the widest sector is subdivided first so the budget buys visible detail.
- * [ringCount] then bounds how far out the picture goes, and zooming into a node is what reveals more.
+ * [minDrawArcLength], past [maxChildrenPerNode] — [maxRootChildren] for the node in the middle — or
+ * outside the [maxCells] budget become one [CellSubject.Group], and the widest sector is subdivided
+ * first so the budget buys visible detail. [ringCount] then bounds how far out the picture goes, and
+ * zooming into a node is what reveals more.
  */
 class RadialLayout<N>(
   /** How many rings around the centre disk. Deeper than that needs a zoom. */
@@ -95,7 +96,9 @@ class RadialLayout<N>(
   private val minSubdivideArcLength: Double = 24.0,
   private val minDrawArcLength: Double = 3.0,
   private val maxCells: Int = 5000,
-  private val maxChildrenPerNode: Int = 200
+  private val maxChildrenPerNode: Int = 200,
+  /** And how many for the node in the middle, which has the whole first ring. See [TreemapLayout]. */
+  private val maxRootChildren: Int = maxCells / 2
 ) {
 
   fun layout(
@@ -169,7 +172,8 @@ class RadialLayout<N>(
       )
       val drawnCount = minOf(
         drawableChildCount(weights, span.arcLength),
-        maxChildrenPerNode,
+        // Depth 0 is the node the rings are drawn around, and the only cell there is.
+        if (cell.depth == 0) maxRootChildren else maxChildrenPerNode,
         budget - 1
       )
       val childDepth = cell.depth + 1

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapLayout.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapLayout.kt
@@ -101,9 +101,10 @@ class TreemapLayoutResult<N>(
  *
  * A node is subdivided only when its rectangle is at least [minSubdivideWidth] by
  * [minSubdivideHeight]. Its children are drawn largest first, and those that would come out below
- * [minDrawSize], that are past [maxChildrenPerNode] or that don't fit in the remaining [maxCells]
- * budget become one [CellSubject.Group] instead. Subdivision happens largest rectangle first, so the
- * budget is spent where there is space to show detail.
+ * [minDrawSize], that are past [maxChildrenPerNode] — [maxRootChildren] for the node the viewport is
+ * rooted at — or that don't fit in the remaining [maxCells] budget become one [CellSubject.Group]
+ * instead. Subdivision happens largest rectangle first, so the budget is spent where there is space to
+ * show detail.
  *
  * **A rectangle's area is its weight's share of the whole, at every depth.** A node's children cover
  * it exactly, and what it weighs on its own gets a [CellSubject.Own] cell rather than being spread
@@ -131,7 +132,20 @@ class TreemapLayout<N>(
    * tree has tens of thousands of children, and past a couple of hundred rectangles in one parent
    * there is nothing left to read.
    */
-  private val maxChildrenPerNode: Int = 200
+  private val maxChildrenPerNode: Int = 200,
+  /**
+   * And how many for the node the viewport is rooted at, which is more because it has the whole
+   * viewport to itself.
+   *
+   * Zooming into a node is how the siblings a rectangle had no room for get drawn, so a cap that
+   * doesn't move when the room does makes zooming pointless: a node with 668 children draws 200 of
+   * them and a pile of 468 whether it is a sliver of the map or the whole of it, and clicking that
+   * pile lands on the same picture it was clicked from.
+   *
+   * Still capped, at half the cell budget, so that one level can't spend all of [maxCells] and leave
+   * nothing to draw what is inside the rectangles it drew.
+   */
+  private val maxRootChildren: Int = maxCells / 2
 ) {
 
   fun layout(
@@ -188,7 +202,8 @@ class TreemapLayout<N>(
       val weights = LongArray(children.size) { tree.weight(children[it]) }
       val drawnCount = minOf(
         drawableChildCount(weights, rect.area, cell.weight),
-        maxChildrenPerNode,
+        // Depth 0 is the node the viewport is rooted at, and the only cell there is.
+        if (cell.depth == 0) maxRootChildren else maxChildrenPerNode,
         budget - 2
       )
       val groupedCount = children.size - drawnCount

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/RadialLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/RadialLayoutTest.kt
@@ -136,7 +136,8 @@ class RadialLayoutTest {
     val children = List(50) { index -> Node("child$index", ownWeight = 100L - index) }
     val tree = NodeTree(Node("root", children = children))
 
-    val result = RadialLayout<Node>(maxChildrenPerNode = 10).layout(tree, viewport)
+    val result = RadialLayout<Node>(maxChildrenPerNode = 10, maxRootChildren = 10)
+      .layout(tree, viewport)
 
     assertThat(result.names).hasSize(11) // The root and its 10 largest children.
     val group = result.groups.single()
@@ -149,7 +150,8 @@ class RadialLayoutTest {
     val children = List(50) { index -> Node("child$index", ownWeight = 100L - index) }
     val tree = NodeTree(Node("root", children = children))
 
-    val result = RadialLayout<Node>(maxChildrenPerNode = 10).layout(tree, viewport)
+    val result = RadialLayout<Node>(maxChildrenPerNode = 10, maxRootChildren = 10)
+      .layout(tree, viewport)
 
     val ring = result.cells.filter { it.depth == 1 }
     assertThat(ring.sumOf { it.arc.sweepAngle }).isCloseTo(RadialArc.FULL_CIRCLE, offset(1e-9))

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapLayoutTest.kt
@@ -229,7 +229,8 @@ class TreemapLayoutTest {
     val children = List(50) { index -> Node("child$index", ownWeight = 100L - index) }
     val tree = NodeTree(Node("root", children = children))
 
-    val result = TreemapLayout<Node>(maxChildrenPerNode = 10).layout(tree, viewport)
+    val result = TreemapLayout<Node>(maxChildrenPerNode = 10, maxRootChildren = 10)
+      .layout(tree, viewport)
 
     assertThat(result.groups.single().groupParent.name).isEqualTo("root")
   }
@@ -354,11 +355,40 @@ class TreemapLayoutTest {
     assertThat(result.cells.size).isLessThanOrEqualTo(5000)
   }
 
+  @Test fun `zooming into the node holding a group draws the children it stood for`() {
+    // The pile a rectangle's siblings are gathered into is what zooming into that rectangle is for, so
+    // the node the viewport is rooted at draws as many children as it has room for rather than as many
+    // as fit in a rectangle. Clicking a pile used to land on the same pile, one level in.
+    val wide = Node("wide", children = List(50) { index -> Node("child$index", ownWeight = 100L - index) })
+    val tree = NodeTree(Node("root", children = listOf(wide)))
+    val layout = TreemapLayout<Node>(maxChildrenPerNode = 10)
+
+    val nested = layout.layout(tree, viewport)
+    val zoomed = layout.layout(tree, viewport, root = wide)
+
+    assertThat(nested.groups.single().nodeCount).isEqualTo(40)
+    assertThat(zoomed.groups).isEmpty()
+    assertThat(zoomed.names).hasSize(51) // The wide node and all 50 of its children.
+  }
+
+  @Test fun `the node the viewport is rooted at still stops short of the cell budget`() {
+    // Room for every one of them at a 3x3 square, so nothing but the budget stands in the way.
+    val children = List(5_000) { index -> Node("child$index", ownWeight = 100L) }
+    val tree = NodeTree(Node("root", children = children))
+
+    val result = TreemapLayout<Node>(maxCells = 400).layout(tree, viewport)
+
+    // Half the budget on one level at the most, so there is room left to draw inside what it drew.
+    assertThat(result.names).hasSize(201)
+    assertThat(result.groups.single().nodeCount).isEqualTo(4_800)
+  }
+
   @Test fun `children past the per node limit are grouped into one rectangle`() {
     val children = List(50) { index -> Node("child$index", ownWeight = 100L - index) }
     val tree = NodeTree(Node("root", children = children))
 
-    val result = TreemapLayout<Node>(maxChildrenPerNode = 10).layout(tree, viewport)
+    val result = TreemapLayout<Node>(maxChildrenPerNode = 10, maxRootChildren = 10)
+      .layout(tree, viewport)
 
     assertThat(result.names).hasSize(11) // The root and its 10 largest children.
     val group = result.groups.single()
@@ -388,7 +418,8 @@ class TreemapLayoutTest {
     val children = List(50) { index -> Node("child$index", ownWeight = 100L - index) }
     val tree = NodeTree(Node("root", children = children))
 
-    val result = TreemapLayout<Node>(maxChildrenPerNode = 10).layout(tree, viewport)
+    val result = TreemapLayout<Node>(maxChildrenPerNode = 10, maxRootChildren = 10)
+      .layout(tree, viewport)
 
     val covered = result.cells.drop(1).sumOf { it.rect.area }
     assertThat(covered).isCloseTo(viewport.area, offset(1.0))


### PR DESCRIPTION
## The name on a rectangle is now the way to reach it

A rectangle's children cover every pixel of it, so the name the map writes on a child of the current root is the one piece of that rectangle still showing — and reading the map is reading those names. Pointing at one answered with whichever descendant happened to be under the lettering, which is a question nobody asked.

The translucent plate under a name is now a hit target of its own:

- **Hovering it** describes the rectangle it names, in the chain beside the view and in the card at the pointer.
- **Clicking it** walks into that rectangle, rather than jumping to the bottom of the map.

Everywhere else the innermost rectangle still wins, and a container is still pressed by its outline (`edgeGrab`) too — this is one more way in, not a replacement.

The plate is measured once, into a new `MeasuredLabel`, so the rectangle painted and the rectangle pointed at are literally the same value. It is clamped to the cell it names: a name on a rectangle barely a line of text tall would otherwise overhang, and the overhang would both be drawn on the sibling below it and answer the pointer for it. The lettering can still overflow, as it always could; what stands for the rectangle can't reach outside it.

`namedCellAt` lives in `shark-explorer-app` rather than in `core` because only Compose can measure text.

## And a pile of objects gets to say what it is

A rectangle has room for `400 × Sibling` or `300 smaller objects` and no more, so the fully qualified class name — or which rectangle a leftover pile was left out of — fits nowhere but the card at the pointer. That card was drawn for `Selection.Object` alone, which meant pointing at the one kind of cell whose name is *incomplete* answered nothing at all.

`PointerCard` now takes a `Selection` and says its piece for all three kinds:

| What's under the pointer | What the card says |
| --- | --- |
| One object | unchanged |
| Every instance of one class, or the uncollected garbage | the title, the **qualified class name**, how it's held, what it retains, and that it isn't one object — click it to reach them |
| The children a subdivision had no room for | how many, which rectangle holds them, what they retain, and that they're too small or too many to draw one by one |

Those last two lines are separate constants on purpose: a pile of one class is a node of the tree, so clicking it goes into it and the objects are there, while a leftover pile has nothing to go into. Promising otherwise would be a lie.

Clicking needed no change for either: a class group is already a tree node with a path, and a leftover group already becomes the selection in place.

## Testing

- `TreemapViewTest` — two tests pressing and hovering a name over a child that covers its parent entirely.
- `MapNamesTest` — four window-level tests: a name reports and opens what it names rather than the array drawn inside it, a class pile gives up its qualified name, and a leftover pile says what it is. New file rather than more of `ExplorerAppTest`, which is at detekt's `LargeClass` limit.

Both halves were checked by removal: dropping `namedCellAt` from the hit test fails the two view tests, and filtering the card back to `Selection.Object` fails the two pile tests.

`:shark:shark-explorer:shark-explorer-app:check` and `:shark:shark-explorer:shark-explorer-core:test` are green, detekt included. Notes updated in `notes/treemap-rendering.md` and `notes/decisions.md`. No changelog entry — the explorer modules aren't published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
