### PR TITLE
Document Shark Explorer on the docs site

### DIFF
--- a/.github/workflows/release-shark-explorer.yml
+++ b/.github/workflows/release-shark-explorer.yml
@@ -240,9 +240,9 @@ jobs:
           NOTES: |
             Shark Explorer ${{ needs.version.outputs.version }}, an alpha release.
 
-            A desktop app that opens an Android heap dump and shows what is holding its memory, as a
-            navigable treemap. Download the build for your platform below, open it, and drag the app to
-            Applications.
+            What it is and how to read it: https://square.github.io/leakcanary/shark-explorer/
+
+            Download the build for your platform below, open it, and drag the app to Applications.
 
             | Platform | Download | Signed |
             | --- | --- | --- |

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -1,8 +1,8 @@
 # Shark Explorer Change Log
 
-Shark Explorer is a desktop app released on its own schedule, so it has its own change log. The
-[LeakCanary change log](changelog.md) covers the libraries and never mentions this app. See
-[Releasing Shark Explorer](releasing-shark-explorer.md) for how a version gets cut.
+[Shark Explorer](shark-explorer.md) is a desktop app released on its own schedule, so it has its own
+change log. The [LeakCanary change log](changelog.md) covers the libraries and never mentions this app.
+See [Releasing Shark Explorer](releasing-shark-explorer.md) for how a version gets cut.
 
 Each entry starts with a marker for the kind of change it is, the same markers the LeakCanary change log
 uses, without the one for a newly recognized library leak:

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -1,0 +1,81 @@
+# Shark Explorer
+
+Shark Explorer is a desktop app that opens an Android heap dump and shows **what is holding its memory**.
+
+LeakCanary answers "which of these objects should have been garbage collected". Shark Explorer answers the
+question next to it: this app is using 200 MB — *what is all of it, and what is keeping it around?* It runs
+on [Shark](shark.md), so there is nothing to add to your app: any `.hprof` from any debuggable app will do.
+
+What it draws is the heap dump's **dominator tree**, as a treemap or as rings. Every object is drawn inside
+the object that is keeping it alive, so a block's area is the memory that would come back if the block
+around it let go, and the nesting is the chain of responsibility.
+
+!!! info "Shark Explorer is an alpha"
+    It is released separately from LeakCanary, on its own version line, and every release so far is marked
+    as a prerelease.
+
+## Install it
+
+Download from the
+[Shark Explorer releases](https://github.com/square/leakcanary/releases?q=shark-explorer&expanded=true):
+
+| Platform | Download | Signed |
+| --- | --- | --- |
+| macOS, Apple Silicon | `Shark-Explorer-<version>-macos-arm64.dmg` | Yes |
+| macOS, Intel | `Shark-Explorer-<version>-macos-x64.dmg` | Yes |
+| Windows | `Shark-Explorer-<version>-windows-x64.msi` | No |
+| Linux | `Shark-Explorer-<version>-linux-x64.deb` | No |
+
+The macOS builds are signed and notarized by Block, so they open like any other app. The Windows and Linux
+installers are not signed, so they warn — on Windows, SmartScreen calls the publisher unknown and the
+installer runs from **More info → Run anyway**.
+
+Nothing has to be installed alongside it: the app ships with the Java runtime it needs, and it tells you
+when a newer release exists.
+
+## Open a heap dump
+
+**Open heap dump…** takes any Android `.hprof` file. **Take heap dump…** dumps one off a connected device,
+through the `adb` of your Android SDK: pick a device, then a process. Only an app built debuggable can be
+dumped, unless the device's whole build is debuggable (`ro.debuggable=1`, which is what a `userdebug`
+emulator image is), where every process on it can be.
+
+Each heap dump opens in a window of its own, so two of them stay on screen side by side. Opening one takes
+a few seconds.
+
+## Read the map
+
+* **A rectangle is an object, and its area is what that object retains**: its own bytes, plus everything it
+  alone is keeping alive. A rectangle drawn inside another is retained by it.
+* **Point at one and the window describes it; click it and the map goes there**, redrawing that object's
+  contents across the whole view. So reading the map is a sweep of the mouse, and a rectangle a pixel wide
+  at the top of the tree is a full picture two clicks down.
+* **The pane on the left is the answer to "what holds this"**: the shortest chain from a garbage collection
+  root down to the object, one row per object, naming the field that holds the next. Every row is
+  clickable, which is also the way back out of a zoom.
+* **Shape** switches between rectangles and rings. A ring has room for fewer children, so it groups the
+  small ones sooner: better for the shape of the tree, worse for exact sizes.
+* **Colour** splits the dump by how firmly things are held. Unchecking a strength greys it out rather than
+  hiding it, which is what makes the little there is of everything else stand out.
+* Bitmaps are drawn as their own pictures where the dump has the pixels. Android keeps them outside the
+  Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
+* **All objects** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
+  come back to.
+
+## Reporting a problem
+
+Bug reports go to the [LeakCanary issue tracker](https://github.com/square/leakcanary/issues). Every run
+writes a log file to `~/.shark-explorer/logs`, one per run, the last 20 kept — **attach the one for the run
+that went wrong**. It holds the JVM, the OS and the heap limit the app was given, every step of opening the
+heap dump with how long it took, and every read of it afterwards.
+
+## Run it from source
+
+```bash
+git clone git@github.com:square/leakcanary.git
+cd leakcanary
+./gradlew :shark:shark-explorer:shark-explorer-app:run --args="path/to/dump.hprof"
+```
+
+Needs JDK 17. The path is optional: without one, the window opens with the **Open heap dump…** button and
+nothing else.

--- a/docs/shark.md
+++ b/docs/shark.md
@@ -16,7 +16,8 @@ Shark is released in layers:
 3. **Shark**: Generate heap analysis reports.
 4. **Shark Android**: Android heuristics to generate tailored heap analysis reports.
 5. **Shark CLI**: Analyze the heap of debuggable apps installed on an Android device connected to your desktop. The output is similar to the output of LeakCanary, except you don't have to add the LeakCanary dependency to your app.
-6. **LeakCanary**: Builds on top. It automatically watches destroyed activities and fragments, triggers a heap dump, runs Shark Android and then displays the result.
+6. **Shark Explorer**: A desktop app that opens a heap dump and draws what is holding its memory as a navigable treemap. See [Shark Explorer](shark-explorer.md).
+7. **LeakCanary**: Builds on top. It automatically watches destroyed activities and fragments, triggers a heap dump, runs Shark Android and then displays the result.
 
 A few more things:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - 'Overview': shark.md
     - 'Shark API': api/shark/index.md
   - 'Shark Explorer':
+    - 'Overview': shark-explorer.md
     - 'Change Log': shark-explorer-changelog.md
   - 'LeakCanary API': api/index.md
   - 'Change Log': changelog.md


### PR DESCRIPTION
Shark Explorer had no user-facing page, so #2926's release notes described the app in three lines and linked nowhere. This is the page, and the release now links to it instead of describing itself.

#2926 has merged, so this is rebased onto `main` and is one commit, `d7ca6a6`, touching five files.

## The page

`docs/shark-explorer.md`, in `docs/shark.md`'s voice: what it is and what question it answers, how to install it, how to open a heap dump, how to read the map, where the log file is, and how to run it from source. Two screens, no screenshots — the UI is still moving too fast for a picture of it to stay true.

![Rendered page, top](https://d24qwcpro867f5.cloudfront.net/repos/leakcanary/prs/2928/page-0.png)

![Rendered page, bottom](https://d24qwcpro867f5.cloudfront.net/repos/leakcanary/prs/2928/page-1.png)

## Wiring

- `Overview` joins `Change Log` under `Shark Explorer` in the nav, above the change log rather than below it.
- The change log page names the app in its first line, so that link is now the way in from a release note, which points at the change log rather than at this page.
- Shark's "released in layers" list gains an entry for the app, between Shark CLI and LeakCanary.
- The release notes swap their three-line description for a link to the page. The rest of that block, including the "What changed" link and `drag the app to Applications`, is `main`'s.

No entry in either change log: a docs page is not a change to the app, and `docs/changelog.md` is the libraries'.

## Verified

- `mkdocs build` adds no warning of its own, and every cross-link resolves, including the new one from the change log page. The two warnings it does print are `docs/api/` not being generated in this worktree, which is true on `main` too.
- The screenshots above are that build, served and rendered, not the Markdown read by eye.
- The release notes still parse as YAML, and the block scalar still comes out as Markdown rather than as one code block.
- The download table's filenames match what the workflow's rename steps actually produce.

## The two code scanning comments above are stale

`github-advanced-security[bot]` flagged both `setup-gradle` steps in `release-shark-explorer.yml` (zizmor's [`cache-poisoning`](https://docs.zizmor.sh/audits/#cache-poisoning) audit) while this branch was stacked on #2926. Those lines were #2926's, not this PR's, and they were fixed there in `c599311` — both steps now pass `cache-disabled: true`. The comments predate that commit and the rebase onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
