### PR TITLE
Gather the explorer's dominator rules into one rule set

### DIFF
--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -21,13 +21,13 @@ per open heap dump, built once, holding every object of the dump.
 **Which reference matchers go in matters, and it isn't "none".** The matchers do two unrelated jobs,
 and only one of them belongs here:
 
-- **Reference strength** is `ReferenceStrengthReader.WEAKENING_REFERENCE_MATCHERS`, one
-  `IgnoredReferenceMatcher` per field of `WEAKENING_FIELDS_BY_CLASS_NAME` and nothing else, read off the
-  same map that gives those fields their strength: the `referent` and `zombie` of the five reference
-  classes, plus the cache and thread local fields. Follow one of those and a weak reference looks like it
-  retains its referent, and retained size stops meaning anything. **Required.** A field pattern matches on
-  any class of an object's hierarchy, so a `KeyedWeakReference` is covered by the `WeakReference` entry and
-  needs none of its own.
+- **Reference strength** is `ExplorerRules.weakeningReferenceMatchers`, one `IgnoredReferenceMatcher` per
+  field of its weakening field rules and nothing else, derived from the same list that gives those fields
+  their strength: the `referent` of the five reference classes, the `zombie` of Android's
+  `FinalizerReference`, and the cache and thread local fields. Follow one of those and a weak reference
+  looks like it retains its referent, and retained size stops meaning anything. **Required.** A field
+  pattern matches on any class of an object's hierarchy, so a `KeyedWeakReference` is covered by the
+  `WeakReference` entry and needs none of its own.
 - **Deliberately not `JdkReferenceMatchers.REFERENCES`**, which is that list plus the `prev`, `next` and
   `element` links of the lists a runtime keeps its `Finalizer`s, `FinalizerReference`s and `Cleaner`s on,
   ignored there so that a leak trace can't run through the queue of objects waiting to be finalized.
@@ -185,8 +185,8 @@ them apart, so it hands the bytes to the root — which is what `ReachabilityStr
 ## A cache is not an owner: the `CACHE` strength
 
 The fix for the above is to stop treating a cache's reference as retaining. `CACHE` ranks between
-`STRONG` and `SOFT`, and `ReferenceStrengthReader.CACHE_FIELDS_BY_CLASS_NAME` is the curated list of
-fields it applies to — one entry today, `coil3.memory.RealStrongMemoryCache$InternalValue.image`.
+`STRONG` and `SOFT`, and `ExplorerRules`' cache entries are the curated list of fields it applies to — one
+today, `coil3.memory.RealStrongMemoryCache$InternalValue.image`.
 
 The mechanics fall out of the weak reference machinery that was already there, because the rule the
 explorer wants is exactly the rule for a weak reference: **the target's strength decides**. A weakening
@@ -221,10 +221,10 @@ itself and retained 4.2 KB and 3.9 KB instead of their windows. The damaging ref
 `PhoneFallbackEventHandler.mView`, `RealWorkflowLifecycleOwner.view`, `ComposeToastServiceImpl.rootView`,
 view bindings and `StandardRowSpec$StandardViewHolder.itemView`.
 
-`OwnerReferences` applies a curated list of `OwnerRule`s: a class whose instances something owns, plus the
-references that own them — named fields, or the virtual references a class's instances hand out. Three
-today — `android.view.View` owned by the `ViewGroup` that reads it as a child (see below) and by
-`Activity.mDecor` or `Dialog.mDecor`, and `android.app.Activity` owned by
+`OwnerReferences` applies a curated list of `OwnerRule`s from `ExplorerRules`: a class whose instances
+something owns, plus the references that own them — named fields, or the virtual references a class's
+instances hand out. Three today — `android.view.View` owned by the `ViewGroup` that reads it as a child
+(see below) and by `Activity.mDecor` or `Dialog.mDecor`, and `android.app.Activity` owned by
 `ActivityThread$ActivityClientRecord.activity`. After: **every one of the 277 child views is under its
 parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity` retains
 18 MB under the record the framework runs it from, which is the second largest rectangle under the GC
@@ -241,7 +241,7 @@ rule the 82 MB dump comes out at exactly the same numbers as before — 80 MB st
 28 B local, 2.6 KB finalizer, 186 KB unreachable.
 
 **Parking is also why a rule needs no check on the state of the object**, which is the thing that looks
-missing when you read `RULES`. "The parent owns an *attached* view" needs no attachment test, because a
+missing when you read the rules. "The parent owns an *attached* view" needs no attachment test, because a
 detached hierarchy isn't held by whatever holds the window: if the parent isn't reachable, no owner
 reference reaches the child and the fallback handles it. "Unless the activity is destroyed" needs no
 `mDestroyed` test either — `ActivityThread.handleDestroyActivity` sets `mDecor = null` and takes the
@@ -298,6 +298,34 @@ Three things make it safe, and each one is a decision:
 Byte counts are untouched by all of it, which is the check that no object moved out of the graph: 83.83 MB
 strong, 2.05 MB thread local, 28 B local, 2.6 KB finalizer, 190 KB unreachable, 1,019,837 objects, before
 and after.
+
+## One rule set, and why the explorer can't just reuse shark's matchers
+
+Every curated list is in `ExplorerRules`: the fields that weaken and how, and the `OwnerRule`s. Each used
+to be declared next to the class applying it, which is fine until you want to read them all and ask whether
+they're still true — and the `java.lang.ref` fields were for a while declared twice over, the strengths here
+and the ignoring of the same fields inherited from LeakCanary. That is worth recording even though the
+second copy is gone, because of *why* it was there.
+
+**That duplication was not a design, it was the absence of a place to put a strength.** Shark's matchers
+are a boolean: `IgnoredReferenceMatcher` carries no payload, `FieldInstanceReferenceReader` drops a matched
+reference with `if (referenceMatcher !is IgnoredReferenceMatcher)`, and `Reference.LazyDetails` carries only
+a `matchedLibraryLeak`. So there is nowhere for "and it's weak" to live, and no way to ask shark which
+matcher dropped a reference. Two ways out: add a strength-carrying matcher to shark — `ReferenceMatcher` is
+`sealed`, so it has to be added *in* shark, an ABI change plus a reader that emits what it currently drops,
+on LeakCanary's hot path — or invert the direction and derive the ignore list from the strengths. The second
+is what the matchers section above describes, and it's why the explorer keeps its own copy of those field
+names rather than importing one.
+
+One redundancy went with the gathering: `zombie` on the four reference classes that don't declare it, which
+only Android's `FinalizerReference` has. That takes the matcher list from 12 to 8, and A/B'd on
+`leak_asynctask_o.hprof` and on the 39 MB `large-dump.hprof` the two lists come out at the same tree —
+every per-strength byte and object count identical, totals identical, and the same number of children
+under the root weighing the same.
+
+**GC root strength is still code**, in `GcRoot.reachabilityStrength()`, and is deliberately not part of the
+rule set: it's a mapping from a `sealed` hierarchy, so making it data means mirroring that hierarchy in an
+enum of our own — more duplication of exactly the kind this section is about.
 
 ## What holds an object: one chain, with the dominators on it marked
 

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -224,11 +224,11 @@ view bindings and `StandardRowSpec$StandardViewHolder.itemView`.
 `OwnerReferences` applies a curated list of `OwnerRule`s from `ExplorerRules`: a class whose instances
 something owns, plus the references that own them — named fields, or the virtual references a class's
 instances hand out. Three today — `android.view.View` owned by the `ViewGroup` that reads it as a child
