### PR TITLE
Stop calling every object waiting to be finalized garbage

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -361,6 +361,13 @@ numbers belong in `notes/bitmaps.md`.
 - **A click is a fraction of the view, never of the window.** `ExplorerAppTest.viewBounds` measures the
   view by its `contentDescription`, and every press helper is relative to that. Window fractions break
   the moment anything above the view changes height, which is a change to the top bar away.
+- **A test about `java.lang.ref` strengths needs a dump of a real JVM, taken without collecting first.**
+  `JvmReferenceStrengthTest` writes one with `HotSpotDiagnosticMXBean.dumpHeap(path, live = false)`,
+  because the collection a heap dump normally begins with clears a weak referent nothing else holds and,
+  since JDK 9, a phantom one — so the strengths the test is about would be missing from a dump taken the
+  usual way. That leaves it fragile in a way its KDoc explains: anything allocated between its
+  `System.gc()` and the dump can trigger a collection that clears the lot. It doesn't replace the
+  `dump { }` cases either, ART's reference classes and the lists it keeps them on not being HotSpot's.
 - Build test heap dumps with the `hprofFile.dump { }` DSL from `shark-hprof-test` rather than
   checking in binary fixtures or hand-writing hprof bytes. A dump with bitmaps in it is `BitmapDumps.kt`
   in `shark-explorer-core`'s tests — the `"a.b.C" instance { }` shorthand declares a class per instance,

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -21,12 +21,23 @@ per open heap dump, built once, holding every object of the dump.
 **Which reference matchers go in matters, and it isn't "none".** The matchers do two unrelated jobs,
 and only one of them belongs here:
 
-- `JdkReferenceMatchers.REFERENCES` is where **reference strength** lives. `WeakReference.referent`,
-  `SoftReference.referent`, `PhantomReference.referent`, `KeyedWeakReference.referent` and the
-  `Finalizer` / `FinalizerReference` / `Cleaner` list links are `IgnoredReferenceMatcher`s and nothing
-  else marks them. Follow them and a weak reference looks like it retains its referent, and the
-  finalizer list looks like one long chain of objects retaining each other. Retained size stops
-  meaning anything. **Required.**
+- **Reference strength** is `ReferenceStrengthReader.WEAKENING_REFERENCE_MATCHERS`, one
+  `IgnoredReferenceMatcher` per field of `WEAKENING_FIELDS_BY_CLASS_NAME` and nothing else, read off the
+  same map that gives those fields their strength: the `referent` and `zombie` of the five reference
+  classes, plus the cache and thread local fields. Follow one of those and a weak reference looks like it
+  retains its referent, and retained size stops meaning anything. **Required.** A field pattern matches on
+  any class of an object's hierarchy, so a `KeyedWeakReference` is covered by the `WeakReference` entry and
+  needs none of its own.
+- **Deliberately not `JdkReferenceMatchers.REFERENCES`**, which is that list plus the `prev`, `next` and
+  `element` links of the lists a runtime keeps its `Finalizer`s, `FinalizerReference`s and `Cleaner`s on,
+  ignored there so that a leak trace can't run through the queue of objects waiting to be finalized.
+  Those links retain what they point at, and on Android they are the only thing that does: the list hangs
+  off one static field, the head through that static and every entry after it through the one before. So
+  ignoring them left everything past the head of the list reading as uncollected garbage, and with it
+  every object waiting to be finalized or cleaned — on `large-dump.hprof`, 4773 of its 4774
+  `FinalizerReference`s and 3392 of its 3553 `Cleaner`s, a fifth of everything the explorer called
+  garbage. Pinned by two `HeapReachabilityTest` cases that build such a list and by
+  `JvmReferenceStrengthTest`, which dumps a real JVM that has one.
 - `AndroidReferenceMatchers` mostly suppresses noise so a leak trace stays readable. Those are real
   strong references, so ignoring them here would hide memory that really is retained. **Left out.**
   This is why `ActualMatchingReferenceReaderFactory` and not `AndroidReferenceReaderFactory`: the
@@ -50,9 +61,16 @@ the whole heap dump and they only pick which strengths are drawn in colour. See 
 
 **`SOFT`, `WEAK` and `PHANTOM` often come out at 0 bytes — but don't treat that as a rule.** The
 collection that precedes a dump clears a `Reference` whose referent nothing else was holding, so on
