### PR TITLE
Say what share of the heap a retained size is in Shark Explorer

### DIFF
--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -35,6 +35,7 @@ import shark.explorer.HeapObjectSummary
 import shark.explorer.ObjectGroupKind
 import shark.explorer.ObjectGroupSummary
 import shark.explorer.formatByteSize
+import shark.explorer.formatByteSizeOfTotal
 import shark.explorer.formatObjectCount
 
 /**
@@ -54,6 +55,8 @@ import shark.explorer.formatObjectCount
 @Composable
 internal fun DetailsPanel(
   selection: Selection?,
+  /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
   /** The selected object's pixels, when it's a bitmap anything has the pixels of. */
   bitmap: ImageBitmap?,
   isStarred: Boolean,
@@ -79,11 +82,13 @@ internal fun DetailsPanel(
             "Held by ${selection.parentLabel}. $GROUP_EXPLANATION",
             style = MaterialTheme.typography.bodySmall
           )
-          Detail("Retained", formatByteSize(selection.byteCount))
+          Detail("Retained", formatByteSizeOfTotal(selection.byteCount, stronglyReachableByteCount))
         }
-        is Selection.ObjectGroup -> ObjectGroupDetails(selection.summary, coloring)
+        is Selection.ObjectGroup ->
+          ObjectGroupDetails(selection.summary, stronglyReachableByteCount, coloring)
         is Selection.Object -> ObjectDetails(
           summary = selection.summary,
+          stronglyReachableByteCount = stronglyReachableByteCount,
           bitmap = bitmap,
           isStarred = isStarred,
           coloring = coloring,
@@ -120,6 +125,7 @@ internal sealed interface Selection {
 @Composable
 private fun ObjectGroupDetails(
   summary: ObjectGroupSummary,
+  stronglyReachableByteCount: Long,
   coloring: CellColoring
 ) {
   Text(summary.title(), style = MaterialTheme.typography.titleMedium)
@@ -131,7 +137,7 @@ private fun ObjectGroupDetails(
     Box(Modifier.size(SWATCH_SIZE).background(legendColor(coloring, summary.strength)))
     Text(summary.explanation(), style = MaterialTheme.typography.bodySmall)
   }
-  Detail("Retained together", formatByteSize(summary.retainedSize))
+  Detail("Retained together", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
   Detail("Objects", formatObjectCount(summary.objectCount))
 }
 
@@ -149,6 +155,7 @@ private fun ObjectGroupSummary.explanation(): String = when (kind) {
 @Composable
 private fun ObjectDetails(
   summary: HeapObjectSummary,
+  stronglyReachableByteCount: Long,
   bitmap: ImageBitmap?,
   isStarred: Boolean,
   coloring: CellColoring,
@@ -176,8 +183,11 @@ private fun ObjectDetails(
     Box(Modifier.size(SWATCH_SIZE).background(legendColor(coloring, summary.strength)))
     Text(summary.strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
   }
-  Detail("Retained", formatByteSize(summary.retainedSize))
+  Detail("Retained", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
   Detail("Retained objects", summary.retainedCount.toString())
+  // No share of the total on the shallow size: what one object is made of on its own is never a
+  // meaningful fraction of a heap dump, and a second percentage in the column would only dilute the
+  // one that says something.
   Detail("Shallow", formatByteSize(summary.shallowSize))
   Detail("Dominates", "${summary.dominatedObjectCount} objects")
   summary.inspectorLabels.forEach { label ->

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -467,6 +467,7 @@ internal fun HeapDumpExplorer(
           hoveredSelection = hoveredCellDetails?.selection,
           hoveredRootPath = hoveredCellDetails?.rootPath,
           rootNodeId = view.navigation.current,
+          stronglyReachableByteCount = sizes.stronglyReachableByteCount,
           ways = detourWays,
           chosenWays = chosenWays,
           onChooseWay = { detour, way -> chosenWays = chosenWays + (detour to way) },
@@ -492,6 +493,7 @@ internal fun HeapDumpExplorer(
           when (screen) {
             is ExplorerScreen.Tree -> TreeScreen(
               view = view,
+              stronglyReachableByteCount = sizes.stronglyReachableByteCount,
               coloring = coloring,
               selected = clicked?.cell,
               hovered = hovered?.cell,
@@ -510,6 +512,7 @@ internal fun HeapDumpExplorer(
             )
             is ExplorerScreen.Objects -> ObjectsScreen(
               list = objects,
+              stronglyReachableByteCount = sizes.stronglyReachableByteCount,
               filter = screen.filter,
               isListing = isListing,
               coloring = coloring,
@@ -523,6 +526,7 @@ internal fun HeapDumpExplorer(
             )
             is ExplorerScreen.Starred -> StarredScreen(
               favourites = favourites,
+              stronglyReachableByteCount = sizes.stronglyReachableByteCount,
               onOpen = onOpen,
               onRemove = { objectId -> favourites = favourites.filterNot { it.objectId == objectId } },
               modifier = Modifier.fillMaxSize()
@@ -533,6 +537,7 @@ internal fun HeapDumpExplorer(
       if (screen is ExplorerScreen.Tree) {
         DetailsPanel(
           selection = details?.selection,
+          stronglyReachableByteCount = sizes.stronglyReachableByteCount,
           bitmap = describedBitmap,
           isStarred = favourites.any { it.objectId == describedSummary?.objectId },
           coloring = coloring,
@@ -648,6 +653,8 @@ private fun ScreenBar(
 @Composable
 private fun TreeScreen(
   view: ViewState,
+  /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
   coloring: CellColoring,
   selected: SelectedCell?,
   hovered: SelectedCell?,
@@ -698,6 +705,7 @@ private fun TreeScreen(
     if (pointedSelection != null && pointerOffset != null) {
       PointerCard(
         selection = pointedSelection,
+        stronglyReachableByteCount = stronglyReachableByteCount,
         coloring = coloring,
         modifier = Modifier
           .onSizeChanged { cardSize = it }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ObjectsScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ObjectsScreen.kt
@@ -41,6 +41,7 @@ import shark.explorer.ObjectListEntry
 import shark.explorer.ObjectListFilter
 import shark.explorer.formatByteSize
 import shark.explorer.formatObjectCount
+import shark.explorer.formatPercentOfTotal
 
 /**
  * Every object of the heap dump as a list, largest first, filtered by class name and kind.
@@ -52,6 +53,8 @@ import shark.explorer.formatObjectCount
 @Composable
 internal fun ObjectsScreen(
   list: ObjectList,
+  /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
   filter: ObjectListFilter,
   isListing: Boolean,
   coloring: CellColoring,
@@ -76,7 +79,7 @@ internal fun ObjectsScreen(
       HorizontalDivider()
       LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
         items(list.entries, key = { it.objectId }) { entry ->
-          ObjectRow(entry, coloring, onOpen)
+          ObjectRow(entry, stronglyReachableByteCount, coloring, onOpen)
         }
       }
     }
@@ -189,6 +192,7 @@ private fun HeaderCell(
 @Composable
 private fun ObjectRow(
   entry: ObjectListEntry,
+  stronglyReachableByteCount: Long,
   coloring: CellColoring,
   onOpen: (Long) -> Unit
 ) {
@@ -223,12 +227,23 @@ private fun ObjectRow(
       style = MaterialTheme.typography.bodySmall,
       textAlign = TextAlign.End
     )
-    Text(
-      formatByteSize(entry.retainedSize),
-      Modifier.width(SIZE_COLUMN_WIDTH),
-      style = MaterialTheme.typography.bodyMedium,
-      textAlign = TextAlign.End
-    )
+    // The share under the size rather than beside it: the column is as wide as a size and no wider,
+    // and a table's numbers only line up while every cell in the column is the same shape.
+    Column(Modifier.width(SIZE_COLUMN_WIDTH)) {
+      Text(
+        formatByteSize(entry.retainedSize),
+        Modifier.fillMaxWidth(),
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = TextAlign.End
+      )
+      Text(
+        formatPercentOfTotal(entry.retainedSize, stronglyReachableByteCount),
+        Modifier.fillMaxWidth(),
+        style = MaterialTheme.typography.labelSmall,
+        color = MUTED_TEXT,
+        textAlign = TextAlign.End
+      )
+    }
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -43,7 +43,7 @@ import shark.explorer.HeapObjectKind
 import shark.explorer.PathReference
 import shark.explorer.PathStep
 import shark.explorer.ReachabilityStrength
-import shark.explorer.formatByteSize
+import shark.explorer.formatByteSizeOfTotal
 import shark.explorer.formatObjectCount
 import shark.explorer.hexObjectId
 
@@ -121,6 +121,8 @@ internal fun PathStepRow(
   /** How this step points at the next one, which is what that step was reached through. */
   reference: PathReference?,
   nextStrength: ReachabilityStrength?,
+  /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
   coloring: CellColoring,
   onOpen: (Long) -> Unit,
   role: PathRole = PathRole.STEP,
@@ -155,7 +157,7 @@ internal fun PathStepRow(
         onOpen = if (step.isInspectable) ({ onOpen(step.objectId) }) else null
       )
     } else {
-      BriefStepLine(step)
+      BriefStepLine(step, stronglyReachableByteCount)
     }
     if (role == PathRole.DOMINATOR && detail == PathDetail.FULL) {
       // In words as well as with the ring: a chain from a GC root runs through a dozen objects, and which
@@ -172,7 +174,8 @@ internal fun PathStepRow(
       step.headline?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
       if (step.retainedCount > 0) {
         Text(
-          "Retaining ${formatByteSize(step.retainedSize)} in " + formatObjectCount(step.retainedCount),
+          "Retaining ${formatByteSizeOfTotal(step.retainedSize, stronglyReachableByteCount)} in " +
+            formatObjectCount(step.retainedCount),
           style = MaterialTheme.typography.bodySmall
         )
       }
@@ -369,14 +372,19 @@ internal fun ObjectIdentity(
 
 /** What a step of a chain that is only being glanced at says: its class, and how much of the heap it holds. */
 @Composable
-private fun BriefStepLine(step: PathStep) {
+private fun BriefStepLine(
+  step: PathStep,
+  stronglyReachableByteCount: Long
+) {
   Text(
     buildAnnotatedString {
       append(step.className.substringAfterLast('.'))
       if (step.retainedCount > 0) {
         // Beside the class name rather than under it, which is the one place a brief chain has room for how
         // much of the heap a step holds — and that is what the map is being read for.
-        withStyle(MUTED_SPAN) { append(" · ${formatByteSize(step.retainedSize)}") }
+        withStyle(MUTED_SPAN) {
+          append(" · ${formatByteSizeOfTotal(step.retainedSize, stronglyReachableByteCount)}")
+        }
       }
     },
     style = MaterialTheme.typography.bodyMedium,

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
@@ -25,6 +25,7 @@ import shark.explorer.HeapObjectSummary
 import shark.explorer.ObjectGroupSummary
 import shark.explorer.ReachabilityStrength
 import shark.explorer.formatByteSize
+import shark.explorer.formatByteSizeOfTotal
 import shark.explorer.formatObjectCount
 
 /**
@@ -45,6 +46,8 @@ import shark.explorer.formatObjectCount
 @Composable
 internal fun PointerCard(
   selection: Selection,
+  /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
   coloring: CellColoring,
   modifier: Modifier = Modifier
 ) {
@@ -59,9 +62,9 @@ internal fun PointerCard(
       verticalArrangement = Arrangement.spacedBy(1.dp)
     ) {
       when (selection) {
-        is Selection.Object -> ObjectLines(selection.summary, coloring)
-        is Selection.ObjectGroup -> ObjectGroupLines(selection.summary, coloring)
-        is Selection.Group -> GroupLines(selection)
+        is Selection.Object -> ObjectLines(selection.summary, stronglyReachableByteCount, coloring)
+        is Selection.ObjectGroup -> ObjectGroupLines(selection.summary, stronglyReachableByteCount, coloring)
+        is Selection.Group -> GroupLines(selection, stronglyReachableByteCount)
       }
     }
   }
@@ -70,6 +73,7 @@ internal fun PointerCard(
 @Composable
 private fun ObjectLines(
   summary: HeapObjectSummary,
+  stronglyReachableByteCount: Long,
   coloring: CellColoring
 ) {
   // The same three lines a step of a chain names an object with, so that the card and the chain beside
@@ -85,7 +89,7 @@ private fun ObjectLines(
   StrengthLine(summary.strength, coloring)
   // The same numbers the details panel gives a labelled row each, on two lines: a card that follows the
   // pointer has to be read at a glance, and it covers the map for as long as it's up.
-  Text(summary.retainedText(), style = MaterialTheme.typography.bodySmall)
+  Text(summary.retainedText(stronglyReachableByteCount), style = MaterialTheme.typography.bodySmall)
   Text(summary.shallowText(), style = MaterialTheme.typography.bodySmall)
 }
 
@@ -98,18 +102,22 @@ private fun ObjectLines(
 @Composable
 private fun ObjectGroupLines(
   summary: ObjectGroupSummary,
+  stronglyReachableByteCount: Long,
   coloring: CellColoring
 ) {
   Text(summary.title(), style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
   summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
   StrengthLine(summary.strength, coloring)
-  Text(summary.retainedText(), style = MaterialTheme.typography.bodySmall)
+  Text(summary.retainedText(stronglyReachableByteCount), style = MaterialTheme.typography.bodySmall)
   Text(PILE_OF_OBJECTS, style = MaterialTheme.typography.bodySmall)
 }
 
 /** The children of a rectangle that its subdivision had no room for. See [shark.explorer.CellSubject.Group]. */
 @Composable
-private fun GroupLines(selection: Selection.Group) {
+private fun GroupLines(
+  selection: Selection.Group,
+  stronglyReachableByteCount: Long
+) {
   Text(
     "${selection.nodeCount} smaller objects",
     style = MaterialTheme.typography.bodyMedium,
@@ -118,7 +126,10 @@ private fun GroupLines(selection: Selection.Group) {
   // Which rectangle they were left out of, since they have nothing else in common: that is the object to
   // go to if any of them is worth finding.
   Text("Held by ${selection.parentLabel}", style = MaterialTheme.typography.bodySmall)
-  Text("Retains ${formatByteSize(selection.byteCount)}", style = MaterialTheme.typography.bodySmall)
+  Text(
+    "Retains ${formatByteSizeOfTotal(selection.byteCount, stronglyReachableByteCount)}",
+    style = MaterialTheme.typography.bodySmall
+  )
   Text(LEFTOVER_OBJECTS, style = MaterialTheme.typography.bodySmall)
 }
 
@@ -137,14 +148,16 @@ private fun StrengthLine(
   }
 }
 
-private fun HeapObjectSummary.retainedText(): String =
-  "Retains ${formatByteSize(retainedSize)} in ${formatObjectCount(retainedCount)}"
+private fun HeapObjectSummary.retainedText(stronglyReachableByteCount: Long): String =
+  "Retains ${formatByteSizeOfTotal(retainedSize, stronglyReachableByteCount)} in " +
+    formatObjectCount(retainedCount)
 
 private fun HeapObjectSummary.shallowText(): String =
   "${formatByteSize(shallowSize)} of its own, dominates ${formatObjectCount(dominatedObjectCount)}"
 
-private fun ObjectGroupSummary.retainedText(): String =
-  "Retains ${formatByteSize(retainedSize)} in ${formatObjectCount(objectCount)}"
+private fun ObjectGroupSummary.retainedText(stronglyReachableByteCount: Long): String =
+  "Retains ${formatByteSizeOfTotal(retainedSize, stronglyReachableByteCount)} in " +
+    formatObjectCount(objectCount)
 
 /**
  * What a pile of objects has to say for itself in one line, because a rectangle full of them looks exactly

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
@@ -63,6 +63,8 @@ internal fun RootPathPanel(
   hoveredRootPath: RootPath?,
   /** The node the map is rooted at, which is where a hovered chain starts when it isn't below this one. */
   rootNodeId: Long,
+  /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
   /** The ways each stretch of the chain could run, by [shark.explorer.RootPathDetour.fromIndex]. */
   ways: Map<Int, List<RootPathWay>>,
   /** Which of them is drawn, for the stretches the reader has switched. */
@@ -119,6 +121,7 @@ internal fun RootPathPanel(
       if (drawn != null) {
         RootPathTrace(
           drawn = drawn,
+          stronglyReachableByteCount = stronglyReachableByteCount,
           ways = ways,
           chosenWays = chosenWays,
           onChooseWay = onChooseWay,
@@ -131,10 +134,20 @@ internal fun RootPathPanel(
         }
       }
       if (tail != null) {
-        HoveredTail(steps = tail, isCut = false, coloring = coloring)
+        HoveredTail(
+          steps = tail,
+          isCut = false,
+          stronglyReachableByteCount = stronglyReachableByteCount,
+          coloring = coloring
+        )
       } else if (cutTail != null) {
         // Nothing above it on screen is what holds it, so the end of it is the object being described here.
-        HoveredTail(steps = cutTail, isCut = true, coloring = coloring)
+        HoveredTail(
+          steps = cutTail,
+          isCut = true,
+          stronglyReachableByteCount = stronglyReachableByteCount,
+          coloring = coloring
+        )
       }
     }
   }
@@ -163,6 +176,7 @@ private fun noChainText(
 @Composable
 private fun RootPathTrace(
   drawn: DrawnRootPath,
+  stronglyReachableByteCount: Long,
   ways: Map<Int, List<RootPathWay>>,
   chosenWays: Map<Int, Int>,
   onChooseWay: (Int, Int) -> Unit,
@@ -184,6 +198,7 @@ private fun RootPathTrace(
         // How this step points at the next one, which is what the next step was reached through.
         reference = next?.step?.reference,
         nextStrength = next?.step?.strength,
+        stronglyReachableByteCount = stronglyReachableByteCount,
         coloring = coloring,
         onOpen = onOpen,
         role = when {
@@ -210,6 +225,7 @@ private fun HoveredTail(
   steps: List<RootPathStep>,
   /** Whether it runs on from the chain above or starts somewhere else, which the dots say. */
   isCut: Boolean,
+  stronglyReachableByteCount: Long,
   coloring: CellColoring
 ) {
   Column(Modifier.fillMaxWidth()) {
@@ -224,6 +240,7 @@ private fun HoveredTail(
         step = step.step,
         reference = next?.step?.reference,
         nextStrength = next?.step?.strength,
+        stronglyReachableByteCount = stronglyReachableByteCount,
         coloring = coloring,
         // Nothing to click: the pointer is on the map, and it leaving the map is what takes this away.
         onOpen = {},

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StarredScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StarredScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import shark.explorer.HeapObjectSummary
 import shark.explorer.ObjectDominator
 import shark.explorer.formatByteSize
+import shark.explorer.formatByteSizeOfTotal
 import shark.explorer.hexObjectId
 
 /**
@@ -29,6 +30,8 @@ import shark.explorer.hexObjectId
 @Composable
 internal fun StarredScreen(
   favourites: List<Favourite>,
+  /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
   onOpen: (Long) -> Unit,
   onRemove: (Long) -> Unit,
   modifier: Modifier = Modifier
@@ -51,7 +54,7 @@ internal fun StarredScreen(
               Text(hexObjectId(favourite.objectId), style = MaterialTheme.typography.bodySmall)
             }
             Text(
-              "Retained ${formatByteSize(favourite.retainedSize)} · " +
+              "Retained ${formatByteSizeOfTotal(favourite.retainedSize, stronglyReachableByteCount)} · " +
                 "shallow ${formatByteSize(favourite.shallowSize)} · " +
                 "dominated by ${favourite.dominatorLabel}",
               style = MaterialTheme.typography.bodySmall

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ByteSizeFormat.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ByteSizeFormat.kt
@@ -1,6 +1,8 @@
 package shark.explorer
 
 import java.util.Locale
+import kotlin.math.floor
+import kotlin.math.log10
 
 /**
  * Formats [byteCount] for display, e.g. `1.4 MB`.
@@ -26,6 +28,60 @@ fun formatByteSize(byteCount: Long): String {
 }
 
 /**
+ * Formats [byteCount] with what it is of [totalByteCount], e.g. `1.4 MB (0.0012% total)`.
+ *
+ * The share is what says whether a size matters: the same megabyte is a tenth of a small heap dump
+ * and a rounding error of a large one. It goes right after the size it qualifies rather than at the
+ * end of the line, where it would read as a share of whatever else the line says.
+ */
+fun formatByteSizeOfTotal(
+  byteCount: Long,
+  totalByteCount: Long
+): String = "${formatByteSize(byteCount)} (${formatPercentOfTotal(byteCount, totalByteCount)} total)"
+
+/**
+ * [byteCount] as a percentage of [totalByteCount], e.g. `1%` or `0.0012%`, and `<0.0001%` below what
+ * that can show.
+ *
+ * Two significant digits rather than whole percents, because what a single object holds is usually a
+ * thousandth of a percent of the heap dump, and rounding would report all but the largest as holding
+ * nothing at all. Always [Locale.US], for the same reason [formatByteSize] is.
+ */
+fun formatPercentOfTotal(
+  byteCount: Long,
+  totalByteCount: Long
+): String {
+  if (totalByteCount <= 0L) {
+    // Nothing to be a share of. Never divide by zero rather than something a reader gets to see: an
+    // empty heap dump is no heap dump.
+    return "0%"
+  }
+  val percent = byteCount * PERCENT_SCALE / totalByteCount
+  if (percent <= 0.0) {
+    return "0%"
+  }
+  if (percent < MIN_PERCENT) {
+    // Written out rather than interpolated, which would render it as 1.0E-4.
+    return "<${percentWithDecimals(MIN_PERCENT, MAX_DECIMALS)}%"
+  }
+  // As many decimals as two significant digits take: one for 1.4, four for 0.0012, none past 10.
+  val decimals = (1 - floor(log10(percent)).toInt()).coerceIn(0, MAX_DECIMALS)
+  val formatted = percentWithDecimals(percent, decimals)
+  // The zeros rounding left behind read as precision that isn't there: 1.0 becomes 1, 1.4 stays.
+  // Only past the point, or trimming would turn 100 into 1.
+  return if ('.' in formatted) {
+    "${formatted.trimEnd('0').trimEnd('.')}%"
+  } else {
+    "$formatted%"
+  }
+}
+
+private fun percentWithDecimals(
+  percent: Double,
+  decimals: Int
+): String = String.format(Locale.US, "%.${decimals}f", percent)
+
+/**
  * Formats [objectCount] for display, e.g. `1 object` or `807,231 objects`.
  *
  * Grouped in threes and never abbreviated: a count of objects sits next to a byte count, and rounding
@@ -39,3 +95,11 @@ fun formatObjectCount(objectCount: Int): String {
 
 private const val UNIT = 1024
 private val UNITS = listOf("KB", "MB", "GB", "TB")
+
+private const val PERCENT_SCALE = 100.0
+
+/** Below this a percentage is reported as being under it. See [formatPercentOfTotal]. */
+private const val MIN_PERCENT = 0.0001
+
+/** Enough decimals for [MIN_PERCENT] to be written out. */
+private const val MAX_DECIMALS = 4

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapReachability.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapReachability.kt
@@ -32,6 +32,17 @@ data class HeapSizes(
   val totalObjectCount: Int
 ) {
 
+  /**
+   * Bytes held by the objects nothing is going to let go of on its own, i.e. what [STRONG] holds.
+   *
+   * What a retained size is shown as a share of, being the memory that stays taken until something
+   * drops a reference. A share of it can pass 100%, though nothing here has come close: a strongly held
+   * object can dominate objects that are only weakly held, and those bytes count towards its retained
+   * size and not towards this.
+   */
+  val stronglyReachableByteCount: Long
+    get() = byteCountByStrength.getValue(STRONG)
+
   /** Bytes held by every object a GC root reaches, however weakly. */
   val reachableByteCount: Long
     get() = byteCountByStrength.entries.sumOf { (strength, byteCount) ->

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ByteSizeFormatTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ByteSizeFormatTest.kt
@@ -24,4 +24,45 @@ class ByteSizeFormatTest {
 
     assertThat(formatByteSize(fourPetabytes)).isEqualTo("4096 TB")
   }
+
+  @Test fun `a share of the total rounds to two significant digits`() {
+    assertThat(percentOf(42.3)).isEqualTo("42%")
+    assertThat(percentOf(9.64)).isEqualTo("9.6%")
+    assertThat(percentOf(1.04)).isEqualTo("1%")
+    assertThat(percentOf(0.96)).isEqualTo("0.96%")
+  }
+
+  @Test fun `a share of a thousandth of a percent keeps its digits`() {
+    // The usual size of one object: rounded to whole percents this would read as nothing at all.
+    assertThat(percentOf(0.001)).isEqualTo("0.001%")
+    assertThat(percentOf(0.0012)).isEqualTo("0.0012%")
+  }
+
+  @Test fun `a share smaller than a ten thousandth of a percent is reported as under it`() {
+    assertThat(percentOf(0.00004)).isEqualTo("<0.0001%")
+  }
+
+  @Test fun `a size that is the whole total is all of it`() {
+    assertThat(formatPercentOfTotal(byteCount = 100_000, totalByteCount = 100_000)).isEqualTo("100%")
+  }
+
+  @Test fun `a share of nothing is no share rather than a division by zero`() {
+    assertThat(formatPercentOfTotal(byteCount = 42, totalByteCount = 0)).isEqualTo("0%")
+  }
+
+  @Test fun `a size is formatted with its share`() {
+    val total = 100L * 1024 * 1024
+
+    assertThat(formatByteSizeOfTotal(byteCount = 1024 * 1024, totalByteCount = total))
+      .isEqualTo("1.0 MB (1% total)")
+  }
+
+  /** [formatPercentOfTotal] of a size that works out to [percent] percent of a 10 GB heap dump. */
+  private fun percentOf(percent: Double): String {
+    val totalByteCount = 10_000_000_000
+    return formatPercentOfTotal(
+      byteCount = (totalByteCount * percent / 100).toLong(),
+      totalByteCount = totalByteCount
+    )
+  }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapReachabilityTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapReachabilityTest.kt
@@ -132,6 +132,10 @@ class HeapReachabilityTest {
 
       assertThat(sizes.reachableByteCount + sizes.unreachableByteCount)
         .isEqualTo(sizes.totalByteCount)
+      // What a retained size is shown as a share of: everything the GC roots reach, less what only a
+      // soft or a weak reference points at, since a collection that needs the room can take those.
+      assertThat(sizes.stronglyReachableByteCount)
+        .isEqualTo(sizes.reachableByteCount - (64L + 128L) * ID_BYTE_SIZE)
       assertThat(sizes.byteCountByStrength.getValue(SOFT)).isEqualTo(64L * ID_BYTE_SIZE)
       assertThat(sizes.byteCountByStrength.getValue(WEAK)).isEqualTo(128L * ID_BYTE_SIZE)
       assertThat(sizes.unreachableByteCount).isEqualTo(32L * ID_BYTE_SIZE)


### PR DESCRIPTION
Every retained size in Shark Explorer now says what share of the heap it is:

`Retained 36 KB (0.39% total)`

A retained size on its own doesn't say whether an object is worth chasing — the same megabyte is a tenth of a small heap and a rounding error of a large one.

### Where

- the steps of a chain from a GC root, in full and in the one-line form a hover gets
- the card that follows the pointer
- the details panel: `Retained` and `Retained together`
- the starred list
- the objects table, which stacks the share under the size, because that column is only as wide as a size and a table's numbers only line up while every cell in a column is the same shape

Shallow sizes get no share: what one object is made of on its own is never a meaningful fraction of a heap, and a second percentage in the column would only dilute the one that says something.

### What the share is of

The strongly reachable bytes — the memory that stays taken until something drops a reference, and so what an object is competing for. `HeapReachability` already counts it and the reachability legend already displays it, so this reads nothing extra from the heap dump: `HeapSizes` gets a name for `byteCountByStrength[STRONG]` and the composables get it passed in.

On the Android heap dumps in this repo that is 95% to 97% of the whole heap dump, the rest being soft and weak referents plus the garbage that hadn't been collected when the dump was written:

| heap dump | whole dump | strongly reachable |
| --- | --- | --- |
| `large-dump.hprof` | 29 MB | 28 MB (97%) |
| `leak_asynctask_o.hprof` | 9.0 MB | 8.6 MB (95%) |
| `compose_leak.hprof` | 15 MB | 15 MB (97%) |

A share can in principle pass 100%, since a strongly held object can dominate objects that are only weakly held and those bytes count towards its retained size. Nothing here comes close — the largest single retained size in `large-dump.hprof` is 41% of the strong total.

### Format

Two significant digits — `1%`, `0.96%`, `0.0012%`, and `<0.0001%` below that — rather than whole percents, because what a single object holds is usually a thousandth of a percent of the heap, which whole percents would report as holding nothing at all.

### Testing

`:shark:shark-explorer:shark-explorer-core:check` and `:shark:shark-explorer:shark-explorer-app:check` (tests + detekt) are green. New unit tests cover the two formatters and the strongly reachable byte count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)