-(see below) and by `Activity.mDecor` or `Dialog.mDecor`, and `android.app.Activity` owned by
-`ActivityThread$ActivityClientRecord.activity`. After: **every one of the 277 child views is under its
-parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity` retains
-18 MB under the record the framework runs it from, which is the second largest rectangle under the GC
-roots.
+(see below) and by `Activity.mDecor` or `Dialog.mDecor`, and `android.app.Activity` owned by the
+`ActivityThread` that reads it out of `mActivities` (see below). After: **every one of the 277 child views
+is under its parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and
+`MainActivity` retains 18 MB under the thread that runs it, which is the second largest rectangle under
+the GC roots.
 
 **A rule is parked, not dropped, and that's the whole design.** The walk in
 `HeapReachability.walkFromGcRoots` keeps a second queue per strength and only takes from it once the main
@@ -298,6 +298,30 @@ Three things make it safe, and each one is a decision:
 Byte counts are untouched by all of it, which is the check that no object moved out of the graph: 83.83 MB
 strong, 2.05 MB thread local, 28 B local, 2.6 KB finalizer, 190 KB unreachable, 1,019,837 objects, before
 and after.
+
+### An `ActivityThread` points at the activities it runs: the second virtual reference
+
+`ActivityThreadReferenceReader` gives an `ActivityThread` one reference per running activity, named
+`mActivities` and marked virtual, which is what the activity `OwnerRule` claims ownership through. Same
+shape as the `ViewGroup` one above, and for the same reason: the field is an
+`ArrayMap<IBinder, ActivityClientRecord>`, so every activity of every dump is five objects down from the
+thread that runs it, and the record is the only thing a field rule could name.
+
+The rule this replaced named `ActivityThread$ActivityClientRecord.activity`, which worked and read badly.
+A record is an implementation detail of how the framework runs an activity, so a tree built on it draws
+every screen of an app under a different unnamed record instead of side by side under the one thread that
+runs them all. Measured on `leak_asynctask_o.hprof`: the live `MainActivity` retains 51,634 B either way,
+its dominator moves from `ActivityThread$ActivityClientRecord` to `ActivityThread`, and the chain down to
+it goes from `mActivities → ArrayMap, mArray → Object[], 1 → ActivityClientRecord, activity → MainActivity`
+to `mActivities → MainActivity`. The leaked `MainActivity` in that dump is untouched — 211,038 B under the
+`MainActivity$2` that leaks it — which is the fallback doing its job on a destroyed activity.
+
+**Read the `ArrayMap` the way the map reads itself**: keys at the even slots, values at the odd ones, over
+the first `mSize` pairs. Bounded by the count for the same reason `mChildrenCount` bounds the children, and
+it matters more here: an `ArrayMap` doesn't null the slots it gives up, it leaves them for the next put, so
+past the count is exactly where the record of a destroyed activity is still written down. Attributing that
+activity to the framework would hide the leak. `an activity in a slot the map doesn't count is not one the
+process is running` pins it.
 
 ## One rule set, and why the explorer can't just reuse shark's matchers
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ActivityThreadReferenceReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ActivityThreadReferenceReader.kt
@@ -1,0 +1,108 @@
+package shark.explorer
+
+import shark.HeapGraph
+import shark.HeapObject
+import shark.HeapObject.HeapInstance
+import shark.Reference
+import shark.Reference.LazyDetails
+import shark.ReferenceLocationType.INSTANCE_FIELD
+import shark.ValueHolder
+
+/**
+ * The activities the process is running, as references from the `ActivityThread` straight to each one, the
+ * way you'd describe what the field holds — `mActivities` — rather than the way it's stored.
+ *
+ * It's stored as an `ArrayMap<IBinder, ActivityClientRecord>`, so every activity of every dump is five
+ * objects down from the thread that runs it: `ActivityThread.mActivities → ArrayMap → Object[] → [1] →
+ * ActivityClientRecord.activity → MainActivity`. Two things follow from reading it that way. A path spends
+ * four steps saying what one says, and it's the record that gets to own the activity — see [OwnerReferences]
+ * — which draws every screen of an app under a different unnamed record instead of side by side under the
+ * one thread running them.
+ *
+ * So this adds one virtual reference per running activity, named after the field they're in. **Additive** —
+ * the map, its array and each record are still reached through `mActivities` and are still nodes holding
+ * their own bytes, because the explorer needs every object of a heap dump to be a node exactly once (see
+ * [ReferenceStrengthReader]). What takes them out of the middle of the tree is the dominator tree rather
+ * than this: both ways to an activity now start at the `ActivityThread`, so it dominates it and the record
+ * is left retaining what it holds besides the activity.
+ */
+internal class ActivityThreadReferenceReader(private val graph: HeapGraph) {
+
+  /**
+   * The class id of `ActivityThread`, resolved once. There is one of these per process, so this turns "is
+   * this the activity thread" into a single comparison — where [HeapGraph.findClassByName] scans every
+   * string of the heap dump and calling it per object costs minutes.
+   */
+  private val activityThreadClassId: Long by lazy {
+    graph.findClassByName(ACTIVITY_THREAD_CLASS_NAME)?.objectId ?: ValueHolder.NULL_REFERENCE
+  }
+
+  /** The running activities when [source] is the `ActivityThread`, and nothing for anything else. */
+  fun runningActivityReferencesOf(source: HeapObject): Sequence<Reference> {
+    if (source !is HeapInstance || source.instanceClassId != activityThreadClassId) {
+      return emptySequence()
+    }
+    val activities = source[ACTIVITY_THREAD_CLASS_NAME, ACTIVITIES_FIELD_NAME]?.valueAsInstance
+      ?: return emptySequence()
+    val entries = activities[ARRAY_MAP_CLASS_NAME, ENTRIES_FIELD_NAME]?.valueAsObjectArray
+      ?: return emptySequence()
+    val elementIds = entries.readRecord().elementIds
+    // An ArrayMap keeps its keys at the even slots and its values at the odd ones, over the first mSize
+    // pairs of an array it grows in chunks. Bounded by the count for the same reason ViewGroup's children
+    // are: a pair the map doesn't count is not an entry, and an ArrayMap doesn't null the slots it gives up
+    // — it leaves them for the next put — so past the count is where a removed activity is still written
+    // down. Which is exactly the leak you'd be looking for, and calling it a running activity hides it.
+    val entryCount = activities[ARRAY_MAP_CLASS_NAME, SIZE_FIELD_NAME]?.value?.asInt
+      ?.coerceIn(0, elementIds.size / 2)
+      ?: return emptySequence()
+    val activityThreadClassObjectId = source.instanceClassId
+    return (0 until entryCount).asSequence()
+      .mapNotNull { entryIndex ->
+        val recordId = elementIds[entryIndex * 2 + 1]
+        if (recordId == ValueHolder.NULL_REFERENCE) {
+          null
+        } else {
+          graph.findObjectByIdOrNull(recordId)?.asInstance
+        }
+      }
+      .mapNotNull { record ->
+        record[ACTIVITY_CLIENT_RECORD_CLASS_NAME, ACTIVITY_FIELD_NAME]?.value?.asNonNullObjectId
+      }
+      .map { activityObjectId ->
+        Reference(
+          valueObjectId = activityObjectId,
+          isLowPriority = false,
+          lazyDetailsResolver = {
+            LazyDetails(
+              name = ACTIVITIES_FIELD_NAME,
+              // The field really is declared here, and it really does hold this activity — through four
+              // objects this reference stands in for. So a path reads ActivityThread.mActivities rather
+              // than naming the record the map happens to keep it in.
+              locationClassObjectId = activityThreadClassObjectId,
+              locationType = INSTANCE_FIELD,
+              isVirtual = true,
+              matchedLibraryLeak = null
+            )
+          }
+        )
+      }
+  }
+
+  companion object {
+    /** Also what an [OwnerRule] names to say that the thread owns the activities read here. */
+    const val ACTIVITY_THREAD_CLASS_NAME = "android.app.ActivityThread"
+
+    private const val ACTIVITY_CLIENT_RECORD_CLASS_NAME =
+      "android.app.ActivityThread\$ActivityClientRecord"
+
+    private const val ARRAY_MAP_CLASS_NAME = "android.util.ArrayMap"
+
+    private const val ACTIVITIES_FIELD_NAME = "mActivities"
+
+    private const val ACTIVITY_FIELD_NAME = "activity"
+
+    private const val ENTRIES_FIELD_NAME = "mArray"
+
+    private const val SIZE_FIELD_NAME = "mSize"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ExplorerRules.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ExplorerRules.kt
@@ -203,16 +203,22 @@ internal class ExplorerRules(
           "android.app.Dialog" to setOf("mDecor")
         )
       ),
-      // An activity belongs to the list of activities the process is running, and everything else that
-      // points at one — a context wrapper, a view, a fragment, a presenter, a callback — is something the
-      // activity brought along. Self-clearing in the same way: ActivityThread.handleDestroyActivity takes
-      // the record out of mActivities, so a destroyed activity has no owner left and falls back on
-      // whatever is leaking it, which is exactly what you want its bytes drawn under.
+      // An activity is held by the list of activities the process is running, through the virtual
+      // reference [ActivityThreadReferenceReader] reads from the ActivityThread to each of them.
+      // Everything else that points at one — a context wrapper, a view, a fragment, a presenter, a
+      // callback — is something the activity brought along.
+      //
+      // Not ActivityThread$ActivityClientRecord.activity, which is the same construct named one level
+      // lower and was this rule's first form: the record is an implementation detail of how the framework
+      // runs an activity, so a tree built on it draws every screen of an app under a different unnamed
+      // record instead of side by side under the one thread that runs them.
+      //
+      // Self-clearing either way: ActivityThread.handleDestroyActivity takes the record out of
+      // mActivities, so a destroyed activity has no owner left and falls back on whatever is leaking it,
+      // which is exactly what you want its bytes drawn under.
       OwnerRule(
         ownedClassName = ACTIVITY_CLASS_NAME,
-        ownerFieldsByClassName = mapOf(
-          "android.app.ActivityThread\$ActivityClientRecord" to setOf("activity")
-        )
+        ownerVirtualClassNames = setOf(ActivityThreadReferenceReader.ACTIVITY_THREAD_CLASS_NAME)
       )
     )
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ExplorerRules.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ExplorerRules.kt
@@ -1,0 +1,226 @@
+package shark.explorer
+
+import shark.ReferenceMatcher
+import shark.ReferenceMatcher.Companion.ALWAYS
+import shark.ReferencePattern.Companion.instanceField
+import shark.ignored
+import shark.explorer.ReachabilityStrength.CACHE
+import shark.explorer.ReachabilityStrength.FINALIZER
+import shark.explorer.ReachabilityStrength.PHANTOM
+import shark.explorer.ReachabilityStrength.SOFT
+import shark.explorer.ReachabilityStrength.THREAD_LOCAL
+import shark.explorer.ReachabilityStrength.WEAK
+
+/**
+ * Fields that hold their value without retaining it, and how firmly the value is held instead.
+ *
+ * Read against the whole class hierarchy of the referring object, so a rule on a base class covers every
+ * subclass and a subclass's rule for the same field name wins — which is how a `FinalizerReference` reads
+ * as a finalizer reference rather than as the `PhantomReference` it extends.
+ */
+internal class WeakeningFieldRule(
+  val className: String,
+  val fieldNames: Set<String>,
+  /** Why this field doesn't retain, for the reader of this list. */
+  val description: String,
+  val strength: ReachabilityStrength
+)
+
+/**
+ * Everything the explorer knows about a heap dump that the heap dump doesn't say itself: which references
+ * hold their target without retaining it, and which reference is the one way an object is held.
+ *
+ * All of it curated, all of it a claim about a class the explorer doesn't own, and all of it here rather
+ * than spread over the classes applying it — because a rule is only as good as the reader who can see the
+ * whole list and say whether it's still true.
+ *
+ * Two properties every entry has to have, and the reason a wrong one is worse than a missing one:
+ *
+ * - **Names are matched literally**, so a wrong class or field name doesn't fail, it silently does nothing.
+ *   Add one only against a heap dump that has it. An obfuscated dump needs its mapping applied first, which
+ *   is why none of the app level entries fire on a production dump as it comes off a device.
+ * - **A wrong entry moves bytes rather than breaking**, which reads as an answer instead of as an error. The
+ *   tree still holds every object either way — see [OwnerReferences] and [HeapReachability.isHeldThrough] —
+ *   so what's at stake is where the reader is told to look, and that's the whole product.
+ */
+internal class ExplorerRules(
+  val weakeningFields: List<WeakeningFieldRule>,
+  val ownerRules: List<OwnerRule>
+) {
+
+  /** [weakeningFields] as [ReferenceStrengthReader] reads it: by class name, then by field name. */
+  val strengthByFieldNameByClassName: Map<String, Map<String, ReachabilityStrength>> =
+    weakeningFields.groupBy { it.className }
+      .mapValues { (_, rules) ->
+        rules.flatMap { rule -> rule.fieldNames.map { it to rule.strength } }.toMap()
+      }
+
+  /**
+   * The matchers that stop the retaining reader from following a reference that doesn't retain: one per
+   * field of [weakeningFields] and nothing else, derived from the same list that gives those fields their
+   * strength — so the two halves of [ReferenceStrengthReader] can't disagree about a reference, and one
+   * edit covers both.
+   *
+   * Deliberately **not** [shark.JdkReferenceMatchers.REFERENCES], which is where LeakCanary keeps the same
+   * `java.lang.ref` fields. That list says what a leak trace shouldn't route through and never says why, so
+   * inheriting it left the strengths declared here and the ignoring declared there with nothing tying the
+   * two together — and it carries fields that are no weakening reference at all, the `prev`, `next` and
+   * `element` links of the lists a runtime keeps its finalizer and cleaner references on. Ignoring those
+   * cost the explorer every object waiting to be finalized; see `notes/dominator-tree.md`.
+   */
+  val weakeningReferenceMatchers: List<ReferenceMatcher> =
+    weakeningFields.flatMap { rule ->
+      rule.fieldNames.map { instanceField(rule.className, it).ignored(patternApplies = ALWAYS) }
+    }
+
+  companion object {
+
+    private const val VIEW_CLASS_NAME = "android.view.View"
+
+    private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
+
+    /** The fields a `java.lang.ref.Reference` holds its referent in. */
+    private const val REFERENT_FIELD_NAME = "referent"
+
+    /**
+     * What the `java.lang.ref` classes hold their referent with, most derived first for the reader — the
+     * hierarchy walk in [ReferenceStrengthReader] is what actually resolves an override.
+     *
+     * `FinalizerReference` is Android's, `FinalReference` is the JVM's — `java.lang.ref.Finalizer` extends
+     * it, and it's package private so nothing else can. `zombie` is Android's alone: it's where a
+     * `FinalizerReference` moves its referent while `finalize()` runs.
+     *
+     * `leakcanary.KeyedWeakReference` needs no entry of its own even though LeakCanary's list has one: it
+     * extends `WeakReference`, and a rule on a base class covers every subclass.
+     */
+    private val REFERENCE_WEAKENING_FIELDS = listOf(
+      WeakeningFieldRule(
+        className = "java.lang.ref.FinalizerReference",
+        fieldNames = setOf(REFERENT_FIELD_NAME, "zombie"),
+        description = "Android's finalizer queue, holding an object until finalize() has run",
+        strength = FINALIZER
+      ),
+      WeakeningFieldRule(
+        className = "java.lang.ref.FinalReference",
+        fieldNames = setOf(REFERENT_FIELD_NAME),
+        description = "The JVM's finalizer queue, which java.lang.ref.Finalizer extends",
+        strength = FINALIZER
+      ),
+      WeakeningFieldRule(
+        className = "java.lang.ref.PhantomReference",
+        fieldNames = setOf(REFERENT_FIELD_NAME),
+        description = "Enqueued once the referent is gone, and unreachable to the program before that",
+        strength = PHANTOM
+      ),
+      WeakeningFieldRule(
+        className = "java.lang.ref.WeakReference",
+        fieldNames = setOf(REFERENT_FIELD_NAME),
+        description = "Cleared at the next collection, whether or not memory is short",
+        strength = WEAK
+      ),
+      WeakeningFieldRule(
+        className = "java.lang.ref.SoftReference",
+        fieldNames = setOf(REFERENT_FIELD_NAME),
+        description = "Cleared when the VM wants the memory back",
+        strength = SOFT
+      )
+    )
+
+    /**
+     * The caches the explorer recognizes, whose entries read as [CACHE] rather than as retained, so that an
+     * object a cache and something else both hold is attributed to the something else. See [CACHE] for why
+     * this is a list rather than something read off the heap dump.
+     *
+     * An entry belongs here once two things are true of the class: it is a cache that evicts on its own, and
+     * its entries are worth blaming their owner for rather than it.
+     *
+     * Cutting as low as the value a cache entry wraps, rather than at the cache itself, is what keeps the
+     * cache's own bookkeeping — the map, the entries, the sizes — where it belongs: strongly held by the
+     * cache, and its bytes attributed to it.
+     */
+    private val CACHE_WEAKENING_FIELDS = listOf(
+      WeakeningFieldRule(
+        className = "coil3.memory.RealStrongMemoryCache\$InternalValue",
+        fieldNames = setOf("image"),
+        description = "Coil 3's memory cache: a bounded LRU of decoded images, halved on " +
+          "TRIM_MEMORY_RUNNING_LOW and cleared on TRIM_MEMORY_BACKGROUND by AndroidSystemCallbacks",
+        strength = CACHE
+      )
+    )
+
+    /**
+     * Where a thread keeps what it put in a `ThreadLocal`, held for as long as the thread lives.
+     *
+     * `ThreadLocalMap.Entry` is a `WeakReference` to the `ThreadLocal` itself, so its `referent` is already
+     * weakened by [REFERENCE_WEAKENING_FIELDS]; what's added here is the value, which the map holds
+     * strongly. Attributing it to the thread is what the tree does otherwise, and a thread of an app's pool
+     * retaining everything anything ever left in a thread local of it is a picture of the pool rather than
+     * of the app.
+     */
+    private val THREAD_LOCAL_WEAKENING_FIELDS = listOf(
+      WeakeningFieldRule(
+        className = "java.lang.ThreadLocal\$ThreadLocalMap\$Entry",
+        fieldNames = setOf("value"),
+        description = "A thread's own storage, given up when the thread dies",
+        strength = THREAD_LOCAL
+      )
+    )
+
+    /**
+     * The constructs where one reference is the one that really holds an object. Each one is a claim that a
+     * reference is *the* way an object is held, and getting that wrong moves bytes to the wrong place in the
+     * tree — so one owner per construct, and it should be the one you'd want to read the bytes under.
+     */
+    private val OWNER_RULES = listOf(
+      // A view of a hierarchy is held by its parent, through the virtual reference
+      // [ViewChildReferenceReader] reads from a ViewGroup to each of its children.
+      //
+      // Not through the View[] the framework really keeps them in, which is what this rule used to say.
+      // An array owns by its type or not at all — there is nothing on it to say whose children it holds —
+      // so a rule about View[] also hands ownership to an app's own array of views it merely points at,
+      // and it leaves a hierarchy hanging off an unnamed array at every level of the tree.
+      OwnerRule(
+        ownedClassName = VIEW_CLASS_NAME,
+        ownerVirtualClassNames = setOf(ViewChildReferenceReader.VIEW_GROUP_CLASS_NAME)
+      ),
+      // The root view of a hierarchy has no parent to own it, and belongs to whatever the hierarchy is
+      // for. Attributing a window's views to the Activity or Dialog they're for is the whole point:
+      // otherwise they land under the WindowManagerGlobal that holds every window of the process, which
+      // tells you nothing about which screen is expensive.
+      //
+      // The framework nulls Activity.mDecor when it destroys the activity, and that is the whole of
+      // "unless the activity is destroyed": a rule needs no state check when the field is already gone.
+      //
+      // Not PhoneWindow.mDecor, which also holds the decor view and is set whether the activity is
+      // destroyed or not. Two owner references are two ways of owning, so the decor view ends up
+      // dominated by whatever dominates both, and on a real app dump that's the top of the tree: a jank
+      // monitor held the window from a GC root of its own, which cost the activity all 18 MB of its
+      // hierarchy.
+      OwnerRule(
+        ownedClassName = VIEW_CLASS_NAME,
+        ownerFieldsByClassName = mapOf(
+          ACTIVITY_CLASS_NAME to setOf("mDecor"),
+          "android.app.Dialog" to setOf("mDecor")
+        )
+      ),
+      // An activity belongs to the list of activities the process is running, and everything else that
+      // points at one — a context wrapper, a view, a fragment, a presenter, a callback — is something the
+      // activity brought along. Self-clearing in the same way: ActivityThread.handleDestroyActivity takes
+      // the record out of mActivities, so a destroyed activity has no owner left and falls back on
+      // whatever is leaking it, which is exactly what you want its bytes drawn under.
+      OwnerRule(
+        ownedClassName = ACTIVITY_CLASS_NAME,
+        ownerFieldsByClassName = mapOf(
+          "android.app.ActivityThread\$ActivityClientRecord" to setOf("activity")
+        )
+      )
+    )
+
+    /** What the explorer applies unless something says otherwise, which today nothing does. */
+    val DEFAULT = ExplorerRules(
+      weakeningFields = REFERENCE_WEAKENING_FIELDS + CACHE_WEAKENING_FIELDS +
+        THREAD_LOCAL_WEAKENING_FIELDS,
+      ownerRules = OWNER_RULES
+    )
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapExplorer.kt
@@ -69,9 +69,13 @@ class HeapExplorer private constructor(
         )
       }
       try {
-        val strengthReader = ReferenceStrengthReader(graph)
+        // Everything the explorer knows that the heap dump doesn't say itself, in one place and read by
+        // both halves of the edge set: which references don't retain, and which ones are the one way an
+        // object is held.
+        val rules = ExplorerRules.DEFAULT
+        val strengthReader = ReferenceStrengthReader(graph, rules)
         val ownerReferences = steps.run("Working out what owns what") {
-          OwnerReferences.computeFor(graph)
+          OwnerReferences.computeFor(graph, rules)
         }
         val reachability = steps.run("Working out what's reachable") {
           HeapReachability.computeFor(

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
@@ -43,7 +43,8 @@ internal class OwnerRule(
    * Those are the references the explorer adds itself, to present a structure the way you think about it
    * instead of the way it's built, and an owner named that way is named by what it is rather than by a
    * field it holds the object in: a `ViewGroup` owns the children [ViewChildReferenceReader] reads for it,
-   * whichever slot of whichever array each one is really in.
+   * whichever slot of whichever array each one is really in, and an `ActivityThread` owns the activities
+   * [ActivityThreadReferenceReader] reads for it, whichever record of its map each one is really in.
    */
   val ownerVirtualClassNames: Set<String> = emptySet()
 )

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
@@ -26,6 +26,8 @@ import shark.Reference
  * isn't held by whatever holds the window, so if its parent isn't reachable, no owner reaches the child
  * and [OwnerReferences] falls back on the rivals by itself. The state the rule seems to need is already
  * expressed by which references exist.
+ *
+ * The rules the explorer applies are [ExplorerRules.ownerRules].
  */
 internal class OwnerRule(
   /** The class whose instances something owns, subclasses included. */
@@ -173,78 +175,30 @@ internal class OwnerReferences private constructor(
 
   companion object {
 
-    private const val VIEW_CLASS_NAME = "android.view.View"
-
-    private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
-
-    /**
-     * The constructs the explorer knows about. Curated: each one is a claim that a reference is *the* way
-     * an object is held, and getting that wrong moves bytes to the wrong place in the tree.
-     */
-    private val RULES = listOf(
-      // A view of a hierarchy is held by its parent, through the virtual reference
-      // [ViewChildReferenceReader] reads from a ViewGroup to each of its children.
-      //
-      // Not through the View[] the framework really keeps them in, which is what this rule used to say.
-      // An array owns by its type or not at all — there is nothing on it to say whose children it holds —
-      // so a rule about View[] also hands ownership to an app's own array of views it merely points at,
-      // and it leaves a hierarchy hanging off an unnamed array at every level of the tree.
-      OwnerRule(
-        ownedClassName = VIEW_CLASS_NAME,
-        ownerVirtualClassNames = setOf(ViewChildReferenceReader.VIEW_GROUP_CLASS_NAME)
-      ),
-      // The root view of a hierarchy has no parent to own it, and belongs to whatever the hierarchy is
-      // for. Attributing a window's views to the Activity or Dialog they're for is the whole point:
-      // otherwise they land under the WindowManagerGlobal that holds every window of the process, which
-      // tells you nothing about which screen is expensive.
-      //
-      // The framework nulls Activity.mDecor when it destroys the activity, and that is the whole of
-      // "unless the activity is destroyed": a rule needs no state check when the field is already gone.
-      //
-      // Not PhoneWindow.mDecor, which also holds the decor view and is set whether the activity is
-      // destroyed or not. Two owner references are two ways of owning, so the decor view ends up
-      // dominated by whatever dominates both, and on a real app dump that's the top of the tree: a jank
-      // monitor held the window from a GC root of its own, which cost the activity all 18 MB of its
-      // hierarchy. One owner per construct, and it should be the one you'd want to read the bytes under.
-      OwnerRule(
-        ownedClassName = VIEW_CLASS_NAME,
-        ownerFieldsByClassName = mapOf(
-          ACTIVITY_CLASS_NAME to setOf("mDecor"),
-          "android.app.Dialog" to setOf("mDecor")
-        )
-      ),
-      // An activity belongs to the list of activities the process is running, and everything else that
-      // points at one — a context wrapper, a view, a fragment, a presenter, a callback — is something the
-      // activity brought along. Self-clearing in the same way: ActivityThread.handleDestroyActivity takes
-      // the record out of mActivities, so a destroyed activity has no owner left and falls back on
-      // whatever is leaking it, which is exactly what you want its bytes drawn under.
-      OwnerRule(
-        ownedClassName = ACTIVITY_CLASS_NAME,
-        ownerFieldsByClassName = mapOf(
-          "android.app.ActivityThread\$ActivityClientRecord" to setOf("activity")
-        )
-      )
-    )
-
     private val OWNS_NOTHING = Ownership(emptySet(), false)
 
     /**
-     * Applies [RULES] to [graph], which takes one pass over its classes and one over its instances.
+     * Applies [ExplorerRules.ownerRules] to [graph], which takes one pass over its classes and one over its
+     * instances.
      *
      * The pass over the instances is what buys a hash lookup per reference later on, instead of a class
      * hierarchy walk: reading which objects are owned up front costs one index scan, and a heap dump has
      * millions of references but only thousands of views.
      */
-    fun computeFor(graph: HeapGraph): OwnerReferences {
+    fun computeFor(
+      graph: HeapGraph,
+      rules: ExplorerRules
+    ): OwnerReferences {
+      val ownerRules = rules.ownerRules
       val ownedClassIds = MutableLongSet()
-      RULES.mapTo(mutableSetOf()) { it.ownedClassName }.forEach { className ->
+      ownerRules.mapTo(mutableSetOf()) { it.ownedClassName }.forEach { className ->
         graph.findClassByName(className)?.let { ownedClassIds += it.objectId }
       }
       return OwnerReferences(
         graph = graph,
         ownedObjectIds = ownedObjectIdsOf(graph, ownedClassIds),
-        ownerFieldsByClassName = ownerFieldsByClassName(),
-        ownerVirtualClassNames = RULES.flatMapTo(mutableSetOf()) { it.ownerVirtualClassNames }
+        ownerFieldsByClassName = ownerFieldsByClassName(ownerRules),
+        ownerVirtualClassNames = ownerRules.flatMapTo(mutableSetOf()) { it.ownerVirtualClassNames }
       )
     }
 
@@ -276,10 +230,10 @@ internal class OwnerReferences private constructor(
       return ownedObjectIds
     }
 
-    /** [RULES]' owner fields merged, so that two rules on the same class both hold. */
-    private fun ownerFieldsByClassName(): Map<String, Set<String>> {
+    /** The rules' owner fields merged, so that two rules on the same class both hold. */
+    private fun ownerFieldsByClassName(ownerRules: List<OwnerRule>): Map<String, Set<String>> {
       val merged = mutableMapOf<String, Set<String>>()
-      RULES.forEach { rule ->
+      ownerRules.forEach { rule ->
         rule.ownerFieldsByClassName.forEach { (className, fieldNames) ->
           merged[className] = merged[className].orEmpty() + fieldNames
         }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReachabilityStrength.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReachabilityStrength.kt
@@ -27,7 +27,7 @@ enum class ReachabilityStrength {
    * [LOCAL] being the others. A cache holds its entries with ordinary strong references, so as far as the
    * GC is concerned this is [STRONG]; what makes it weaker is the cache's own contract, which no heap dump
    * records. So it comes from a curated list of the caches the explorer recognizes — see
-   * [ReferenceStrengthReader].
+   * [ExplorerRules].
    *
    * Ranked below [STRONG] so that an object a cache and something else both hold reads as the something
    * else's: an image the view showing it also holds is the view's, and the cache is why the dominator

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -62,7 +62,7 @@ internal class WeakeningReference(
  * Where a structure is worth presenting the way you think about it anyway, the reference is **added**
  * rather than swapped in: [ViewChildReferenceReader] gives a `ViewGroup` a reference to each of its
  * children, and the `View[]` they really live in is still reached through `mChildren` and still a node of
- * its own.
+ * its own. [ActivityThreadReferenceReader] does the same for the activities the process is running.
  */
 internal class ReferenceStrengthReader(
   private val graph: HeapGraph,
@@ -73,6 +73,8 @@ internal class ReferenceStrengthReader(
     ActualMatchingReferenceReaderFactory(rules.weakeningReferenceMatchers).createFor(graph)
 
   private val viewChildReader = ViewChildReferenceReader(graph)
+
+  private val activityThreadReader = ActivityThreadReferenceReader(graph)
 
   /**
    * Which fields of a class hold their value without retaining it, by class object id. Cached because
@@ -92,7 +94,8 @@ internal class ReferenceStrengthReader(
   /** The references from [source] that keep their target alive. */
   fun retainingReferencesOf(source: HeapObject): Sequence<Reference> =
     retainingReader.read(source) + classMetadataReferencesOf(source) +
-      viewChildReader.childReferencesOf(source)
+      viewChildReader.childReferencesOf(source) +
+      activityThreadReader.runningActivityReferencesOf(source)
 
   /**
    * The arrays ART hangs off a class object to hold what it embeds — its method tables in

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -11,19 +11,9 @@ import shark.Reference
 import shark.Reference.LazyDetails
 import shark.ReferenceLocationType.INSTANCE_FIELD
 import shark.ReferenceLocationType.STATIC_FIELD
-import shark.ReferenceMatcher
-import shark.ReferenceMatcher.Companion.ALWAYS
-import shark.ReferencePattern.Companion.instanceField
 import shark.ReferenceReader
 import shark.ValueHolder
-import shark.ignored
-import shark.explorer.ReachabilityStrength.CACHE
-import shark.explorer.ReachabilityStrength.FINALIZER
-import shark.explorer.ReachabilityStrength.PHANTOM
-import shark.explorer.ReachabilityStrength.SOFT
 import shark.explorer.ReachabilityStrength.STRONG
-import shark.explorer.ReachabilityStrength.THREAD_LOCAL
-import shark.explorer.ReachabilityStrength.WEAK
 
 /**
  * A reference that doesn't keep its target alive, and the [ReachabilityStrength] a path through it
@@ -57,9 +47,10 @@ internal class WeakeningReference(
  * entries with.
  *
  * Reference strength lives entirely in Shark's ignored reference matchers, and those only say what
- * not to follow, never why. So this reads both halves: a matched [ReferenceReader] for everything
- * that retains, and the fields listed in [WEAKENING_FIELDS_BY_CLASS_NAME] for everything that doesn't,
- * with the strength coming from which class declares them.
+ * not to follow, never why. So this reads both halves out of one list: a matched [ReferenceReader] built
+ * from [ExplorerRules.weakeningReferenceMatchers] for everything that retains, and
+ * [ExplorerRules.strengthByFieldNameByClassName] for everything that doesn't, with the strength coming from
+ * which class declares the field.
  *
  * Deliberately uses the plain field and array readers rather than
  * [shark.AndroidReferenceReaderFactory]: the Android readers present data structures the way you
@@ -73,10 +64,13 @@ internal class WeakeningReference(
  * children, and the `View[]` they really live in is still reached through `mChildren` and still a node of
  * its own.
  */
-internal class ReferenceStrengthReader(private val graph: HeapGraph) {
+internal class ReferenceStrengthReader(
+  private val graph: HeapGraph,
+  private val rules: ExplorerRules
+) {
 
   private val retainingReader: ReferenceReader<HeapObject> =
-    ActualMatchingReferenceReaderFactory(WEAKENING_REFERENCE_MATCHERS).createFor(graph)
+    ActualMatchingReferenceReaderFactory(rules.weakeningReferenceMatchers).createFor(graph)
 
   private val viewChildReader = ViewChildReferenceReader(graph)
 
@@ -153,8 +147,8 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
   /**
    * The references from [source] that don't keep their target alive: a `java.lang.ref.Reference`'s
    * `referent`, the `zombie` a `FinalizerReference` holds an object in while it's being finalized, a
-   * thread's own storage, and the entries of a cache from [CACHE_FIELDS_BY_CLASS_NAME]. Empty for anything
-   * else, which is nearly every object of a heap dump.
+   * thread's own storage, and the entries of a cache — every [WeakeningFieldRule] of [ExplorerRules], that
+   * is. Empty for anything else, which is nearly every object of a heap dump.
    */
   fun weakeningReferencesOf(source: HeapObject): List<WeakeningReference> {
     if (source !is HeapInstance) {
@@ -188,7 +182,7 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
         .toList()
         .asReversed()
         .fold(emptyMap<String, ReachabilityStrength>()) { inherited, heapClass ->
-          WEAKENING_FIELDS_BY_CLASS_NAME[heapClass.name]?.let { inherited + it } ?: inherited
+          rules.strengthByFieldNameByClassName[heapClass.name]?.let { inherited + it } ?: inherited
         }
       if (strengthByFieldName.isEmpty()) NOTHING_WEAKENING else WeakeningFields(strengthByFieldName)
     }
@@ -220,91 +214,8 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
       "java.lang.Double[]"
     )
 
-    /** The fields a `java.lang.ref.Reference` holds its referent in. */
-    private val REFERENT_FIELD_NAMES = setOf("referent", "zombie")
-
-    /**
-     * The `java.lang.ref.Reference` subclasses whose referent isn't retained, most derived first.
-     *
-     * `FinalizerReference` is Android's, `FinalReference` is the JVM's — `java.lang.ref.Finalizer`
-     * extends it, and it's package private so nothing else can.
-     */
-    private val STRENGTH_BY_REFERENCE_CLASS_NAME = mapOf(
-      "java.lang.ref.FinalizerReference" to FINALIZER,
-      "java.lang.ref.FinalReference" to FINALIZER,
-      "java.lang.ref.PhantomReference" to PHANTOM,
-      "java.lang.ref.WeakReference" to WEAK,
-      "java.lang.ref.SoftReference" to SOFT
-    )
-
-    /**
-     * The fields a cache holds its entries in, which the explorer treats as [CACHE] rather than as
-     * retaining, so that an object a cache and something else both hold is attributed to the something
-     * else. See [CACHE] for why this is a list rather than something read off the heap dump.
-     *
-     * Curated, and deliberately short. An entry belongs here once two things are true of the class: it
-     * is a cache that evicts on its own, and its entries are worth blaming their owner for rather than
-     * it. Add one only against a heap dump that has it — the fields are matched by name, so a wrong
-     * guess doesn't fail, it silently does nothing. Which is also what happens to a dump obfuscated
-     * without a mapping applied.
-     *
-     * Cutting as low as the value a cache entry wraps, rather than at the cache itself, is what keeps
-     * the cache's own bookkeeping — the map, the entries, the sizes — where it belongs: strongly held by
-     * the cache, and its bytes attributed to it.
-     */
-    private val CACHE_FIELDS_BY_CLASS_NAME = mapOf(
-      // Coil 3's memory cache: a bounded LRU of decoded images, halved on TRIM_MEMORY_RUNNING_LOW and
-      // cleared on TRIM_MEMORY_BACKGROUND by AndroidSystemCallbacks.
-      "coil3.memory.RealStrongMemoryCache\$InternalValue" to setOf("image")
-    )
-
-    /**
-     * Where a thread keeps what it put in a `ThreadLocal`, held for as long as the thread lives.
-     *
-     * `ThreadLocalMap.Entry` is a `WeakReference` to the `ThreadLocal` itself, so its `referent` is
-     * already weakened above; what's added here is the value, which the map holds strongly. Attributing
-     * it to the thread is what the tree does otherwise, and a thread of an app's pool retaining
-     * everything anything ever left in a thread local of it is a picture of the pool rather than of the
-     * app.
-     */
-    private val THREAD_LOCAL_FIELDS_BY_CLASS_NAME = mapOf(
-      "java.lang.ThreadLocal\$ThreadLocalMap\$Entry" to setOf("value")
-    )
-
-    /** Every class whose fields don't all retain, and what each holds its values with. */
-    private val WEAKENING_FIELDS_BY_CLASS_NAME: Map<String, Map<String, ReachabilityStrength>> =
-      STRENGTH_BY_REFERENCE_CLASS_NAME.mapValues { (_, strength) ->
-        REFERENT_FIELD_NAMES.associateWith { strength }
-      } + CACHE_FIELDS_BY_CLASS_NAME.mapValues { (_, fieldNames) ->
-        fieldNames.associateWith { CACHE }
-      } + THREAD_LOCAL_FIELDS_BY_CLASS_NAME.mapValues { (_, fieldNames) ->
-        fieldNames.associateWith { THREAD_LOCAL }
-      }
-
     /** For the classes that retain everything they point at, cached like the rest. */
     private val NOTHING_WEAKENING = WeakeningFields(emptyMap())
-
-    /**
-     * The matchers that stop the retaining reader from following a reference that doesn't retain: every
-     * field of [WEAKENING_FIELDS_BY_CLASS_NAME] and nothing else, read off the same map that gives them
-     * their strength, so that the two halves of this class can't disagree about a reference.
-     *
-     * **Deliberately not [shark.JdkReferenceMatchers.REFERENCES]**, which is a leak trace's list rather
-     * than an explorer's. Besides the referents, it drops the `prev`, `next` and `element` links of the
-     * lists a runtime keeps its `FinalizerReference`s, `Finalizer`s and `Cleaner`s on, so that a leak trace
-     * can't run through the queue of objects waiting to be finalized. Those links retain what they point
-     * at, and on Android they are the only thing that does: the list hangs off one static field, so
-     * dropping them left every entry but the head of it reading as uncollected garbage, and with them
-     * every object waiting to be finalized or cleaned. Measured on `large-dump.hprof`: 4773 of its 4774
-     * `FinalizerReference`s and 3392 of its 3553 `Cleaner`s, a fifth of everything the explorer called
-     * garbage.
-     */
-    val WEAKENING_REFERENCE_MATCHERS: List<ReferenceMatcher> =
-      WEAKENING_FIELDS_BY_CLASS_NAME.flatMap { (className, strengthByFieldName) ->
-        strengthByFieldName.keys.map {
-          instanceField(className, it).ignored(patternApplies = ALWAYS)
-        }
-      }
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
@@ -85,13 +85,29 @@ class OwnerReferencesTest {
       val tree = explorer.tree
       val activity = tree.findByLabel("MainActivity")
 
-      // Something else holding a live activity is holding what the framework is running, so the record in
-      // ActivityThread.mActivities is where its bytes belong. Once the framework destroys it that record
-      // is gone, and then the thing still pointing at it is both its owner and its leak.
-      assertThat(tree.dominatorOf(activity.objectId)!!.label)
-        .isEqualTo("ActivityThread\$ActivityClientRecord")
+      // Something else holding a live activity is holding what the framework is running, so the thread
+      // running it is where its bytes belong. Once the framework destroys it the record is out of
+      // mActivities, and then the thing still pointing at it is both its owner and its leak.
+      //
+      // The ActivityThread, not the ActivityClientRecord the map keeps it in: the thread points at each
+      // activity itself — see [ActivityThreadReferenceReader] — so the map, its array and the record are no
+      // step on the way down to an activity, and the one step there is names the field on the thread.
+      assertThat(tree.dominatorOf(activity.objectId)!!.label).isEqualTo("ActivityThread")
       assertThat(tree.independentPathsBelowDominator(activity.objectId).paths.map { it.stepLabels() })
-        .containsExactly(listOf("activity → MainActivity"))
+        .containsExactly(listOf("mActivities → MainActivity"))
+    }
+  }
+
+  @Test fun `an activity in a slot the map doesn't count is not one the process is running`() {
+    HeapExplorer.open(viewHierarchyHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val stale = tree.findByLabel("StaleActivity")
+
+      // What the thread runs is what mSize covers, not what its map has room for. An ArrayMap leaves the
+      // slots it gives up for the next put rather than nulling them, so past the count is where the record
+      // of a destroyed activity is still written down — and calling it a running activity attributes a
+      // leaked screen to the framework, which is the opposite of what you'd want to read.
+      assertThat(tree.dominatorOf(stale.objectId)!!.label).isEqualTo("ActivityThread\$ActivityClientRecord")
     }
   }
 