-many dumps there's nothing left at those strengths. Measured on `compose_leak.hprof`: 12 MB strong,
-exactly 0 B soft/weak/finalizer/phantom, 3 MB uncollected garbage. On a 287 MB production dump: 262 MB
-strong, 7 MB uncollected garbage, and 5 finalizer reachable objects totalling 1.1 KB.
+many dumps there's nothing left at those strengths. Measured on `compose_leak.hprof`: 15.8 MB strong over
+243,672 objects, 8 B weak over one, exactly 0 B soft, finalizer and phantom, 418 KB uncollected garbage
+over 15,320 objects. On a 287 MB production dump: 262 MB strong, 7 MB uncollected garbage, and 5 finalizer
+reachable objects totalling 1.1 KB — measured before the list links above were followed, so its finalizer
+count would be higher today.
+
+**And a dump where none of them is 0 looks like this.** `leak_asynctask_o.hprof`, same repo, 9.0 MB strong
+over 120,601 objects: 164 KB phantom over 1,266, 405 B finalizer over 17, 366 B thread local over 14,
+140 B soft over 5, 97 B weak over 7, and 255 KB garbage over 7,847. Worth having a dump like that to hand,
+because every one of those strengths reading 0 is also what a broken strength computation looks like.
 
 **A dump can and does contain objects that are only weakly reachable**, and not as uncollected
 garbage: a referent a thread pulled out of a reference, used, and has since let go of is weakly
