### PR TITLE
Draw the dominator tree as a stack of rows

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -193,6 +193,17 @@ tiles.
 - **Relaunching a title while a window of that title is open** is the one thing to avoid: the bundle is
   rewritten in place, and that window is reading it.
 
+**And a Gradle build of any kind kills every explorer window already open.** `run` and `runNamed` both
+put the module jars on the classpath rather than a copy of them, and a JVM reads a jar's index once and
+then trusts it, so recompiling under a live window makes every class that window hasn't happened to load
+yet disappear. What that looks like is the window dying on the next pointer move with
+`NoClassDefFoundError: shark/explorer/TreemapPoint`, a `ClassNotFoundException` under it, and a stack
+trace through code nobody has touched — the class is in the source and in the jar, which is exactly what
+makes it read like a real bug in whatever was being worked on. Measured: a window launched at 16:42, a
+`shark-explorer-core:check` rewriting that jar at 16:46, and the first hover after it gone. So **launch
+the window you are handing over last**, after everything that builds — and when one dies this way, check
+the jar's mtime against the process start before believing the stack trace.
+
 [dock-bug]: https://bugs.openjdk.org/browse/JDK-8173753
 
 ## Reading these names without being able to see the screen

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -1,7 +1,8 @@
 # Shark Explorer — agent guide
 
-A desktop app that renders a heap dump's dominator tree as a navigable treemap, or as rings around a
-centre. The long term goal is a YourKit-style heap explorer; these are the first surfaces.
+A desktop app that renders a heap dump's dominator tree as a navigable treemap, as rings around a
+centre, or as a stack of rows the way a profiler draws a call tree. The long term goal is a YourKit-style
+heap explorer; these are the first surfaces.
 
 This file is scoped to `shark/shark-explorer/`. It only records things an agent would get wrong by
 reading the source alone — everything else is in the code. Keep it that way.
@@ -304,6 +305,13 @@ numbers belong in `notes/bitmaps.md`.
 - **Hovering takes two moves.** A view describes what the pointer *moved* onto and ignores the enter that
   comes with a pointer arriving, so a single injected `moveTo` reports nothing hovered. `hover()` in
   `ExplorerUiTest.kt` moves twice; `notes/decisions.md` says why the views read events that way.
+- **An injected scroll only lands after a `waitForIdle()`.** `performMouseInput { scroll(n) }` on the
+  stack does scroll it, but the offset is still 0 in the same breath, because the scroll is animated and
+  the frame hasn't run — so reading it, or the callback it fires, right after the injection says nothing
+  happened. Which reads exactly like a wheel a headless test can't deliver, and cost an afternoon of
+  looking for one. **How far one notch scrolls is the platform's**, ten pixels with no AWT wheel event
+  behind the pointer event to say otherwise, so a test scrolls by notches and reads the pixels back off
+  `SemanticsProperties.VerticalScrollAxisRange` rather than asserting a number of its own.
 - **Each shape draws into a single `Canvas`, so there are no per-cell semantics nodes.** UI
   tests can't find cells by tag, and **not by label either** — a cell's label is painted text, so no
   assertion and no wait can reach it. Test layout and hit testing as pure functions in

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -1,26 +1,63 @@
 # Rendering the dominator tree
 
 Implemented in `shark-explorer-core`: `Squarify.kt` (row layout), `TreemapLayout.kt` (adaptive depth
-and hit testing), `RadialLayout.kt` (the same, as rings), `TreemapRect.kt`, `LayoutCell.kt` (what the
-two layouts have in common), `HeapDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and
-`present()` / `presentRadial()`, which turn a layout into the labelled, coloured presentation the UI
-draws). Drawn by `TreemapView` and `RadialView` in `shark-explorer-app`.
+and hit testing), `RadialLayout.kt` (the same, as rings), `StackLayout.kt` (the same, as a row per
+level), `TreemapRect.kt`, `LayoutCell.kt` (what the three layouts have in common),
+`HeapDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and `present()` / `presentRadial()` /
+`presentStack()`, which turn a layout into the labelled, coloured presentation the UI draws). Drawn by
+`TreemapView`, `RadialView` and `StackView` in `shark-explorer-app`.
 
-## Two shapes, one cut of the tree
+## Three shapes, one cut of the tree
 
 A cell is a `LayoutCell`: a `CellSubject` — one node, or the children a node didn't draw — plus a
 depth, a weight and whatever geometry its layout adds. `TreemapCell` adds a rectangle, `RadialCell` an
-annular sector. Everything downstream of the geometry works off `CellSubject` alone: labels, colours,
-where a click goes. That split is what keeps the second shape from being a second copy of all of it, and
-it's why adding a third would mean one new layout plus one new `Canvas`, nothing else.
+annular sector, `StackCell` a rectangle again, on a row. Everything downstream of the geometry works off
+`CellSubject` alone: labels, colours, where a click goes. That split is what keeps a second shape from
+being a second copy of all of it, and the third shape is what confirmed the price: `StackLayout` plus
+`StackView`, one new `Canvas`, and three lines elsewhere — a `ViewShape`, a `ViewPresentation` and a
+`presentStack()`. Nothing about colouring, labelling, selection, hit resolution or navigation moved.
 
-The two layouts make the same decisions — largest cell subdivided first, children too small to see
+The three layouts make the same decisions — largest cell subdivided first, children too small to see
 grouped, a cell budget, truncation counted — differing only in what "too small" measures. A treemap
 compares areas; the radial view compares arc lengths along the middle of a ring, because a sector of
-the same sweep is bigger the further out it sits. A ring holds far less than a rectangle does: 50
-equally sized children under one node is already past what a ring can show one by one, where a treemap
-draws a couple of hundred. So the radial view groups sooner and is the better read of the *shape* of
-the tree, while the treemap is the better read of sizes.
+the same sweep is bigger the further out it sits; the stack compares widths, since a row's height is
+fixed. A ring holds far less than a rectangle does: 50 equally sized children under one node is already
+past what a ring can show one by one, where a treemap draws a couple of hundred. So the radial view
+groups sooner and is the better read of the *shape* of the tree, while the treemap is the better read of
+sizes.
+
+## The stack: depth is a row, not an area
+
+Profilers draw a call tree as an icicle chart — a row per level, roots at the top, a block's width its
+share of the whole — and a dominator tree reads the same way, with "who retains this" in place of "who
+called this". `StackLayout` is that chart.
+
+What it buys over the other two is that **a level costs no width**. A treemap and a ring both pay area
+for nesting, so the deep end of a chain is a sliver; a stack gives every level a full row, so the last
+object in a 22-level chain is drawn as wide as its share of the heap deserves and — this is the part
+that matters — **named**, at every depth, along with its size. The treemap can only name one level
+(see below) because a subdivided rectangle is covered by its children. A row is covered by the row
+below it, not by its own contents, so there is nothing in the way of a label.
+
+Three consequences of that, each of them a decision:
+
+- **Children are sized against the parent's own weight, and the remainder is a `CellSubject.Own`
+  block** at the right end of the row — the same reason the treemap has one, for the same effect: a
+  block is its share of the whole heap at every depth rather than of its siblings. It also means no
+  pixel of a row belongs to nothing, so hit testing has no gaps to explain.
+- **The stack has to bound its rows** (`maxRows`, 64). The cell budget doesn't bound it: a chain of
+  single dominators never narrows, so every level of it clears the subdivide floor and 5,000 cells is a
+  5,000-row canvas. The other two shapes are bounded by their own geometry — a ring's arc, a
+  rectangle's area — and needed no such number.
+- **It is the one shape taller than the window, so it scrolls.** Which puts the pointer and the blocks
+  a scroll offset apart: `StackView` keeps the pointer where the pointer is, in the view's coordinates,
+  and adds the scroll only when asking the layout what is under it. The hover has to be worked out again
+  when the offset changes, too, since scrolling under a still pointer moves a different block under it
+  without any pointer event to say so.
+
+It skips one thing the treemap does: **a row doesn't draw its bitmap**. A row is a line of text tall,
+and a bitmap fitted into 18 dp is a smear — the picture is the treemap's contribution, and asking for it
+here would cost a heap dump read and a decode per row for nothing.
 
 ## Depth is area-driven, not a fixed level
 
@@ -103,6 +140,10 @@ Two things make that one level legible:
 
 Which also means a bitmap at that depth is named over its own picture, and one below it isn't named at all.
 
+All of which is the treemap's problem and the radial view's, and **not the stack's**: a row is covered by
+the row below it rather than by its own contents, so every row wide enough is named and given its size,
+whatever depth it is at. See "The stack" above.
+
 ### The children that don't fit become one rectangle, they aren't dropped
 
 All-or-nothing subdivision — a node is either fully laid out or shown as a bare rectangle — was the
@@ -133,6 +174,11 @@ A radial layout has one more bound: **rings**. Eight around the centre disk, the
 from the viewport, so the picture always fills the circle and depth past that needs a zoom. Sectors
 take their parent's whole sweep divided by weight, and a ring band is where a node's own name fits, so
 the radial view has not needed the treemap's own-weight cell.
+
+The stack's own bound is **rows**, `maxRows`, and its floors are lower than the treemap's — 6 dp to
+subdivide, 2 dp to draw, against 12 dp and 3 dp. A level of a stack costs no width, so subdividing a
+narrow block still buys a full row of detail, where in a picture that pays area for nesting it buys a
+sliver of a sliver.
 
 ### A negative node id is not the tree's own
 
