### PR TITLE
Draw the heap dump's references as an expandable graph

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -1,8 +1,9 @@
 # Shark Explorer — agent guide
 
 A desktop app that renders a heap dump's dominator tree as a navigable treemap, as rings around a
-centre, or as a stack of rows the way a profiler draws a call tree. The long term goal is a YourKit-style
-heap explorer; these are the first surfaces.
+centre, or as a stack of rows the way a profiler draws a call tree — and the heap dump's own references
+as a graph of circles and arrows expanded a click at a time. The long term goal is a YourKit-style heap
+explorer; these are the first surfaces.
 
 This file is scoped to `shark/shark-explorer/`. It only records things an agent would get wrong by
 reading the source alone — everything else is in the code. Keep it that way.
@@ -41,6 +42,10 @@ dump. Doing any of that in a composable freezes the window.
 What follows for the UI: a composable never holds a tree, only what was already computed from one. A
 laid out, labelled view is a `TreemapPresentation` or a `RadialPresentation`, and a selection is a
 `HeapObjectSummary`; both arrive a little after whatever asked for them changed.
+
+**The graph shape is the exception, deliberately**: what it draws was read into an `ObjectGraph` a
+circle at a time already, so arranging it reads nothing and happens in composition — see
+`notes/decisions.md`. A `ViewRequest` is never made for it, and building one throws.
 
 The one thing that isn't thread safe is a `Sequence` a `HeapGraph` hands out — iterating one reads
 through it — so a thread reading `graph.objects` needs its own rather than a shared one.
@@ -380,8 +385,8 @@ Design decisions and findings, kept current as the work proceeds:
 
 - `notes/decisions.md` — stack and structure decisions, with rationale
 - `notes/dominator-tree.md` — dominator algorithm findings, memory/perf numbers
-- `notes/treemap-rendering.md` — adaptive depth model, the two shapes, bugs in the existing Android
-  treemap
+- `notes/treemap-rendering.md` — adaptive depth model, the shapes and what each is for, bugs in the
+  existing Android treemap
 - `notes/bitmaps.md` — which Android versions put a bitmap's pixels in the heap dump, and the two ways
   the ones that don't are fetched off the device
 

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -302,6 +302,27 @@ What made this affordable, on the 38 MB dump in the repo, over all 4,572 rectang
   expensive question — are **only asked for the object clicked**, once its chain has come back, and the
   answer is drawn into that chain. The pointer has nowhere to put a question that expensive.
 