@@ -406,8 +424,14 @@ arrays, 10.7 MB, 88% of what was left. `ReferenceStrengthReader.classMetadataRef
 as static field references of the class holding them.
 
 Together the garbage went from **117,997 objects / 12.0 MB to 6,029 / 190 KB**, the same order as YourKit's
-1,863. What's left is reference queue plumbing — 2,403 `Cleaner`, 2,401 `CleanerThunk`, 763
+1,863. What was left was reference queue plumbing — 2,403 `Cleaner`, 2,401 `CleanerThunk`, 763
 `FinalizerReference`, 40 `NativeAllocationRegistry` — plus a small tail.
+
+**Most of that plumbing was a third cause, found later**: it was garbage only because the list links its
+runtime holds it by were ignored, see the matchers section above. That dump isn't in the repo, so measured
+on `large-dump.hprof` instead — garbage from **38,219 objects / 1,020,454 B to 26,466 / 631,761 B**, and
+`FINALIZER` from nothing to 72 objects / 9,353 B. On `leak_asynctask_o.hprof`, garbage from 10,771 objects
+to 7,847 and `PHANTOM` from nothing to 1,266 objects / 163,917 B.
 
 The String `value` arrays are *not* part of this, though they look like they should be: the unreachable
 value arrays matched the unreachable Strings one for one, 19,278 each, so folding had been accounting for

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -1,14 +1,12 @@
 package shark.explorer
 
 import androidx.collection.MutableLongObjectMap
-import java.util.EnumSet
 import shark.ActualMatchingReferenceReaderFactory
 import shark.HeapGraph
 import shark.HeapObject
 import shark.HeapObject.HeapClass
 import shark.HeapObject.HeapInstance
 import shark.HeapObject.HeapObjectArray
-import shark.JdkReferenceMatchers
 import shark.Reference
 import shark.Reference.LazyDetails
 import shark.ReferenceLocationType.INSTANCE_FIELD
@@ -287,22 +285,26 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
     private val NOTHING_WEAKENING = WeakeningFields(emptyMap())
 
     /**
-     * The matchers that stop the retaining reader from following a reference that doesn't retain.
+     * The matchers that stop the retaining reader from following a reference that doesn't retain: every
+     * field of [WEAKENING_FIELDS_BY_CLASS_NAME] and nothing else, read off the same map that gives them
+     * their strength, so that the two halves of this class can't disagree about a reference.
      *
-     * [JdkReferenceMatchers.REFERENCES] covers weak, soft and phantom referents and the finalizer
-     * list links. The two added here are the ones it misses because LeakCanary doesn't need them:
-     * a JVM `FinalReference`'s referent, and the `zombie` an Android `FinalizerReference` moves its
-     * referent into while `finalize()` runs. Then every field of the curated lists, from the same map that
-     * gives them their strength, so that the two halves of this class can't disagree about a reference.
+     * **Deliberately not [shark.JdkReferenceMatchers.REFERENCES]**, which is a leak trace's list rather
+     * than an explorer's. Besides the referents, it drops the `prev`, `next` and `element` links of the
+     * lists a runtime keeps its `FinalizerReference`s, `Finalizer`s and `Cleaner`s on, so that a leak trace
+     * can't run through the queue of objects waiting to be finalized. Those links retain what they point
+     * at, and on Android they are the only thing that does: the list hangs off one static field, so
+     * dropping them left every entry but the head of it reading as uncollected garbage, and with them
+     * every object waiting to be finalized or cleaned. Measured on `large-dump.hprof`: 4773 of its 4774
+     * `FinalizerReference`s and 3392 of its 3553 `Cleaner`s, a fifth of everything the explorer called
+     * garbage.
      */
     val WEAKENING_REFERENCE_MATCHERS: List<ReferenceMatcher> =
-      ReferenceMatcher.fromListBuilders(EnumSet.of(JdkReferenceMatchers.REFERENCES)) + listOf(
-        instanceField("java.lang.ref.FinalReference", "referent").ignored(patternApplies = ALWAYS),
-        instanceField("java.lang.ref.FinalizerReference", "zombie").ignored(patternApplies = ALWAYS)
-      ) + (CACHE_FIELDS_BY_CLASS_NAME + THREAD_LOCAL_FIELDS_BY_CLASS_NAME)
-        .flatMap { (className, fieldNames) ->
-          fieldNames.map { instanceField(className, it).ignored(patternApplies = ALWAYS) }
+      WEAKENING_FIELDS_BY_CLASS_NAME.flatMap { (className, strengthByFieldName) ->
+        strengthByFieldName.keys.map {
+          instanceField(className, it).ignored(patternApplies = ALWAYS)
         }
+      }
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapReachabilityTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapReachabilityTest.kt
@@ -55,6 +55,61 @@ class HeapReachabilityTest {
     assertThat(strength).isEqualTo(FINALIZER)
   }
 
+  @Test fun `an object the finalizer list is the only holder of is finalizer reachable`() {
+    val file = testFolder.newFile("finalizer-list.hprof")
+    var payloadObjectId = 0L
+    file.dump {
+      // ART puts a FinalizerReference on the list FinalizerReference.head starts for every object whose
+      // class overrides finalize(), and that list is the only thing holding it: the head through the
+      // static, every entry after it through the one before. So an entry that isn't the head is only
+      // reachable through `next`, and an object waiting to be finalized only through that entry.
+      val headId = reserveObjectId()
+      val classes = referenceClasses(finalizerListHead = headId)
+      val payload = ReferenceHolder(
+        objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT))
+      )
+      payloadObjectId = payload.value
+      val second = finalizerReference(classes, referent = payload)
+      finalizerReference(classes, next = second, objectId = headId)
+      gcRoot(StickyClass(id = classes.finalizerId))
+    }
+
+    HeapExplorer.open(file).use { explorer ->
+      val tree = explorer.tree
+
+      assertThat(tree.strengthOf(payloadObjectId)).isEqualTo(FINALIZER)
+      assertThat(tree.dominatorOf(payloadObjectId)!!.label).isEqualTo("FinalizerReference")
+      assertThat(explorer.sizes.unreachableByteCount).isZero()
+    }
+  }
+
+  @Test fun `an object the cleaner list is the only holder of is phantom reachable`() {
+    val file = testFolder.newFile("cleaner-list.hprof")
+    var payloadObjectId = 0L
+    file.dump {
+      // Same list, one class down: a Cleaner is a PhantomReference, so what only a Cleaner holds is
+      // phantom reachable rather than waiting to be finalized.
+      val firstId = reserveObjectId()
+      val classes = referenceClasses()
+      val cleanerClassId = cleanerClass(classes, firstCleaner = firstId)
+      val payload = ReferenceHolder(
+        objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT))
+      )
+      payloadObjectId = payload.value
+      val second = cleaner(cleanerClassId, referent = payload)
+      cleaner(cleanerClassId, next = second, objectId = firstId)
+      gcRoot(StickyClass(id = cleanerClassId))
+    }
+
+    HeapExplorer.open(file).use { explorer ->
+      val tree = explorer.tree
+
+      assertThat(tree.strengthOf(payloadObjectId)).isEqualTo(PHANTOM)
+      assertThat(tree.dominatorOf(payloadObjectId)!!.label).isEqualTo("Cleaner")
+      assertThat(explorer.sizes.unreachableByteCount).isZero()
+    }
+  }
+
   @Test fun `a strong reference wins over a weak one`() {
     val strength = strengthOfPayload { classes, payload ->
       "com.example.Holder" instance {

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/JvmReferenceStrengthTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/JvmReferenceStrengthTest.kt
@@ -1,0 +1,296 @@
+package shark.explorer
+
+import com.sun.management.HotSpotDiagnosticMXBean
+import java.io.File
+import java.lang.management.ManagementFactory
+import java.lang.ref.PhantomReference
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.SoftReference
+import java.lang.ref.WeakReference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import shark.explorer.ReachabilityStrength.FINALIZER
+import shark.explorer.ReachabilityStrength.PHANTOM
+import shark.explorer.ReachabilityStrength.SOFT
+import shark.explorer.ReachabilityStrength.STRONG
+import shark.explorer.ReachabilityStrength.WEAK
+
+/**
+ * What the explorer makes of the four `java.lang.ref` strengths in a heap dump of a real JVM, this one:
+ * the class hierarchies, the field names and the lists the runtime keeps its references on are the
+ * runtime's own rather than this repo's idea of them.
+ *
+ * Worth a test of its own next to the `dump { }` ones, because the difference between the two is where
+ * the bug was: the lists. A `Finalizer` and a `Cleaner` live on a doubly linked list hanging off one
+ * static field, so `next` is the only thing that reaches any entry but the first, and the explorer used
+ * to inherit LeakCanary's matchers, which drop those links so that no leak trace runs through the
+ * finalization queue. Everything on such a list past its head read as uncollected garbage, and every
+ * object waiting to be finalized or cleaned with it. Nothing about the shape of a reference class says
+ * that — only a runtime that really keeps such a list does.
+ *
+ * **The dump is written without collecting first**, which taking a heap dump normally does, because a
+ * collection clears exactly what this is about: a weak referent nothing else holds is then gone from the
+ * dump rather than weakly reachable in it, and since JDK 9 a phantom referent is cleared as soon as the
+ * collector finds the object phantom reachable. It is also the shape a real Android dump has —
+ * `large-dump.hprof` holds 4769 `FinalizerReference`s and 3542 `Cleaner`s with a referent still in them.
+ *
+ * **The dump is left in `build/heap-dumps` rather than in a temporary folder**, so that the explorer can
+ * be opened on the same heap dump these assertions ran against:
+ *
+ * ```
+ * ./gradlew :shark:shark-explorer:shark-explorer-app:runNamed --args="--title=\"Reference strengths\" \
+ *   shark/shark-explorer/shark-explorer-core/build/heap-dumps/jvm-reference-strengths.hprof"
+ * ```
+ *
+ * Each payload holds an array large enough to be a rectangle of its own on the treemap, and no two of
+ * them are the same size, so that the strengths tell each other apart there.
+ */
+class JvmReferenceStrengthTest {
+
+  @Test fun `an object only a weak reference holds is weakly reachable`() {
+    val weak = explorer.tree.onlyInstanceOf("WeaklyHeldPayload")
+
+    assertThat(weak.strength).isEqualTo(WEAK)
+    assertThat(explorer.tree.dominatorOf(weak.objectId)!!.label).isEqualTo("WeakReference")
+    assertThat(explorer.tree.rootPathTo(weak.objectId).stepLabels().last())
+      .isEqualTo("referent → WeaklyHeldPayload")
+  }
+
+  @Test fun `an object only a soft reference holds is softly reachable`() {
+    val soft = explorer.tree.onlyInstanceOf("SoftlyHeldPayload")
+
+    assertThat(soft.strength).isEqualTo(SOFT)
+    assertThat(explorer.tree.dominatorOf(soft.objectId)!!.label).isEqualTo("SoftReference")
+  }
+
+  @Test fun `an object only a phantom reference holds is phantom reachable`() {
+    val phantom = explorer.tree.onlyInstanceOf("PhantomlyHeldPayload")
+
+    assertThat(phantom.strength).isEqualTo(PHANTOM)
+    assertThat(explorer.tree.dominatorOf(phantom.objectId)!!.label).isEqualTo("PhantomReference")
+  }
+
+  @Test fun `every object waiting to be finalized is finalizer reachable`() {
+    val finalizable = explorer.tree.instancesOf("FinalizablePayload")
+
+    // All of them rather than only the first: they are entries of the list `Finalizer.unfinalized`
+    // starts, and only the head of that list is reachable without following `next`.
+    assertThat(finalizable).hasSize(FINALIZABLE_COUNT)
+    assertThat(finalizable).allSatisfy { assertThat(it.strength).isEqualTo(FINALIZER) }
+    assertThat(finalizable.map { explorer.tree.dominatorOf(it.objectId)!!.label })
+      .allMatch { it == "Finalizer" }
+  }
+
+  @Test fun `an object a field also holds is strongly reachable`() {
+    val both = explorer.tree.onlyInstanceOf("StronglyAndWeaklyHeldPayload")
+
+    // A weak reference holds nothing that something else holds, so the field wins and the tree draws the
+    // object under whatever owns it. Which here is the class rather than the singleton: a Kotlin object's
+    // fields are reached through the `INSTANCE` static of its own class.
+    assertThat(both.strength).isEqualTo(STRONG)
+    assertThat(explorer.tree.dominatorOf(both.objectId)!!.label).isEqualTo("class References")
+  }
+
+  @Test fun `a path through a weak reference is weak the rest of the way down`() {
+    val box = explorer.tree.onlyInstanceOf("WeaklyHeldBox")
+    val boxed = explorer.tree.onlyInstanceOf("BoxedPayload")
+
+    // The box holds the payload with an ordinary field and only a weak reference holds the box, so the
+    // payload goes when the box does and is no more firmly held than the box is.
+    assertThat(box.strength).isEqualTo(WEAK)
+    assertThat(boxed.strength).isEqualTo(WEAK)
+    assertThat(explorer.tree.dominatorOf(boxed.objectId)!!.label).isEqualTo("WeaklyHeldBox")
+  }
+
+  @Test fun `every object of the heap dump has a strength`() {
+    // Which is what makes the strengths above a breakdown of the whole heap dump rather than of a part
+    // of it: nothing is left over to be counted at no strength at all.
+    assertThat(explorer.sizes.objectCountByStrength.values.sum())
+      .isEqualTo(explorer.sizes.totalObjectCount)
+  }
+
+  companion object {
+    private const val FINALIZABLE_COUNT = 3
+
+    private val HEAP_DUMP_FILE = File("build/heap-dumps", "jvm-reference-strengths.hprof")
+
+    /**
+     * One heap dump for the whole class: writing it is IO and opening it is three passes over what came
+     * out, and no test here changes either.
+     */
+    private lateinit var explorer: HeapExplorer
+
+    @BeforeClass @JvmStatic fun openHeapDumpOfThisJvm() {
+      allocateEveryPayload()
+
+      // Everything already dead in this JVM goes now, so that a dump of every object is a dump of the
+      // live set plus the payloads. Without this the dump came out 172 MB against 21 MB, most of it what
+      // the tests that ran before left behind, and opening that runs the test JVM out of heap. A hint
+      // rather than a promise, but HotSpot collects on it unless told not to.
+      //
+      // Every payload is still strongly held while it runs, so it neither clears a reference to one nor
+      // finalizes one, and it leaves the most room there is for the little that comes after it.
+      System.gc()
+
+      holdEachPayloadOnlyAsItsTestIsAbout()
+      failIfAnythingCollectedTheReferents()
+
+      HEAP_DUMP_FILE.parentFile.mkdirs()
+      // Left behind by the last run, and the MBean refuses to overwrite a file.
+      HEAP_DUMP_FILE.delete()
+      dumpHeapWithoutCollecting(HEAP_DUMP_FILE)
+      explorer = HeapExplorer.open(HEAP_DUMP_FILE)
+    }
+
+    @AfterClass @JvmStatic fun closeHeapDump() {
+      explorer.close()
+    }
+
+    private fun allocateEveryPayload() {
+      References.softlyHeld = SoftlyHeldPayload()
+      References.weaklyHeld = WeaklyHeldPayload()
+      References.phantomlyHeld = PhantomlyHeldPayload()
+      References.boxHeld = WeaklyHeldBox()
+      References.finalizableHeld = Array(FINALIZABLE_COUNT) { FinalizablePayload() }
+      References.strong = StronglyAndWeaklyHeldPayload()
+    }
+
+    /**
+     * Nothing but the references themselves is allocated between the collection above and the heap dump
+     * below, because a collection in that window is what would clear them — see
+     * [failIfAnythingCollectedTheReferents].
+     */
+    private fun holdEachPayloadOnlyAsItsTestIsAbout() {
+      References.soft = SoftReference(References.softlyHeld)
+      References.weak = WeakReference(References.weaklyHeld)
+      References.phantomQueue = ReferenceQueue()
+      References.phantom = PhantomReference(References.phantomlyHeld, References.phantomQueue)
+      References.weakBox = WeakReference(References.boxHeld)
+      References.weakToStrong = WeakReference(References.strong)
+      References.releaseStrongHolds()
+    }
+
+    /**
+     * A collection between the references being created and the heap dump being written would clear them,
+     * and what that looks like from a test is a payload missing from the heap dump rather than held the
+     * way it should be. Said here instead, where it can name the cause.
+     */
+    private fun failIfAnythingCollectedTheReferents() {
+      val cleared = References.soft!!.get() == null ||
+        References.weak!!.get() == null ||
+        References.weakBox!!.get() == null ||
+        // A phantom reference hands its referent to nobody, so what says it still has one is not having
+        // been enqueued: since JDK 9 the collector clears a phantom referent as it finds it and enqueues
+        // the reference in the same breath.
+        References.phantomQueue!!.poll() != null
+      check(!cleared) {
+        "A garbage collection ran between these references being created and the heap dump being " +
+          "written, and cleared them, so the heap dump holds nothing for this test to find. Whatever " +
+          "was added between the System.gc() above and the dump allocates enough to have caused one."
+      }
+    }
+
+    /**
+     * Writes a heap dump of this JVM to [file], every object of it rather than only the live ones, which
+     * is what keeps the collection that would clear these references from running first. See this class.
+     *
+     * Not [shark.JvmTestHeapDumper], which collects, as taking a heap dump normally should.
+     */
+    private fun dumpHeapWithoutCollecting(file: File) {
+      val mBean = ManagementFactory.newPlatformMXBeanProxy(
+        ManagementFactory.getPlatformMBeanServer(),
+        "com.sun.management:type=HotSpotDiagnostic",
+        HotSpotDiagnosticMXBean::class.java
+      )
+      mBean.dumpHeap(file.absolutePath, false)
+    }
+  }
+}
+
+/*
+ * The objects [JvmReferenceStrengthTest] holds each way, one class per way so that each is found by its
+ * own name and drawn as its own rectangle. Top level rather than nested, so that the name on that
+ * rectangle is the name of the thing rather than the test's name with the thing after a dollar sign.
+ */
+
+/**
+ * Where they are all held from: a Kotlin object, so a field here is a field of a singleton its own
+ * class's static points at, which is a GC root.
+ *
+ * Every payload is held twice over its life. First strongly, through one of the `*Held` fields, so that
+ * the collection the heap dump is taken after finds none of them collectable. Then only the way its test
+ * is about, once [releaseStrongHolds] has let the first hold go — which nulls fields rather than dropping
+ * an object holding them all, because such an object would be garbage still pointing at every payload,
+ * and the tree draws an object that garbage holds under the garbage.
+ */
+private object References {
+  @JvmField var softlyHeld: SoftlyHeldPayload? = null
+  @JvmField var weaklyHeld: WeaklyHeldPayload? = null
+  @JvmField var phantomlyHeld: PhantomlyHeldPayload? = null
+  @JvmField var boxHeld: WeaklyHeldBox? = null
+  @JvmField var finalizableHeld: Array<FinalizablePayload?>? = null
+
+  @JvmField var soft: SoftReference<SoftlyHeldPayload>? = null
+  @JvmField var weak: WeakReference<WeaklyHeldPayload>? = null
+  @JvmField var phantom: PhantomReference<PhantomlyHeldPayload>? = null
+  @JvmField var phantomQueue: ReferenceQueue<PhantomlyHeldPayload>? = null
+  @JvmField var weakBox: WeakReference<WeaklyHeldBox>? = null
+
+  /** The one payload held both ways at once, which is what says which of the two the tree draws. */
+  @JvmField var strong: StronglyAndWeaklyHeldPayload? = null
+  @JvmField var weakToStrong: WeakReference<StronglyAndWeaklyHeldPayload>? = null
+
+  fun releaseStrongHolds() {
+    softlyHeld = null
+    weaklyHeld = null
+    phantomlyHeld = null
+    boxHeld = null
+    // The array itself stays, emptied: dropping it is what would leave the garbage described above.
+    finalizableHeld!!.fill(null)
+  }
+}
+
+private const val MB = 1024 * 1024
+
+private class WeaklyHeldPayload {
+  @JvmField val bytes = ByteArray(4 * MB)
+}
+
+private class SoftlyHeldPayload {
+  @JvmField val bytes = ByteArray(3 * MB)
+}
+
+private class PhantomlyHeldPayload {
+  @JvmField val bytes = ByteArray(2 * MB)
+}
+
+private class StronglyAndWeaklyHeldPayload {
+  @JvmField val bytes = ByteArray(MB)
+}
+
+/** Held weakly, and holding [BoxedPayload] with an ordinary field. */
+private class WeaklyHeldBox {
+  @JvmField val boxed = BoxedPayload()
+}
+
+private class BoxedPayload {
+  @JvmField val bytes = ByteArray(5 * MB)
+}
+
+private class FinalizablePayload {
+  @JvmField val bytes = ByteArray(MB)
+
+  /**
+   * Deliberately not empty: HotSpot registers no finalizer for a `finalize()` whose body only returns, so
+   * an empty one here would mean no `Finalizer` in the heap dump and nothing for the test to find.
+   *
+   * Finalization is deprecated for removal, and a JVM run with `--finalization=disabled` writes no
+   * `Finalizer` either — which would show as the objects that should be finalizer reachable being
+   * reported as garbage.
+   */
+  protected fun finalize() {
+    bytes[0] = 1
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ReferenceClasses.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ReferenceClasses.kt
@@ -4,10 +4,17 @@ import shark.HprofWriterHelper
 import shark.ValueHolder
 import shark.ValueHolder.ReferenceHolder
 
+/** No reference: the value a field of a heap dump holds when it points at nothing. */
+private val NULL = ReferenceHolder(ValueHolder.NULL_REFERENCE)
+
 /**
  * The `java.lang.ref` class hierarchy, written the way a real heap dump has it: `referent` is
  * declared on `java.lang.ref.Reference` and inherited, which is what the reference matchers have to
  * cope with, and `FinalizerReference` extends `PhantomReference` the way Android's does.
+ *
+ * `FinalizerReference` also carries the `head` static and the `prev` and `next` fields of the doubly
+ * linked list ART keeps every object with a `finalize()` method on, because that list is the only thing
+ * holding an object waiting to be finalized — see [finalizerReference].
  */
 class ReferenceClasses(
   val referenceId: Long,
@@ -17,7 +24,14 @@ class ReferenceClasses(
   val finalizerId: Long
 )
 
-fun HprofWriterHelper.referenceClasses(): ReferenceClasses {
+/**
+ * [finalizerListHead] is what `FinalizerReference.head` points at, the first entry of the list. Its id
+ * has to come from [HprofWriterHelper.reserveObjectId], since the class is written before its instances.
+ * Null for a dump that isn't about that list, which is most of them.
+ */
+fun HprofWriterHelper.referenceClasses(
+  finalizerListHead: ReferenceHolder = NULL
+): ReferenceClasses {
   val referenceId = clazz(
     className = "java.lang.ref.Reference",
     fields = listOf("referent" to ReferenceHolder::class)
@@ -31,7 +45,12 @@ fun HprofWriterHelper.referenceClasses(): ReferenceClasses {
     finalizerId = clazz(
       className = "java.lang.ref.FinalizerReference",
       superclassId = phantomId,
-      fields = listOf("zombie" to ReferenceHolder::class)
+      staticFields = listOf("head" to finalizerListHead),
+      fields = listOf(
+        "zombie" to ReferenceHolder::class,
+        "prev" to ReferenceHolder::class,
+        "next" to ReferenceHolder::class
+      )
     )
   )
 }
@@ -51,9 +70,55 @@ fun HprofWriterHelper.reference(
 /**
  * An Android `FinalizerReference`, which holds the object it's about in [referent] until `finalize()`
  * starts and in [zombie] while it runs.
+ *
+ * [next] and [prev] are its place in the list `FinalizerReference.head` starts. [objectId] is for the
+ * entry that static points at, whose id therefore had to be reserved before the class was written.
  */
 fun HprofWriterHelper.finalizerReference(
   classes: ReferenceClasses,
-  referent: ReferenceHolder = ReferenceHolder(ValueHolder.NULL_REFERENCE),
-  zombie: ReferenceHolder = ReferenceHolder(ValueHolder.NULL_REFERENCE)
-): ReferenceHolder = instance(classes.finalizerId, fields = listOf(zombie, referent))
+  referent: ReferenceHolder = NULL,
+  zombie: ReferenceHolder = NULL,
+  next: ReferenceHolder = NULL,
+  prev: ReferenceHolder = NULL,
+  objectId: ReferenceHolder? = null
+): ReferenceHolder = instance(
+  classes.finalizerId,
+  fields = listOf(zombie, prev, next, referent),
+  objectId = objectId
+)
+
+/**
+ * `sun.misc.Cleaner`, the `PhantomReference` subclass Android runs a `thunk` from once its referent is
+ * gone, with the `first` static and the `next` and `prev` fields of the list it lives on. Held on a list
+ * of its own for the same reason a `FinalizerReference` is, so it strands the same way when the links
+ * aren't followed: `large-dump.hprof` has 3553 of these.
+ *
+ * [firstCleaner] is what the `first` static points at, from [HprofWriterHelper.reserveObjectId].
+ */
+fun HprofWriterHelper.cleanerClass(
+  classes: ReferenceClasses,
+  firstCleaner: ReferenceHolder = NULL
+): Long = clazz(
+  className = "sun.misc.Cleaner",
+  superclassId = classes.phantomId,
+  staticFields = listOf("first" to firstCleaner),
+  fields = listOf(
+    "thunk" to ReferenceHolder::class,
+    "prev" to ReferenceHolder::class,
+    "next" to ReferenceHolder::class
+  )
+)
+
+/** One `sun.misc.Cleaner` of [cleanerClassId]. See [cleanerClass] for what each field is. */
+fun HprofWriterHelper.cleaner(
+  cleanerClassId: Long,
+  referent: ReferenceHolder = NULL,
+  thunk: ReferenceHolder = NULL,
+  next: ReferenceHolder = NULL,
+  prev: ReferenceHolder = NULL,
+  objectId: ReferenceHolder? = null
+): ReferenceHolder = instance(
+  cleanerClassId,
+  fields = listOf(thunk, prev, next, referent),
+  objectId = objectId
+)

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapReading.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapReading.kt
@@ -5,6 +5,23 @@ package shark.explorer
 internal fun HeapDominatorTreemap.findByLabel(label: String): HeapObjectSummary =
   allSummaries().single { it.label == label }
 
+/**
+ * The instances of one class, by simple name, found the way the window's object list finds them: through
+ * the index. Which is what the tests of a dump of a real JVM have to use, [allSummaries] reading every
+ * object of the dump out of the heap dump file.
+ */
+internal fun HeapDominatorTreemap.instancesOf(simpleClassName: String): List<ObjectListEntry> =
+  listObjects(
+    ObjectListFilter(
+      query = simpleClassName,
+      isExactMatch = true,
+      kinds = setOf(HeapObjectKind.INSTANCE)
+    )
+  ).entries
+
+internal fun HeapDominatorTreemap.onlyInstanceOf(simpleClassName: String): ObjectListEntry =
+  instancesOf(simpleClassName).single()
+
 /** Every object of the tree, walked past the groups, which stand for objects rather than being one. */
 internal fun HeapDominatorTreemap.allSummaries(): List<HeapObjectSummary> {
   val summaries = mutableListOf<HeapObjectSummary>()


### PR DESCRIPTION
The explorer wasn't reporting weak, soft, phantom and finalizer reachability correctly, and here's why.

`HeapExplorer` took its reference matchers from `JdkReferenceMatchers.REFERENCES`, which is a *leak trace's* list. Besides the referents, it ignores the `prev`, `next` and `element` links of the lists a runtime keeps its `FinalizerReference`s, `Finalizer`s and `Cleaner`s on, so that a leak trace can't run through the queue of objects waiting to be finalized.

Those links retain what they point at, and on Android they are the only thing that does: the list hangs off one static field, the head through that static and every entry after it through the one before. So everything past the head of the list read as uncollected garbage, and with it every object waiting to be finalized or cleaned. On `large-dump.hprof`, **4773 of its 4774 `FinalizerReference`s and 3392 of its 3553 `Cleaner`s** — a fifth of everything the explorer called garbage.

`WEAKENING_REFERENCE_MATCHERS` now comes from `WEAKENING_FIELDS_BY_CLASS_NAME`, the same map that gives those fields their strength, so the two halves of `ReferenceStrengthReader` can't disagree about a reference again.

## Measured

| | before | after |
| --- | --- | --- |
| `large-dump.hprof` garbage | 38,219 objects / 1,020,454 B | 26,466 / 631,761 B |
| `large-dump.hprof` `FINALIZER` | 0 | 72 objects / 9,353 B |
| `leak_asynctask_o.hprof` garbage | 10,771 objects | 7,847 |
| `leak_asynctask_o.hprof` `PHANTOM` | 0 | 1,266 objects / 163,917 B |
| `compose_leak.hprof` garbage | 16,899 objects | 15,320 |

Open times after: 1788 / 611 / 1619 ms. `HeapDominatorTree` is fully iterative, so the deep list chains this introduces are safe.

## Tests

Three, each pinning something the others can't.

- Two `HeapReachabilityTest` cases build the list with the `dump { }` DSL, one for `FinalizerReference` and one for `sun.misc.Cleaner`. That's the ART shape, which no JVM test can produce.
- `JvmReferenceStrengthTest` dumps the test JVM itself, so the class hierarchies, the field names and the list are the runtime's own rather than this repo's idea of them. It holds a payload each of the four `java.lang.ref` ways plus two mixed cases, and asserts the strength, the dominator and the path the explorer reports for each.

  It writes the dump **without collecting first**, because the collection a heap dump normally begins with clears a weak referent nothing else holds and, since JDK 9, a phantom one — the strengths it's about would be missing from a dump taken the usual way. That's also the shape a real Android dump has. Its KDoc says what that ordering makes fragile.

All three fail without the fix — the JVM one with 2 of its 3 finalizable payloads reading `UNREACHABLE`, the head of the list being the only one that survived.

Also updated: `notes/dominator-tree.md` (the matcher section said keeping those ignores was **required**, and its measured per-strength numbers moved) and the `shark-explorer` testing conventions.

No changelog entry — shark-explorer isn't published — and no ABI dump, all three explorer modules being in `modulesWithoutPublicApi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)