@@ -255,7 +301,8 @@ colour and it would still cost a heap dump read and a decode — and `bitmapImag
 
 Cells are drawn into a single `Canvas`, so Compose has no per-cell node to hit test or to expose to
 tests. Hit testing is therefore explicit: keep the laid out cells and resolve a click against their
-geometry — deepest rectangle containing the point for a treemap, ring and angle for the radial view.
+geometry — deepest rectangle containing the point for a treemap, ring and angle for the radial view,
+row and the block along it for the stack.
 
 **Except that the deepest rectangle is not always the answer.** A subdivided rectangle is covered by its
 own children, so `cellAt` takes an `edgeGrab`: within that distance of an edge, a container wins over

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -3,9 +3,18 @@
 Implemented in `shark-explorer-core`: `Squarify.kt` (row layout), `TreemapLayout.kt` (adaptive depth
 and hit testing), `RadialLayout.kt` (the same, as rings), `StackLayout.kt` (the same, as a row per
 level), `TreemapRect.kt`, `LayoutCell.kt` (what the three layouts have in common),
-`HeapDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and `present()` / `presentRadial()` /
-`presentStack()`, which turn a layout into the labelled, coloured presentation the UI draws). Drawn by
-`TreemapView`, `RadialView` and `StackView` in `shark-explorer-app`.
+`HeapDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and `present()`, which labels and
+colours the cells a layout produced), `TreemapPresentation.kt` (a presentation per shape, each with an
+`of()` pairing a layout with that). Drawn by `TreemapView`, `RadialView` and `StackView` in
+`shark-explorer-app`.
+
+**`of()` is a presentation's own, not a method per shape on `HeapDominatorTreemap`.** It used to be the
+other way round, and adding a third shape is what moved it: that class is a 1,200 line heap dump reader
+which detekt allows 50 functions, and `presentStack` was the fiftieth. Rather than split it somewhere
+arbitrary, the per-shape method came out of it — which is also the better line, since which shapes exist
+is no business of a heap dump reader. `present(cells)` is all that stayed behind: it reads a name and a
+strength off a `CellSubject`, and every shape's cells are those. **So a fourth shape needs nothing in
+`HeapDominatorTreemap` at all.**
 
 ## Three shapes, one cut of the tree
 
@@ -14,8 +23,9 @@ depth, a weight and whatever geometry its layout adds. `TreemapCell` adds a rect
 annular sector, `StackCell` a rectangle again, on a row. Everything downstream of the geometry works off
 `CellSubject` alone: labels, colours, where a click goes. That split is what keeps a second shape from
 being a second copy of all of it, and the third shape is what confirmed the price: `StackLayout` plus
-`StackView`, one new `Canvas`, and three lines elsewhere — a `ViewShape`, a `ViewPresentation` and a
-`presentStack()`. Nothing about colouring, labelling, selection, hit resolution or navigation moved.
+`StackView`, one new `Canvas`, and three small things beside them — a `ViewShape`, a `ViewPresentation`
+and a `StackPresentation` with its `of()`. Nothing about colouring, labelling, selection, hit resolution
+or navigation moved.
 
 The three layouts make the same decisions — largest cell subdivided first, children too small to see
 grouped, a cell budget, truncation counted — differing only in what "too small" measures. A treemap

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
@@ -44,7 +44,15 @@ internal enum class ViewShape(val displayName: String) {
    * its share of what the ring inside it retains. Nesting reads as distance from the middle, which
    * says more about the shape of the tree than a treemap does and less about exact sizes.
    */
-  RADIAL("Radial")
+  RADIAL("Radial"),
+
+  /**
+   * A row per level, roots at the top, the way a profiler draws a call tree upside down: a block's
+   * width is its share of the heap and its depth is how far down the screen it is. The one shape that
+   * doesn't spend area on nesting, so the deep end of a chain is drawn and named at full size — and
+   * therefore the one shape taller than the window, which is why it scrolls.
+   */
+  STACK("Stack")
 }
 
 /**
@@ -167,9 +175,28 @@ internal val EDGE_GRAB = 4.dp
 internal val MIN_SUBDIVIDE_ARC_LENGTH = 40.dp
 internal val MIN_DRAW_ARC_LENGTH = 3.dp
 
+/**
+ * How tall one row of the stack is: a line of [LABEL_STYLE] with [LABEL_PADDING] above and below it,
+ * since a row holds a name and nothing else.
+ */
+internal val STACK_ROW_HEIGHT = 18.dp
+
+/**
+ * And how wide a block has to be for the row under it to say anything, and to be drawn at all.
+ *
+ * Both smaller than the treemap's floors, because a level of a stack costs no width: a block half as
+ * wide as another still gets a full row for its children, so subdividing further is worth it for longer
+ * than it is in a picture where nesting eats area.
+ */
+internal val MIN_SUBDIVIDE_STACK_WIDTH = 6.dp
+internal val MIN_DRAW_STACK_WIDTH = 2.dp
+
 internal val LABEL_PADDING = 3.dp
 internal val MIN_LABEL_WIDTH = 24.dp
 internal val MIN_LABEL_HEIGHT = 13.dp
+
+/** How far apart two pieces of text on one cell have to be to read as two. See [StackView]. */
+internal val LABEL_GAP = 8.dp
 internal const val BORDER_WIDTH = 1f
 internal const val SELECTION_WIDTH = 3f
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -55,6 +55,8 @@ import shark.explorer.RadialLayout
 import shark.explorer.RadialPresentation
 import shark.explorer.RootPath
 import shark.explorer.RootPathWay
+import shark.explorer.StackLayout
+import shark.explorer.StackPresentation
 import shark.explorer.TreemapLayout
 import shark.explorer.TreemapNavigation
 import shark.explorer.TreemapPresentation
@@ -66,8 +68,8 @@ import shark.explorer.nodeIdText
 import shark.explorer.waysOf
 
 /**
- * One open heap dump, read through one of its screens: the dominator tree as a treemap or as rings, every
- * object as a list, the ones starred so far.
+ * One open heap dump, read through one of its screens: the dominator tree as a treemap, as rings or as a
+ * stack of rows, every object as a list, the ones starred so far.
  *
  * The map is the screen with panes: the chain holding an object on one side of it and what that object holds
  * on the other, with which object it is in the bar above them both. Every other screen is the width of the
@@ -161,6 +163,7 @@ internal fun HeapDumpExplorer(
 
   val treemapLayout = rememberTreemapLayout()
   val radialLayout = rememberRadialLayout()
+  val stackLayout = rememberStackLayout()
   // In pixels, like everything a layout is measured in, so that how small is too small for an image to be
   // worth drawing is the same size on every display. See MIN_BITMAP_DRAW_SIZE.
   val minBitmapDrawSize = with(LocalDensity.current) { MIN_BITMAP_DRAW_SIZE.toPx() }
@@ -174,7 +177,8 @@ internal fun HeapDumpExplorer(
       viewportSize = size,
       shape = shape,
       treemapLayout = treemapLayout,
-      radialLayout = radialLayout
+      radialLayout = radialLayout,
+      stackLayout = stackLayout
     )
   }
 
@@ -208,6 +212,9 @@ internal fun HeapDumpExplorer(
           )
           ViewShape.RADIAL -> ViewPresentation.Radial(
             tree.presentRadial(viewRequest.radialLayout, viewRequest.viewport, reachablePath.current)
+          )
+          ViewShape.STACK -> ViewPresentation.Stack(
+            tree.presentStack(viewRequest.stackLayout, viewRequest.viewport, reachablePath.current)
           )
         }
       )
@@ -644,7 +651,7 @@ private fun ScreenBar(
   }
 }
 
-/** The dominator tree, drawn as rectangles or as rings, with a card naming what the pointer is on. */
+/** The dominator tree, drawn as one of the [ViewShape]s, with a card naming what the pointer is on. */
 @Composable
 private fun TreeScreen(
   view: ViewState,
@@ -684,6 +691,15 @@ private fun TreeScreen(
         modifier = Modifier.fillMaxSize()
       )
       is ViewPresentation.Radial -> RadialView(
+        presentation = presentation.presentation,
+        coloring = coloring,
+        selected = selected,
+        hovered = hovered,
+        onHover = onHover,
+        onClick = onClick,
+        modifier = Modifier.fillMaxSize()
+      )
+      is ViewPresentation.Stack -> StackView(
         presentation = presentation.presentation,
         coloring = coloring,
         selected = selected,
@@ -763,6 +779,21 @@ private fun rememberRadialLayout(): RadialLayout<Long> {
   }
 }
 
+/** And the stack layout, whose row height is a line of text and so is scaled like the rest of them. */
+@Composable
+private fun rememberStackLayout(): StackLayout<Long> {
+  val density = LocalDensity.current
+  return remember(density) {
+    with(density) {
+      StackLayout(
+        rowHeight = STACK_ROW_HEIGHT.toPx().toDouble(),
+        minSubdivideWidth = MIN_SUBDIVIDE_STACK_WIDTH.toPx().toDouble(),
+        minDrawWidth = MIN_DRAW_STACK_WIDTH.toPx().toDouble()
+      )
+    }
+  }
+}
+
 /**
  * Everything one view of the tree follows from, which is therefore everything that lays it out again:
  * where the map is, how big the view is, which shape it's drawn as, and the thresholds that shape is laid
@@ -780,7 +811,8 @@ private data class ViewRequest(
   val viewportSize: IntSize,
   val shape: ViewShape,
   val treemapLayout: TreemapLayout<Long>,
-  val radialLayout: RadialLayout<Long>
+  val radialLayout: RadialLayout<Long>,
+  val stackLayout: StackLayout<Long>
 ) {
   val viewport: TreemapRect
     get() = TreemapRect(
@@ -817,6 +849,8 @@ internal sealed interface ViewPresentation {
   data class Treemap(val presentation: TreemapPresentation) : ViewPresentation
 
   data class Radial(val presentation: RadialPresentation) : ViewPresentation
+
+  data class Stack(val presentation: StackPresentation) : ViewPresentation
 }
 
 /** What a laid out view amounts to, for the log: one that drew nothing at all says so here. */
@@ -825,6 +859,10 @@ private fun ViewPresentation.description(): String = when (this) {
     "${presentation.cells.size} rectangles, ${presentation.truncatedNodeCount} nodes not expanded"
   is ViewPresentation.Radial ->
     "${presentation.cells.size} sectors, ${presentation.truncatedNodeCount} nodes not expanded"
+  // How deep it came out as well, since that is what a stack has instead of a shape that fits the view.
+  is ViewPresentation.Stack ->
+    "${presentation.cells.size} blocks in ${presentation.layout.rowCount} rows, " +
+      "${presentation.truncatedNodeCount} nodes not expanded"
 }
 
 /**
@@ -990,6 +1028,11 @@ internal const val FORWARD_ARROW = "→"
 /** What the button that goes back to the live process offers, before it says how many bitmaps. */
 internal const val FETCH_BITMAPS = "Fetch the pixels of"
 
-/** What the tree looks like to anything that can't look at it, a screen reader or a test. */
+/**
+ * What the tree looks like to anything that can't look at it, a screen reader or a test.
+ *
+ * The same for every [ViewShape], because it says what is drawn rather than how: only one of the three
+ * draws a cell inside the one that holds it.
+ */
 internal const val VIEW_DESCRIPTION =
-  "The dominator tree of the heap dump: every cell is an object, drawn inside the one that holds it."
+  "The dominator tree of the heap dump: every cell is an object, as big as what it retains."

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -208,13 +208,28 @@ internal fun HeapDumpExplorer(
         navigation = reachablePath,
         presentation = when (viewRequest.shape) {
           ViewShape.TREEMAP -> ViewPresentation.Treemap(
-            tree.present(viewRequest.treemapLayout, viewRequest.viewport, reachablePath.current)
+            TreemapPresentation.of(
+              tree,
+              viewRequest.treemapLayout,
+              viewRequest.viewport,
+              reachablePath.current
+            )
           )
           ViewShape.RADIAL -> ViewPresentation.Radial(
-            tree.presentRadial(viewRequest.radialLayout, viewRequest.viewport, reachablePath.current)
+            RadialPresentation.of(
+              tree,
+              viewRequest.radialLayout,
+              viewRequest.viewport,
+              reachablePath.current
+            )
           )
           ViewShape.STACK -> ViewPresentation.Stack(
-            tree.presentStack(viewRequest.stackLayout, viewRequest.viewport, reachablePath.current)
+            StackPresentation.of(
+              tree,
+              viewRequest.stackLayout,
+              viewRequest.viewport,
+              reachablePath.current
+            )
           )
         }
       )

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StackView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StackView.kt
@@ -1,0 +1,305 @@
+package shark.explorer.app
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import shark.explorer.CellContent
+import shark.explorer.CellSubject
+import shark.explorer.LayoutCell
+import shark.explorer.PresentedCell
+import shark.explorer.StackCell
+import shark.explorer.StackPresentation
+import shark.explorer.TreemapPoint
+import shark.explorer.formatByteSize
+
+/**
+ * Draws an already laid out [StackPresentation]: the node it's rooted at as the row across the top and
+ * every level below it as the row under the one before, the way a profiler draws a call tree upside
+ * down.
+ *
+ * The same gestures as [TreemapView] — a press reports the block under the pointer, moving over one
+ * reports it as hovered — and the same single [Canvas], so the same holds for tests. What it adds is a
+ * scroll: a stack is as deep as the tree it drew, so unlike the other two shapes it does not fit the
+ * window, and the pointer's coordinates and the block under them are a scroll offset apart.
+ *
+ * Every block that has the width for it carries its own name and size, which the treemap can't do — a
+ * rectangle there is covered by its children, and naming every level of it was unreadable. Here a level
+ * is a row of its own, so there is nothing to cover and nothing to leave out.
+ */
+@Composable
+internal fun StackView(
+  presentation: StackPresentation,
+  coloring: CellColoring,
+  selected: SelectedCell?,
+  /** The block the pointer is on, which is outlined more lightly than the selected one. */
+  hovered: SelectedCell?,
+  /** The block the pointer moved onto and where it is, or null when it moved onto none or left. */
+  onHover: (PointedAt?) -> Unit,
+  /** The block pressed, which is where the window goes. */
+  onClick: (LayoutCell<Long>) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val textMeasurer = rememberTextMeasurer()
+  val density = LocalDensity.current
+  val dots = remember(density) { pileDots(density) }
+  // As in [TreemapView]: measuring the names is the one part of drawing that isn't cheap, so it happens
+  // when the presentation changes and never on a redraw. There are more of them here than on a treemap,
+  // since every row is named rather than one level of them.
+  val blocks = remember(presentation, coloring, textMeasurer, density, dots) {
+    val colors = CellColors.of(coloring, presentation.cells)
+    presentation.cells.map { it.measure(colors, textMeasurer, density, dots) }
+  }
+  val scrollState = rememberScrollState()
+  // A move re-roots the stack, and the new one starts at its own top: the row someone had scrolled down
+  // to belonged to the tree they have just left. Resizing keeps the scroll, since the tree is the same.
+  LaunchedEffect(presentation.rootNode) {
+    scrollState.scrollTo(0)
+  }
+  // Where the pointer is *in the view*, which is what the card following it is placed by, and null when
+  // it is outside. The blocks are a scroll away from that, hence [pointedAt].
+  var pointerOffset: Offset? by remember { mutableStateOf(null) }
+  // Scrolling moves the blocks under a pointer that hasn't moved, and so does being laid out again, and
+  // neither sends a pointer event: without this the panes would keep describing the row that was there.
+  LaunchedEffect(presentation, blocks, scrollState.value) {
+    onHover(pointerOffset?.let { presentation.pointedAt(it, scrollState.value) })
+  }
+  Box(modifier) {
+    Box(Modifier.fillMaxSize().verticalScroll(scrollState)) {
+      Canvas(
+        Modifier.fillMaxWidth()
+          // As tall as the stack came out, which is what there is to scroll through. The layout works in
+          // pixels, like the presentation it laid out.
+          .height(with(density) { presentation.layout.contentHeight.toFloat().toDp() })
+          // Before the tap handler, as in [TreemapView], so that the block under the pointer is read
+          // wherever it is rather than only where a gesture hasn't already claimed the events.
+          .pointerInput(presentation, blocks) {
+            awaitPointerEventScope {
+              while (true) {
+                val event = awaitPointerEvent()
+                when (event.type) {
+                  // A move, and not the enter that comes with it, as in [TreemapView].
+                  PointerEventType.Move -> {
+                    // The scroll is read here rather than keyed on, so that scrolling doesn't restart
+                    // the gesture loop, and it is read live so that a wheel between two moves counts.
+                    val offset = event.changes.first().position.inTheView(scrollState.value)
+                    pointerOffset = offset
+                    onHover(presentation.pointedAt(offset, scrollState.value))
+                  }
+                  PointerEventType.Exit -> {
+                    pointerOffset = null
+                    onHover(null)
+                  }
+                }
+              }
+            }
+          }
+          .pointerInput(presentation, blocks) {
+            detectTapGestures(
+              onPress = { offset ->
+                presentation.cellAt(offset.inTheView(scrollState.value), scrollState.value)
+                  ?.let(onClick)
+              }
+            )
+          }
+      ) {
+        // Fills first and outlines after, all of them, as in [TreemapView]: a stroke straddles the edge
+        // it is drawn on, so a neighbour's fill would paint over half of a border drawn with it.
+        blocks.forEach { block -> drawFill(block) }
+        blocks.forEach { block -> drawOutline(block) }
+        blocks.forEach { block -> drawLabel(block) }
+        // On top of both, so that a neighbour's border doesn't cover the outline of the block the panes
+        // are about. The hover goes under the selection, so that the two landing on one block reads as
+        // selected.
+        if (hovered != selected) {
+          blocks.firstOrNull { it.selects == hovered }?.let { block ->
+            drawRect(
+              color = HOVER_COLOR,
+              topLeft = block.topLeft,
+              size = block.size,
+              style = Stroke(width = HOVER_WIDTH)
+            )
+          }
+        }
+        blocks.firstOrNull { it.selects == selected }?.let { block ->
+          drawRect(
+            color = SELECTION_COLOR,
+            topLeft = block.topLeft,
+            size = block.size,
+            style = Stroke(width = SELECTION_WIDTH)
+          )
+        }
+      }
+    }
+    // The one shape that has more than it can show, so the one that needs saying so: nothing else in
+    // this window scrolls without a pane around it to make that obvious.
+    if (scrollState.maxValue > 0) {
+      VerticalScrollbar(
+        rememberScrollbarAdapter(scrollState),
+        Modifier.align(Alignment.CenterEnd).fillMaxHeight()
+      )
+    }
+    NotExpandedBadge(presentation.truncatedNodeCount)
+  }
+}
+
+/** Where the pointer is in the view, given where it is on the stack: the stack scrolls, the view doesn't. */
+private fun Offset.inTheView(scroll: Int): Offset = Offset(x, y - scroll)
+
+private fun StackPresentation.cellAt(
+  /** In the view, which is [scroll] pixels down the stack. */
+  viewOffset: Offset,
+  scroll: Int
+): StackCell<Long>? =
+  layout.cellAt(TreemapPoint(viewOffset.x.toDouble(), (viewOffset.y + scroll).toDouble()))
+
+/** What the pointer is on, with where it is in the view kept: the card following it needs both. */
+private fun StackPresentation.pointedAt(
+  viewOffset: Offset,
+  scroll: Int
+): PointedAt? = cellAt(viewOffset, scroll)?.let { PointedAt(cell = it, offset = viewOffset) }
+
+/** The node across the top, which is what a move changes and what the scroll goes back to the top for. */
+private val StackPresentation.rootNode: Long?
+  get() = (cells.firstOrNull()?.cell?.subject as? CellSubject.Node)?.node
+
+/** A block with its name and size measured and its colour resolved, so that drawing does no work. */
+private class MeasuredBlock(
+  val selects: SelectedCell,
+  val topLeft: Offset,
+  val size: Size,
+  val color: Color,
+  /** The dots filling a pile of siblings its row had no width for, and null for every other block. */
+  val dots: Brush?,
+  val borderColor: Color,
+  val outline: Stroke,
+  val labelColor: Color,
+  /** Null when the block is too narrow for a readable name. */
+  val label: TextLayoutResult?,
+  val labelTopLeft: Offset,
+  /**
+   * How much the block stands for, and null when the name has taken the row.
+   *
+   * On the row rather than only in the panes because a stack is read down a chain: a row is where a
+   * reader asks how much of the heap is still below them, and every row here is wide enough to be worth
+   * asking about.
+   */
+  val byteSize: TextLayoutResult?,
+  val byteSizeTopLeft: Offset
+)
+
+private fun PresentedCell<StackCell<Long>>.measure(
+  colors: CellColors,
+  textMeasurer: TextMeasurer,
+  density: Density,
+  dots: Brush
+): MeasuredBlock {
+  val rect = cell.rect
+  val padding = with(density) { LABEL_PADDING.toPx() }
+  val labelWidth = rect.width - 2 * padding
+  val topLeft = Offset(rect.left.toFloat(), rect.top.toFloat())
+  val size = Size(rect.width.toFloat(), rect.height.toFloat())
+  val measured = if (labelWidth < with(density) { MIN_LABEL_WIDTH.toPx() }) {
+    null
+  } else {
+    textMeasurer.measure(
+      text = label,
+      style = LABEL_STYLE,
+      overflow = TextOverflow.Ellipsis,
+      maxLines = 1,
+      constraints = Constraints(maxWidth = labelWidth.toInt())
+    )
+  }
+  // The size at the far end of the row, and only where the name has left room for it with a gap: two
+  // pieces of text that run into each other read as one word.
+  val byteSize = measured?.let {
+    val room = labelWidth - it.size.width - with(density) { LABEL_GAP.toPx() }
+    textMeasurer.measure(text = formatByteSize(cell.weight), style = LABEL_STYLE, maxLines = 1)
+      .takeIf { byteSize -> byteSize.size.width <= room }
+  }
+  return MeasuredBlock(
+    selects = SelectedCell.of(cell.subject),
+    topLeft = topLeft,
+    size = size,
+    color = colors.colorOf(this),
+    dots = dots.takeIf { content is CellContent.Leftover },
+    borderColor = colors.borderOf(this),
+    outline = outlineOf(content),
+    labelColor = colors.label,
+    label = measured,
+    labelTopLeft = Offset(topLeft.x + padding, topLeft.y + centered(measured, size)),
+    byteSize = byteSize,
+    byteSizeTopLeft = Offset(
+      x = topLeft.x + size.width - padding - (byteSize?.size?.width ?: 0),
+      y = topLeft.y + centered(byteSize, size)
+    )
+  )
+}
+
+/** Where a line of text goes down a row, which is the middle of it: a row is one line tall. */
+private fun centered(
+  text: TextLayoutResult?,
+  size: Size
+): Float = (size.height - (text?.size?.height ?: 0)) / 2
+
+private fun DrawScope.drawFill(block: MeasuredBlock) {
+  drawRect(color = block.color, topLeft = block.topLeft, size = block.size)
+  // Straight after its own fill, as in [TreemapView]: a pile is where the stack stops, so there is
+  // never a row drawn under one for the dots to end up beneath.
+  val dots = block.dots ?: return
+  drawRect(brush = dots, topLeft = block.topLeft, size = block.size)
+}
+
+private fun DrawScope.drawOutline(block: MeasuredBlock) {
+  drawRect(
+    color = block.borderColor,
+    topLeft = block.topLeft,
+    size = block.size,
+    style = block.outline
+  )
+}
+
+/**
+ * What a block is and how much it holds, on the block itself.
+ *
+ * No plate under it, unlike the treemap's names: nothing is drawn inside a block here, so the text sits
+ * on the fill it was measured against rather than over pictures and outlines it has no say over.
+ */
+private fun DrawScope.drawLabel(block: MeasuredBlock) {
+  val label = block.label ?: return
+  drawText(textLayoutResult = label, color = block.labelColor, topLeft = block.labelTopLeft)
+  block.byteSize?.let { byteSize ->
+    drawText(textLayoutResult = byteSize, color = MUTED_TEXT, topLeft = block.byteSizeTopLeft)
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -688,6 +688,22 @@ class ExplorerAppTest {
     }
   }
 
+  @Test fun `the same tree can be drawn as a stack`() {
+    explorerUiTest {
+      openHeapDump()
+      shapeOption(ViewShape.TREEMAP).assertIsSelected()
+
+      shapeOption(ViewShape.STACK).performClick()
+
+      // Laying the stack out is another read of the heap dump, so the tree comes back a beat later.
+      shapeOption(ViewShape.STACK).assertIsSelected()
+      waitForTheTree(OPEN_TIMEOUT_MILLIS)
+      clickAt(stackRow(STACK_ROW))
+
+      waitUntilAtLeastOneExists(hasText("Retained objects"), OPEN_TIMEOUT_MILLIS)
+    }
+  }
+
   @Test fun `the colour scheme can be switched`() {
     explorerUiTest {
       openHeapDump()
@@ -1007,6 +1023,9 @@ class ExplorerAppTest {
     /** Just off the middle of the view, which is in the first ring the rings are drawn out from. */
     private const val RING_X = 0.45f
     private const val RING_Y = 0.55f
+
+    /** A row of the stack below the top one, so that it is an object of the dump rather than the dump. */
+    private const val STACK_ROW = 1
 
     /** How far inside the left edge of the view a container's outline is pressed. Within EDGE_GRAB. */
     private const val EDGE_PRESS_INSET = 2f

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerUiTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerUiTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.MouseInjectionScope
 import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.v2.runSkikoComposeUiTest
 
 /**
@@ -41,6 +42,26 @@ internal fun ComposeUiTest.waitForTheTree(timeoutMillis: Long) {
         .fetchSemanticsNodes()
         .isEmpty()
   }
+}
+
+/**
+ * The middle of a row of the stack, counting from the one across the top, in the window's coordinates.
+ *
+ * In rows rather than in a fraction of the view, because rows are what the stack is laid out in: they are
+ * [STACK_ROW_HEIGHT] tall from the top of the view however deep the tree is, so a point given as a
+ * fraction of a view six hundred pixels tall is past the last row of a shallow tree. Density is 1 in a UI
+ * test, so a dp of row height is a pixel of view — see [explorerUiTest].
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun ComposeUiTest.stackRow(
+  row: Int,
+  xFraction: Float = 0.5f
+): Offset {
+  val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
+  return Offset(
+    x = view.left + view.width * xFraction,
+    y = view.top + STACK_ROW_HEIGHT.value * (row + 0.5f)
+  )
 }
 
 /**

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/RadialViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/RadialViewTest.kt
@@ -157,7 +157,7 @@ class RadialViewTest {
     }
   }
 
-  /** What [shark.explorer.HeapDominatorTreemap.presentRadial] does, for a tree that isn't a heap dump. */
+  /** What [shark.explorer.RadialPresentation.of] does, for a tree that isn't a heap dump. */
   private fun TreemapTree<Long>.present(
     layout: RadialLayout<Long> = RadialLayout()
   ): RadialPresentation {

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/StackViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/StackViewTest.kt
@@ -1,0 +1,328 @@
+package shark.explorer.app
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.ScrollAxisRange
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.explorer.CellContent
+import shark.explorer.CellSubject
+import shark.explorer.LayoutCell
+import shark.explorer.PresentedCell
+import shark.explorer.ReachabilityStrength.STRONG
+import shark.explorer.StackCell
+import shark.explorer.StackLayout
+import shark.explorer.StackPresentation
+import shark.explorer.TreemapRect
+import shark.explorer.TreemapTree
+
+/**
+ * The same wiring [TreemapViewTest] covers, for the stack: a click reports the block under the pointer,
+ * which is where the window goes, and moving over one reports it as hovered. The layout and the hit
+ * testing are unit tested in `shark-explorer-core`.
+ *
+ * What is only testable here is the scroll, which is this shape's alone: the blocks are laid out down a
+ * stack taller than the view, so where the pointer is and which block is under it are a scroll apart.
+ */
+@OptIn(ExperimentalTestApi::class)
+class StackViewTest {
+
+  /** A root with a single child, so the child fills the whole row under it. */
+  private val oneChild = mapTree(ROOT to listOf(CHILD))
+
+  /**
+   * A tree deeper than the view is tall, which is what a stack is for and the one thing it has to scroll
+   * to show: a chain of single dominators is full width at every level, so nothing else stops it growing.
+   */
+  private val deeperThanTheView = chain(length = 40)
+
+  @Test fun `clicking a block reports it`() {
+    runComposeUiTest {
+      val presentation = oneChild.present()
+      val clicked = mutableListOf<LayoutCell<Long>>()
+      setContent { StackUnderTest(presentation, onClick = { clicked += it }) }
+
+      onRoot().performMouseInput { click(presentation.middleOf(CHILD)) }
+
+      assertThat(clicked.map { it.node }).containsExactly(CHILD)
+    }
+  }
+
+  @Test fun `clicking the row across the top reports the root`() {
+    runComposeUiTest {
+      val presentation = oneChild.present()
+      val clicked = mutableListOf<LayoutCell<Long>>()
+      setContent { StackUnderTest(presentation, onClick = { clicked += it }) }
+
+      onRoot().performMouseInput { click(presentation.middleOf(ROOT)) }
+
+      assertThat(clicked.map { it.node }).containsExactly(ROOT)
+    }
+  }
+
+  @Test fun `clicking a block two rows down reports that block`() {
+    runComposeUiTest {
+      // The window works out what to open from the node clicked, so a block two rows down reports
+      // itself rather than the dominators drawn above it.
+      val presentation = mapTree(ROOT to listOf(PARENT), PARENT to listOf(CHILD)).present()
+      val clicked = mutableListOf<LayoutCell<Long>>()
+      setContent { StackUnderTest(presentation, onClick = { clicked += it }) }
+
+      onRoot().performMouseInput { click(presentation.middleOf(CHILD)) }
+
+      assertThat(clicked.map { it.node }).containsExactly(CHILD)
+    }
+  }
+
+  @Test fun `clicking the block standing for the siblings that did not fit reports a group`() {
+    runComposeUiTest {
+      val presentation = mapTree(ROOT to listOf(PARENT), PARENT to (1000L..1049L).toList())
+        .present(StackLayout(maxChildrenPerNode = 10))
+      val clicked = mutableListOf<LayoutCell<Long>>()
+      setContent { StackUnderTest(presentation, onClick = { clicked += it }) }
+
+      onRoot().performMouseInput { click(presentation.middleOfGroupUnder(PARENT)) }
+
+      val group = clicked.single().subject as CellSubject.Group
+      assertThat(group.nodeCount).isEqualTo(40)
+      assertThat(group.parent).isEqualTo(PARENT)
+    }
+  }
+
+  @Test fun `moving the pointer onto a block reports it as hovered`() {
+    runComposeUiTest {
+      val presentation = oneChild.present()
+      val hovered = mutableListOf<LayoutCell<Long>?>()
+      setContent { StackUnderTest(presentation, onHover = { hovered += it }) }
+
+      onRoot().performMouseInput { hover(presentation.middleOf(CHILD)) }
+
+      assertThat(hovered.last()?.node).isEqualTo(CHILD)
+    }
+  }
+
+  @Test fun `moving the pointer out of the view reports nothing hovered`() {
+    runComposeUiTest {
+      val presentation = oneChild.present()
+      val hovered = mutableListOf<LayoutCell<Long>?>()
+      setContent { StackUnderTest(presentation, onHover = { hovered += it }) }
+
+      onRoot().performMouseInput {
+        hover(presentation.middleOf(CHILD))
+        exit()
+      }
+
+      assertThat(hovered.last()).isNull()
+    }
+  }
+
+  @Test fun `clicking below the last row reports nothing`() {
+    runComposeUiTest {
+      val presentation = oneChild.present()
+      val clicked = mutableListOf<LayoutCell<Long>>()
+      setContent { StackUnderTest(presentation, onClick = { clicked += it }) }
+
+      // Two rows of a view four hundred pixels tall: the rest of it is no block of the stack.
+      onRoot().performMouseInput { click(Offset(VIEWPORT_WIDTH / 2, VIEWPORT_HEIGHT - 1)) }
+
+      assertThat(clicked).isEmpty()
+    }
+  }
+
+  @Test fun `the stack scrolls when it is taller than the view`() {
+    runComposeUiTest {
+      setContent { StackUnderTest(deeperThanTheView.present()) }
+
+      assertThat(verticalScrollRange().maxValue()).isGreaterThan(0f)
+    }
+  }
+
+  @Test fun `a stack that fits does not scroll`() {
+    runComposeUiTest {
+      setContent { StackUnderTest(oneChild.present()) }
+
+      // Two rows of a view four hundred pixels tall, so there is nothing below to scroll to. The canvas
+      // being exactly as tall as the stack, rather than as tall as the view, is what this holds.
+      assertThat(verticalScrollRange().maxValue()).isEqualTo(0f)
+    }
+  }
+
+  @Test fun `scrolling down brings deeper rows under a pointer that has not moved`() {
+    runComposeUiTest {
+      val presentation = deeperThanTheView.present()
+      val hovered = mutableListOf<LayoutCell<Long>?>()
+      setContent { StackUnderTest(presentation, onHover = { hovered += it }) }
+      val middle = Offset(VIEWPORT_WIDTH / 2, VIEWPORT_HEIGHT / 2)
+
+      onRoot().performMouseInput { hover(middle) }
+      val beforeScrolling = hovered.last()!!.depth
+      val scrolled = scrollDown()
+
+      // No pointer event says the blocks moved, so this is the view working out what it is on again from
+      // the scroll alone: the block hovered is the one that was `scrolled` pixels further down the stack.
+      val deeper = presentation.layout.cellAt(middle.movedDown(scrolled).toTreemapPoint())!!
+      assertThat(deeper.depth).isGreaterThan(beforeScrolling)
+      assertThat(hovered.last()!!.depth).isEqualTo(deeper.depth)
+    }
+  }
+
+  @Test fun `nodes left out for lack of room are reported`() {
+    runComposeUiTest {
+      val presentation = mapTree(ROOT to listOf(PARENT), PARENT to listOf(CHILD))
+        .present(StackLayout(maxCells = 3))
+      setContent { StackUnderTest(presentation) }
+
+      onNodeWithText("1 node not expanded").assertIsDisplayed()
+    }
+  }
+
+  /**
+   * Turns the wheel down over the stack, and answers how far it scrolled.
+   *
+   * How far is read back rather than worked out, because how many pixels one turn of a wheel is worth is
+   * the platform's business: a headless desktop test has no AWT wheel event to read an amount off, so it
+   * falls back to ten pixels a notch, which is not something to write into a test.
+   */
+  private fun ComposeUiTest.scrollDown(): Float {
+    onRoot().performMouseInput { scroll(SCROLLED_NOTCHES) }
+    waitForIdle()
+    return verticalScrollRange().value()
+  }
+
+  /** Where the view is scrolled to and how far it can go, which is the only place either is readable. */
+  private fun ComposeUiTest.verticalScrollRange(): ScrollAxisRange =
+    onNode(hasScrollAction()).fetchSemanticsNode().config[SemanticsProperties.VerticalScrollAxisRange]
+
+  private fun mapTree(vararg children: Pair<Long, List<Long>>): TreemapTree<Long> {
+    val childrenByNode = children.toMap()
+    return object : TreemapTree<Long> {
+      override val root = ROOT
+      override fun weight(node: Long) = 100L
+      override fun children(node: Long) = childrenByNode[node] ?: emptyList()
+    }
+  }
+
+  /** A tree that is one chain of single dominators, [length] of them below the root. */
+  private fun chain(length: Int): TreemapTree<Long> = object : TreemapTree<Long> {
+    override val root = ROOT
+    override fun weight(node: Long) = 100L
+    override fun children(node: Long) =
+      if (node < length) listOf(node + 1) else emptyList()
+  }
+
+  /** What [shark.explorer.HeapDominatorTreemap.presentStack] does, for a tree that isn't a heap dump. */
+  private fun TreemapTree<Long>.present(
+    layout: StackLayout<Long> = StackLayout()
+  ): StackPresentation {
+    val result = layout.layout(this, VIEWPORT)
+    return StackPresentation(
+      layout = result,
+      cells = result.cells.map { cell ->
+        when (val subject = cell.subject) {
+          is CellSubject.Node -> PresentedCell(cell, "node ${subject.node}", CellContent.Object(STRONG))
+          is CellSubject.Group -> PresentedCell(
+            cell,
+            "${subject.nodeCount} smaller objects",
+            CellContent.Leftover(STRONG)
+          )
+          is CellSubject.Own -> PresentedCell(
+            cell,
+            "node ${subject.node}",
+            CellContent.Object(STRONG)
+          )
+        }
+      }
+    )
+  }
+
+  private val LayoutCell<Long>.node: Long get() = (subject as CellSubject.Node).node
+
+  private fun StackPresentation.middleOf(node: Long): Offset =
+    middleOf(layout.cells.last { (it.subject as? CellSubject.Node)?.node == node })
+
+  private fun StackPresentation.middleOfGroupUnder(parent: Long): Offset =
+    middleOf(layout.cells.single { (it.subject as? CellSubject.Group)?.parent == parent })
+
+  /** The middle of a block, in the view's coordinates, which is the stack's while it hasn't scrolled. */
+  private fun middleOf(cell: StackCell<Long>): Offset = Offset(
+    x = ((cell.rect.left + cell.rect.right) / 2).toFloat(),
+    y = ((cell.rect.top + cell.rect.bottom) / 2).toFloat()
+  )
+
+  private fun Offset.movedDown(pixels: Float): Offset = Offset(x, y + pixels)
+
+  companion object {
+    private const val ROOT = 0L
+    private const val CHILD = 1L
+    private const val PARENT = 2L
+
+    private const val VIEWPORT_WIDTH = 600f
+    private const val VIEWPORT_HEIGHT = 400f
+
+    private val VIEWPORT = TreemapRect(
+      left = 0.0,
+      top = 0.0,
+      right = VIEWPORT_WIDTH.toDouble(),
+      bottom = VIEWPORT_HEIGHT.toDouble()
+    )
+
+    /** Turns of the wheel. Enough of them to be sure of clearing a row, whatever one is worth. */
+    private const val SCROLLED_NOTCHES = 10f
+  }
+}
+
+@Composable
+private fun StackUnderTest(
+  presentation: StackPresentation,
+  onClick: (LayoutCell<Long>) -> Unit = {},
+  onHover: (LayoutCell<Long>?) -> Unit = {}
+) {
+  MaterialTheme {
+    var selected: SelectedCell? by remember { mutableStateOf(null) }
+    var hovered: SelectedCell? by remember { mutableStateOf(null) }
+    val density = LocalDensity.current
+    // Sized in pixels, matching the viewport the presentation was laid out in, so that a click at a
+    // block's coordinates lands on that block.
+    Box(
+      Modifier.requiredSize(
+        width = with(density) { 600f.toDp() },
+        height = with(density) { 400f.toDp() }
+      )
+    ) {
+      StackView(
+        presentation = presentation,
+        coloring = CellColoring.DEFAULT,
+        selected = selected,
+        hovered = hovered,
+        onClick = {
+          selected = SelectedCell.of(it.subject)
+          onClick(it)
+        },
+        // Only which block, as in [TreemapViewTest]: where the pointer is on it is the card's business.
+        onHover = { pointedAt ->
+          hovered = pointedAt?.let { SelectedCell.of(it.cell.subject) }
+          onHover(pointedAt?.cell)
+        }
+      )
+    }
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/StackViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/StackViewTest.kt
@@ -229,7 +229,7 @@ class StackViewTest {
       if (node < length) listOf(node + 1) else emptyList()
   }
 
-  /** What [shark.explorer.HeapDominatorTreemap.presentStack] does, for a tree that isn't a heap dump. */
+  /** What [shark.explorer.StackPresentation.of] does, for a tree that isn't a heap dump. */
   private fun TreemapTree<Long>.present(
     layout: StackLayout<Long> = StackLayout()
   ): StackPresentation {

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
@@ -46,7 +46,7 @@ class TreeLayoutTest {
     explorerUiTest {
       openHeapDump()
 
-      settleTheHeapDumpThread()
+      settleTheHeapDumpThread(ViewShape.TREEMAP)
     }
 
     assertThat(treeLayoutsOf(ViewShape.TREEMAP)).hasSize(1)
@@ -62,10 +62,23 @@ class TreeLayoutTest {
       openHeapDump()
 
       shapeOption(ViewShape.RADIAL).performClick()
-      settleTheHeapDumpThread()
+      settleTheHeapDumpThread(ViewShape.RADIAL)
     }
 
     assertThat(treeLayoutsOf(ViewShape.RADIAL)).hasSize(1)
+    assertThat(treeLayoutsOf(ViewShape.TREEMAP)).hasSize(1)
+  }
+
+  /** And a stack, whose thresholds are its own again, so it is a view of its own again too. */
+  @Test fun `switching to a stack lays the tree out once more`() {
+    explorerUiTest {
+      openHeapDump()
+
+      shapeOption(ViewShape.STACK).performClick()
+      settleTheHeapDumpThread(ViewShape.STACK)
+    }
+
+    assertThat(treeLayoutsOf(ViewShape.STACK)).hasSize(1)
     assertThat(treeLayoutsOf(ViewShape.TREEMAP)).hasSize(1)
   }
 
@@ -76,12 +89,20 @@ class TreeLayoutTest {
    *
    * Pointing at a cell is the read to wait for rather than clicking one, because a click goes to what it
    * landed on, and going somewhere lays the tree out again — which is the very thing being counted.
+   *
+   * Where the pointer goes depends on [shape], because a point that is a cell of one shape is empty in
+   * another: the middle of the view is a rectangle and it is a ring, and it is well past the last row of a
+   * stack three rows deep.
    */
-  private fun ComposeUiTest.settleTheHeapDumpThread() {
-    val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
-    onRoot().performMouseInput {
-      hover(Offset(view.left + view.width * CELL_X, view.top + view.height * CELL_Y))
+  private fun ComposeUiTest.settleTheHeapDumpThread(shape: ViewShape) {
+    val cell = when (shape) {
+      ViewShape.TREEMAP, ViewShape.RADIAL -> {
+        val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
+        Offset(view.left + view.width * CELL_X, view.top + view.height * CELL_Y)
+      }
+      ViewShape.STACK -> stackRow(CELL_ROW, CELL_X)
     }
+    onRoot().performMouseInput { hover(cell) }
     waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { logged.any { it.startsWith(HOVER_READ) } }
   }
 
@@ -132,6 +153,9 @@ class TreeLayoutTest {
      */
     private const val CELL_X = 0.45f
     private const val CELL_Y = 0.55f
+
+    /** The row of a stack that holds a cell to point at, counting from the one across the top. */
+    private const val CELL_ROW = 1
 
     private const val PAYLOAD_LENGTH = 4096
 

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreemapViewTest.kt
@@ -307,7 +307,7 @@ class TreemapViewTest {
     }
   }
 
-  /** What [shark.explorer.HeapDominatorTreemap.present] does, for a tree that isn't a heap dump. */
+  /** What [shark.explorer.TreemapPresentation.of] does, for a tree that isn't a heap dump. */
   private fun TreemapTree<Long>.present(
     layout: TreemapLayout<Long> = TreemapLayout()
   ): TreemapPresentation {

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -1045,6 +1045,16 @@ class HeapDominatorTreemap internal constructor(
     return RadialPresentation(layout = result, cells = result.cells.map { it.presented() })
   }
 
+  /** The same again, laid out as a stack of rows, one row per level of domination. */
+  fun presentStack(
+    layout: StackLayout<Long>,
+    viewport: TreemapRect,
+    root: Long = this.root
+  ): StackPresentation {
+    val result = layout.layout(this, viewport, root)
+    return StackPresentation(layout = result, cells = result.cells.map { it.presented() })
+  }
+
   private fun <C : LayoutCell<Long>> C.presented(): PresentedCell<C> = when (val subject = subject) {
     is CellSubject.Node -> group(subject.node)?.let { group ->
       PresentedCell(

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -1023,37 +1023,16 @@ class HeapDominatorTreemap internal constructor(
   }
 
   /**
-   * Lays this tree out into [viewport] rooted at [root], and reads a label and a strength for every
-   * rectangle: everything the UI needs to draw a treemap without touching the heap dump itself.
+   * Reads a label and a strength for every one of [cells]: everything the UI needs to draw a laid out
+   * shape of this tree without touching the heap dump itself.
+   *
+   * What shape they are is no business of this, which is why there is one of these rather than one per
+   * shape — a `TreemapCell`, a `RadialCell` and a `StackCell` are all a [CellSubject] with geometry, and
+   * a name is read off the subject. Pairing a layout with this is [TreemapPresentation.of] and its two
+   * siblings, so a fourth shape needs nothing here.
    */
-  fun present(
-    layout: TreemapLayout<Long>,
-    viewport: TreemapRect,
-    root: Long = this.root
-  ): TreemapPresentation {
-    val result = layout.layout(this, viewport, root)
-    return TreemapPresentation(layout = result, cells = result.cells.map { it.presented() })
-  }
-
-  /** The same, laid out as rings around a centre rather than as rectangles. */
-  fun presentRadial(
-    layout: RadialLayout<Long>,
-    viewport: TreemapRect,
-    root: Long = this.root
-  ): RadialPresentation {
-    val result = layout.layout(this, viewport, root)
-    return RadialPresentation(layout = result, cells = result.cells.map { it.presented() })
-  }
-
-  /** The same again, laid out as a stack of rows, one row per level of domination. */
-  fun presentStack(
-    layout: StackLayout<Long>,
-    viewport: TreemapRect,
-    root: Long = this.root
-  ): StackPresentation {
-    val result = layout.layout(this, viewport, root)
-    return StackPresentation(layout = result, cells = result.cells.map { it.presented() })
-  }
+  fun <C : LayoutCell<Long>> present(cells: List<C>): List<PresentedCell<C>> =
+    cells.map { it.presented() }
 
   private fun <C : LayoutCell<Long>> C.presented(): PresentedCell<C> = when (val subject = subject) {
     is CellSubject.Node -> group(subject.node)?.let { group ->

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/StackLayout.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/StackLayout.kt
@@ -1,0 +1,249 @@
+package shark.explorer
+
+import java.util.PriorityQueue
+
+/**
+ * A block placed by [StackLayout]: one row of the stack, as wide as its share of the heap.
+ *
+ * [rect] is the whole of it, so hit testing and drawing work off one value the way they do for a
+ * treemap. Its top edge says the same thing [depth] does — every row is [StackLayoutResult.rowHeight]
+ * tall, and a node's row is its depth — which is what makes a stack readable as a stack: the level a
+ * block sits at is where it is on the screen, not how deeply it's nested in something else.
+ */
+data class StackCell<out N>(
+  override val subject: CellSubject<N>,
+  val rect: TreemapRect,
+  override val depth: Int,
+  override val weight: Long
+) : LayoutCell<N>
+
+/**
+ * The result of laying a [TreemapTree] out as a stack of rows, one row per level.
+ *
+ * [cells] is ordered so that a node always precedes its descendants, matching
+ * [TreemapLayoutResult.cells]. Nothing overlaps: a row is a level of its own and the blocks along one
+ * are laid side by side, so the block at a point is the only block at that point.
+ */
+class StackLayoutResult<N>(
+  val cells: List<StackCell<N>>,
+  /** How many rows the blocks fill, which is the deepest level reached plus the root's own row. */
+  val rowCount: Int,
+  /** How tall one row is, in the pixels the viewport was measured in. */
+  val rowHeight: Double,
+  /** See [TreemapLayoutResult.truncatedNodeCount]. */
+  val truncatedNodeCount: Int
+) {
+
+  /**
+   * How tall everything laid out is, which is what a view of it has to scroll through: a stack is as
+   * deep as the tree it drew, and that is regularly deeper than a viewport.
+   */
+  val contentHeight: Double get() = rowCount * rowHeight
+
+  /** The block [point] falls in, or null where the stack has none: past its last row, or in a notch. */
+  fun cellAt(point: TreemapPoint): StackCell<N>? = cells.firstOrNull { point in it.rect }
+}
+
+/**
+ * Lays a [TreemapTree] out as a stack of rows — an icicle plot, the way a profiler draws a call tree
+ * upside down: the node it's rooted at is the row across the top, its children are the row under it,
+ * and so on downwards, each one as wide as its weight's share of the row above.
+ *
+ * **What it is for is the shape of one chain of domination.** A treemap and a ring both spend a
+ * dimension on nesting, so a level is smaller than the level above it and the deep end of a chain is
+ * where the pixels have run out. Here a level costs a row and nothing else: the twentieth dominator of
+ * an object is as wide as the object's share of the heap, drawn at full height and named, however deep
+ * it sits. What that costs instead is the whole picture at a glance — a stack is a tall thing to scroll
+ * rather than a shape that fits a window, which is why the other two shapes are still the ones to
+ * open on.
+ *
+ * Depth is bounded by [maxRows] rather than by the room a level gets, and width is what stops the
+ * layout: a node is subdivided while its row is at least [minSubdivideWidth] wide, and children
+ * narrower than [minDrawWidth], past [maxChildrenPerNode] — [maxRootChildren] for the row across the
+ * top — or outside the [maxCells] budget become one [CellSubject.Group]. The widest block is
+ * subdivided first so the budget buys visible detail.
+ *
+ * **A block's width is its share of the whole heap at every depth**, as in [TreemapLayout], and for
+ * the same reason: children are given their share of what their parent *weighs*, not of what they add
+ * up to. What the parent holds on its own is the width left over at the right end of the row, drawn as
+ * a [CellSubject.Own] block, so a bitmap reads as a wide block with almost nothing under it and every
+ * row of the stack can be compared with every other.
+ */
+class StackLayout<N>(
+  /** How tall one row is. A row holds a line of text and nothing else, so this is a text height. */
+  private val rowHeight: Double = 18.0,
+  private val minSubdivideWidth: Double = 6.0,
+  private val minDrawWidth: Double = 2.0,
+  /**
+   * How many rows to lay out at all, which is how far a view of this scrolls.
+   *
+   * A bound is needed because a row costs no width: a chain of single dominators is as wide at the
+   * bottom as at the top, so nothing else would ever stop it, and a heap dump is free to hold a
+   * hundred thousand of those in a linked list. Deeper than any chain a real dump has been measured to
+   * have — 22 levels from an activity down to a list row on an 82 MB production dump — so what this
+   * cuts off is the pathological rather than the interesting, and zooming into a node is how the rest
+   * of it is reached.
+   */
+  private val maxRows: Int = 64,
+  private val maxCells: Int = 5000,
+  private val maxChildrenPerNode: Int = 200,
+  /** And how many for the node the stack is rooted at, which has the whole width. See [TreemapLayout]. */
+  private val maxRootChildren: Int = maxCells / 2
+) {
+
+  fun layout(
+    tree: TreemapTree<N>,
+    viewport: TreemapRect,
+    /** The node to put across the top, which is what zooming changes. */
+    root: N = tree.root
+  ): StackLayoutResult<N> {
+    val rootCell = StackCell(
+      subject = CellSubject.Node(node = root, parent = null, siblingIndex = 0),
+      rect = rowRect(viewport, depth = 0, left = viewport.left, width = viewport.width),
+      depth = 0,
+      weight = tree.weight(root)
+    )
+    val cells = mutableListOf(rootCell)
+    if (viewport.width <= 0.0 || rowHeight <= 0.0) {
+      return StackLayoutResult(cells, rowCount = 1, rowHeight = rowHeight, truncatedNodeCount = 0)
+    }
+
+    // Widest first, so that the budget is spent where a row has the room to be read. Ties broken by
+    // insertion order to keep the layout deterministic.
+    var insertionCount = 0L
+    val pending = PriorityQueue<Pending<N>>(
+      compareByDescending<Pending<N>> { it.cell.rect.width }.thenBy { it.insertionOrder }
+    )
+    pending += Pending(root, rootCell, insertionCount++)
+
+    var truncatedNodeCount = 0
+
+    while (pending.isNotEmpty()) {
+      val (node, cell) = pending.poll()
+      val childDepth = cell.depth + 1
+      if (childDepth >= maxRows || cell.rect.width < minSubdivideWidth) {
+        continue
+      }
+
+      // Only nodes with weight can be given a proportional width.
+      val children = tree.children(node)
+        .filter { tree.weight(it) > 0L }
+        .sortedByDescending { tree.weight(it) }
+      if (children.isEmpty()) {
+        continue
+      }
+
+      // Three cells at the least: one child, the group standing for the rest and the node's own bytes.
+      // Narrower rows keep being considered, so a node too wide to fit doesn't end the layout.
+      val budget = maxCells - cells.size
+      if (budget < 3) {
+        truncatedNodeCount++
+        continue
+      }
+
+      val weights = LongArray(children.size) { tree.weight(children[it]) }
+      val childrenWeight = weights.sum()
+      // What the row above is worth, which is what the row below shares out: the difference between the
+      // two is what the node holds on its own, and it stays as width rather than being spread over the
+      // children. Clamped because a tree is free to weigh a node by something other than the sum of
+      // what's below it.
+      val totalWeight = maxOf(cell.weight, childrenWeight)
+      val drawnCount = minOf(
+        drawableChildCount(weights, cell.rect.width, totalWeight),
+        // Depth 0 is the node the stack is rooted at, and the only block on that row.
+        if (cell.depth == 0) maxRootChildren else maxChildrenPerNode,
+        budget - 2
+      )
+
+      var left = cell.rect.left
+      var drawnWeight = 0L
+      for (index in 0 until drawnCount) {
+        val width = cell.rect.width * weights[index] / totalWeight
+        val childCell = StackCell(
+          subject = CellSubject.Node(node = children[index], parent = node, siblingIndex = index),
+          rect = rowRect(viewport, childDepth, left, width),
+          depth = childDepth,
+          weight = weights[index]
+        )
+        cells += childCell
+        pending += Pending(children[index], childCell, insertionCount++)
+        left += width
+        drawnWeight += weights[index]
+      }
+
+      // Then the children this row had no room for, as one block, and what the node holds itself at the
+      // right end of the row. Both advance the row whether or not they're wide enough to draw, so that
+      // what is drawn stays where its share of the width puts it.
+      val groupedCount = children.size - drawnCount
+      if (groupedCount > 0) {
+        val groupWeight = childrenWeight - drawnWeight
+        val width = cell.rect.width * groupWeight / totalWeight
+        if (width >= minDrawWidth) {
+          cells += StackCell(
+            subject = CellSubject.Group(parent = node, nodeCount = groupedCount),
+            rect = rowRect(viewport, childDepth, left, width),
+            depth = childDepth,
+            weight = groupWeight
+          )
+        }
+        left += width
+      }
+      val ownWeight = totalWeight - childrenWeight
+      if (ownWeight > 0) {
+        val width = cell.rect.width * ownWeight / totalWeight
+        if (width >= minDrawWidth) {
+          cells += StackCell(
+            subject = CellSubject.Own(node = node),
+            rect = rowRect(viewport, childDepth, left, width),
+            depth = childDepth,
+            weight = ownWeight
+          )
+        }
+      }
+    }
+
+    return StackLayoutResult(
+      cells = cells,
+      rowCount = cells.maxOf { it.depth } + 1,
+      rowHeight = rowHeight,
+      truncatedNodeCount = truncatedNodeCount
+    )
+  }
+
+  /**
+   * How many of [weights], which are sorted descending, are worth a block of their own along a row
+   * [totalWidth] wide shared out in proportion to [totalWeight]. The weights only go down, so the ones
+   * worth drawing are a prefix.
+   */
+  private fun drawableChildCount(
+    weights: LongArray,
+    totalWidth: Double,
+    totalWeight: Long
+  ): Int {
+    if (totalWeight <= 0L) {
+      return 0
+    }
+    var count = 0
+    while (count < weights.size && totalWidth * weights[count] / totalWeight >= minDrawWidth) {
+      count++
+    }
+    return count
+  }
+
+  /** One block's rectangle: [width] of the row [depth] rows down from the top of [viewport]. */
+  private fun rowRect(
+    viewport: TreemapRect,
+    depth: Int,
+    left: Double,
+    width: Double
+  ): TreemapRect {
+    val top = viewport.top + depth * rowHeight
+    return TreemapRect(left = left, top = top, right = left + width, bottom = top + rowHeight)
+  }
+
+  private data class Pending<N>(
+    val node: N,
+    val cell: StackCell<N>,
+    val insertionOrder: Long
+  )
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
@@ -2,7 +2,7 @@ package shark.explorer
 
 /**
  * A treemap laid out and labelled, holding everything needed to draw it and nothing that needs the
- * heap dump. Produced by [HeapDominatorTreemap.present], off the UI thread.
+ * heap dump. Produced by [of], off the UI thread.
  */
 class TreemapPresentation(
   /** Kept for hit testing, which is [TreemapLayoutResult.cellAt]. */
@@ -19,13 +19,27 @@ class TreemapPresentation(
       layout = TreemapLayoutResult(emptyList(), truncatedNodeCount = 0),
       cells = emptyList()
     )
+
+    /**
+     * Lays [tree] out into [viewport] rooted at [root] and reads what it takes to draw the result.
+     *
+     * Here rather than in [HeapDominatorTreemap] — as is every shape's — because which shapes there are
+     * is not something a heap dump reader should have to know: it labels cells, and pairing that with a
+     * layout is this side of the line. See [HeapDominatorTreemap.present].
+     */
+    fun of(
+      tree: HeapDominatorTreemap,
+      layout: TreemapLayout<Long>,
+      viewport: TreemapRect,
+      root: Long = tree.root
+    ): TreemapPresentation {
+      val result = layout.layout(tree, viewport, root)
+      return TreemapPresentation(layout = result, cells = tree.present(result.cells))
+    }
   }
 }
 
-/**
- * The same tree as a [TreemapPresentation], laid out as rings instead. Produced by
- * [HeapDominatorTreemap.presentRadial].
- */
+/** The same tree as a [TreemapPresentation], laid out as rings instead. */
 class RadialPresentation(
   /** Kept for hit testing, which is [RadialLayoutResult.cellAt]. */
   val layout: RadialLayoutResult<Long>,
@@ -35,12 +49,22 @@ class RadialPresentation(
 
   /** See [TreemapLayoutResult.truncatedNodeCount]. */
   val truncatedNodeCount: Int get() = layout.truncatedNodeCount
+
+  companion object {
+    /** See [TreemapPresentation.of]. */
+    fun of(
+      tree: HeapDominatorTreemap,
+      layout: RadialLayout<Long>,
+      viewport: TreemapRect,
+      root: Long = tree.root
+    ): RadialPresentation {
+      val result = layout.layout(tree, viewport, root)
+      return RadialPresentation(layout = result, cells = tree.present(result.cells))
+    }
+  }
 }
 
-/**
- * The same tree as a [TreemapPresentation], laid out as a stack of rows instead. Produced by
- * [HeapDominatorTreemap.presentStack].
- */
+/** The same tree as a [TreemapPresentation], laid out as a stack of rows instead. */
 class StackPresentation(
   /** Kept for hit testing, which is [StackLayoutResult.cellAt], and for how tall the stack came out. */
   val layout: StackLayoutResult<Long>,
@@ -50,6 +74,19 @@ class StackPresentation(
 
   /** See [TreemapLayoutResult.truncatedNodeCount]. */
   val truncatedNodeCount: Int get() = layout.truncatedNodeCount
+
+  companion object {
+    /** See [TreemapPresentation.of]. */
+    fun of(
+      tree: HeapDominatorTreemap,
+      layout: StackLayout<Long>,
+      viewport: TreemapRect,
+      root: Long = tree.root
+    ): StackPresentation {
+      val result = layout.layout(tree, viewport, root)
+      return StackPresentation(layout = result, cells = tree.present(result.cells))
+    }
+  }
 }
 
 /**

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
@@ -38,6 +38,21 @@ class RadialPresentation(
 }
 
 /**
+ * The same tree as a [TreemapPresentation], laid out as a stack of rows instead. Produced by
+ * [HeapDominatorTreemap.presentStack].
+ */
+class StackPresentation(
+  /** Kept for hit testing, which is [StackLayoutResult.cellAt], and for how tall the stack came out. */
+  val layout: StackLayoutResult<Long>,
+  /** In the same order as [StackLayoutResult.cells]. */
+  val cells: List<PresentedCell<StackCell<Long>>>
+) {
+
+  /** See [TreemapLayoutResult.truncatedNodeCount]. */
+  val truncatedNodeCount: Int get() = layout.truncatedNodeCount
+}
+
+/**
  * One cell of a presentation: a laid out cell of some shape, plus what the heap dump had to be read
  * for. Generic in the shape so that a view keeps hold of the geometry it draws, while everything that
  * only needs [LayoutCell] works for either.

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
@@ -91,7 +91,7 @@ class HeapExplorerTest {
     HeapExplorer.open(testFolder.pixelBitmapHeapDump()).use { explorer ->
       val tree = explorer.tree
       val bitmap = tree.findByLabel("Bitmap")
-      val presented = tree.present(TreemapLayout(), VIEWPORT)
+      val presented = TreemapPresentation.of(tree, TreemapLayout(), VIEWPORT)
         .cells
         .single { (it.cell.subject as? CellSubject.Node)?.node == bitmap.objectId }
 
@@ -550,7 +550,7 @@ class HeapExplorerTest {
     HeapExplorer.open(testFolder.crowdedRootHeapDump()).use { explorer ->
       val tree = explorer.tree
       val group = tree.classGroup().nodeId
-      val presented = tree.present(TreemapLayout(), VIEWPORT)
+      val presented = TreemapPresentation.of(tree, TreemapLayout(), VIEWPORT)
         .cells
         .single { (it.cell.subject as? CellSubject.Node)?.node == group }
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/StackLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/StackLayoutTest.kt
@@ -1,0 +1,298 @@
+package shark.explorer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset.offset
+import org.junit.Test
+
+class StackLayoutTest {
+
+  /** A tree of named nodes, where a parent weighs what it holds itself plus what its children weigh. */
+  private class Node(
+    val name: String,
+    val ownWeight: Long = 0,
+    val children: List<Node> = emptyList()
+  ) {
+    val weight: Long = ownWeight + children.sumOf { it.weight }
+  }
+
+  private class NodeTree(override val root: Node) : TreemapTree<Node> {
+    override fun weight(node: Node) = node.weight
+    override fun children(node: Node) = node.children
+  }
+
+  /** A node with [breadth] children at every level, [depth] levels deep. */
+  private fun uniformTree(
+    name: String,
+    depth: Int,
+    breadth: Int,
+    leafWeight: Long
+  ): Node = if (depth == 0) {
+    Node(name, ownWeight = leafWeight)
+  } else {
+    Node(
+      name,
+      children = (0 until breadth).map { uniformTree("$name.$it", depth - 1, breadth, leafWeight) }
+    )
+  }
+
+  /** A chain of single children, which is what only a row bound stops: every row of it is full width. */
+  private fun chain(length: Int): Node =
+    (length downTo 1).fold(Node("chain.$length", ownWeight = 1_000_000)) { below, index ->
+      Node("chain.${index - 1}", children = listOf(below))
+    }
+
+  private val viewport = TreemapRect(0.0, 0.0, 1000.0, 800.0)
+
+  private val StackCell<Node>.node: Node get() = (subject as CellSubject.Node).node
+
+  private val StackLayoutResult<Node>.nodeCells: List<StackCell<Node>>
+    get() = cells.filter { it.subject is CellSubject.Node }
+
+  private val StackLayoutResult<Node>.groups: List<StackCell<Node>>
+    get() = cells.filter { it.subject is CellSubject.Group }
+
+  private val StackLayoutResult<Node>.names: List<String>
+    get() = nodeCells.map { it.node.name }
+
+  private fun StackLayoutResult<Node>.cellOf(name: String): StackCell<Node> =
+    nodeCells.single { it.node.name == name }
+
+  @Test fun `the root is the row across the top`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 10), Node("b", 5))))
+
+    val result = StackLayout<Node>(rowHeight = 20.0).layout(tree, viewport)
+
+    val rootCell = result.cells.first()
+    assertThat(rootCell.node.name).isEqualTo("root")
+    assertThat(rootCell.depth).isEqualTo(0)
+    assertThat(rootCell.rect).isEqualTo(TreemapRect(0.0, 0.0, 1000.0, 20.0))
+  }
+
+  @Test fun `children fill their parent's row in proportion to their weight`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 30), Node("b", 10))))
+
+    val result = StackLayout<Node>(rowHeight = 20.0).layout(tree, viewport)
+
+    val children = result.nodeCells.drop(1)
+    assertThat(children.map { it.node.name }).containsExactly("a", "b")
+    // Heaviest first from the left edge, each one where the one before it ended.
+    assertThat(children.map { it.rect.left }).containsExactly(0.0, 750.0)
+    assertThat(children.map { it.rect.right }).containsExactly(750.0, 1000.0)
+    assertThat(children.map { it.rect.top }).containsOnly(20.0)
+    assertThat(children.map { it.rect.bottom }).containsOnly(40.0)
+  }
+
+  @Test fun `a block is its share of the whole however deep it sits`() {
+    // The one guarantee that makes rows comparable across levels: "a" holds as much itself as its child
+    // does, so a child that filled its parent's row would read as twice what it is.
+    val tree = NodeTree(
+      Node(
+        "root",
+        children = listOf(
+          Node("a", ownWeight = 50, children = listOf(Node("a.0", 50))),
+          Node("b", ownWeight = 100)
+        )
+      )
+    )
+
+    val result = StackLayout<Node>().layout(tree, viewport)
+
+    val rootWeight = tree.root.weight
+    result.cells.forEach { cell ->
+      assertThat(cell.rect.width)
+        .isCloseTo(viewport.width * cell.weight / rootWeight, offset(1e-9))
+    }
+    assertThat(result.cellOf("a.0").rect.width).isEqualTo(250.0)
+  }
+
+  @Test fun `what a node holds itself is the block at the end of its row`() {
+    val tree = NodeTree(Node("root", ownWeight = 250, children = listOf(Node("a", 750))))
+
+    val result = StackLayout<Node>().layout(tree, viewport)
+
+    val own = result.cells.single { it.subject is CellSubject.Own }
+    assertThat((own.subject as CellSubject.Own).node.name).isEqualTo("root")
+    assertThat(own.weight).isEqualTo(250)
+    assertThat(own.depth).isEqualTo(1)
+    // At the right end of the row, after the children, and up against its edge.
+    assertThat(own.rect.left).isEqualTo(750.0)
+    assertThat(own.rect.right).isEqualTo(viewport.right)
+  }
+
+  @Test fun `each level is one row further down`() {
+    val tree = NodeTree(uniformTree("root", depth = 3, breadth = 2, leafWeight = 1_000_000))
+
+    val result = StackLayout<Node>(rowHeight = 18.0).layout(tree, viewport)
+
+    result.cells.forEach { cell ->
+      assertThat(cell.rect.top).isCloseTo(cell.depth * 18.0, offset(1e-9))
+      assertThat(cell.rect.bottom).isCloseTo((cell.depth + 1) * 18.0, offset(1e-9))
+    }
+    assertThat(result.rowCount).isEqualTo(4)
+    assertThat(result.contentHeight).isEqualTo(4 * 18.0)
+  }
+
+  @Test fun `a parent is always laid out before its descendants`() {
+    val tree = NodeTree(uniformTree("root", depth = 3, breadth = 3, leafWeight = 1_000_000))
+
+    val result = StackLayout<Node>().layout(tree, viewport)
+
+    val positions = result.nodeCells.withIndex().associate { (index, cell) -> cell.node.name to index }
+    result.nodeCells.forEach { cell ->
+      val parent = (cell.subject as CellSubject.Node).parent ?: return@forEach
+      assertThat(positions.getValue(parent.name)).isLessThan(positions.getValue(cell.node.name))
+    }
+  }
+
+  @Test fun `a block too narrow to subdivide is left as it is`() {
+    // One huge child and a two hundred and fiftieth of it: the small one still gets a block of its own,
+    // four pixels of the thousand, but that is under the width a row is worth dividing, so it stays whole.
+    val tree = NodeTree(
+      Node(
+        "root",
+        children = listOf(
+          uniformTree("big", depth = 2, breadth = 2, leafWeight = 1_000_000),
+          Node("small", children = listOf(Node("small.0", 8_000), Node("small.1", 8_000)))
+        )
+      )
+    )
+
+    val result = StackLayout<Node>().layout(tree, viewport)
+
+    assertThat(result.names).contains("big.0", "small")
+    assertThat(result.names).doesNotContain("small.0", "small.1")
+  }
+
+  @Test fun `nothing is laid out past the last row`() {
+    val tree = NodeTree(chain(length = 20))
+
+    val result = StackLayout<Node>(maxRows = 5).layout(tree, viewport)
+
+    assertThat(result.cells.map { it.depth }.max()).isEqualTo(4)
+    assertThat(result.rowCount).isEqualTo(5)
+  }
+
+  @Test fun `a chain of single children is as wide at the bottom as at the top`() {
+    val tree = NodeTree(chain(length = 30))
+
+    val result = StackLayout<Node>(maxRows = 32).layout(tree, viewport)
+
+    assertThat(result.rowCount).isEqualTo(31)
+    assertThat(result.cells.map { it.rect.width }).containsOnly(viewport.width)
+  }
+
+  @Test fun `children past the per node limit become one block`() {
+    val children = List(50) { index -> Node("child$index", ownWeight = 100L - index) }
+    val tree = NodeTree(Node("root", children = children))
+
+    val result = StackLayout<Node>(maxChildrenPerNode = 10, maxRootChildren = 10)
+      .layout(tree, viewport)
+
+    assertThat(result.names).hasSize(11) // The root and its 10 largest children.
+    val group = result.groups.single()
+    assertThat((group.subject as CellSubject.Group).nodeCount).isEqualTo(40)
+    assertThat(group.depth).isEqualTo(1)
+    assertThat(group.weight).isEqualTo((51L..90L).sum())
+  }
+
+  @Test fun `a group and its siblings fill the whole row`() {
+    val children = List(50) { index -> Node("child$index", ownWeight = 100L - index) }
+    val tree = NodeTree(Node("root", children = children))
+
+    val result = StackLayout<Node>(maxChildrenPerNode = 10, maxRootChildren = 10)
+      .layout(tree, viewport)
+
+    val row = result.cells.filter { it.depth == 1 }
+    assertThat(row.first().rect.left).isEqualTo(viewport.left)
+    assertThat(row.last().rect.right).isCloseTo(viewport.right, offset(1e-9))
+    // Laid along the row with no gaps, the group last: it stands for what the row ran out of width for.
+    assertThat(row.zipWithNext()).allSatisfy { (before, after) ->
+      assertThat(after.rect.left).isCloseTo(before.rect.right, offset(1e-9))
+    }
+    assertThat(row.last().subject).isInstanceOf(CellSubject.Group::class.java)
+  }
+
+  @Test fun `cell count stays within the budget`() {
+    val tree = NodeTree(uniformTree("root", depth = 8, breadth = 4, leafWeight = 1_000_000))
+
+    val result = StackLayout<Node>(maxCells = 200).layout(tree, viewport)
+
+    assertThat(result.cells.size).isLessThanOrEqualTo(200)
+  }
+
+  @Test fun `reaching the budget is reported as truncation`() {
+    val tree = NodeTree(uniformTree("root", depth = 4, breadth = 4, leafWeight = 1_000_000))
+
+    val result = StackLayout<Node>(maxCells = 10).layout(tree, viewport)
+
+    assertThat(result.truncatedNodeCount).isGreaterThan(0)
+  }
+
+  @Test fun `a tree that fits is not reported as truncated`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 10), Node("b", 5))))
+
+    val result = StackLayout<Node>().layout(tree, viewport)
+
+    assertThat(result.truncatedNodeCount).isEqualTo(0)
+  }
+
+  @Test fun `hit testing finds the block a point falls in`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 30), Node("b", 10))))
+
+    val result = StackLayout<Node>(rowHeight = 20.0).layout(tree, viewport)
+
+    assertThat(result.cellAt(TreemapPoint(500.0, 10.0))).isEqualTo(result.cellOf("root"))
+    assertThat(result.cellAt(TreemapPoint(500.0, 30.0))).isEqualTo(result.cellOf("a"))
+    assertThat(result.cellAt(TreemapPoint(800.0, 30.0))).isEqualTo(result.cellOf("b"))
+  }
+
+  @Test fun `hit testing past the last row returns null`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 10))))
+
+    val result = StackLayout<Node>(rowHeight = 20.0).layout(tree, viewport)
+
+    // Two rows of twenty pixels, and a stack is only as tall as what it drew: the rest of a viewport
+    // taller than that is no block of it.
+    assertThat(result.contentHeight).isEqualTo(40.0)
+    assertThat(result.cellAt(TreemapPoint(500.0, 40.0))).isNull()
+  }
+
+  @Test fun `an empty viewport lays out only the root`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 10))))
+
+    val result = StackLayout<Node>().layout(tree, TreemapRect(0.0, 0.0, 0.0, 0.0))
+
+    assertThat(result.cells).hasSize(1)
+    assertThat(result.rowCount).isEqualTo(1)
+  }
+
+  @Test fun `zero weight children are left out`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 10), Node("empty", 0))))
+
+    val result = StackLayout<Node>().layout(tree, viewport)
+
+    assertThat(result.names).containsExactly("root", "a")
+  }
+
+  @Test fun `layout is deterministic`() {
+    val tree = NodeTree(uniformTree("root", depth = 4, breadth = 3, leafWeight = 1_000_000))
+    val layout = StackLayout<Node>()
+
+    val first = layout.layout(tree, viewport)
+    val second = layout.layout(tree, viewport)
+
+    assertThat(second.cells).isEqualTo(first.cells)
+  }
+
+  @Test fun `laying out a subtree puts it across the top`() {
+    val tree = NodeTree(uniformTree("root", depth = 3, breadth = 2, leafWeight = 1_000_000))
+    val subtree = tree.root.children.first()
+
+    val result = StackLayout<Node>().layout(tree, viewport, root = subtree)
+
+    val rootCell = result.cells.first()
+    assertThat(rootCell.node.name).isEqualTo(subtree.name)
+    assertThat(rootCell.rect.width).isEqualTo(viewport.width)
+    assertThat(rootCell.depth).isEqualTo(0)
+  }
+}