@@ -105,7 +121,8 @@ class OwnerReferencesTest {
     }
   }
   /**
-   * A heap dump shaped like the view hierarchies of a running app: an activity holding its decor view, the
+   * A heap dump shaped like the view hierarchies of a running app: an `ActivityThread` running an activity
+   * through the `ArrayMap` of client records it keeps them in, the activity holding its decor view, the
    * decor view holding a child through the array a `ViewGroup` keeps its children in — plus a view in a
    * slot of that array it doesn't count — and two things pointing at views they don't hold, a
    * `ViewRootImpl` and an `InputMethodManager`, each a GC root of its own so that both are closer to a
@@ -148,15 +165,16 @@ class OwnerReferencesTest {
       )
       // The owner field is declared by android.app.Activity and the instance is a subclass of it, which is
       // how a real dump looks and what makes this cover the class hierarchy walk.
+      val activityClassId = clazz(
+        className = "android.app.Activity",
+        fields = listOf(
+          "mDecor" to ReferenceHolder::class,
+          "mDestroyed" to BooleanHolder::class
+        )
+      )
       val mainActivityClassId = clazz(
         className = "com.example.MainActivity",
-        superclassId = clazz(
-          className = "android.app.Activity",
-          fields = listOf(
-            "mDecor" to ReferenceHolder::class,
-            "mDestroyed" to BooleanHolder::class
-          )
-        )
+        superclassId = activityClassId
       )
       // Views point back at their parent, at their hierarchy's root and at their activity, so their ids
       // have to exist before the objects they point at are written.
@@ -210,9 +228,44 @@ class OwnerReferencesTest {
         objectId = detachedRootId
       )
       instance(mainActivityClassId, listOf(decor, BooleanHolder(false)), objectId = activityId)
-      // What the framework runs the activity from, and something outside it that also points at it.
-      val activityRecord = "android.app.ActivityThread\$ActivityClientRecord" instance {
-        field["activity"] = activityId
+      // What the framework runs the activity from: an ArrayMap of binder token to client record, keys at the
+      // even slots and records at the odd ones. Written out the way a real dump has it, because the
+      // reference the ownership rule waits on is the one the explorer reads through all of it.
+      //
+      // One class declaration for both records rather than the `"a.b.C" instance { }` shorthand, which
+      // declares a class per instance and would put two ActivityClientRecord classes in a dump that has one.
+      val activityRecordClassId = clazz(
+        className = "android.app.ActivityThread\$ActivityClientRecord",
+        fields = listOf("activity" to ReferenceHolder::class)
+      )
+      val binderTokenClassId = clazz(className = "android.os.BinderProxy")
+      val activityRecord = instance(activityRecordClassId, listOf(ReferenceHolder(activityId.value)))
+      // A record in a slot past mSize, holding the activity the framework has already destroyed — which is
+      // what an ArrayMap leaves behind, since it keeps the slots it gives up for the next put.
+      val staleRecord = instance(
+        activityRecordClassId,
+        listOf(
+          instance(
+            clazz(className = "com.example.StaleActivity", superclassId = activityClassId),
+            listOf(NO_REFERENCE, BooleanHolder(true))
+          )
+        )
+      )
+      val activityThread = "android.app.ActivityThread" instance {
+        field["mActivities"] = "android.util.ArrayMap" instance {
+          field["mArray"] = ReferenceHolder(
+            objectArray(
+              arrayClass("java.lang.Object"),
+              longArrayOf(
+                instance(binderTokenClassId).value,
+                activityRecord.value,
+                instance(binderTokenClassId).value,
+                staleRecord.value
+              )
+            )
+          )
+          field["mSize"] = IntHolder(1)
+        }
       }
       val leaker = "com.example.Leaker" instance { field["activity"] = activityId }
       val fallbackHandler = "com.android.internal.policy.PhoneFallbackEventHandler" instance {
@@ -222,7 +275,7 @@ class OwnerReferencesTest {
         field["mServedView"] = leaf
         field["mNextServedView"] = detachedRootId
       }
-      gcRoot(JniGlobal(id = activityRecord.value, jniGlobalRefId = 0))
+      gcRoot(JniGlobal(id = activityThread.value, jniGlobalRefId = 0))
       gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 1))
       gcRoot(JniGlobal(id = fallbackHandler.value, jniGlobalRefId = 2))
       gcRoot(JniGlobal(id = inputMethodManager.value, jniGlobalRefId = 3))


### PR DESCRIPTION
The explorer applies a handful of curated rules on top of the exact dominator tree, so that a treemap says something true about an app: a view is held by its parent, an activity by the framework, a cached image by whatever is showing it. They had grown into four different places.

Rebased onto #2930, which landed the other half of this while it was open — see the last section.

### One rule set

`ExplorerRules` now holds every curated list — the fields that weaken and how, and the `OwnerRule`s — read by both halves of the edge set through `ReferenceStrengthReader` and `OwnerReferences`. One wiring point in `HeapExplorer.open`, and one file to read when asking whether a rule about a class we don't own is still true.

Why the explorer keeps its own copy of the `java.lang.ref` field names rather than importing shark's is worth writing down, because it isn't a preference: **shark's matchers are a boolean.** An `IgnoredReferenceMatcher` carries no payload, `FieldInstanceReferenceReader` drops what it matches with `!is IgnoredReferenceMatcher`, and `LazyDetails` carries only a matched library leak, so shark can't be asked *why* a reference was dropped and there is nowhere for "and it's weak" to live. Two ways out: add a strength-carrying matcher to shark — `ReferenceMatcher` is `sealed`, so an ABI change plus a reader that emits what it currently drops, on LeakCanary's hot path — or derive the ignore list from the strengths, which is what #2930 did.

One redundancy fell out: `zombie` on the four reference classes that don't declare it, which only Android's `FinalizerReference` has. That takes the matcher list from 12 to 8.

**A/B on two real dumps, 12 matchers against 8:** every per-strength byte and object count identical, totals identical, and the same number of children under the root weighing the same, on `leak_asynctask_o.hprof` and on the 39 MB `large-dump.hprof`.

### The ActivityThread owns the activities it runs

The activity rule named `ActivityThread$ActivityClientRecord.activity`, which is the construct named one level too low: a record is an implementation detail of how the framework runs an activity, so a tree built on it draws every screen of an app under a different unnamed record instead of side by side under the one thread that runs them all.

`ActivityThreadReferenceReader` now gives the `ActivityThread` one virtual `mActivities` reference per running activity, read out of the `ArrayMap` it keeps them in, and the owner rule claims ownership through that. Same shape as a `ViewGroup` pointing at its children, and additive in the same way — the map, its array and each record are still nodes holding their own bytes, and it is the dominator tree that takes them out of the middle rather than any pruning.

Measured on `leak_asynctask_o.hprof`:

| | before | after |
| --- | --- | --- |
| live `MainActivity` retains | 51,634 B | 51,634 B |
| its dominator | `ActivityThread$ActivityClientRecord` | `ActivityThread` |
| the chain down to it | `mActivities → ArrayMap, mArray → Object[], 1 → ActivityClientRecord, activity → MainActivity` | `mActivities → MainActivity` |
| leaked `MainActivity` | 211,038 B under `MainActivity$2` | unchanged |

The leaked one being unchanged is the fallback doing its job: `handleDestroyActivity` takes the record out of `mActivities`, so a destroyed activity has no owner left and lands under whatever is leaking it.

The `ArrayMap` is read the way it reads itself — keys at the even slots, values at the odd ones, over the first `mSize` pairs. The bound matters more here than for a `ViewGroup`'s children: an `ArrayMap` leaves the slots it gives up for the next put rather than nulling them, so past the count is exactly where the record of a destroyed activity is still written down, and attributing that activity to the framework would hide the leak. Pinned by `an activity in a slot the map doesn't count is not one the process is running`.

### What #2930 changed about this PR

It answered the same question from the other end, and it found a bug doing it. This PR originally also gathered the `prev`/`element`/`next` links of `Finalizer`, `FinalizerReference` and `Cleaner` into the rule set as "fields followed for nothing", inherited from `JdkReferenceMatchers.REFERENCES`, with a note saying that following them at `FINALIZER` instead was a change worth measuring and nobody had measured it. #2930 measured it: those links are the only thing holding the finalizer and cleaner lists on Android, so ignoring them was calling 4773 of `large-dump.hprof`'s 4774 `FinalizerReference`s garbage.

So that category is gone from `ExplorerRules` rather than gathered into it — a rule set is the wrong place for something that shouldn't exist — and `weakeningReferenceMatchers` derives from the weakening fields alone, which is what #2930 made it do. The A/B above was re-run against the post-#2930 baseline rather than carried over.

### Notes

`notes/dominator-tree.md` gets the measurements above, a section on the rule set and on why shark's matchers can't carry a strength, and a subsection on the new reader beside the `ViewGroup` one. `GcRoot.reachabilityStrength()` is deliberately left as code and out of the rule set: it maps a `sealed` hierarchy, so making it data means mirroring that hierarchy in an enum of our own, which is more of exactly the duplication this PR is about.

`ExplorerRules` is `internal`, and `HeapExplorer.open` gained no `rules` parameter, because nothing would pass one yet. Surfacing the rules in the UI and letting them be edited is the follow-up this makes possible, and that is when the type earns being public.

Tested: `:shark:shark-explorer:shark-explorer-core:check`, `…-app:check`, `…-jdwp:check`, detekt included. #2930's `JvmReferenceStrengthTest` and its two `HeapReachabilityTest` list cases pass on the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