+## On the graph, a click expands rather than goes there
+
+The graph is the one shape where a click doesn't move the window. It draws the heap dump's references
+outwards from where the view is rooted, and the whole of what it says is what has been expanded, so a
+click that re-rooted it would throw that away every time — the reader would be building the picture and
+losing it in the same gesture. Pressing a circle opens it, pressing it again closes it, and pressing the
+cell counting what didn't fit reveals another page (`ObjectGraph.pressing`).
+
+Which leaves the panels as the way to go somewhere from here: a click still describes what it landed on,
+so the chain, the details panel and the bar above the view all follow the circle pressed, and going to it
+is a click on the name there. That is the same route every other screen uses, so nothing new to learn —
+and it keeps "go there" and "show me more" as two different gestures rather than a click and a
+double click on the same circle.
+
+**Arranging the graph is done in composition, not on the heap dump's thread.** Everything drawn was read
+into `ObjectGraph` already, a circle at a time, so laying it out reads nothing and is a pure function of
+state the window holds. Putting it on that thread — where the other three shapes' layouts belong, since
+they read the heap dump for every label — cost a spinner flash on every click and three misleading "read
+the graph rooted at" lines per shape switch. `ViewRequest` refuses to be built for this shape and the
+layout `when` errors on it, so there is one way for it to be arranged rather than two.
+
 ## The chain from a GC root is a pane, not a popover
 
 Hovering used to draw the tree's containers as a grey popover following the pointer. What it said was a

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -2,11 +2,11 @@
 
 Implemented in `shark-explorer-core`: `Squarify.kt` (row layout), `TreemapLayout.kt` (adaptive depth
 and hit testing), `RadialLayout.kt` (the same, as rings), `StackLayout.kt` (the same, as a row per
-level), `TreemapRect.kt`, `LayoutCell.kt` (what the three layouts have in common),
-`HeapDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and `present()`, which labels and
-colours the cells a layout produced), `TreemapPresentation.kt` (a presentation per shape, each with an
-`of()` pairing a layout with that). Drawn by `TreemapView`, `RadialView` and `StackView` in
-`shark-explorer-app`.
+level), `TreemapRect.kt`, `LayoutCell.kt` (what the layouts have in common), `HeapDominatorTreemap.kt`
+(the dominator tree as a `TreemapTree`, and `present()`, which labels and colours the cells a layout
+produced), `TreemapPresentation.kt` (a presentation per shape, each with an `of()` pairing a layout
+with that), plus `ObjectGraph.kt` and `GraphLayout.kt` for the fourth shape, which is expanded rather
+than cut. Drawn by `TreemapView`, `RadialView`, `StackView` and `GraphView` in `shark-explorer-app`.
 
 **`of()` is a presentation's own, not a method per shape on `HeapDominatorTreemap`.** It used to be the
 other way round, and adding a third shape is what moved it: that class is a 1,200 line heap dump reader
@@ -17,6 +17,9 @@ strength off a `CellSubject`, and every shape's cells are those. **So a fourth s
 `HeapDominatorTreemap` at all.**
 
 ## Three shapes, one cut of the tree
+
+(Four shapes now; the fourth is not a cut of the tree and has its own section below. Everything here is
+about the three that are.)
 
 A cell is a `LayoutCell`: a `CellSubject` — one node, or the children a node didn't draw — plus a
 depth, a weight and whatever geometry its layout adds. `TreemapCell` adds a rectangle, `RadialCell` an
@@ -68,6 +71,51 @@ Three consequences of that, each of them a decision:
 It skips one thing the treemap does: **a row doesn't draw its bitmap**. A row is a line of text tall,
 and a bitmap fitted into 18 dp is a smear — the picture is the treemap's contribution, and asking for it
 here would cost a heap dump read and a decode per row for nothing.
+
+## The graph: the heap dump's own references, a click at a time
+
+The other three shapes divide an area between the nodes of the dominator tree. The graph divides
+nothing: circles joined by arrows, expanded outwards from the node the view is rooted at, the way Xcode's
+memory graph is read. Which makes it **the one shape that draws the heap dump's own references**, so the
+only one that can say *which field* holds an object, and whether anything else does.
+
+That difference is what shapes everything about it:
+
+- **What is drawn is state, not a cut.** `ObjectGraph` is which circles have been expanded and what each
+  of them references, immutable and grown a click at a time; `GraphLayout` arranges it into columns and
+  rows. A treemap is a function of the tree and the viewport, so it is laid out again on every resize; a
+  graph is a function of what the reader asked for, so **resizing it doesn't change it** and the reader
+  pans and zooms instead of the picture fitting the window.
+- **It reads the heap dump a circle at a time**, in `referencesFrom` — expanding one object is one read
+  of what that object points at, kept for as long as the window is open. Collapsing keeps it, so opening
+  a circle again reads nothing (`GraphViewTest` asserts exactly that). Nothing else about the shape
+  touches the heap dump.
+- **The root is an object, and the whole heap dump is not one.** Rooted at the top of the tree there is
+  no object to read references off, so `referencesFrom` answers for that node with the tree's own
+  children — `reference = null`, `isDominator = true` — which draws as unnamed arrows to what the GC
+  roots hold. One code path, not a mode: every other node answers the same call with real references.
+- **Fan-out is paged, not truncated.** A node with 4,000 references is 4,000 circles nobody can read, so
+  a page is the `REFERENCES_PER_PAGE` (24) heaviest and the rest become one `CellSubject.Group` cell
+  that reveals another page when pressed — the same subject the other three shapes use for the children
+  they didn't draw, so labels, colours and selection needed nothing new.
+- **Expanding never moves what is already on screen.** `GraphLayout` normalizes the root's centre to
+  (0, 0) and lays every column out from there, so a circle expanded at the bottom of the picture adds
+  rows below without sliding the row the reader is looking at.
+- **An object is drawn once**, at the shallowest depth it was reached by; a second arrow to it crosses
+  the picture rather than duplicating the circle. Which is what makes a cycle finite, and what makes
+  "two things hold this" visible at all.
+
+**Dominators are ringed, and the ring is the same one the chain draws.** `dominatorTree.immediateDominatorOf`
+is asked per arrow, so an arrow says both *how* an object is reached and *whether that is the reason it is
+alive* — the pair of questions this whole app is about, on one picture.
+
+**The style is shared with the chain pane, in `PathStyle.kt`.** A circle, its badge letter, its ring, the
+connector colours, the dash for a weak reference and the arrow head are one set of functions, used both by
+`PathDrawing` (a column of circles joined top to bottom) and by `GraphView` (circles joined left to right).
+They are the same picture in two arrangements, and two drawings of the same heap dump that don't match are
+two things a reader has to learn instead of one. What each keeps for itself is its arrangement: row height,
+where the gutter runs, what a click does. `drawArrowHead` takes a direction because of this — the chain's
+arrows point down, the graph's point right, and it is the same arrow.
 
 ## Depth is area-driven, not a fixed level
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
@@ -52,7 +52,17 @@ internal enum class ViewShape(val displayName: String) {
    * doesn't spend area on nesting, so the deep end of a chain is drawn and named at full size — and
    * therefore the one shape taller than the window, which is why it scrolls.
    */
-  STACK("Stack")
+  STACK("Stack"),
+
+  /**
+   * Circles joined by arrows, expanded a click at a time from the node the view is rooted at: the one
+   * shape that draws the heap dump's own references rather than the tree over them, so the one that can
+   * say *which* field holds an object and whether anything else does.
+   *
+   * Nothing is divided between anything here, so how much is drawn is entirely what was clicked, and the
+   * view pans and zooms instead of fitting the window. See [shark.explorer.GraphLayout].
+   */
+  GRAPH("Graph")
 }
 
 /**
@@ -190,6 +200,18 @@ internal val STACK_ROW_HEIGHT = 18.dp
  */
 internal val MIN_SUBDIVIDE_STACK_WIDTH = 6.dp
 internal val MIN_DRAW_STACK_WIDTH = 2.dp
+
+/**
+ * How far apart the columns of the graph are: a name's width, the arrow between two circles, and room
+ * on it for the field the reference is held in.
+ */
+internal val GRAPH_COLUMN_WIDTH = 220.dp
+
+/** And how much room one circle gets down the picture: two lines of text, with air around them. */
+internal val GRAPH_ROW_HEIGHT = 44.dp
+
+/** How wide the name beside a circle is, which is the rest of what a click on a node hits. */
+internal val GRAPH_LABEL_WIDTH = 170.dp
 
 internal val LABEL_PADDING = 3.dp
 internal val MIN_LABEL_WIDTH = 24.dp

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/GraphView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/GraphView.kt
@@ -1,0 +1,459 @@
+package shark.explorer.app
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlin.math.hypot
+import kotlin.math.pow
+import shark.explorer.CellSubject
+import shark.explorer.GraphEdgeCell
+import shark.explorer.GraphLayoutResult
+import shark.explorer.GraphNodeCell
+import shark.explorer.ReachabilityStrength
+import shark.explorer.TreemapPoint
+import shark.explorer.formatByteSize
+
+/**
+ * Draws an already laid out [GraphLayoutResult]: the object the view is rooted at on the left, what it
+ * references in the column beside it, and so on rightwards for as far as the reader has expanded.
+ *
+ * The other three shapes fit the window, so a click on one of them is a move to somewhere else. Here a
+ * click *adds to the picture* — it draws what a circle references, or takes them off again — and the
+ * picture grows past the window instead, which is why this is the one view that is dragged and zoomed.
+ *
+ * Everything in it is drawn the way a chain of objects draws it, from [PathStyle]: the same circles with
+ * the same letter of the same kind in them, the same purple line, dashed and red where the link may be
+ * let go of, the same teal for an object that dominates what hangs off it. A chain and this are one
+ * picture in two arrangements, and the two of them agreeing is what makes either worth learning.
+ */
+@Composable
+internal fun GraphView(
+  layout: GraphLayoutResult,
+  selected: SelectedCell?,
+  /** The circle the pointer is on, which is ringed more lightly than the selected one. */
+  hovered: SelectedCell?,
+  /** The circle the pointer moved onto and where it is, or null when it moved onto none or left. */
+  onHover: (PointedAt?) -> Unit,
+  /** The circle pressed, which is what expands or collapses it. See [shark.explorer.pressing]. */
+  onClick: (GraphNodeCell) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val textMeasurer = rememberTextMeasurer()
+  val density = LocalDensity.current
+  // As in every other shape: measuring the names is the one part of drawing that isn't cheap, so it
+  // happens when the picture changes and never on a redraw — and dragging one is a redraw a frame.
+  val circles = remember(layout, textMeasurer, density) {
+    layout.nodes.map { it.measure(textMeasurer, density) }
+  }
+  val arrows = remember(layout, textMeasurer, density) {
+    layout.edges.map { it.measure(textMeasurer, density) }
+  }
+  val nameColor = MaterialTheme.colorScheme.onSurface
+  var viewSize by remember { mutableStateOf(IntSize.Zero) }
+  // Null until the reader has moved it, and again whenever the graph is re-rooted: a picture rooted at
+  // another object is not one the last drag and zoom mean anything about.
+  var moved: GraphTransform? by remember(layout.rootObjectId) { mutableStateOf(null) }
+  val rootMargin = with(density) { GRAPH_ROOT_MARGIN.toPx() }
+
+  /**
+   * Where the picture is now, read every time rather than held: the gesture handlers below are started
+   * once per picture, so a value captured there would be where it was before it was ever dragged — and
+   * reading it as it is drawn is what redraws a drag without recomposing anything.
+   */
+  fun transform() = moved ?: GraphTransform.rootedIn(viewSize, rootMargin)
+
+  Box(
+    modifier
+      .onSizeChanged { viewSize = it }
+      // Before the gesture handlers, as in every other shape, so that the circle under the pointer is
+      // read wherever it is rather than only where a gesture hasn't already claimed the events.
+      .pointerInput(layout) {
+        awaitPointerEventScope {
+          while (true) {
+            val event = awaitPointerEvent()
+            when (event.type) {
+              // A move, and not the enter that comes with a pointer arriving, as in [TreemapView].
+              PointerEventType.Move -> {
+                val offset = event.changes.first().position
+                onHover(layout.cellAt(offset, transform())?.let { PointedAt(it, offset) })
+              }
+              PointerEventType.Exit -> onHover(null)
+              PointerEventType.Scroll -> {
+                val change = event.changes.first()
+                // About the pointer rather than about the middle of the view, which is how anyone
+                // aims a zoom: what is under the pointer is what the reader is zooming into.
+                moved = transform().zoomedAt(change.position, change.scrollDelta.y)
+                change.consume()
+              }
+            }
+          }
+        }
+      }
+      .pointerInput(layout) {
+        detectDragGestures { change, dragged ->
+          change.consume()
+          moved = transform().pannedBy(dragged)
+        }
+      }
+      .pointerInput(layout) {
+        // On the tap rather than on the press, unlike the shapes that don't move: a drag across this
+        // view starts with a press, and expanding whatever the drag started on is not what it asked for.
+        detectTapGestures(onTap = { offset -> layout.cellAt(offset, transform())?.let(onClick) })
+      }
+  ) {
+    Canvas(Modifier.fillMaxSize()) {
+      val transform = transform()
+      withTransform({
+        translate(transform.pan.x, transform.pan.y)
+        scale(transform.zoom, transform.zoom, pivot = Offset.Zero)
+      }) {
+        // Arrows under the circles, so that a line crossing the picture runs behind whatever it passes
+        // rather than through the middle of it.
+        arrows.forEach { arrow -> drawArrow(arrow, transform.zoom) }
+        circles.forEach { circle ->
+          drawNode(
+            circle = circle,
+            role = when {
+              circle.selects == selected -> PathRole.TARGET
+              // Which is `Dominates ↓` on a step of a chain, and the same colour: this object is why
+              // what hangs off it is still in memory.
+              circle.cell.dominatesBelow -> PathRole.DOMINATOR
+              else -> PathRole.STEP
+            },
+            isHovered = circle.selects == hovered && hovered != selected,
+            nameColor = nameColor,
+            measurer = textMeasurer,
+            zoom = transform.zoom
+          )
+        }
+      }
+    }
+  }
+}
+
+/** Where the picture sits under the view: dragged to there, and zoomed to there. */
+internal data class GraphTransform(
+  /** Where the object at the origin of the layout is drawn, in the view's own pixels. */
+  val pan: Offset,
+  val zoom: Float
+) {
+
+  fun pannedBy(dragged: Offset): GraphTransform = copy(pan = pan + dragged)
+
+  /**
+   * Zoomed by [scrollDelta] notches of the wheel, keeping whatever is under [pointer] under it.
+   *
+   * Which is the whole of what makes zooming usable: a zoom about the middle of the view walks the
+   * thing being looked at off the edge, and the reader spends the zoom dragging it back.
+   */
+  fun zoomedAt(
+    pointer: Offset,
+    scrollDelta: Float
+  ): GraphTransform {
+    val zoomed = (zoom * ZOOM_PER_NOTCH.pow(-scrollDelta)).coerceIn(MIN_ZOOM, MAX_ZOOM)
+    return GraphTransform(
+      pan = pointer - (pointer - pan) * (zoomed / zoom),
+      zoom = zoomed
+    )
+  }
+
+  companion object {
+    /**
+     * Where a picture starts: the object it is rooted at against the left edge, half way down.
+     *
+     * Half way down because everything is laid out *around* that object rather than below it — what it
+     * references runs off in both directions — and against the left edge because everything is laid
+     * out to the right of it. See [shark.explorer.GraphLayout].
+     */
+    fun rootedIn(
+      viewSize: IntSize,
+      margin: Float
+    ) = GraphTransform(pan = Offset(margin, viewSize.height / 2f), zoom = 1f)
+  }
+}
+
+/** The circle [offset] falls on, given where the picture has been dragged and zoomed to. */
+private fun GraphLayoutResult.cellAt(
+  offset: Offset,
+  transform: GraphTransform
+): GraphNodeCell? {
+  val inThePicture = (offset - transform.pan) / transform.zoom
+  return cellAt(TreemapPoint(inThePicture.x.toDouble(), inThePicture.y.toDouble()))
+}
+
+/** A circle with its name measured and what it stands for resolved, so that drawing does no work. */
+private class MeasuredCircle(
+  val cell: GraphNodeCell,
+  val selects: SelectedCell,
+  val center: Offset,
+  /** What the object is, beside the circle: its class, or how many references were left out. */
+  val name: TextLayoutResult,
+  /** How much of the heap it holds, under its name, and null for the cell that stands for no object. */
+  val retained: TextLayoutResult?
+) {
+
+  /** Whether there is more to draw under it, which is what marks a circle as worth pressing. */
+  val hasMore: Boolean
+    get() {
+      // The cell counting what a node had no room for always has: that is the whole of what it is.
+      val drawn = cell.drawn ?: return true
+      return !cell.isExpanded && drawn.referenceCount > 0
+    }
+}
+
+private fun GraphNodeCell.measure(
+  measurer: TextMeasurer,
+  density: Density
+): MeasuredCircle {
+  val drawn = drawn
+  val name = measurer.measure(
+    // The class it is, or — for the cell standing for the references its node had no room for, which
+    // is no object of the heap dump — how many of them there are.
+    text = drawn?.className?.substringAfterLast('.') ?: leftoverLabel(subject),
+    style = GRAPH_NAME_STYLE,
+    overflow = TextOverflow.Ellipsis,
+    maxLines = 1,
+    constraints = Constraints(maxWidth = with(density) { GRAPH_LABEL_WIDTH.toPx() }.toInt())
+  )
+  return MeasuredCircle(
+    cell = this,
+    selects = SelectedCell.of(subject),
+    center = Offset(center.x.toFloat(), center.y.toFloat()),
+    name = name,
+    retained = drawn?.let {
+      measurer.measure(text = formatByteSize(it.retainedSize), style = LABEL_STYLE, maxLines = 1)
+    }
+  )
+}
+
+/** An arrow with the field it is held in measured, and the geometry its head is drawn from. */
+private class MeasuredArrow(
+  val from: Offset,
+  val to: Offset,
+  /** Which way it points, as a unit vector, which the head at the far end of it is drawn along. */
+  val direction: Offset,
+  val strength: ReachabilityStrength,
+  /**
+   * Whether it points at the circle drawn hanging off this one, or at one drawn elsewhere.
+   *
+   * The second kind is what says an object is held by more than the one thing the picture hangs it
+   * below, which is half of what this shape exists to answer, so it is drawn rather than left out.
+   */
+  val isSpanning: Boolean,
+  /** Whether it is the reference the object at the end of it is still in memory because of. */
+  val isDominator: Boolean,
+  /** The field it is held in, and null where no field holds it: see [shark.explorer.GraphReference]. */
+  val name: TextLayoutResult?
+)
+
+private fun GraphEdgeCell.measure(
+  measurer: TextMeasurer,
+  density: Density
+): MeasuredArrow {
+  val start = Offset(from.x.toFloat(), from.y.toFloat())
+  val end = Offset(to.x.toFloat(), to.y.toFloat())
+  val length = hypot(end.x - start.x, end.y - start.y)
+  return MeasuredArrow(
+    from = start,
+    to = end,
+    // A reference from an object to itself is never laid out, so there is always a direction to point.
+    direction = if (length == 0f) RIGHTWARDS else (end - start) / length,
+    strength = strength,
+    isSpanning = isSpanning,
+    isDominator = reference.isDominator,
+    name = reference.reference?.let {
+      measurer.measure(
+        // The field alone, without the class it is declared on: on an arrow, the class is the circle
+        // the arrow leaves. See [referenceName].
+        text = buildAnnotatedString { append(referenceName(it)) },
+        style = LABEL_STYLE,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        constraints = Constraints(maxWidth = with(density) { GRAPH_COLUMN_WIDTH.toPx() }.toInt())
+      )
+    }
+  )
+}
+
+/**
+ * One arrow: a line from the edge of one circle to the edge of the next, with the field it is held in
+ * written along it.
+ *
+ * The name is left off below [MIN_LABEL_ZOOM], where it would be unreadable anyway and where there are
+ * enough circles on screen for every name to be crossing another one.
+ */
+private fun DrawScope.drawArrow(
+  arrow: MeasuredArrow,
+  zoom: Float
+) {
+  val radius = NODE_RADIUS.toPx()
+  val color = if (arrow.isDominator && arrow.strength == ReachabilityStrength.STRONG) {
+    // The teal a chain rings a dominator in, on the line rather than around the circle: whether an
+    // object is dominated depends on which reference reached it, so only an arrow can say it.
+    DOMINATOR_COLOR
+  } else {
+    connectorColor(arrow.strength)
+  }
+  val start = arrow.from + arrow.direction * radius
+  val end = arrow.to - arrow.direction * (radius + ARROW_HEIGHT.toPx())
+  drawLine(
+    color = color,
+    start = start,
+    end = end,
+    strokeWidth = CONNECTOR_WIDTH.toPx(),
+    pathEffect = dashOrNull(arrow.strength) ?: spanningDashOrNull(arrow.isSpanning)
+  )
+  drawArrowHead(arrow.to - arrow.direction * radius, color, arrow.direction)
+  val name = arrow.name
+  if (name == null || zoom < MIN_LABEL_ZOOM) {
+    return
+  }
+  // Half way along and on a plate, because an arrow crossing the picture runs over whatever is between
+  // its two ends — the same reason a name on the treemap sits on one.
+  val middle = (start + end) / 2f
+  val topLeft = Offset(
+    x = middle.x - name.size.width / 2f,
+    y = middle.y - name.size.height - LABEL_PLATE_PADDING
+  )
+  drawRect(
+    color = LABEL_PLATE_COLOR,
+    topLeft = topLeft - Offset(LABEL_PLATE_PADDING, LABEL_PLATE_PADDING),
+    size = Size(
+      width = name.size.width + 2 * LABEL_PLATE_PADDING,
+      height = name.size.height + 2 * LABEL_PLATE_PADDING
+    )
+  )
+  drawText(textLayoutResult = name, color = MUTED_TEXT, topLeft = topLeft)
+}
+
+/** One circle, with what the object is beside it and how much of the heap it holds under that. */
+private fun DrawScope.drawNode(
+  circle: MeasuredCircle,
+  role: PathRole,
+  isHovered: Boolean,
+  nameColor: Color,
+  measurer: TextMeasurer,
+  zoom: Float
+) {
+  val radius = NODE_RADIUS.toPx()
+  drawObjectCircle(
+    center = circle.center,
+    kind = circle.cell.drawn?.kind,
+    role = role,
+    radius = radius,
+    measurer = measurer
+  )
+  // Outside the ring the role already drew, so that a hovered dominator reads as both.
+  if (isHovered) {
+    drawNodeRing(circle.center, radius, HOVER_COLOR, HOVER_RING_GAP.toPx())
+  }
+  // A triangle beside a node with references nobody has drawn yet, the way a tree draws the handle
+  // that opens a row — which is the one thing a picture expanded a click at a time has to say: where
+  // there is more to click. Before the names are given up on, since that is when it matters most.
+  val markerTip = circle.center.x + radius + MORE_MARKER_GAP.toPx() + ARROW_HEIGHT.toPx()
+  if (circle.hasMore) {
+    drawArrowHead(Offset(markerTip, circle.center.y), CONNECTOR_COLOR, RIGHTWARDS)
+  }
+  if (zoom < MIN_LABEL_ZOOM) {
+    return
+  }
+  // Past where that triangle goes whether or not there is one, so that the names of one column line up.
+  val left = markerTip + NAME_GAP.toPx()
+  drawText(
+    textLayoutResult = circle.name,
+    color = nameColor,
+    topLeft = Offset(left, circle.center.y - circle.name.size.height)
+  )
+  circle.retained?.let { retained ->
+    drawText(textLayoutResult = retained, color = MUTED_TEXT, topLeft = Offset(left, circle.center.y))
+  }
+}
+
+/**
+ * What the cell standing for the references a node had no room for says: how many of them there are.
+ *
+ * Pressing it draws another page rather than all of them, because a node holding thousands is exactly
+ * the node whose references nobody wants drawn at once. See [shark.explorer.ObjectGraph].
+ */
+private fun leftoverLabel(subject: CellSubject<Long>): String {
+  val count = (subject as? CellSubject.Group)?.nodeCount ?: 0
+  return if (count == 1) "1 more reference" else "$count more references"
+}
+
+/**
+ * How an arrow to a circle drawn elsewhere is told from one to the circle hanging off it: dashed, where
+ * the strength of the link hasn't already dashed it.
+ *
+ * Sparser than the dashes of a link the collector may let go of, and for the same reason the dots above
+ * a cut chain are: this says how the picture was drawn rather than how the object is held.
+ */
+private fun DrawScope.spanningDashOrNull(isSpanning: Boolean): PathEffect? =
+  if (isSpanning) {
+    null
+  } else {
+    PathEffect.dashPathEffect(floatArrayOf(SPANNING_DASH_ON.toPx(), SPANNING_DASH_OFF.toPx()))
+  }
+
+/** Where an arrow points when its two ends are the same point, which nothing laid out ever is. */
+private val RIGHTWARDS = Offset(1f, 0f)
+
+/** How far the object the picture is rooted at sits from the left edge when it opens. */
+private val GRAPH_ROOT_MARGIN = 48.dp
+
+/** Between a circle and the name beside it, which is what keeps the two reading as two things. */
+private val NAME_GAP = 6.dp
+
+/** And between the circle and the triangle saying there is more under it. */
+private val MORE_MARKER_GAP = 4.dp
+
+/** Far enough out to clear the ring a dominator or the selection already drew. */
+private val HOVER_RING_GAP = 5.5.dp
+
+private val SPANNING_DASH_ON = 6.dp
+private val SPANNING_DASH_OFF = 4.dp
+
+/** What a circle's name is written in: a label, in the weight the rest of the window names objects in. */
+private val GRAPH_NAME_STYLE = LABEL_STYLE.copy(fontWeight = FontWeight.Bold)
+
+/**
+ * How far one notch of the wheel zooms, and how far in and out it goes at all.
+ *
+ * Out to where a few hundred circles fit the window, which is a picture read for its shape rather than
+ * for its names, and in to twice size, which is what looking closely at one corner of it wants.
+ */
+private const val ZOOM_PER_NOTCH = 1.1f
+private const val MIN_ZOOM = 0.15f
+private const val MAX_ZOOM = 2.5f
+
+/** Below which nothing is named: the text would be unreadable, and there is a great deal of it. */
+private const val MIN_LABEL_ZOOM = 0.55f

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -42,6 +42,9 @@ import shark.explorer.BitmapCounts
 import shark.explorer.CellSubject
 import shark.explorer.DeviceHeapDumps
 import shark.explorer.ExplorerScreen
+import shark.explorer.GraphLayout
+import shark.explorer.GraphLayoutResult
+import shark.explorer.GraphNodeCell
 import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectKind
 import shark.explorer.HeapSizes
@@ -49,6 +52,7 @@ import shark.explorer.LayoutCell
 import shark.explorer.NativeBitmapPixels
 import shark.explorer.NavigationHistory
 import shark.explorer.ObjectDominator
+import shark.explorer.ObjectGraph
 import shark.explorer.ObjectList
 import shark.explorer.ObjectListFilter
 import shark.explorer.RadialLayout
@@ -65,6 +69,7 @@ import shark.explorer.detours
 import shark.explorer.formatObjectCount
 import shark.explorer.hexObjectId
 import shark.explorer.nodeIdText
+import shark.explorer.pressing
 import shark.explorer.waysOf
 
 /**
@@ -138,6 +143,13 @@ internal fun HeapDumpExplorer(
   var favourites by remember { mutableStateOf(emptyList<Favourite>()) }
   /** A move something led to, until the path the treemap has its destination under is worked out. */
   var nodeToOpen: NodeToOpen? by remember { mutableStateOf(null) }
+  /**
+   * How much of the heap dump's own object graph the reader has expanded, which is the one shape that
+   * is drawn a click at a time rather than laid out to fit. Empty until the graph is opened.
+   */
+  var graph by remember { mutableStateOf(ObjectGraph.EMPTY) }
+  /** Whether the object the graph is being rooted at is still being read, which is a spinner. */
+  var isRootingGraph by remember { mutableStateOf(false) }
 
   /**
    * Points the panels at a node, which is what walking the history does. Each screen says which node that
@@ -164,23 +176,31 @@ internal fun HeapDumpExplorer(
   val treemapLayout = rememberTreemapLayout()
   val radialLayout = rememberRadialLayout()
   val stackLayout = rememberStackLayout()
+  val graphLayout = rememberGraphLayout()
   // In pixels, like everything a layout is measured in, so that how small is too small for an image to be
   // worth drawing is the same size on every display. See MIN_BITMAP_DRAW_SIZE.
   val minBitmapDrawSize = with(LocalDensity.current) { MIN_BITMAP_DRAW_SIZE.toPx() }
 
   // Everything one laid out view follows from, as one value: a view is asked for, and the one that comes
-  // back is the answer to it. Null until the view has been measured, which is the one state there is
-  // nothing to lay out for.
-  val viewRequest = viewportSize.takeIf { it != IntSize.Zero }?.let { size ->
-    ViewRequest(
-      navigation = navigation,
-      viewportSize = size,
-      shape = shape,
-      treemapLayout = treemapLayout,
-      radialLayout = radialLayout,
-      stackLayout = stackLayout
-    )
-  }
+  // back is the answer to it. Null where there is nothing to lay out: before the view has been measured,
+  // and for the graph, which is arranged from what the reader expanded rather than read from the tree.
+  val viewRequest = viewportSize
+    .takeIf { it != IntSize.Zero && shape != ViewShape.GRAPH }
+    ?.let { size ->
+      ViewRequest(
+        navigation = navigation,
+        viewportSize = size,
+        shape = shape,
+        treemapLayout = treemapLayout,
+        radialLayout = radialLayout,
+        stackLayout = stackLayout
+      )
+    }
+
+  // Which is the graph, arranged here rather than on the heap dump's thread: what to draw was read a
+  // circle at a time into [graph] already, so arranging it reads nothing at all and is a pure function
+  // of state this window is holding. Which is also what makes expanding a circle instant.
+  val graphPresentation = remember(graph, graphLayout) { ViewPresentation.Graph(graphLayout.layout(graph)) }
 
   // Resizing, zooming and switching shape all lay the tree out again, which reads the heap dump for
   // every visible label. All of it ends up here, on the heap dump's thread. Keyed on the request rather
@@ -188,8 +208,16 @@ internal fun HeapDumpExplorer(
   // ready by the time a screen is left for it.
   LaunchedEffect(session, viewRequest) {
     if (viewRequest == null) {
-      // Which is what a window showing a spinner and nothing else has been waiting for all along.
-      SharkLog.d { "Not laying the tree out yet: the view has no size" }
+      // Either a window showing a spinner and nothing else, which has been waiting for this all along,
+      // or the graph, which is drawn from what has been expanded rather than laid out from the tree.
+      SharkLog.d {
+        val why = if (shape == ViewShape.GRAPH) {
+          "the graph is drawn from what has been expanded"
+        } else {
+          "the view has no size"
+        }
+        "Not laying the tree out: $why"
+      }
       return@LaunchedEffect
     }
     isLayingOut = true
@@ -231,6 +259,7 @@ internal fun HeapDumpExplorer(
               reachablePath.current
             )
           )
+          ViewShape.GRAPH -> error(GRAPH_IS_NOT_LAID_OUT)
         }
       )
     }
@@ -243,6 +272,46 @@ internal fun HeapDumpExplorer(
       history = history.replacingCurrent(history.current.withTreeNavigation(view.navigation))
     }
     isLayingOut = false
+  }
+
+  // The graph is rooted at wherever the window is, so a move re-roots it and everything expanded under
+  // the object left behind is dropped. Not keyed on the graph itself, which is what expanding changes:
+  // only a move, or opening this shape for the first time, starts a picture over.
+  LaunchedEffect(session, shape, navigation.current) {
+    // An empty graph is rooted nowhere, whatever its root id says, so it is always started: the id it
+    // carries is the whole heap dump's, which is also where the window opens.
+    if (shape != ViewShape.GRAPH || (!graph.isEmpty && graph.rootObjectId == navigation.current)) {
+      return@LaunchedEffect
+    }
+    isRootingGraph = true
+    // Named for the object rather than for the shape, because this is not a view being laid out: the
+    // log tells the two apart, and so does the test counting how often the tree is laid out.
+    val root = session.read("the circle the graph opens on, ${nodeIdText(navigation.current)}") {
+      it.tree.graphObject(navigation.current)
+    }
+    // Null is a node the tree doesn't have, which [HeapDominatorTreemap.graphObject] has already said
+    // so about: the view stays empty until the window is moved somewhere it can draw.
+    graph = if (root == null) ObjectGraph.EMPTY else ObjectGraph.rootedAt(root)
+    isRootingGraph = false
+  }
+
+  // And what that came out as. The other shapes say so from the read that laid them out; this one is
+  // arranged in the window, so without this a picture that came out empty or huge says so nowhere.
+  LaunchedEffect(shape, graphPresentation) {
+    if (shape == ViewShape.GRAPH) {
+      SharkLog.d { "Drew ${graphPresentation.description()}" }
+    }
+  }
+
+  // What each expanded circle references, one read at a time: a click draws the circle straight away
+  // and this fills in what hangs off it. Keyed on the graph, so folding one answer in is what asks the
+  // next question, until there is nothing left unread.
+  LaunchedEffect(session, graph) {
+    val pending = graph.pendingObjectId ?: return@LaunchedEffect
+    val references = session.read("what ${nodeIdText(pending)} references") { explorer ->
+      explorer.tree.referencesFrom(pending, graph.referenceLimitOf(pending))
+    }
+    graph = graph.withReferences(references)
   }
 
   // How many bitmaps there are is a pass over the instances of one class, so it's read once. Fetching
@@ -425,6 +494,20 @@ internal fun HeapDumpExplorer(
       NodeToOpen.of(SelectedCell.of(subject).objectId)
     }
   }
+  /**
+   * And where a click on a circle of the graph goes, which is nowhere: it draws what that object
+   * references, or takes them off the picture again.
+   *
+   * The one shape a click doesn't move the window for. Everything else fits the window, so the only way
+   * to see more of the tree is to be shown somewhere else; here the picture itself grows, and moving the
+   * window would throw away everything the reader has expanded. What a circle *is* is still the panels'
+   * job, so a click describes it as well — and the panels are how the graph is re-rooted, since a name
+   * there leads to the object the way it does on every other screen.
+   */
+  val onExpand: (GraphNodeCell) -> Unit = { cell ->
+    clicked = DescribedCell.of(cell)
+    graph = graph.pressing(cell)
+  }
   /** Shows a node on the map with it selected, and describes it, which is the object detail view. */
   val onOpen: (Long) -> Unit = { nodeId -> nodeToOpen = NodeToOpen.of(nodeId) }
   val onGoTo: (ExplorerScreen) -> Unit = { destination -> history = history.goTo(destination) }
@@ -513,7 +596,9 @@ internal fun HeapDumpExplorer(
         Box(Modifier.weight(1f).fillMaxWidth()) {
           when (screen) {
             is ExplorerScreen.Tree -> TreeScreen(
-              view = view,
+              // What the shape picker is on, which for the graph is state this window arranged rather
+              // than a view that was laid out.
+              presentation = if (shape == ViewShape.GRAPH) graphPresentation else view.presentation,
               coloring = coloring,
               selected = clicked?.cell,
               hovered = hovered?.cell,
@@ -522,10 +607,13 @@ internal fun HeapDumpExplorer(
               pointedSelection = hoveredCellDetails?.selection,
               pointerOffset = pointerOffset,
               viewSize = viewportSize,
-              isLayingOut = isLayingOut,
+              // Rooting the graph is a read of its own, and the one read the view has nothing at all
+              // to draw during: an empty picture with no spinner over it reads as a broken shape.
+              isLayingOut = isLayingOut || isRootingGraph,
               bitmapImages = bitmapImages,
               onHover = onHover,
               onClick = onClick,
+              onExpand = onExpand,
               // Measured here rather than around every screen, so that leaving the map and coming back
               // doesn't lay it out twice for a viewport that ends up the size it already was.
               modifier = Modifier.fillMaxSize().onSizeChanged { viewportSize = it }
@@ -669,7 +757,7 @@ private fun ScreenBar(
 /** The dominator tree, drawn as one of the [ViewShape]s, with a card naming what the pointer is on. */
 @Composable
 private fun TreeScreen(
-  view: ViewState,
+  presentation: ViewPresentation,
   coloring: CellColoring,
   selected: SelectedCell?,
   hovered: SelectedCell?,
@@ -684,6 +772,8 @@ private fun TreeScreen(
   bitmapImages: Map<Long, ImageBitmap>,
   onHover: (PointedAt?) -> Unit,
   onClick: (LayoutCell<Long>) -> Unit,
+  /** What a click on the graph does instead of moving the window, which is expand or collapse. */
+  onExpand: (GraphNodeCell) -> Unit,
   modifier: Modifier = Modifier
 ) {
   // Kept across cards rather than per card, so that the first frame of the next one is placed by the size of
@@ -694,7 +784,7 @@ private fun TreeScreen(
   // says instead. It's also how a test finds where the view starts, since none of the cells is a node
   // of its own.
   Box(modifier.semantics { contentDescription = VIEW_DESCRIPTION }) {
-    when (val presentation = view.presentation) {
+    when (presentation) {
       is ViewPresentation.Treemap -> TreemapView(
         presentation = presentation.presentation,
         coloring = coloring,
@@ -721,6 +811,16 @@ private fun TreeScreen(
         hovered = hovered,
         onHover = onHover,
         onClick = onClick,
+        modifier = Modifier.fillMaxSize()
+      )
+      // Coloured by nothing the picker above it offers: a circle says what kind of object it is and a
+      // line how firmly it is held, which is the chain's scheme rather than the map's.
+      is ViewPresentation.Graph -> GraphView(
+        layout = presentation.layout,
+        selected = selected,
+        hovered = hovered,
+        onHover = onHover,
+        onClick = onExpand,
         modifier = Modifier.fillMaxSize()
       )
     }
@@ -810,6 +910,25 @@ private fun rememberStackLayout(): StackLayout<Long> {
 }
 
 /**
+ * And the graph layout, scaled the same way. Its circle is the same size as a chain's, since the two
+ * are the same drawing: see [PathStyle].
+ */
+@Composable
+private fun rememberGraphLayout(): GraphLayout {
+  val density = LocalDensity.current
+  return remember(density) {
+    with(density) {
+      GraphLayout(
+        columnWidth = GRAPH_COLUMN_WIDTH.toPx().toDouble(),
+        rowHeight = GRAPH_ROW_HEIGHT.toPx().toDouble(),
+        nodeRadius = NODE_RADIUS.toPx().toDouble(),
+        labelWidth = GRAPH_LABEL_WIDTH.toPx().toDouble()
+      )
+    }
+  }
+}
+
+/**
  * Everything one view of the tree follows from, which is therefore everything that lays it out again:
  * where the map is, how big the view is, which shape it's drawn as, and the thresholds that shape is laid
  * out to. A [ViewState] is the answer to one of these.
@@ -829,6 +948,11 @@ private data class ViewRequest(
   val radialLayout: RadialLayout<Long>,
   val stackLayout: StackLayout<Long>
 ) {
+
+  init {
+    check(shape != ViewShape.GRAPH) { GRAPH_IS_NOT_LAID_OUT }
+  }
+
   val viewport: TreemapRect
     get() = TreemapRect(
       left = 0.0,
@@ -866,6 +990,8 @@ internal sealed interface ViewPresentation {
   data class Radial(val presentation: RadialPresentation) : ViewPresentation
 
   data class Stack(val presentation: StackPresentation) : ViewPresentation
+
+  data class Graph(val layout: GraphLayoutResult) : ViewPresentation
 }
 
 /** What a laid out view amounts to, for the log: one that drew nothing at all says so here. */
@@ -878,6 +1004,10 @@ private fun ViewPresentation.description(): String = when (this) {
   is ViewPresentation.Stack ->
     "${presentation.cells.size} blocks in ${presentation.layout.rowCount} rows, " +
       "${presentation.truncatedNodeCount} nodes not expanded"
+  // How wide it came out as well, since that is how far the reader has expanded it.
+  is ViewPresentation.Graph ->
+    "${layout.nodes.size} circles and ${layout.edges.size} arrows, " +
+      "${layout.nodes.maxOfOrNull { it.depth + 1 } ?: 0} columns"
 }
 
 /**
@@ -1023,6 +1153,14 @@ private fun SelectionRequest.description(): String = when (this) {
   is SelectionRequest.Object -> "what ${nodeIdText(objectId)} is"
   is SelectionRequest.Group -> "what the $nodeCount objects under ${nodeIdText(parentObjectId)} are"
 }
+
+/**
+ * Why the shape the reader expands is the one shape a [ViewRequest] is never made for: nothing about it
+ * comes off the heap dump's thread, so asking for it as a view is a mistake rather than a slow path.
+ */
+private const val GRAPH_IS_NOT_LAID_OUT =
+  "The graph is arranged from the object graph the reader has expanded rather than laid out from the " +
+    "tree, so it is never asked for as a view. See graphPresentation in HeapDumpExplorer."
 
 private const val ROOT_NODE = HeapDominatorTreemap.ROOT_OBJECT_ID
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -18,26 +18,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextMeasurer
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.drawText
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import shark.ReferenceLocationType
 import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectKind
 import shark.explorer.PathReference
@@ -55,10 +44,9 @@ import shark.explorer.hexObjectId
  * draws is drawn by this — see [RootPathPanel] — so that two chains of the same heap dump never read
  * differently.
  *
- * Each object's circle carries the letter of its kind, in that kind's colour, so that a column of them says
- * what it is a column of before any of the names are read: `I` for an instance, `C` for a class. How firmly
- * a link holds is the line rather than the circle — colour and dashes — which is what leaves the circle free
- * to say what the object is.
+ * What a circle, a line and an arrow head look like is [PathStyle], which the graph draws its objects with
+ * too. What this file owns is the column: a row per object, the gutter down the left of it, and the
+ * reference tied to that line under each row.
  */
 
 /**
@@ -295,6 +283,26 @@ internal fun PathCutRow(
 }
 
 /**
+ * What one object is to the object a drawing is about, drawn as a ring around its circle by
+ * [drawObjectCircle]. Named after the chain because that is where it was first said, and read by
+ * everything that draws an object: the graph gives its circles a role from the same three.
+ */
+internal enum class PathRole {
+
+  /** An object on the way rather than the reason: no ring. */
+  STEP,
+
+  /**
+   * An object that dominates what hangs below it: every path from a GC root to those objects goes
+   * through it, so releasing it is what would free them.
+   */
+  DOMINATOR,
+
+  /** The object the window is describing, which the panels beside the view are about. */
+  TARGET
+}
+
+/**
  * How much a chain says about each of its objects.
  *
  * A chain from a GC root down to a bitmap of a real app runs through a dozen objects and can be cut at
@@ -309,22 +317,6 @@ internal enum class PathDetail(val rowSpacing: Dp) {
 
   /** Its class alone, with its retained size beside it, and the gutter for how it is held. */
   BRIEF(6.dp)
-}
-
-/** What one object of a chain is to the object the chain leads to, drawn as a ring around its circle. */
-internal enum class PathRole {
-
-  /** An object the chain runs through, on the way rather than the reason. */
-  STEP,
-
-  /**
-   * An object that dominates the one the chain leads to: every path from a GC root goes through it, so
-   * releasing it is what would free the object.
-   */
-  DOMINATOR,
-
-  /** The object the chain leads to, which is the last of its steps. */
-  TARGET
 }
 
 /**
@@ -389,20 +381,10 @@ private fun BriefStepLine(step: PathStep) {
 private fun ReferenceLine(reference: PathReference) {
   Text(
     buildAnnotatedString {
+      // Which class the field is read on as well as its name, because the row above names the object's
+      // own class and an inherited field is declared on another one.
       withStyle(MUTED_SPAN) { append(reference.ownerPrefix()) }
-      withStyle(
-        SpanStyle(
-          textDecoration = TextDecoration.Underline,
-          // Italic for a static field, which belongs to the class rather than to the instance above.
-          fontStyle = if (reference.locationType == ReferenceLocationType.STATIC_FIELD) {
-            FontStyle.Italic
-          } else {
-            FontStyle.Normal
-          }
-        )
-      ) {
-        append(reference.displayName())
-      }
+      append(referenceName(reference))
     },
     style = MaterialTheme.typography.bodySmall
   )
@@ -417,26 +399,13 @@ private fun ReferenceLine(reference: PathReference) {
 internal fun Modifier.clickableRow(onClick: () -> Unit): Modifier =
   pointerHoverIcon(PointerIcon.Hand).clickable(onClick = onClick)
 
-/** The class the field is read on, with no dot before an array index: `Tile.view`, `Object[][3]`. */
-private fun PathReference.ownerPrefix(): String =
-  if (locationType == ReferenceLocationType.ARRAY_ENTRY) ownerClassName else "$ownerClassName."
-
-private fun PathReference.displayName(): String = when (locationType) {
-  ReferenceLocationType.ARRAY_ENTRY -> "[$name]"
-  ReferenceLocationType.LOCAL -> LOCAL_VARIABLE
-  ReferenceLocationType.INSTANCE_FIELD, ReferenceLocationType.STATIC_FIELD -> name
-}
-
 /**
- * The line running through the objects of a chain: this one's circle with the letter of its kind in it, and
- * half a line to each of its neighbours, which the neighbour draws the other half of.
+ * The line running through the objects of a chain: this one's circle, and half a line to each of its
+ * neighbours, which the neighbour draws the other half of.
  *
  * A link no stronger than a `java.lang.ref.Reference` or a cache is dashed and takes that strength's
- * colour, which is how a path that only holds until memory runs short reads as one.
- *
- * A null [kind] draws the circle hollow and empty, for a row that stands above the objects of a chain rather
- * than being one of them. A [role] other than [PathRole.STEP] rings it, which is how the objects that own
- * the one at the end of the chain are picked out of the ones merely on the way.
+ * colour, which is how a path that only holds until memory runs short reads as one. The circle itself is
+ * [drawObjectCircle], which is also what the graph draws its objects with.
  */
 @Composable
 private fun NodeGutter(
@@ -474,84 +443,18 @@ private fun NodeGutter(
         drawArrowHead(Offset(centerX, size.height), connectorColor(outgoing))
       }
     }
-    val center = Offset(centerX, centerY)
-    if (kind != null) {
-      drawCircle(color = kind.badgeColor, radius = radius, center = center)
-      drawBadgeLetter(measurer, kind, center)
-    }
-    drawCircle(
-      color = if (kind == null) CONNECTOR_COLOR else kind.badgeColor,
+    drawObjectCircle(
+      center = Offset(centerX, centerY),
+      kind = kind,
+      role = role,
       radius = radius,
-      center = center,
-      style = Stroke(width = strokeWidth)
+      measurer = measurer
     )
-    val ringColor = when (role) {
-      PathRole.STEP -> null
-      PathRole.DOMINATOR -> DOMINATOR_COLOR
-      PathRole.TARGET -> SELECTION_COLOR
-    }
-    if (ringColor != null) {
-      drawCircle(
-        color = ringColor,
-        radius = radius + RING_GAP.toPx(),
-        center = center,
-        style = Stroke(width = RING_WIDTH.toPx())
-      )
-    }
   }
 }
-
-/** The letter of a kind, in the middle of its circle: what the object is, before its name is read. */
-private fun DrawScope.drawBadgeLetter(
-  measurer: TextMeasurer,
-  kind: HeapObjectKind,
-  center: Offset
-) {
-  val letter = measurer.measure(
-    text = kind.badgeLetter,
-    style = TextStyle(
-      color = BADGE_LETTER_COLOR,
-      fontSize = BADGE_LETTER_SIZE,
-      fontWeight = FontWeight.Bold
-    )
-  )
-  drawText(
-    textLayoutResult = letter,
-    topLeft = Offset(center.x - letter.size.width / 2f, center.y - letter.size.height / 2f)
-  )
-}
-
-/** Says which way the line runs, at the bottom of it, where the next object is. */
-private fun DrawScope.drawArrowHead(
-  tip: Offset,
-  color: Color
-) {
-  val halfWidth = ARROW_WIDTH.toPx() / 2
-  val height = ARROW_HEIGHT.toPx()
-  val head = Path().apply {
-    moveTo(tip.x, tip.y)
-    lineTo(tip.x - halfWidth, tip.y - height)
-    lineTo(tip.x + halfWidth, tip.y - height)
-    close()
-  }
-  drawPath(head, color)
-}
-
-private fun connectorColor(strength: ReachabilityStrength): Color =
-  if (strength == ReachabilityStrength.STRONG) CONNECTOR_COLOR else WEAK_CONNECTOR_COLOR
-
-private fun DrawScope.dashOrNull(strength: ReachabilityStrength): PathEffect? =
-  if (strength == ReachabilityStrength.STRONG) {
-    null
-  } else {
-    PathEffect.dashPathEffect(floatArrayOf(DASH_ON.toPx(), DASH_OFF.toPx()))
-  }
 
 /** What a step that dominates the object at the end of the chain says about itself. */
 internal const val DOMINATES_BELOW = "Dominates ↓"
-
-/** How a leak trace names the reference a running method holds, which has no field to name. */
-private const val LOCAL_VARIABLE = "<local variable>"
 
 /** Wide enough for the line, its arrow head and a ring to sit clear of the text beside it. */
 private val GUTTER_WIDTH = 26.dp
@@ -559,75 +462,15 @@ private val GUTTER_WIDTH = 26.dp
 /** Where down a row the object's circle sits, which is the middle of its first line of text. */
 private val NODE_CENTER_Y = 11.dp
 
-/** Big enough for a letter to be read in, which is what makes the circle say what the object is. */
-private val NODE_RADIUS = 8.dp
-
 /** And where down a reference's own row the bracket tying it to the line sits, which is its first line. */
 private val REFERENCE_TIE_Y = 9.dp
-
-private val CONNECTOR_WIDTH = 1.5.dp
-private val ARROW_WIDTH = 7.dp
-private val ARROW_HEIGHT = 5.dp
-private val DASH_ON = 3.dp
-private val DASH_OFF = 3.dp
 
 /** Tall enough for the dots above a cut chain to read as a line, short enough to cost it no room. */
 private val CUT_ROW_HEIGHT = 14.dp
 private val CUT_DASH_ON = 2.dp
 private val CUT_DASH_OFF = 4.dp
 
-/** How far outside a step's own circle the ring picking it out sits. */
-private val RING_GAP = 2.5.dp
-private val RING_WIDTH = 1.5.dp
-
-private val BADGE_LETTER_SIZE = 10.sp
-
-/** On every kind's colour, all of which are dark enough to read white out of. */
-private val BADGE_LETTER_COLOR = Color.White
-
 /** What the object the panel is describing is drawn behind, which is the end of the chain. */
 private val TARGET_BACKGROUND = Color(0x1A2196F3)
 private val TARGET_SHAPE = RoundedCornerShape(4.dp)
 private val TARGET_PADDING = 4.dp
-
-/** The purple LeakCanary draws a leak trace in, which this is the same shape as. */
-private val CONNECTOR_COLOR = Color(0xFF7E57C2)
-
-/** And what a link the garbage collector may let go of is drawn in, dashed. */
-private val WEAK_CONNECTOR_COLOR = Color(0xFFB0453A)
-
-/**
- * What an object that owns the one at the end of a chain is ringed and labelled in. Its own hue, because
- * the two colours already in a chain mean how firmly a link holds, and this says nothing about that.
- */
-internal val DOMINATOR_COLOR = Color(0xFF00796B)
-
-/** For the parts of a line that say what an object is rather than which one it is. */
-internal val MUTED_TEXT = Color(0xFF6E6E6E)
-
-/** The same, for the part of a line that is one text: greyed, and unbolded where the line is bold. */
-private val MUTED_SPAN = SpanStyle(color = MUTED_TEXT, fontWeight = FontWeight.Normal)
-
-/** The letter drawn in an object's circle, which is what kind of object it is. */
-private val HeapObjectKind.badgeLetter: String
-  get() = when (this) {
-    HeapObjectKind.CLASS -> "C"
-    HeapObjectKind.INSTANCE -> "I"
-    HeapObjectKind.OBJECT_ARRAY -> "A"
-    HeapObjectKind.PRIMITIVE_ARRAY -> "P"
-  }
-
-/**
- * And the colour of that circle: one per kind, so that a chain of instances and a chain that runs through
- * an array read differently at a glance.
- *
- * Every one of them dark enough for the white letter inside it, and none of them a colour a chain already
- * uses: the purple of the line, the red of a link that may be let go of, the teal of a dominator.
- */
-private val HeapObjectKind.badgeColor: Color
-  get() = when (this) {
-    HeapObjectKind.CLASS -> Color(0xFFEF6C00)
-    HeapObjectKind.INSTANCE -> Color(0xFF3949AB)
-    HeapObjectKind.OBJECT_ARRAY -> Color(0xFF00838F)
-    HeapObjectKind.PRIMITIVE_ARRAY -> Color(0xFF558B2F)
-  }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathStyle.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathStyle.kt
@@ -1,0 +1,243 @@
+package shark.explorer.app
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import shark.ReferenceLocationType
+import shark.explorer.HeapObjectKind
+import shark.explorer.PathReference
+import shark.explorer.ReachabilityStrength
+
+/**
+ * How an object and a reference are drawn, wherever the window draws one.
+ *
+ * Two surfaces draw the heap dump's own objects and references rather than the tree's cells: a chain
+ * from a GC root ([PathDrawing]) and the expandable graph ([GraphView]). They are the same picture in
+ * two arrangements — a column of circles joined top to bottom, and circles joined left to right — so
+ * what a circle, a line and an arrow head look like lives here and neither of them owns it. Change a
+ * colour or a radius here and both change together, which is the whole point: two drawings of the same
+ * heap dump that don't match are two things a reader has to learn instead of one.
+ *
+ * What each surface keeps for itself is its arrangement: how tall a row is, where the gutter runs,
+ * what happens on a click.
+ */
+
+/**
+ * One object's circle: the letter of its kind in it, in that kind's colour, and a ring around it when
+ * it is more than a step on the way.
+ *
+ * The letter is what makes a picture of circles say what it is a picture of before any of the names
+ * are read: `I` for an instance, `C` for a class. How firmly an object is held is said by the lines
+ * into it rather than by the circle, which is what leaves the circle free to say what the object is.
+ *
+ * A null [kind] draws it hollow and empty, for something that is no object of the heap dump: the whole
+ * heap dump itself, a GC root, a pile of objects the dominator tree gathered under one node.
+ */
+internal fun DrawScope.drawObjectCircle(
+  center: Offset,
+  kind: HeapObjectKind?,
+  role: PathRole = PathRole.STEP,
+  radius: Float = NODE_RADIUS.toPx(),
+  measurer: TextMeasurer? = null
+) {
+  if (kind != null) {
+    drawCircle(color = kind.badgeColor, radius = radius, center = center)
+    measurer?.let { drawBadgeLetter(it, kind, center, radius) }
+  }
+  drawCircle(
+    color = if (kind == null) CONNECTOR_COLOR else kind.badgeColor,
+    radius = radius,
+    center = center,
+    style = Stroke(width = CONNECTOR_WIDTH.toPx())
+  )
+  when (role) {
+    PathRole.STEP -> Unit
+    PathRole.DOMINATOR -> drawNodeRing(center, radius, DOMINATOR_COLOR)
+    PathRole.TARGET -> drawNodeRing(center, radius, SELECTION_COLOR)
+  }
+}
+
+/** What picks one circle out of the rest: a ring outside it, clear of the circle's own outline. */
+internal fun DrawScope.drawNodeRing(
+  center: Offset,
+  radius: Float,
+  color: Color,
+  gap: Float = RING_GAP.toPx()
+) {
+  drawCircle(
+    color = color,
+    radius = radius + gap,
+    center = center,
+    style = Stroke(width = RING_WIDTH.toPx())
+  )
+}
+
+/** The letter of a kind, in the middle of its circle, and nothing at all when it won't fit in one. */
+private fun DrawScope.drawBadgeLetter(
+  measurer: TextMeasurer,
+  kind: HeapObjectKind,
+  center: Offset,
+  radius: Float
+) {
+  val letter = measurer.measure(
+    text = kind.badgeLetter,
+    style = TextStyle(
+      color = BADGE_LETTER_COLOR,
+      fontSize = BADGE_LETTER_SIZE,
+      fontWeight = FontWeight.Bold
+    )
+  )
+  if (letter.size.width > radius * 2) {
+    return
+  }
+  drawText(
+    textLayoutResult = letter,
+    topLeft = Offset(center.x - letter.size.width / 2f, center.y - letter.size.height / 2f)
+  )
+}
+
+/** Says which way a line runs, at the end of it, where the object it points at is. */
+internal fun DrawScope.drawArrowHead(
+  tip: Offset,
+  color: Color,
+  /** Which way it points, as a unit vector. Down the gutter by default, which is a chain's direction. */
+  direction: Offset = DOWNWARDS
+) {
+  val base = tip - direction * ARROW_HEIGHT.toPx()
+  val across = Offset(-direction.y, direction.x) * (ARROW_WIDTH.toPx() / 2)
+  val head = Path().apply {
+    moveTo(tip.x, tip.y)
+    lineTo(base.x - across.x, base.y - across.y)
+    lineTo(base.x + across.x, base.y + across.y)
+    close()
+  }
+  drawPath(head, color)
+}
+
+/**
+ * The colour of the line into an object: the purple a leak trace is drawn in, or the red of a link the
+ * garbage collector may let go of.
+ */
+internal fun connectorColor(strength: ReachabilityStrength): Color =
+  if (strength == ReachabilityStrength.STRONG) CONNECTOR_COLOR else WEAK_CONNECTOR_COLOR
+
+/** And its dashes, which is how a path that only holds until memory runs short reads as one. */
+internal fun DrawScope.dashOrNull(strength: ReachabilityStrength): PathEffect? =
+  if (strength == ReachabilityStrength.STRONG) {
+    null
+  } else {
+    PathEffect.dashPathEffect(floatArrayOf(DASH_ON.toPx(), DASH_OFF.toPx()))
+  }
+
+/**
+ * The field a reference is held in: underlined, and italic for a static field, which belongs to the
+ * class rather than to the instance holding it.
+ *
+ * Without the class it is declared on, which is [ownerPrefix] and is written before this wherever
+ * there is room: on an arrow of the graph the class is the circle the arrow leaves.
+ */
+internal fun referenceName(reference: PathReference): AnnotatedString = buildAnnotatedString {
+  withStyle(
+    SpanStyle(
+      textDecoration = TextDecoration.Underline,
+      fontStyle = if (reference.locationType == ReferenceLocationType.STATIC_FIELD) {
+        FontStyle.Italic
+      } else {
+        FontStyle.Normal
+      }
+    )
+  ) {
+    append(
+      when (reference.locationType) {
+        ReferenceLocationType.ARRAY_ENTRY -> "[${reference.name}]"
+        ReferenceLocationType.LOCAL -> LOCAL_VARIABLE
+        ReferenceLocationType.INSTANCE_FIELD, ReferenceLocationType.STATIC_FIELD -> reference.name
+      }
+    )
+  }
+}
+
+/** The class the field is read on, with no dot before an array index: `Tile.view`, `Object[][3]`. */
+internal fun PathReference.ownerPrefix(): String =
+  if (locationType == ReferenceLocationType.ARRAY_ENTRY) ownerClassName else "$ownerClassName."
+
+/** How a leak trace names the reference a running method holds, which has no field to name. */
+private const val LOCAL_VARIABLE = "<local variable>"
+
+/** Where a line goes when nothing says otherwise, which is down a chain's gutter to the next object. */
+private val DOWNWARDS = Offset(0f, 1f)
+
+/** Big enough for a letter to be read in, which is what makes a circle say what the object is. */
+internal val NODE_RADIUS = 8.dp
+
+internal val CONNECTOR_WIDTH = 1.5.dp
+internal val ARROW_WIDTH = 7.dp
+internal val ARROW_HEIGHT = 5.dp
+internal val DASH_ON = 3.dp
+internal val DASH_OFF = 3.dp
+
+/** How far outside a circle the ring picking it out sits. */
+internal val RING_GAP = 2.5.dp
+internal val RING_WIDTH = 1.5.dp
+
+private val BADGE_LETTER_SIZE = 10.sp
+
+/** On every kind's colour, all of which are dark enough to read white out of. */
+private val BADGE_LETTER_COLOR = Color.White
+
+/** The purple LeakCanary draws a leak trace in, which a chain of objects is the same shape as. */
+internal val CONNECTOR_COLOR = Color(0xFF7E57C2)
+
+/** And what a link the garbage collector may let go of is drawn in, dashed. */
+internal val WEAK_CONNECTOR_COLOR = Color(0xFFB0453A)
+
+/**
+ * What an object that dominates what hangs below it is ringed and labelled in. Its own hue, because the
+ * two colours a chain already uses mean how firmly a link holds, and this says nothing about that.
+ */
+internal val DOMINATOR_COLOR = Color(0xFF00796B)
+
+/** For the parts of a line that say what an object is rather than which one it is. */
+internal val MUTED_TEXT = Color(0xFF6E6E6E)
+
+/** The same, for the part of a line that is one text: greyed, and unbolded where the line is bold. */
+internal val MUTED_SPAN = SpanStyle(color = MUTED_TEXT, fontWeight = FontWeight.Normal)
+
+/** The letter drawn in an object's circle, which is what kind of object it is. */
+private val HeapObjectKind.badgeLetter: String
+  get() = when (this) {
+    HeapObjectKind.CLASS -> "C"
+    HeapObjectKind.INSTANCE -> "I"
+    HeapObjectKind.OBJECT_ARRAY -> "A"
+    HeapObjectKind.PRIMITIVE_ARRAY -> "P"
+  }
+
+/**
+ * And the colour of that circle: one per kind, so that a picture of instances and one that runs through
+ * an array read differently at a glance.
+ *
+ * Every one of them dark enough for the white letter inside it, and none of them a colour these drawings
+ * already use: the purple of a line, the red of a link that may be let go of, the teal of a dominator.
+ */
+private val HeapObjectKind.badgeColor: Color
+  get() = when (this) {
+    HeapObjectKind.CLASS -> Color(0xFFEF6C00)
+    HeapObjectKind.INSTANCE -> Color(0xFF3949AB)
+    HeapObjectKind.OBJECT_ARRAY -> Color(0xFF00838F)
+    HeapObjectKind.PRIMITIVE_ARRAY -> Color(0xFF558B2F)
+  }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerUiTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerUiTest.kt
@@ -65,6 +65,24 @@ internal fun ComposeUiTest.stackRow(
 }
 
 /**
+ * The middle of the circle the graph opens on, which is against the left edge half way down, in the
+ * window's coordinates.
+ *
+ * In pixels rather than in a fraction of the view for the same reason [stackRow] is: this shape is laid
+ * out from its root outwards rather than fitted to the view, so the middle of the view is empty until
+ * something has been expanded. Well inside the circle rather than on its centre, since a circle and the
+ * name beside it are one target and the column hanging off it starts a good deal further right.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun ComposeUiTest.graphRootCircle(): Offset {
+  val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
+  return Offset(x = view.left + GRAPH_ROOT_CIRCLE_X, y = view.top + view.height / 2)
+}
+
+/** How far into that circle a click lands: past the circle itself and into the name beside it. */
+private const val GRAPH_ROOT_CIRCLE_X = 100f
+
+/**
  * Moves the pointer onto [offset] the way a mouse gets anywhere: from a pixel away.
  *
  * The first move a view is sent is an enter rather than a move, and the views only describe what the

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/GraphTransformTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/GraphTransformTest.kt
@@ -1,0 +1,76 @@
+package shark.explorer.app
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.Test
+
+/**
+ * Where the graph's picture ends up as it is dragged and zoomed, which is the one part of that view
+ * worth testing without drawing it: a wheel notch is two lines of vector arithmetic, and getting them
+ * wrong is a zoom that walks the picture off the screen.
+ */
+class GraphTransformTest {
+
+  @Test fun `a picture opens with its root against the left edge, half way down`() {
+    val transform = GraphTransform.rootedIn(IntSize(width = 800, height = 600), margin = 48f)
+
+    assertThat(transform.pan).isEqualTo(Offset(48f, 300f))
+    assertThat(transform.zoom).isEqualTo(1f)
+  }
+
+  @Test fun `dragging moves the picture by as much as the pointer moved`() {
+    val dragged = start().pannedBy(Offset(30f, -20f))
+
+    assertThat(dragged.pan).isEqualTo(Offset(78f, 280f))
+    assertThat(dragged.zoom).isEqualTo(1f)
+  }
+
+  @Test fun `zooming leaves whatever is under the pointer under it`() {
+    val pointer = Offset(500f, 120f)
+    val start = start()
+    val under = start.pointsAt(pointer)
+
+    val zoomed = start.zoomedAt(pointer, scrollDelta = -3f)
+
+    assertThat(zoomed.zoom).isGreaterThan(start.zoom)
+    assertThat(zoomed.pointsAt(pointer).x).isCloseTo(under.x, within(0.01f))
+    assertThat(zoomed.pointsAt(pointer).y).isCloseTo(under.y, within(0.01f))
+  }
+
+  @Test fun `zooming out leaves it under the pointer too`() {
+    val pointer = Offset(200f, 400f)
+    val start = start()
+    val under = start.pointsAt(pointer)
+
+    val zoomed = start.zoomedAt(pointer, scrollDelta = 5f)
+
+    assertThat(zoomed.zoom).isLessThan(start.zoom)
+    assertThat(zoomed.pointsAt(pointer).x).isCloseTo(under.x, within(0.01f))
+    assertThat(zoomed.pointsAt(pointer).y).isCloseTo(under.y, within(0.01f))
+  }
+
+  @Test fun `a wheel spun far enough stops rather than shrinking to nothing`() {
+    val pointer = Offset(400f, 300f)
+
+    val out = generateSequence(start()) { it.zoomedAt(pointer, scrollDelta = 10f) }.elementAt(20)
+
+    assertThat(out.zoom).isGreaterThan(0f)
+    // And is where it stays, which is what keeps a picture zoomed all the way out still there to drag.
+    assertThat(out.zoomedAt(pointer, scrollDelta = 10f).zoom).isEqualTo(out.zoom)
+  }
+
+  @Test fun `a wheel spun the other way stops as well`() {
+    val pointer = Offset(400f, 300f)
+
+    val into = generateSequence(start()) { it.zoomedAt(pointer, scrollDelta = -10f) }.elementAt(20)
+
+    assertThat(into.zoomedAt(pointer, scrollDelta = -10f).zoom).isEqualTo(into.zoom)
+  }
+
+  private fun start() = GraphTransform.rootedIn(IntSize(width = 800, height = 600), margin = 48f)
+
+  /** Which point of the picture is drawn at [offset] of the view, which is what a click is read as. */
+  private fun GraphTransform.pointsAt(offset: Offset): Offset = (offset - pan) / zoom
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/GraphViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/GraphViewTest.kt
@@ -1,0 +1,144 @@
+package shark.explorer.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+
+/**
+ * The graph shape drawn in a window, which is where it has to be tested from: the other shapes are a
+ * function of the tree and are driven a presentation at a time — `StackViewTest` and `RadialViewTest` —
+ * but this one is a picture of what the reader has expanded, and what a circle holds is read off the
+ * heap dump a click at a time. So the state under test is the window's, not the view's.
+ *
+ * The arranging and the hit testing are unit tested in `shark-explorer-core` (`GraphLayoutTest`,
+ * `ObjectGraphTest`) and the panning and zooming in [GraphTransformTest]. What is only testable here is
+ * that a click reaches the object under it and comes back as a bigger picture.
+ *
+ * Read off the log throughout, since the view is one canvas with no text of its own.
+ */
+@OptIn(ExperimentalTestApi::class)
+class GraphViewTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  /** Every draw of the graph and every read behind one is a line in here. See [RecordedLog]. */
+  @get:Rule val logged = RecordedLog()
+
+  @Test fun `the same tree can be drawn as a graph of circles and arrows`() {
+    explorerUiTest {
+      openHeapDump()
+      shapeOption(ViewShape.TREEMAP).assertIsSelected()
+
+      shapeOption(ViewShape.GRAPH).performClick()
+
+      shapeOption(ViewShape.GRAPH).assertIsSelected()
+      // The whole heap dump is the circle it opens on, already expanded, with what the GC roots hold
+      // drawn beside it.
+      waitUntilTheGraphHasArrows()
+    }
+  }
+
+  @Test fun `a circle of the graph is pressed to collapse it and pressed again to open it`() {
+    explorerUiTest {
+      openHeapDump()
+      shapeOption(ViewShape.GRAPH).performClick()
+      waitUntilTheGraphHasArrows()
+
+      clickAt(graphRootCircle())
+
+      // A click on this shape adds to the picture rather than moving the window, so pressing the circle
+      // everything hangs off takes the lot off and leaves that one circle.
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { logged.any { GRAPH_COLLAPSED in it } }
+
+      clickAt(graphRootCircle())
+
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
+        logged.count { GRAPH_DRAWN in it && GRAPH_COLLAPSED !in it } >= 2
+      }
+      // And putting it back read nothing: what was read for a circle is kept while it is collapsed.
+      assertThat(logged.filter { it.startsWith(GRAPH_REFERENCES_READ) }).hasSize(1)
+    }
+  }
+
+  /**
+   * Waits until the graph has been drawn with something hanging off the circle it opens on.
+   *
+   * Two reads rather than one: the shape is arranged as soon as it is picked, and what the object it is
+   * rooted at references arrives after that. So a view with no spinner over it is not yet a picture.
+   */
+  private fun ComposeUiTest.waitUntilTheGraphHasArrows() {
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+    waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
+      logged.any { GRAPH_DRAWN in it && GRAPH_COLLAPSED !in it && ZERO_ARROWS !in it }
+    }
+  }
+
+  /** The radio button for [shape] above the view. */
+  private fun ComposeUiTest.shapeOption(shape: ViewShape): SemanticsNodeInteraction =
+    onNode(hasText(shape.displayName) and isSelectable())
+
+  private fun ComposeUiTest.clickAt(offset: Offset) {
+    onRoot().performMouseInput { click(offset) }
+  }
+
+  private fun ComposeUiTest.openHeapDump() {
+    val heapDumpFile = heapDump()
+    setContent {
+      MaterialTheme {
+        var shown: File? by remember { mutableStateOf(heapDumpFile) }
+        ExplorerApp(shown, onHeapDumpChosen = { file, _ -> shown = file })
+      }
+    }
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+  }
+
+  /** An instance holding a large array, so that the circle the graph opens on has arrows off it. */
+  private fun heapDump(): File {
+    val file = testFolder.newFile("heap.hprof")
+    file.dump {
+      val holder = "com.example.Holder" instance {
+        field["payload"] =
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_LENGTH)))
+      }
+      gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+    }
+    return file
+  }
+
+  companion object {
+    /** Opening a heap dump and reading what a circle references both happen on another thread. */
+    private const val OPEN_TIMEOUT_MILLIS = 10_000L
+
+    /** How the log says the graph was drawn, and what it says once the root has been collapsed. */
+    private const val GRAPH_DRAWN = "Drew "
+    private const val GRAPH_COLLAPSED = "Drew 1 circles and 0 arrows"
+
+    /** What the very first draw says, before the read filling the picture in has come back. */
+    private const val ZERO_ARROWS = "0 arrows"
+
+    /** And how it says an expanded circle's references were read, which happens once per circle. */
+    private const val GRAPH_REFERENCES_READ = "Read what the whole heap dump references"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
@@ -83,6 +83,23 @@ class TreeLayoutTest {
   }
 
   /**
+   * And the graph, which is the same rule from the other side: it is arranged from what the reader has
+   * expanded rather than read from the tree, so switching to it lays the tree out no further. What it
+   * does read is the object it is rooted at and what that references, which is not a view.
+   */
+  @Test fun `switching to the graph lays the tree out no further`() {
+    explorerUiTest {
+      openHeapDump()
+
+      shapeOption(ViewShape.GRAPH).performClick()
+      settleTheHeapDumpThread(ViewShape.GRAPH)
+    }
+
+    assertThat(treeLayoutsOf(ViewShape.GRAPH)).isEmpty()
+    assertThat(treeLayoutsOf(ViewShape.TREEMAP)).hasSize(1)
+  }
+
+  /**
    * Waits for a heap dump read that isn't a layout, which is what makes counting the layouts sound rather
    * than a race: reads queue on the heap dump's one thread in the order they were asked for, so a layout
    * queued behind the one that drew what the window is showing is in the log by the time this comes back.
@@ -101,6 +118,9 @@ class TreeLayoutTest {
         Offset(view.left + view.width * CELL_X, view.top + view.height * CELL_Y)
       }
       ViewShape.STACK -> stackRow(CELL_ROW, CELL_X)
+      // The circle the graph opens on: the middle of the view is empty until something has been
+      // expanded, and this shape starts with one circle.
+      ViewShape.GRAPH -> graphRootCircle()
     }
     onRoot().performMouseInput { hover(cell) }
     waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { logged.any { it.startsWith(HOVER_READ) } }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/GraphLayout.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/GraphLayout.kt
@@ -1,0 +1,290 @@
+package shark.explorer
+
+/**
+ * One circle of a laid out [ObjectGraph], with the name written beside it.
+ *
+ * A [LayoutCell] like a treemap's rectangle and a stack's block, so that everything downstream of the
+ * geometry — which cell is selected, what the panels are asked to describe, what the card at the
+ * pointer says — is the same code here as for the three shapes of the dominator tree.
+ */
+data class GraphNodeCell(
+  override val subject: CellSubject<Long>,
+  /**
+   * The object the circle stands for, and null for the cell counting the references a node was not
+   * drawn with, which is a [CellSubject.Group] and no object of the heap dump.
+   */
+  val drawn: GraphObject?,
+  /** The middle of the circle. */
+  val center: TreemapPoint,
+  /** The circle and the name beside it, which together are what a click on the node has to hit. */
+  val bounds: TreemapRect,
+  /** How many references away from the node the graph is rooted at, which is also its column. */
+  override val depth: Int,
+  override val weight: Long,
+  /** Whether what it references is drawn hanging off it. */
+  val isExpanded: Boolean,
+  /**
+   * Whether it dominates any of the objects drawn hanging off it, which is `Dominates ↓` in a chain
+   * and the same ring here.
+   */
+  val dominatesBelow: Boolean
+) : LayoutCell<Long>
+
+/**
+ * What pressing [cell] draws: what an object references, or nothing where they were already drawn, or
+ * one more page of them for the cell counting the ones a node had no room for.
+ *
+ * The one gesture the shape has, so it is here rather than in the view: which of the three a press is,
+ * is a fact about the graph and is what a test of expanding and collapsing drives.
+ */
+fun ObjectGraph.pressing(cell: GraphNodeCell): ObjectGraph = when (val subject = cell.subject) {
+  is CellSubject.Group -> showingMoreOf(subject.parent)
+  is CellSubject.Node ->
+    if (isExpanded(subject.node)) collapsing(subject.node) else expanding(subject.node)
+  // No cell of this shape is an object's own bytes: a circle is the whole object, since nothing here is
+  // drawn inside anything else.
+  is CellSubject.Own -> this
+}
+
+/** One arrow of a laid out [ObjectGraph]: which reference, and between which two circles. */
+data class GraphEdgeCell(
+  val reference: GraphReference,
+  /** The middle of the circle it leaves, which the view draws from the edge of. */
+  val from: TreemapPoint,
+  val to: TreemapPoint,
+  /** How firmly the object it points at is held, which is what the line is drawn as. */
+  val strength: ReachabilityStrength,
+  /**
+   * Whether the object it points at is drawn hanging off this one, or was already drawn elsewhere.
+   *
+   * A heap dump is a graph rather than a tree, so an object can be pointed at from several of the
+   * circles on screen and can point back at one holding it. The layout hangs each object below the
+   * first reference that reached it; every other arrow to it crosses the picture instead.
+   */
+  val isSpanning: Boolean
+)
+
+/**
+ * An [ObjectGraph] with somewhere to draw each of its circles and arrows.
+ *
+ * [nodes] is ordered so that a node precedes everything hanging off it, matching every other layout
+ * in this module.
+ */
+class GraphLayoutResult(
+  /** Which object sits at the origin, which is what a view of it is moved back to the start by. */
+  val rootObjectId: Long,
+  val nodes: List<GraphNodeCell>,
+  val edges: List<GraphEdgeCell>,
+  /**
+   * Everything laid out, which is what a view of it pans and zooms around.
+   *
+   * Around the origin rather than from it: the node the graph is rooted at sits at (0, 0), so top is
+   * negative wherever anything was drawn above it. See [GraphLayout].
+   */
+  val bounds: TreemapRect
+) {
+
+  /** The circle [point] falls on, name included, or null where the picture has none. */
+  fun cellAt(point: TreemapPoint): GraphNodeCell? = nodes.firstOrNull { point in it.bounds }
+
+  companion object {
+    val EMPTY = GraphLayoutResult(
+      rootObjectId = HeapDominatorTreemap.ROOT_OBJECT_ID,
+      nodes = emptyList(),
+      edges = emptyList(),
+      bounds = TreemapRect(0.0, 0.0, 0.0, 0.0)
+    )
+  }
+}
+
+/**
+ * Lays an [ObjectGraph] out as a node-link diagram: the object it is rooted at on the left, what it
+ * references in the column beside it, and so on rightwards for as far as the reader has expanded.
+ *
+ * The other three shapes divide a fixed viewport between everything under a node, so a level costs
+ * area and how deep they go is decided for the reader. This one is the other trade: nothing is
+ * divided, every circle is the same size however deep it sits, and how much is drawn is entirely what
+ * was clicked. Which is what makes it the shape for the question the tree can't answer — *which*
+ * reference holds this, and is it the only one — since a treemap draws where an object's bytes were
+ * attributed and never how it is pointed at.
+ *
+ * **A heap dump is a graph, so the drawing is a tree over it plus the arrows that don't fit.** Each
+ * object hangs below the first reference that reached it, depth first in the order its parent draws
+ * them; a reference to an object already drawn elsewhere is an arrow across the picture and no second
+ * circle. That is also what stops a cycle: an object is placed once.
+ *
+ * **The root sits at the origin**, and everything else is placed around it. So expanding a node moves
+ * the picture rather than the root — a layout numbered from its top edge would slide the whole thing
+ * up whenever something opened up above, which is exactly the object the reader was looking at.
+ */
+class GraphLayout(
+  /** How far apart two columns are, which is a name's width plus room for an arrow. */
+  private val columnWidth: Double = 220.0,
+  /** How much room one circle and its name get down the picture. */
+  private val rowHeight: Double = 44.0,
+  private val nodeRadius: Double = 8.0,
+  /** How wide the name beside a circle may be, which is the rest of what a click on a node hits. */
+  private val labelWidth: Double = 170.0
+) {
+
+  fun layout(graph: ObjectGraph): GraphLayoutResult {
+    if (graph.objectOf(graph.rootObjectId) == null) {
+      return GraphLayoutResult.EMPTY
+    }
+    val placing = Placing(graph)
+    placing.place(graph.rootObjectId, depth = 0, parent = null, siblingIndex = 0)
+    // Around the root rather than from the top edge, so that what opens up above it leaves it where
+    // the reader last saw it.
+    val rootY = placing.yByObjectId.getValue(graph.rootObjectId)
+
+    val nodes = placing.placedObjectIds.map { objectId ->
+      val drawn = graph.objectOf(objectId)
+      val depth = placing.depthByObjectId.getValue(objectId)
+      nodeCell(
+        subject = CellSubject.Node(
+          node = objectId,
+          parent = placing.parentByObjectId[objectId],
+          siblingIndex = placing.siblingIndexByObjectId[objectId] ?: 0
+        ),
+        drawn = drawn,
+        depth = depth,
+        y = placing.yByObjectId.getValue(objectId) - rootY,
+        weight = drawn?.retainedSize ?: 0L,
+        isExpanded = graph.isExpanded(objectId),
+        dominatesBelow = graph.referencesFrom(objectId).any { it.isDominator }
+      )
+    } + placing.leftovers.map { leftover ->
+      nodeCell(
+        subject = CellSubject.Group(parent = leftover.parentObjectId, nodeCount = leftover.nodeCount),
+        drawn = null,
+        depth = leftover.depth,
+        y = leftover.y - rootY,
+        weight = 0L,
+        isExpanded = false,
+        dominatesBelow = false
+      )
+    }
+    val centerByObjectId = nodes.mapNotNull { cell ->
+      (cell.subject as? CellSubject.Node)?.let { it.node to cell.center }
+    }.toMap()
+
+    val edges = placing.placedObjectIds.flatMap { objectId ->
+      val from = centerByObjectId.getValue(objectId)
+      graph.referencesFrom(objectId).mapNotNull { reference ->
+        val to = centerByObjectId[reference.toObjectId] ?: return@mapNotNull null
+        GraphEdgeCell(
+          reference = reference,
+          from = from,
+          to = to,
+          strength = graph.objectOf(reference.toObjectId)?.strength ?: ReachabilityStrength.STRONG,
+          isSpanning = placing.parentByObjectId[reference.toObjectId] == objectId
+        )
+      }
+    }
+    return GraphLayoutResult(
+      rootObjectId = graph.rootObjectId,
+      nodes = nodes.sortedWith(compareBy({ it.depth }, { it.center.y })),
+      edges = edges,
+      bounds = nodes.map { it.bounds }.reduce { bounds, cell ->
+        TreemapRect(
+          left = minOf(bounds.left, cell.left),
+          top = minOf(bounds.top, cell.top),
+          right = maxOf(bounds.right, cell.right),
+          bottom = maxOf(bounds.bottom, cell.bottom)
+        )
+      }
+    )
+  }
+
+  private fun nodeCell(
+    subject: CellSubject<Long>,
+    drawn: GraphObject?,
+    depth: Int,
+    y: Double,
+    weight: Long,
+    isExpanded: Boolean,
+    dominatesBelow: Boolean
+  ): GraphNodeCell {
+    val center = TreemapPoint(x = depth * columnWidth, y = y)
+    return GraphNodeCell(
+      subject = subject,
+      drawn = drawn,
+      center = center,
+      // The name is written to the right of the circle, so that is where the rest of the target is.
+      bounds = TreemapRect(
+        left = center.x - nodeRadius,
+        top = center.y - rowHeight / 2,
+        right = center.x + labelWidth,
+        bottom = center.y + rowHeight / 2
+      ),
+      depth = depth,
+      weight = weight,
+      isExpanded = isExpanded,
+      dominatesBelow = dominatesBelow
+    )
+  }
+
+  /**
+   * Where each circle goes, worked out depth first from the root.
+   *
+   * A node with nothing under it takes the next row; a node with something under it is centred on
+   * what it holds, between the first and the last of them. Which is the plainest tidy tree there is,
+   * and it can't overlap: the rows a subtree takes are consecutive and a node's own row is inside
+   * them, so two nodes in one column are always at least a row apart.
+   */
+  private inner class Placing(private val graph: ObjectGraph) {
+
+    /** In the order they were reached, which puts a node before everything hanging off it. */
+    val placedObjectIds = mutableListOf<Long>()
+    val depthByObjectId = mutableMapOf<Long, Int>()
+    val yByObjectId = mutableMapOf<Long, Double>()
+    val parentByObjectId = mutableMapOf<Long, Long>()
+    val siblingIndexByObjectId = mutableMapOf<Long, Int>()
+    val leftovers = mutableListOf<Leftover>()
+
+    private var nextRow = 0
+
+    fun place(
+      objectId: Long,
+      depth: Int,
+      parent: Long?,
+      siblingIndex: Int
+    ): Double {
+      // Before recursing, so that a reference running back into this object is an arrow across the
+      // picture rather than a second circle and a walk that never ends.
+      placedObjectIds += objectId
+      depthByObjectId[objectId] = depth
+      siblingIndexByObjectId[objectId] = siblingIndex
+      parent?.let { parentByObjectId[objectId] = it }
+
+      val childYs = mutableListOf<Double>()
+      graph.referencesFrom(objectId).forEach { reference ->
+        val target = reference.toObjectId
+        if (target !in depthByObjectId && graph.objectOf(target) != null) {
+          childYs += place(target, depth + 1, parent = objectId, siblingIndex = childYs.size)
+        }
+      }
+      val hiddenCount = graph.hiddenReferenceCountOf(objectId)
+      if (hiddenCount > 0) {
+        // Last of what hangs off the node, since it stands for the references that didn't make the
+        // page: it takes a row like any other dead end, so the node above stays centred on the lot.
+        val y = takeRow()
+        leftovers += Leftover(objectId, depth + 1, y, hiddenCount)
+        childYs += y
+      }
+      val y = if (childYs.isEmpty()) takeRow() else (childYs.first() + childYs.last()) / 2
+      yByObjectId[objectId] = y
+      return y
+    }
+
+    private fun takeRow(): Double = (nextRow++ + 0.5) * rowHeight
+  }
+
+  /** The references one node was not drawn with, as a cell of its own. See [CellSubject.Group]. */
+  private class Leftover(
+    val parentObjectId: Long,
+    val depth: Int,
+    val y: Double,
+    val nodeCount: Int
+  )
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -42,6 +42,7 @@ import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.Sh
 import shark.ObjectDominators.DominatorNode
 import shark.ObjectReporter
 import shark.AndroidObjectInspectors
+import shark.Reference
 import shark.SharkLog
 import shark.ValueHolder.BooleanHolder
 import shark.ValueHolder.ByteHolder
@@ -72,8 +73,9 @@ import shark.ValueHolder.ShortHolder
 // Everything the UI asks about one heap dump: the tree, what a cell of it says, and how an object is held.
 // One class because every answer reads the same graph, reachability, ownership and referrer index, so
 // splitting it means threading all four into a second class that calls back into this one. Worth doing,
-// and worth doing on its own rather than inside a change that adds one more answer.
-@Suppress("LargeClass")
+// and worth doing on its own rather than inside a change that adds one more answer — which is also why the
+// function count is suppressed rather than paid down by splitting somewhere arbitrary.
+@Suppress("LargeClass", "TooManyFunctions")
 class HeapDominatorTreemap internal constructor(
   private val graph: HeapGraph,
   private val reachability: HeapReachability,
@@ -530,6 +532,143 @@ class HeapDominatorTreemap internal constructor(
   }
 
   /**
+   * One node as [ObjectGraph] draws it — a circle with a name beside it — or null for a node this
+   * tree doesn't have.
+   *
+   * Cheap enough to call for the two dozen objects an expansion draws at once, unlike [summarize]:
+   * what it costs is reading the object, its strength and how many references it holds, and none of
+   * Shark's object inspectors.
+   */
+  fun graphObject(nodeId: Long): GraphObject? {
+    val group = group(nodeId)
+    if (group != null) {
+      return GraphObject(
+        objectId = nodeId,
+        className = group.label(),
+        // Drawn hollow: a pile of objects is no object of the heap dump and has no kind.
+        kind = null,
+        strength = group.strength,
+        retainedSize = group.retainedSize,
+        retainedCount = group.objectCount,
+        referenceCount = group.childIds.size
+      )
+    }
+    if (nodeId == root) {
+      return GraphObject(
+        objectId = root,
+        className = ROOT_LABEL,
+        kind = null,
+        strength = ReachabilityStrength.STRONG,
+        retainedSize = weight(root),
+        retainedCount = nodeOf(root).retainedCount,
+        referenceCount = children(root).size
+      )
+    }
+    if (nodeId !in nodes) {
+      SharkLog.d { "Nothing to draw for ${nodeIdText(nodeId)}: it is no node of the tree" }
+      return null
+    }
+    val node = nodeOf(nodeId)
+    val heapObject = graph.findObjectById(nodeId)
+    return GraphObject(
+      objectId = nodeId,
+      className = heapObject.className(),
+      kind = heapObject.kind(),
+      strength = strengthOf(nodeId),
+      retainedSize = node.retainedSize,
+      retainedCount = node.retainedCount,
+      referenceCount = pathReferenceReader.read(heapObject).count()
+    )
+  }
+
+  /**
+   * What [nodeId] points at, as [ObjectGraph] draws it: at most [limit] arrows, heaviest first, with
+   * what each of them points at.
+   *
+   * **The references the dominator tree was built by following**, so that the picture and the sizes
+   * on it are one answer: a reference the tree ignored would draw a way of holding an object that the
+   * tree says isn't why it's in memory. Which is also why an object the tree has no node for — a
+   * string's characters, folded into the string by the size calculator — is left out rather than drawn
+   * as a circle nothing can be asked about.
+   *
+   * One arrow per object pointed at, named after the first field that points at it: two circles joined
+   * by four lines say four times over what one line already says.
+   *
+   * **A node standing for many objects hands out the tree's own children instead** — the whole heap
+   * dump, the uncollected garbage, a class the top of the tree gathers its instances under. There is no
+   * field to name on those arrows, and they are dominator edges by definition, since being drawn there
+   * is what the tree attributing an object's bytes there means. So the graph opens on the whole heap
+   * dump the way every other shape does, and the references start one click in.
+   */
+  fun referencesFrom(
+    nodeId: Long,
+    limit: Int = ObjectGraph.REFERENCES_PER_PAGE
+  ): ObjectReferences {
+    val isPile = nodeId == root || isPileId(nodeId)
+    val found: List<Pair<Long, Reference?>> = when {
+      isPile -> children(nodeId).map { it to null }
+      nodeId !in nodes -> {
+        SharkLog.d { "Nothing to draw below ${nodeIdText(nodeId)}: it is no node of the tree" }
+        emptyList()
+      }
+      else -> referencesOf(nodeId)
+    }
+    // Heaviest first, which is what a reader following bytes down a picture is looking for, and what
+    // makes the arrows a node has no room for the ones worth leaving out.
+    val sorted = found.sortedByDescending { (targetId, _) -> weight(targetId) }
+    val drawn = sorted.take(limit)
+    return ObjectReferences(
+      fromObjectId = nodeId,
+      references = drawn.map { (targetId, reference) ->
+        GraphReference(
+          fromObjectId = nodeId,
+          toObjectId = targetId,
+          reference = reference?.pathReferenceFrom(nodeId),
+          isDominator = isPile || dominatorTree.immediateDominatorOf(targetId) == nodeId
+        )
+      },
+      objects = drawn.mapNotNull { (targetId, _) -> graphObject(targetId) },
+      hiddenCount = sorted.size - drawn.size
+    )
+  }
+
+  /**
+   * The references [objectId] holds that the graph can draw: one per object pointed at, and only
+   * objects this tree has a node for.
+   *
+   * Nothing is resolved here — naming a reference reads the class that declares the field — because an
+   * object array of a real app holds thousands of these and only the heaviest
+   * [ObjectGraph.REFERENCES_PER_PAGE] of them are ever drawn.
+   */
+  private fun referencesOf(objectId: Long): List<Pair<Long, Reference?>> {
+    var foldedCount = 0
+    val references = pathReferenceReader.read(graph.findObjectById(objectId))
+      .filter { reference ->
+        val targetId = reference.valueObjectId
+        // An object holding itself is a fact about one circle, and an arrow from a circle to itself
+        // draws nothing: what it is is said in the details panel, under its own fields.
+        when {
+          targetId == objectId -> false
+          targetId in nodes -> true
+          else -> {
+            foldedCount++
+            false
+          }
+        }
+      }
+      .distinctBy { it.valueObjectId }
+      .map { it.valueObjectId to it }
+      .toList()
+    if (foldedCount > 0) {
+      SharkLog.d {
+        "Left $foldedCount of ${hexObjectId(objectId)}'s references out of the graph: the tree has no " +
+          "node for what they point at"
+      }
+    }
+    return references
+  }
+
+  /**
    * Every way [toObjectId] is held below [fromObjectId], spelled out field by field. See
    * [IndependentPaths] for what "independent" means and what this search does and doesn't guarantee.
    *
@@ -790,11 +929,9 @@ class HeapDominatorTreemap internal constructor(
     objectId: Long,
     referrerId: Long
   ): PathStep {
-    val details = pathReferenceReader.read(graph.findObjectById(referrerId))
+    val found = pathReferenceReader.read(graph.findObjectById(referrerId))
       .firstOrNull { it.valueObjectId == objectId }
-      ?.lazyDetailsResolver
-      ?.resolve()
-    if (details == null) {
+    if (found == null) {
       // The walk found this step through the referrer index, which was built with this same reader, so a
       // step with no reference to name means the two disagree about the same pair of objects. Shows as a
       // step naming the object and not how it's held.
@@ -803,19 +940,25 @@ class HeapDominatorTreemap internal constructor(
           "was found through one"
       }
     }
-    return step(
-      objectId = objectId,
-      reference = details?.let { resolved ->
-        PathReference(
-          name = resolved.name,
-          // The class that declares the field rather than the referrer's own class, which is what tells a
-          // field inherited from a base class apart from one the subclass added.
-          ownerClassName = graph.findObjectByIdOrNull(resolved.locationClassObjectId)
-            ?.let { (it as? HeapClass)?.simpleName }
-            ?: label(referrerId),
-          locationType = resolved.locationType
-        )
-      }
+    return step(objectId = objectId, reference = found?.pathReferenceFrom(referrerId))
+  }
+
+  /**
+   * How the object holding this reference names it: the field, on the class that declares it.
+   *
+   * One definition, because a chain and the graph both write it beside the arrow they draw, and two
+   * objects that name the same field differently is the window contradicting itself.
+   */
+  private fun Reference.pathReferenceFrom(referrerId: Long): PathReference {
+    val resolved = lazyDetailsResolver.resolve()
+    return PathReference(
+      name = resolved.name,
+      // The class that declares the field rather than the referrer's own class, which is what tells a
+      // field inherited from a base class apart from one the subclass added.
+      ownerClassName = graph.findObjectByIdOrNull(resolved.locationClassObjectId)
+        ?.let { (it as? HeapClass)?.simpleName }
+        ?: label(referrerId),
+      locationType = resolved.locationType
     )
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ObjectGraph.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ObjectGraph.kt
@@ -1,0 +1,205 @@
+package shark.explorer
+
+/**
+ * The part of a heap dump's object graph that has been expanded so far: one object at the root, and
+ * whatever the reader has since opened up below it.
+ *
+ * Unlike the three shapes of the dominator tree, which lay out whatever fits the viewport, this is
+ * drawn one click at a time — so it is state rather than a layout, and it is here rather than in the
+ * UI for the usual reason: expanding, collapsing and paging are then unit testable, and
+ * [GraphLayout] is a pure function of this.
+ *
+ * Immutable, and replaced rather than mutated, so it can be held as UI state. Nothing is ever
+ * dropped from [objectOf]: collapsing a node keeps what was read for it, so opening it again is
+ * instant and costs no heap dump read. What *is* drawn is whatever [GraphLayout] can walk to from
+ * the root through [referencesFrom], which is why a collapsed node takes its whole subtree off the
+ * picture without anything having to delete it.
+ *
+ * A node whose references haven't been read yet is [pendingObjectId] rather than empty, so that a
+ * click is instant and the heap dump read fills in behind it. See [HeapDominatorTreemap.referencesFrom].
+ */
+class ObjectGraph private constructor(
+  /** The object every drawn reference hangs below, which is the node the view is rooted at. */
+  val rootObjectId: Long,
+  private val objects: Map<Long, GraphObject>,
+  private val expanded: Set<Long>,
+  private val read: Map<Long, ObjectReferences>,
+  /**
+   * How many pages of references each object has been asked for, where absent means one.
+   *
+   * An object can hold a million references and no picture is going to draw them, so an expansion
+   * draws [REFERENCES_PER_PAGE] of them, heaviest first, with a cell saying how many were left out.
+   * Pressing that cell is what raises this.
+   */
+  private val pageCounts: Map<Long, Int>
+) {
+
+  /** Nothing to draw: no heap dump open yet, or a view rooted at a node the tree doesn't have. */
+  val isEmpty: Boolean get() = objects.isEmpty()
+
+  /** What the circle for [objectId] says, or null for an object the graph hasn't read. */
+  fun objectOf(objectId: Long): GraphObject? = objects[objectId]
+
+  fun isExpanded(objectId: Long): Boolean = objectId in expanded
+
+  /**
+   * The references drawn as arrows leaving [objectId], heaviest first, and none for an object that
+   * is collapsed or hasn't been read yet.
+   */
+  fun referencesFrom(objectId: Long): List<GraphReference> =
+    if (objectId in expanded) read[objectId]?.references.orEmpty() else emptyList()
+
+  /**
+   * How many of [objectId]'s references aren't drawn, which is the cell hanging off it saying so,
+   * and 0 while it is collapsed: a collapsed node draws nothing below it at all.
+   */
+  fun hiddenReferenceCountOf(objectId: Long): Int =
+    if (objectId in expanded) read[objectId]?.hiddenCount ?: 0 else 0
+
+  /** How many references to read for [objectId], which is one page more per press of its last cell. */
+  fun referenceLimitOf(objectId: Long): Int = pageCountOf(objectId) * REFERENCES_PER_PAGE
+
+  /**
+   * An object that is expanded and whose references still have to be read, or null when the picture
+   * is complete.
+   *
+   * One at a time, because reads queue on one thread anyway and because folding one in is what
+   * uncovers the next: a caller reads this, reads the heap dump for it, and hands the answer to
+   * [withReferences] until this comes back null.
+   */
+  val pendingObjectId: Long?
+    get() = expanded.firstOrNull { objectId ->
+      val references = read[objectId]
+      // Read, but for fewer references than are now asked for, is pending again: pressing the cell
+      // that counts what was left out is what puts a node back in this state.
+      references == null ||
+        (references.hiddenCount > 0 && references.references.size < referenceLimitOf(objectId))
+    }
+
+  /** Draws what [objectId] references below it, which its next read fills in. */
+  fun expanding(objectId: Long): ObjectGraph =
+    if (objectId in expanded) this else copy(expanded = expanded + objectId)
+
+  /**
+   * Takes what [objectId] references off the picture again.
+   *
+   * What was read for it is kept, so opening it again draws the same thing without reading the heap
+   * dump: what a reader collapses is what they are done looking at, not what they were done with.
+   */
+  fun collapsing(objectId: Long): ObjectGraph =
+    if (objectId in expanded) copy(expanded = expanded - objectId) else this
+
+  /** Draws one more page of what [objectId] references, which its next read fills in. */
+  fun showingMoreOf(objectId: Long): ObjectGraph =
+    copy(pageCounts = pageCounts + (objectId to pageCountOf(objectId) + 1))
+
+  /** Folds one read into the picture: the arrows leaving an object, and what they point at. */
+  fun withReferences(references: ObjectReferences): ObjectGraph = copy(
+    objects = objects + references.objects.associateBy { it.objectId },
+    read = read + (references.fromObjectId to references)
+  )
+
+  private fun pageCountOf(objectId: Long): Int = pageCounts[objectId] ?: 1
+
+  private fun copy(
+    objects: Map<Long, GraphObject> = this.objects,
+    expanded: Set<Long> = this.expanded,
+    read: Map<Long, ObjectReferences> = this.read,
+    pageCounts: Map<Long, Int> = this.pageCounts
+  ) = ObjectGraph(rootObjectId, objects, expanded, read, pageCounts)
+
+  companion object {
+
+    /**
+     * How many references one expansion draws, heaviest first.
+     *
+     * A `java.lang.Object[]` of a real app holds thousands, and a picture of thousands of circles is
+     * no more readable than the pile of rectangles a treemap would draw — so what a node draws is the
+     * heaviest of them, and what it leaves out is counted in a cell of its own rather than dropped.
+     */
+    const val REFERENCES_PER_PAGE = 24
+
+    val EMPTY = ObjectGraph(
+      rootObjectId = HeapDominatorTreemap.ROOT_OBJECT_ID,
+      objects = emptyMap(),
+      expanded = emptySet(),
+      read = emptyMap(),
+      pageCounts = emptyMap()
+    )
+
+    /**
+     * A graph showing [root] alone, already expanded: a picture of one circle answers nothing, so
+     * what the view is rooted at is opened up as it arrives.
+     */
+    fun rootedAt(root: GraphObject): ObjectGraph = ObjectGraph(
+      rootObjectId = root.objectId,
+      objects = mapOf(root.objectId to root),
+      expanded = setOf(root.objectId),
+      read = emptyMap(),
+      pageCounts = emptyMap()
+    )
+  }
+}
+
+/**
+ * One object of the heap dump as the graph draws it: a circle with the letter of its kind in it, and
+ * what it is beside that.
+ *
+ * Less than a [HeapObjectSummary] on purpose. A summary runs Shark's object inspectors and reads
+ * every field, which is a read worth doing for the one object a reader stopped on and not for the
+ * two dozen an expansion draws at once — what those need is a name, a size and a shape.
+ */
+data class GraphObject(
+  val objectId: Long,
+  /** Fully qualified class name, or what a node standing for many objects is called. */
+  val className: String,
+  /**
+   * Null for a node that stands for many objects rather than for one — the whole heap dump, the
+   * uncollected garbage, a class the top of the tree gathers its instances under — which is drawn as
+   * a hollow circle, the way a chain draws the rows above its objects.
+   */
+  val kind: HeapObjectKind?,
+  val strength: ReachabilityStrength,
+  val retainedSize: Long,
+  val retainedCount: Int,
+  /**
+   * How many references it holds, which is what expanding it would draw.
+   *
+   * 0 says there is nothing under it, which is what lets the view draw a node as a dead end rather
+   * than as something worth pressing.
+   */
+  val referenceCount: Int
+)
+
+/**
+ * One reference of the heap dump as the graph draws it: an arrow from one circle to another, with
+ * the field it is held in written on it.
+ */
+data class GraphReference(
+  val fromObjectId: Long,
+  val toObjectId: Long,
+  /**
+   * Which field of the object above points at it, and null where no field does: the children of a
+   * node that stands for many objects hang off it because the dominator tree puts them there.
+   */
+  val reference: PathReference?,
+  /**
+   * Whether [fromObjectId] is the one node the dominator tree attributes [toObjectId]'s bytes to,
+   * which is what makes this reference the reason that object is still in memory.
+   *
+   * The point of drawing a heap dump this way: a run of these from the node the view is rooted at is
+   * exactly its dominated subtree, and everything else it points at is shared with something else.
+   */
+  val isDominator: Boolean
+)
+
+/** What one expansion read off the heap dump. See [HeapDominatorTreemap.referencesFrom]. */
+data class ObjectReferences(
+  val fromObjectId: Long,
+  /** Heaviest first, one per object pointed at, at most the limit the read was asked for. */
+  val references: List<GraphReference>,
+  /** What those references point at, so that folding this in draws the circles as well as the arrows. */
+  val objects: List<GraphObject>,
+  /** How many more it holds than were read, which the view counts in a cell of its own. */
+  val hiddenCount: Int
+)

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/GraphLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/GraphLayoutTest.kt
@@ -1,0 +1,156 @@
+package shark.explorer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.ReferenceLocationType
+
+/** Where [GraphLayout] puts the circles and the arrows of an expanded [ObjectGraph]. */
+class GraphLayoutTest {
+
+  private val layout = GraphLayout(columnWidth = 200.0, rowHeight = 40.0, nodeRadius = 8.0)
+
+  @Test fun `the object the graph is rooted at sits at the origin`() {
+    val result = layout.layout(graph(ROOT to listOf(2L, 3L)))
+
+    assertThat(result.rootObjectId).isEqualTo(ROOT)
+    assertThat(result.cellOf(ROOT).center).isEqualTo(TreemapPoint(0.0, 0.0))
+  }
+
+  @Test fun `what a node references is drawn in the column beside it, a row each`() {
+    val result = layout.layout(graph(ROOT to listOf(2L, 3L)))
+
+    assertThat(result.cellOf(2L).center.x).isEqualTo(200.0)
+    assertThat(result.cellOf(3L).center.x).isEqualTo(200.0)
+    assertThat(result.cellOf(3L).center.y - result.cellOf(2L).center.y).isEqualTo(40.0)
+    assertThat(result.nodes.map { it.depth }).containsExactly(0, 1, 1)
+  }
+
+  @Test fun `a node is centred on what hangs off it`() {
+    val result = layout.layout(graph(ROOT to listOf(2L, 3L)))
+
+    val childYs = listOf(result.cellOf(2L).center.y, result.cellOf(3L).center.y)
+    assertThat(result.cellOf(ROOT).center.y).isEqualTo(childYs.average())
+  }
+
+  @Test fun `expanding something above the root leaves the root where it was`() {
+    val expanded = layout.layout(graph(ROOT to listOf(2L, 3L), 2L to listOf(4L, 5L)))
+
+    // Two more rows opened up above the middle of the picture, and the object the reader is looking at
+    // is still at the origin: a layout numbered from its top edge would have slid it down instead.
+    assertThat(expanded.cellOf(ROOT).center).isEqualTo(TreemapPoint(0.0, 0.0))
+    assertThat(expanded.cellOf(2L).center.y).isLessThan(0.0)
+  }
+
+  @Test fun `an object pointed at twice is drawn once, and the second arrow crosses the picture`() {
+    val result = layout.layout(graph(ROOT to listOf(2L, 3L), 2L to listOf(4L), 3L to listOf(4L)))
+
+    assertThat(result.nodes.count { it.subject.nodeOrNull() == 4L }).isEqualTo(1)
+    // Hung below the first reference that reached it, and pointed at from the other one across the map.
+    val toFour = result.edges.filter { it.reference.toObjectId == 4L }
+    assertThat(toFour.map { it.reference.fromObjectId }).containsExactly(2L, 3L)
+    assertThat(toFour.single { it.reference.fromObjectId == 2L }.isSpanning).isTrue()
+    assertThat(toFour.single { it.reference.fromObjectId == 3L }.isSpanning).isFalse()
+  }
+
+  @Test fun `a reference running back into what holds it draws an arrow rather than a second circle`() {
+    val result = layout.layout(graph(ROOT to listOf(2L), 2L to listOf(ROOT)))
+
+    assertThat(result.nodes.map { it.subject.nodeOrNull() }).containsExactly(ROOT, 2L)
+    assertThat(result.edges.map { it.reference.fromObjectId to it.reference.toObjectId })
+      .containsExactly(ROOT to 2L, 2L to ROOT)
+  }
+
+  @Test fun `the references a node had no room for are one cell of their own, last`() {
+    val result = layout.layout(graph(ROOT to listOf(2L), hiddenCount = 40))
+
+    val leftover = result.nodes.single { it.subject is CellSubject.Group }
+    assertThat(leftover.subject).isEqualTo(CellSubject.Group(parent = ROOT, nodeCount = 40))
+    // Under everything the node was drawn with, in the same column as them, and no object itself.
+    assertThat(leftover.depth).isEqualTo(1)
+    assertThat(leftover.center.y).isGreaterThan(result.cellOf(2L).center.y)
+    assertThat(leftover.drawn).isNull()
+  }
+
+  @Test fun `a collapsed node draws nothing below it`() {
+    val graph = graph(ROOT to listOf(2L), 2L to listOf(3L)).collapsing(2L)
+
+    val result = layout.layout(graph)
+
+    assertThat(result.nodes.map { it.subject.nodeOrNull() }).containsExactly(ROOT, 2L)
+    assertThat(result.cellOf(2L).isExpanded).isFalse()
+  }
+
+  @Test fun `a click lands on a circle and on the name beside it`() {
+    val result = layout.layout(graph(ROOT to listOf(2L)))
+
+    val cell = result.cellOf(2L)
+    assertThat(result.cellAt(cell.center)).isEqualTo(cell)
+    // The name is written to the right of the circle, and is as much a part of the node as it is.
+    assertThat(result.cellAt(TreemapPoint(cell.bounds.right - 1, cell.center.y))).isEqualTo(cell)
+    assertThat(result.cellAt(TreemapPoint(cell.bounds.right + 1, cell.center.y))).isNull()
+  }
+
+  @Test fun `the bounds cover everything drawn, above the root as well as below it`() {
+    val result = layout.layout(graph(ROOT to listOf(2L, 3L), 2L to listOf(4L, 5L)))
+
+    assertThat(result.bounds.top).isEqualTo(result.nodes.minOf { it.bounds.top })
+    assertThat(result.bounds.bottom).isEqualTo(result.nodes.maxOf { it.bounds.bottom })
+    assertThat(result.bounds.top).isLessThan(0.0)
+  }
+
+  @Test fun `a node whose object is not there is nothing to lay out`() {
+    assertThat(layout.layout(ObjectGraph.EMPTY).nodes).isEmpty()
+  }
+
+  @Test fun `a node dominating what hangs off it says so`() {
+    val result = layout.layout(graph(ROOT to listOf(2L)))
+
+    assertThat(result.cellOf(ROOT).dominatesBelow).isTrue()
+    assertThat(result.cellOf(2L).dominatesBelow).isFalse()
+  }
+
+  /** A graph with every listed node expanded and read, as the window would have filled it in. */
+  private fun graph(
+    vararg expansions: Pair<Long, List<Long>>,
+    hiddenCount: Int = 0
+  ): ObjectGraph = expansions.fold(ObjectGraph.rootedAt(drawnObject(ROOT))) { graph, (from, targets) ->
+    graph.expanding(from).withReferences(
+      ObjectReferences(
+        fromObjectId = from,
+        references = targets.map { target ->
+          GraphReference(
+            fromObjectId = from,
+            toObjectId = target,
+            reference = PathReference(
+              name = "field$target",
+              ownerClassName = "C$from",
+              locationType = ReferenceLocationType.INSTANCE_FIELD
+            ),
+            isDominator = true
+          )
+        },
+        objects = targets.map { drawnObject(it) },
+        hiddenCount = if (from == ROOT) hiddenCount else 0
+      )
+    )
+  }
+
+  private fun drawnObject(objectId: Long) = GraphObject(
+    objectId = objectId,
+    className = "com.example.C$objectId",
+    kind = HeapObjectKind.INSTANCE,
+    strength = ReachabilityStrength.STRONG,
+    retainedSize = 100L,
+    retainedCount = 1,
+    referenceCount = 1
+  )
+
+  private fun GraphLayoutResult.cellOf(objectId: Long): GraphNodeCell =
+    nodes.single { it.subject.nodeOrNull() == objectId }
+
+  private fun CellSubject<Long>.nodeOrNull(): Long? = (this as? CellSubject.Node)?.node
+
+  private companion object {
+    const val ROOT = 1L
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ObjectGraphReadingTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ObjectGraphReadingTest.kt
@@ -1,0 +1,118 @@
+package shark.explorer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * What the tree hands the expandable graph: which object a circle stands for, and which references are
+ * drawn as arrows leaving it.
+ *
+ * The other three shapes ask the tree what dominates what. This is the one that asks the heap dump how
+ * an object is actually pointed at, so what it leaves out and what it names is worth pinning down.
+ */
+class ObjectGraphReadingTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Test fun `the graph opens on the whole heap dump, which is no object`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+
+      val root = tree.graphObject(tree.root)!!
+
+      assertThat(root.className).isEqualTo(HeapDominatorTreemap.ROOT_LABEL)
+      // Drawn hollow, and with what it retains, which is the whole dump.
+      assertThat(root.kind).isNull()
+      assertThat(root.retainedSize).isEqualTo(explorer.sizes.totalByteCount)
+    }
+  }
+
+  @Test fun `what the whole heap dump points at is the tree's own children`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+
+      val references = tree.referencesFrom(tree.root).references
+
+      assertThat(references.map { tree.label(it.toObjectId) }).contains("Holder")
+      // No field points at them, and being drawn there is the tree saying they are held from a GC root.
+      assertThat(references).allMatch { it.reference == null }
+      assertThat(references).allMatch { it.isDominator }
+    }
+  }
+
+  @Test fun `an arrow is named after the field that holds the object`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+      val holder = tree.findByLabel("Holder")
+
+      val read = tree.referencesFrom(holder.objectId)
+
+      assertThat(read.references.map { it.reference?.name }).containsExactly("payload", "name")
+      assertThat(read.references.map { it.reference?.ownerClassName }).containsOnly("Holder")
+      // Heaviest first, which is what a reader following bytes across a picture is after.
+      assertThat(read.references.map { tree.label(it.toObjectId) })
+        .containsExactly("Object[]", "String")
+    }
+  }
+
+  @Test fun `an arrow says whether it is why the object is still in memory`() {
+    HeapExplorer.open(testFolder.cachedPayloadHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val tile = tree.findByLabel("Tile")
+      val view = tree.findByLabel("View")
+
+      val fromTile = tree.referencesFrom(tile.objectId).references
+      val fromView = tree.referencesFrom(view.objectId).references
+
+      // Nothing else reaches the view, so the tile holding it is why it is still there.
+      assertThat(fromTile.single { tree.label(it.toObjectId) == "View" }.isDominator).isTrue()
+      // The payload is reached through the wrapper as well, so the view is only one of the ways it is
+      // held — which is exactly what a treemap can't draw and what this shape exists to say.
+      assertThat(fromView.single { tree.label(it.toObjectId) == "Object[]" }.isDominator).isFalse()
+    }
+  }
+
+  @Test fun `a string's characters are folded into it rather than drawn under it`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+      val name = tree.findByLabel("String")
+
+      // The size calculator folds a string's characters into the string, so the tree has no node for
+      // them: nothing to draw a circle for, and nothing that could be asked about one.
+      assertThat(tree.referencesFrom(name.objectId).references).isEmpty()
+      // Which is also what says the circle is a dead end rather than something worth pressing.
+      assertThat(tree.graphObject(name.objectId)!!.referenceCount).isZero()
+    }
+  }
+
+  @Test fun `only the heaviest references are drawn, and the rest are counted`() {
+    HeapExplorer.open(testFolder.cachedPayloadHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val tile = tree.findByLabel("Tile")
+
+      val read = tree.referencesFrom(tile.objectId, limit = 1)
+
+      assertThat(read.references).hasSize(1)
+      assertThat(read.objects).hasSize(1)
+      // The one left out is counted rather than dropped, which is the cell the reader presses for more.
+      assertThat(read.hiddenCount).isEqualTo(1)
+    }
+  }
+
+  @Test fun `a node the tree doesn't have is nothing to draw`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+
+      assertThat(tree.graphObject(NOT_A_NODE)).isNull()
+      assertThat(tree.referencesFrom(NOT_A_NODE).references).isEmpty()
+    }
+  }
+
+  private companion object {
+    /** An address no synthetic heap dump hands out, which is what a click on a stale node lands on. */
+    const val NOT_A_NODE = 0xDEADBEEFL
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ObjectGraphTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ObjectGraphTest.kt
@@ -1,0 +1,153 @@
+package shark.explorer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import shark.ReferenceLocationType
+
+/**
+ * What expanding, collapsing and paging do to the picture, with no heap dump behind them: the whole
+ * point of [ObjectGraph] being state of its own is that the answers here are the same whether the reads
+ * take a microsecond or a second.
+ */
+class ObjectGraphTest {
+
+  @Test fun `a graph opens on its root, expanded and waiting to be read`() {
+    val graph = ObjectGraph.rootedAt(drawnObject(ROOT, referenceCount = 2))
+
+    assertThat(graph.isEmpty).isFalse()
+    assertThat(graph.isExpanded(ROOT)).isTrue()
+    // Expanded but not read, which is what has the window read the heap dump for it.
+    assertThat(graph.pendingObjectId).isEqualTo(ROOT)
+    assertThat(graph.referencesFrom(ROOT)).isEmpty()
+  }
+
+  @Test fun `folding a read in draws the arrows and what they point at`() {
+    val graph = rootedGraph().reading(ROOT, 2L, 3L)
+
+    assertThat(graph.referencesFrom(ROOT).map { it.toObjectId }).containsExactly(2L, 3L)
+    assertThat(graph.objectOf(2L)?.className).isEqualTo("com.example.C2")
+    // Nothing else was expanded, so there is nothing left to read.
+    assertThat(graph.pendingObjectId).isNull()
+  }
+
+  @Test fun `expanding a node is what asks for its references`() {
+    val graph = rootedGraph().reading(ROOT, 2L).expanding(2L)
+
+    assertThat(graph.pendingObjectId).isEqualTo(2L)
+    // Nothing hangs off it until that read comes back, and the click drew the circle all the same.
+    assertThat(graph.referencesFrom(2L)).isEmpty()
+  }
+
+  @Test fun `collapsing takes what a node references off the picture`() {
+    val graph = rootedGraph().reading(ROOT, 2L).expanding(2L).reading(2L, 3L)
+
+    val collapsed = graph.collapsing(2L)
+
+    assertThat(collapsed.referencesFrom(2L)).isEmpty()
+    assertThat(collapsed.hiddenReferenceCountOf(2L)).isZero()
+    // The circle itself is still there: it is what the reader collapsed, not something they left.
+    assertThat(collapsed.objectOf(2L)).isNotNull
+  }
+
+  @Test fun `opening a node again costs no read`() {
+    val graph = rootedGraph().reading(ROOT, 2L).expanding(2L).reading(2L, 3L)
+
+    val reopened = graph.collapsing(2L).expanding(2L)
+
+    assertThat(reopened.pendingObjectId).isNull()
+    assertThat(reopened.referencesFrom(2L).map { it.toObjectId }).containsExactly(3L)
+  }
+
+  @Test fun `a node with more references than were drawn asks for another page`() {
+    val graph = rootedGraph().reading(ROOT, 2L, hiddenCount = 40)
+
+    assertThat(graph.hiddenReferenceCountOf(ROOT)).isEqualTo(40)
+    assertThat(graph.referenceLimitOf(ROOT)).isEqualTo(ObjectGraph.REFERENCES_PER_PAGE)
+
+    val more = graph.showingMoreOf(ROOT)
+
+    assertThat(more.referenceLimitOf(ROOT)).isEqualTo(2 * ObjectGraph.REFERENCES_PER_PAGE)
+    // Which is the same node pending again, this time for twice as many.
+    assertThat(more.pendingObjectId).isEqualTo(ROOT)
+  }
+
+  @Test fun `a node drawn with everything it references is never pending again`() {
+    val graph = rootedGraph().reading(ROOT, 2L)
+
+    // Nothing was left out, so there is no cell to press and nothing another page would add.
+    assertThat(graph.showingMoreOf(ROOT).pendingObjectId).isNull()
+  }
+
+  @Test fun `pressing a circle expands it, and pressing it again collapses it`() {
+    val graph = rootedGraph().reading(ROOT, 2L)
+    val cell = cellOf(CellSubject.Node(node = 2L, parent = ROOT, siblingIndex = 0))
+
+    val expanded = graph.pressing(cell)
+
+    assertThat(expanded.isExpanded(2L)).isTrue()
+    assertThat(expanded.pressing(cell.copy(isExpanded = true)).isExpanded(2L)).isFalse()
+  }
+
+  @Test fun `pressing the cell counting what was left out draws another page of it`() {
+    val graph = rootedGraph().reading(ROOT, 2L, hiddenCount = 40)
+    val cell = cellOf(CellSubject.Group(parent = ROOT, nodeCount = 40))
+
+    assertThat(graph.pressing(cell).referenceLimitOf(ROOT))
+      .isEqualTo(2 * ObjectGraph.REFERENCES_PER_PAGE)
+  }
+
+  private fun rootedGraph() = ObjectGraph.rootedAt(drawnObject(ROOT, referenceCount = 2))
+
+  /** One expansion's worth of read, as [HeapDominatorTreemap.referencesFrom] would have answered it. */
+  private fun ObjectGraph.reading(
+    from: Long,
+    vararg targets: Long,
+    hiddenCount: Int = 0
+  ): ObjectGraph = withReferences(
+    ObjectReferences(
+      fromObjectId = from,
+      references = targets.map { target ->
+        GraphReference(
+          fromObjectId = from,
+          toObjectId = target,
+          reference = PathReference(
+            name = "field$target",
+            ownerClassName = "C$from",
+            locationType = ReferenceLocationType.INSTANCE_FIELD
+          ),
+          isDominator = true
+        )
+      },
+      objects = targets.map { drawnObject(it) },
+      hiddenCount = hiddenCount
+    )
+  )
+
+  private fun drawnObject(
+    objectId: Long,
+    referenceCount: Int = 0
+  ) = GraphObject(
+    objectId = objectId,
+    className = "com.example.C$objectId",
+    kind = HeapObjectKind.INSTANCE,
+    strength = ReachabilityStrength.STRONG,
+    retainedSize = 100L * objectId,
+    retainedCount = 1,
+    referenceCount = referenceCount
+  )
+
+  private fun cellOf(subject: CellSubject<Long>) = GraphNodeCell(
+    subject = subject,
+    drawn = null,
+    center = TreemapPoint(0.0, 0.0),
+    bounds = TreemapRect(0.0, 0.0, 0.0, 0.0),
+    depth = 1,
+    weight = 0L,
+    isExpanded = false,
+    dominatesBelow = false
+  )
+
+  private companion object {
+    const val ROOT = 1L
+  }
+}


### PR DESCRIPTION
A fourth shape in Shark Explorer, next to the treemap, the rings and the stack.

The three shapes so far all divide an area between the nodes of the dominator tree. They say how much
an object retains and what it sits inside, and they can never say *which field* holds it, or whether
anything else does — that is the heap dump's own references, which the tree is a summary of.

So this one draws the references: circles joined by arrows, expanded outwards a click at a time from
the node the view is rooted at, the way Xcode's memory graph is read.

- **A click expands rather than goes there.** The whole of what this shape says is what has been
  expanded, so a click that re-rooted the window would throw that away every time. Pressing a circle
  opens it, pressing it again closes it — and closing keeps what was read, so opening it again reads
  nothing. Going somewhere is still a click in the panels beside the view, as on every other screen.
- **Arrows are named after the field that points**, on the class that declares it, and a dominator
  edge is ringed: how an object is reached, and whether that is why it is alive, on one picture.
- **Pan and zoom** instead of fitting the window, since what is drawn is what was asked for rather
  than a cut of the tree — and expanding never moves what is already on screen.
- **Fan-out is paged, not truncated**: the 24 heaviest references, with the rest behind the same
  "leftovers" cell the other shapes already use for children they didn't draw.
- **The root can be the whole heap dump**, which is no object: that node answers with the tree's own
  children, so the shape opens where every other one does and the references start one click in. One
  code path, no mode flag.

**The drawing style is shared, not copied.** `PathStyle.kt` is the circle, the badge letter, the ring,
the connector colours, the weak-reference dash and the arrow head; both the chain pane (`PathDrawing`,
a column joined top to bottom) and the graph (`GraphView`, joined left to right) draw through it, so a
colour or a radius changed in one place changes both pictures. The reference-naming is shared the same
way, down in `HeapDominatorTreemap`.

**Where the work happens.** `ObjectGraph` (what has been expanded, and what each circle references,
grown by one heap dump read per circle) and `GraphLayout` (arranging it into columns and rows) are both
in `shark-explorer-core` and unit tested there. Arranging happens in composition rather than on the
heap dump's thread, because it reads nothing — which is what makes expanding a circle instant rather
than a spinner, and what `TreeLayoutTest` holds it to: switching to this shape lays the tree out no
further.

Tests: `ObjectGraphTest`, `GraphLayoutTest`, `ObjectGraphReadingTest` (core), `GraphTransformTest`,
`GraphViewTest` (app). `notes/treemap-rendering.md` and `notes/decisions.md` say why it is shaped this
way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)