### PR DESCRIPTION
A third shape beside the treemap and the rings: an icicle chart, the way a profiler draws a call tree upside down. The row across the top is the node the view is rooted at, every level below it is the row under the one before, and a block's width is its share of the heap.

## Why

A treemap and a ring both spend a dimension on nesting, so a level is smaller than the one above it and the deep end of a chain is where the pixels have gone. Here a level costs a row and nothing else, so the twentieth dominator of an object is drawn at full height and **named, with its size, at every depth** — which the treemap can't do, because a rectangle there is covered by its own children and naming every level of it was unreadable.

On `large-dump.hprof` that is the 24 rows from the whole heap dump down through the activity, the decor view and nine layouts, each of them labelled. What it costs is the picture at a glance, so this is a shape to switch to rather than the one to open on.

## What's in it

- `StackLayout` in `shark-explorer-core`, tested as a pure function like the other two layouts.
- `StackView` in `shark-explorer-app`: one `Canvas`, the same gestures as `TreemapView`, plus the scroll.
- Every row labelled with its name and its retained size, since there is nothing covering a row.

Two decisions in the layout are worth knowing:

- **Children are sized against their parent's own weight**, with the remainder drawn as a `CellSubject.Own` block at the right end of the row, so a width is a share of the whole heap at every depth rather than of its siblings. It also leaves no pixel of a row belonging to nothing, so hit testing has no gaps.
- **Depth is bounded by `maxRows`.** The cell budget doesn't bound it: a chain of single dominators never narrows, so every level of it clears the subdivide floor and 5,000 cells would be a 5,000 row canvas. The other two shapes are bounded by their own geometry and needed no such number.

It is also the only shape taller than the window, so it is the only one that scrolls. That puts the pointer and the blocks a scroll offset apart: the view keeps the pointer where the pointer is and adds the offset only when asking the layout what is under it, and it works the hover out again when the offset changes, since scrolling moves a different block under a still pointer with no pointer event to say so.

## The second commit

Adding this put `HeapDominatorTreemap` at the fifty functions detekt allows a class — it was one function from that limit before this branch. Rather than split a 1,200 line heap dump reader somewhere arbitrary, the per-shape `present*` method came out of it: `TreemapPresentation.of` and its two siblings pair a layout with what labelling its cells takes, and `HeapDominatorTreemap.present(cells)` is what stayed behind, generic in the shape. Which shapes there are is nothing a heap dump reader should have to know, so a fourth shape now needs nothing in that class at all.

## Testing

`StackLayoutTest` (20 cases) covers the layout and the hit testing in `shark-explorer-core`. `StackViewTest` (11) covers the wiring and the scroll; `ExplorerAppTest` and `TreeLayoutTest` gained the stack case each already had for the rings, the second of which holds the window to laying the stack out once per view asked for. `shark-explorer-core:check` and `shark-explorer-app:check` are green.

One finding went into `shark/shark-explorer/AGENTS.md`, because it cost an afternoon: an injected `scroll()` **does** scroll a `verticalScroll` on desktop, but the offset is still 0 in the same breath — the scroll is animated and the frame hasn't run — so reading it right after the injection looks exactly like a wheel a headless test can't deliver.

`notes/treemap-rendering.md` has the model, and the app's `AGENTS.md` header now says there are three shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)