### PR TITLE
Read the heap dump's domination from the classes up

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -1,7 +1,8 @@
 # Shark Explorer — agent guide
 
 A desktop app that renders a heap dump's dominator tree as a navigable treemap, as rings around a
-centre, or as a stack of rows the way a profiler draws a call tree. The long term goal is a YourKit-style
+centre, or as a stack of rows the way a profiler draws a call tree — and that same domination read from
+the classes up, which is the stack of rows the other way round. The long term goal is a YourKit-style
 heap explorer; these are the first surfaces.
 
 This file is scoped to `shark/shark-explorer/`. It only records things an agent would get wrong by
@@ -30,6 +31,20 @@ under-attributed. Don't build on it.
 `shark.HeapDominatorTree` is the exact one, which is what `HeapExplorer` uses. See
 `notes/dominator-tree.md` for its memory profile and for the reference reader behaviour that makes a
 treemap read strangely until you know about it.
+
+## One heap dump, two trees, one shared root
+
+`HeapExplorer.tree` is that domination read from the roots down, and `tree.reverseTree` is the same
+domination read from the classes up, for the classes view — built on first use, because it costs a pass
+over every object of the dump. Both implement `HeapTree`, which is what a layout and a presentation take.
+
+**The whole heap dump is a node of both, with the same id**, so that a path zoomed into either tree
+starts at the same place. Every other node is told apart by its id alone
+(`ReverseDominatorTree.isReverseNode`), and **that one shared node is the trap**: what a clicked cell is
+cannot be worked out from its id, so `selectionOf` in `HeapDumpExplorer.kt` takes the shape being drawn.
+Asking one tree about the other's node is what a `require` there reports; asking the reverse tree for a
+node it doesn't have costs a full pass over the heap dump first. `notes/treemap-rendering.md` has the
+rest of it.
 
 ## The heap dump is read off the UI thread
 

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -80,6 +80,40 @@ Both are why `ReferenceStrengthReader.foldedObjectIdsOf` exists: **whatever Shar
 tracked explicitly**, because the object is in no walk and in no tree, and anything counting objects or
 bytes over the whole dump would otherwise either miss it or count it twice. See the reachability section.
 
+## The same domination, read from the classes up
+
+`ReverseDominatorTree` reads the one tree the other way: every object on the row of its class, and above
+each row the classes of the objects dominating it. It needs no second dominator computation — only
+`immediateDominatorOf`, one object at a time, plus `nodes` for shallow sizes and to know which objects
+were folded. So it costs nothing until the classes view is opened, and the numbers say what opening it
+costs. Measured on `large-dump.hprof` (39 MB, 387,971 objects), which takes 2.4 s to open:
+
+| | |
+| --- | --- |
+| Gathering every object onto its class row — one pass over `graph.objects` | 0.20 s, 8,679 rows |
+| The level above the widest row — one `immediateDominatorOf` per object it gathers | 0.01 s, 44 rows |
+
+**The pass is over `graph.objects` and not over `nodes`**, because an object's class comes off the index
+it's read from, and looking it up per object again is what made the first version of this take minutes.
+The objects with no node are the folded ones, whose bytes are counted in the object holding them:
+311,601 of the dump's 387,971 objects have a node, and those are what the rows hold.
+
+**A row's weight is the shallow bytes of the objects at the bottom of its column.** Which is what makes
+the reverse root weigh exactly what the dominator tree's root does — 30,764,843 bytes on that dump,
+asserted in `ReverseDominatorTreeTest`. Note that this is *not* `HeapSizes.totalByteCount` (30,753,181
+there): that one is the strength legend's arithmetic over the reachability walks, and the 11 KB between
+them is not something to make a test assert.
+
+What it holds between reads is **at most one entry per object of the heap dump**, however many levels are
+open, because expanding a row hands its entries to the rows above it and drops its own — the live entries
+therefore stand for disjoint sets of the objects at the bottom of the columns.
+
+And what it is for, on that dump, in one column: `16,730 × byte[]` is 10.5 MB, a third of the heap; above
+it `151 × Bitmap` accounts for 8.1 MB of those bytes and `14,874 × Class` for 2.2 MB; above the bitmaps,
+two `LinkedHashMap$LinkedHashMapEntry`, one `LinkedHashMap` and one `LruCache`, each holding 3.9 MB of
+them. Six rows of one column, in the picture the view opens on, with no chain walked and nothing clicked —
+where the treemap has that same fact spread over 151 rectangles in different corners of itself.
+
 ## Why big objects sit flat under the root
 
 The first thing a production dump shows is a crowd of rectangles directly under the whole heap dump — on an

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -2,21 +2,23 @@
 
 Implemented in `shark-explorer-core`: `Squarify.kt` (row layout), `TreemapLayout.kt` (adaptive depth
 and hit testing), `RadialLayout.kt` (the same, as rings), `StackLayout.kt` (the same, as a row per
-level), `TreemapRect.kt`, `LayoutCell.kt` (what the three layouts have in common),
-`HeapDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and `present()`, which labels and
-colours the cells a layout produced), `TreemapPresentation.kt` (a presentation per shape, each with an
-`of()` pairing a layout with that). Drawn by `TreemapView`, `RadialView` and `StackView` in
-`shark-explorer-app`.
+level, either way up), `TreemapRect.kt`, `LayoutCell.kt` (what the three layouts have in common),
+`HeapTree.kt` (what a layout can be built from: the two readings of the heap dump both implement it),
+`HeapDominatorTreemap.kt` (the dominator tree as a `HeapTree`, and `present()`, which labels and
+colours the cells a layout produced), `ReverseDominatorTree.kt` (the same domination read from the
+classes up), `TreemapPresentation.kt` (a presentation per shape, each with an `of()` pairing a layout
+with a tree). Drawn by `TreemapView`, `RadialView` and `StackView` in `shark-explorer-app`.
 
 **`of()` is a presentation's own, not a method per shape on `HeapDominatorTreemap`.** It used to be the
 other way round, and adding a third shape is what moved it: that class is a 1,200 line heap dump reader
 which detekt allows 50 functions, and `presentStack` was the fiftieth. Rather than split it somewhere
 arbitrary, the per-shape method came out of it — which is also the better line, since which shapes exist
 is no business of a heap dump reader. `present(cells)` is all that stayed behind: it reads a name and a
-strength off a `CellSubject`, and every shape's cells are those. **So a fourth shape needs nothing in
-`HeapDominatorTreemap` at all.**
+strength off a `CellSubject`, and every shape's cells are those. **Which is what let the fourth view be
+a second tree rather than a second reader**: `of()` takes a `HeapTree`, so a view of the classes is the
+stack layout over `ReverseDominatorTree`, and nothing in `HeapDominatorTreemap` knows about it.
 
-## Three shapes, one cut of the tree
+## Four views, three shapes, two readings
 
 A cell is a `LayoutCell`: a `CellSubject` — one node, or the children a node didn't draw — plus a
 depth, a weight and whatever geometry its layout adds. `TreemapCell` adds a rectangle, `RadialCell` an
@@ -26,6 +28,11 @@ being a second copy of all of it, and the third shape is what confirmed the pric
 `StackView`, one new `Canvas`, and three small things beside them — a `ViewShape`, a `ViewPresentation`
 and a `StackPresentation` with its `of()`. Nothing about colouring, labelling, selection, hit resolution
 or navigation moved.
+
+The fourth view is cheaper still, because it is a *reading* rather than a shape: the classes view is
+`StackLayout` with `rowsGoUp`, over the other tree. What it cost was one `HeapTree` implementation, one
+`Boolean` in the layout, `reverseScrolling` in the view, and the panels learning to describe a row — no
+new canvas, no new layout, no new hit testing.
 
 The three layouts make the same decisions — largest cell subdivided first, children too small to see
 grouped, a cell budget, truncation counted — differing only in what "too small" measures. A treemap
@@ -68,6 +75,53 @@ Three consequences of that, each of them a decision:
 It skips one thing the treemap does: **a row doesn't draw its bitmap**. A row is a line of text tall,
 and a bitmap fitted into 18 dp is a smear — the picture is the treemap's contribution, and asking for it
 here would cost a heap dump read and a decode per row for nothing.
+
+## The classes view: the same stack, read from the leaves
+
+`ReverseDominatorTree` is the heap dump's domination read the other way: every object on the row of its
+class, and above each row the classes of the objects dominating it. Drawn by `StackLayout(rowsGoUp =
+true)`, so the whole heap dump is the row across the bottom and a column grows up from it — an icicle
+chart the way a profiler draws a *reverse* call tree. What a column says is "these bytes are `byte[]`,
+held by `Bitmap`, held by `ImageView`", and how wide it is says how much of the heap's `byte[]` bytes
+that accounts for.
+
+Three things about it are not obvious from the other view:
+
+- **A row is weighed by the objects at the bottom of its column, in their own bytes.** Retained size is
+  the wrong weight here and not by a little: it would count an object's bytes again on every row above
+  it, so the rows would add up to several times the heap and "a fifth of the dump" would mean nothing.
+  Shallow bytes add up to the dump exactly once, which is why the reverse root weighs exactly what the
+  dominator tree's root weighs (asserted in `ReverseDominatorTreeTest`) and why a row's children cover
+  it to the byte.
+- **Every cell of it is a pile of objects, including the root.** Which is why a row is *not* drawn like
+  the treemap's class piles: washing out every cell and dashing every edge would spend the whole picture
+  saying something no cell of it contradicts, and lose the hues that make a column readable. The count
+  in the label (`1,204 × byte[]`) is what says "pile" instead. The two rows that stop a column keep
+  their own look: `Nothing in particular` is slate and dashed, uncollected garbage stays purple.
+- **It is built as it is read, and bounded to one entry per object of the heap dump.** The class rows
+  cost one pass over every object; a row above one costs one dominator read per object that row gathers.
+  Expanding a row hands its entries to the rows above it and drops its own, so however many levels are
+  open, the live entries stand for disjoint sets of the objects at the bottom of the columns.
+
+Two decisions in the wiring, both to keep it a view rather than a screen:
+
+- **The two trees share the root node id**, so a path zoomed into either of them starts at the same
+  place, and switching shape substitutes the root *in the view request* rather than in the history —
+  which is what leaves the path into the tree being left there to come back to. Every other node is told
+  apart by its id: `ReverseDominatorTree.isReverseNode` is a range check at the far end of the range
+  `HeapDominatorTreemap` takes its pile ids from.
+- **What a cell is, is read off the view it was clicked in, not off its node.** Because of that shared
+  root: the whole heap dump is a row of this view and the root of the other, and a pile of siblings that
+  didn't fit is named after the cell they were left out of, which on a dump with more classes than one
+  row can draw is that very node. So `selectionOf` takes the shape. The one thing it must *not* do is
+  re-read the selection when the shape changes, which would be asking one tree about the other's node —
+  hence the effect keyed on the request alone.
+
+Going up is done to the finished layout rather than threaded through it: `StackLayout` places every row
+from the top as usual and flips it once `rowCount` is known, because a row's distance from the *bottom*
+isn't known until the last row has been placed. `contentHeight` is clamped to the viewport when growing
+up, so the root row sits on the bottom edge of the view rather than of the rows, and `StackView` scrolls
+it with `reverseScrolling` so that `scrollTo(0)` still means "where it opens".
 
 ## Depth is area-driven, not a fixed level
 
@@ -196,7 +250,9 @@ The tree's nodes are object ids, and the piles it invents — the uncollected ga
 groups — need ids of their own. **`nodeId < 0` is not the test for one**, and taking it for one is a bug that
 looks like nothing: an object id is a heap address, a 32 bit dump records it in 4 bytes, and shark widens
 those by sign, so **every object above the 2 GB mark of such a dump has a negative id**. `isPileId` is a range
-check against `Int.MIN_VALUE` instead, and the pile ids start at `Long.MIN_VALUE`.
+check against `Int.MIN_VALUE` instead, and the pile ids start at `Long.MIN_VALUE`. The classes view's rows
+are ids of their own out of that same range, counting *down* from just below `Int.MIN_VALUE`, so
+`isReverseNode` is the same kind of range check and the two halves of the range can't collide.
 
 What the sign test cost, before it was a range check: on `large-dump.hprof`, **44 of the 4,616 rectangles of
 the opening view** had `contains()` say the tree didn't hold them, so pointing at one selected nothing, the

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellColors.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellColors.kt
@@ -16,6 +16,7 @@ import shark.explorer.ReachabilityStrength.STRONG
 import shark.explorer.ReachabilityStrength.THREAD_LOCAL
 import shark.explorer.ReachabilityStrength.UNREACHABLE
 import shark.explorer.ReachabilityStrength.WEAK
+import shark.explorer.ReverseNodeKind
 
 /**
  * How the rectangles are coloured. Pick one above the view.
@@ -78,10 +79,16 @@ internal class CellColors private constructor(
   val label: Color get() = LABEL
 
   /** Dark enough on a pile of objects for the dashes of [outlineOf] to read as dashes. */
-  fun borderOf(presented: PresentedCell<*>): Color = when (presented.content) {
-    is CellContent.Object -> if (coloring.scheme == DAISY_SCHEME) DAISY_BORDER else BORDER
+  fun borderOf(presented: PresentedCell<*>): Color = when (val content = presented.content) {
+    is CellContent.Object -> objectBorder
+    // A row of the classes view is drawn like an object, borders included — bar the one row that reads as
+    // a pile there too, whose edge is dashed. See [colorOf].
+    is CellContent.ObjectRow ->
+      if (content.kind == ReverseNodeKind.NO_OWNER) PILE_BORDER else objectBorder
     else -> PILE_BORDER
   }
+
+  private val objectBorder: Color get() = if (coloring.scheme == DAISY_SCHEME) DAISY_BORDER else BORDER
 
   fun colorOf(presented: PresentedCell<*>): Color {
     val depth = presented.cell.depth
@@ -94,6 +101,15 @@ internal class CellColors private constructor(
       // is neither of those things.
       is CellContent.Leftover -> pileColor(strength, depth)
       is CellContent.ObjectGroup -> if (content.kind == ObjectGroupKind.CLASS) {
+        pileColor(strength, depth)
+      } else {
+        objectColor(strength, depth, hueIndexOf(presented))
+      }
+      // A row of the classes view is a pile as well, and coloured like an object all the same: every cell
+      // there is a pile, so the slate would be the whole picture and a column would be one flat block. Its
+      // hue is what makes a column read as one thing, the way nesting does in a treemap.
+      is CellContent.ObjectRow -> if (content.kind == ReverseNodeKind.NO_OWNER) {
+        // Except the row that is objects with nothing in common, which is the one that reads as a pile.
         pileColor(strength, depth)
       } else {
         objectColor(strength, depth, hueIndexOf(presented))

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/CellView.kt
@@ -29,11 +29,14 @@ import androidx.compose.ui.unit.sp
 import kotlin.math.roundToInt
 import shark.explorer.CellContent
 import shark.explorer.CellSubject
+import shark.explorer.HeapDominatorTreemap
 import shark.explorer.LayoutCell
 import shark.explorer.ObjectGroupKind
+import shark.explorer.ReverseDominatorTree
+import shark.explorer.ReverseNodeKind
 import shark.explorer.TreemapPoint
 
-/** Which shape the dominator tree is drawn as. Pick one above the view. */
+/** Which shape a heap dump's domination is drawn as. Pick one above the view. */
 internal enum class ViewShape(val displayName: String) {
 
   /** Nested rectangles: area is retained size, nesting is domination. */
@@ -52,7 +55,27 @@ internal enum class ViewShape(val displayName: String) {
    * doesn't spend area on nesting, so the deep end of a chain is drawn and named at full size — and
    * therefore the one shape taller than the window, which is why it scrolls.
    */
-  STACK("Stack")
+  STACK("Stack"),
+
+  /**
+   * The same stack of rows the other way up, of the other of the heap dump's two trees: every object of
+   * the dump on the row of its class along the bottom, and what dominates them stacked above, class by
+   * class. See [shark.explorer.ReverseDominatorTree].
+   *
+   * So a row here is a pile of objects rather than one object, and reading up a column answers "what
+   * holds all the `byte[]`, and what holds that" — which [STACK] can only answer one object at a time.
+   */
+  CLASSES("Classes");
+
+  /**
+   * Whether this shape draws [nodeId] at all, which is what a shape being switched leaves behind.
+   *
+   * The heap dump's two trees share their root and no other node — see [shark.explorer.HeapTree] — so a
+   * path zoomed into one of them is nothing to the other, and which shape is drawn is what says which of
+   * the two a node is expected to be in.
+   */
+  fun draws(nodeId: Long): Boolean = nodeId == HeapDominatorTreemap.ROOT_OBJECT_ID ||
+    ReverseDominatorTree.isReverseNode(nodeId) == (this == CLASSES)
 }
 
 /**
@@ -108,15 +131,23 @@ internal fun BoxScope.NotExpandedBadge(nodeCount: Int) {
 internal fun Offset.toTreemapPoint() = TreemapPoint(x.toDouble(), y.toDouble())
 
 /**
- * How a cell is outlined: dashed for every instance of one class, dotted for the siblings that didn't
- * fit, solid for an object and for the two halves of the heap dump.
+ * How a cell is outlined: dashed for every instance of one class and for the objects nothing in
+ * particular holds, dotted for the siblings that didn't fit, solid for an object, for the two halves of
+ * the heap dump and for a row of the classes view.
  *
- * A pile of objects shouldn't have the same edge as one object, in either shape. Along with the washed
+ * A pile of objects drawn among objects shouldn't have the same edge as one object. Along with the washed
  * out fill and the label, it's the third thing saying this cell isn't something you can inspect the
- * fields of.
+ * fields of. Every cell of the classes view is a pile, so there a dashed edge would mark nothing out and
+ * make the rows hard to tell apart: see [CellContent.ObjectRow].
  */
 internal fun outlineOf(content: CellContent): Stroke = when {
   content is CellContent.ObjectGroup && content.kind == ObjectGroupKind.CLASS -> Stroke(
+    width = PILE_BORDER_WIDTH,
+    pathEffect = PathEffect.dashPathEffect(CLASS_GROUP_DASH_INTERVALS)
+  )
+  // The one row of that view that isn't objects gathered by something: they have nothing in common but
+  // that nothing in particular holds them, so the edge says so the way a pile's does.
+  content is CellContent.ObjectRow && content.kind == ReverseNodeKind.NO_OWNER -> Stroke(
     width = PILE_BORDER_WIDTH,
     pathEffect = PathEffect.dashPathEffect(CLASS_GROUP_DASH_INTERVALS)
   )

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -34,6 +34,8 @@ import shark.explorer.HeapObjectKind
 import shark.explorer.HeapObjectSummary
 import shark.explorer.ObjectGroupKind
 import shark.explorer.ObjectGroupSummary
+import shark.explorer.ReverseNodeKind
+import shark.explorer.ReverseNodeSummary
 import shark.explorer.formatByteSize
 import shark.explorer.formatObjectCount
 
@@ -71,17 +73,15 @@ internal fun DetailsPanel(
       when (selection) {
         null -> Text(NO_SELECTION, style = MaterialTheme.typography.bodyMedium)
         is Selection.Group -> {
+          Text(selection.title(), style = MaterialTheme.typography.titleMedium)
           Text(
-            "${selection.nodeCount} smaller objects",
-            style = MaterialTheme.typography.titleMedium
-          )
-          Text(
-            "Held by ${selection.parentLabel}. $GROUP_EXPLANATION",
+            "Held by ${selection.parentLabel}. ${selection.explanation()}",
             style = MaterialTheme.typography.bodySmall
           )
-          Detail("Retained", formatByteSize(selection.byteCount))
+          Detail(selection.byteCountName, formatByteSize(selection.byteCount))
         }
         is Selection.ObjectGroup -> ObjectGroupDetails(selection.summary, coloring)
+        is Selection.Row -> RowDetails(selection.summary, coloring, onOpen)
         is Selection.Object -> ObjectDetails(
           summary = selection.summary,
           bitmap = bitmap,
@@ -104,13 +104,41 @@ internal sealed interface Selection {
   /** A cell standing for many objects was clicked, so there's no one object to describe. */
   data class ObjectGroup(val summary: ObjectGroupSummary) : Selection
 
+  /** One row of the classes view, which stands for many objects as well. See [ReverseNodeSummary]. */
+  data class Row(val summary: ReverseNodeSummary) : Selection
+
   /** A [CellSubject.Group] was clicked, so there's no one object to describe. */
   data class Group(
+    /**
+     * Whether they are rows of the classes view rather than objects, which everything said about them
+     * turns on. Read off the view they were clicked in rather than off the cell they were left out of:
+     * that cell is the whole heap dump when a dump has more classes than one row can draw, and the whole
+     * heap dump is a node of both of the heap dump's trees.
+     */
+    val isRows: Boolean,
     val nodeCount: Int,
     val byteCount: Long,
     val parentLabel: String
   ) : Selection
 }
+
+/** What a pile of siblings that didn't fit is called wherever it is described. */
+internal fun Selection.Group.title(): String = if (isRows) {
+  "$nodeCount smaller ${if (nodeCount == 1) "row" else "rows"}"
+} else {
+  "$nodeCount smaller objects"
+}
+
+/** And what a click on it does, which is not the same in a view whose cells are rows. */
+internal fun Selection.Group.explanation(): String =
+  if (isRows) ROW_GROUP_EXPLANATION else GROUP_EXPLANATION
+
+/**
+ * What the bytes of a pile of them are: bytes retained by objects, and bytes accounted for by rows —
+ * a row is as wide as what the objects at the bottom of its column take up, not as what it retains.
+ */
+internal val Selection.Group.byteCountName: String
+  get() = if (isRows) ACCOUNTS_FOR else RETAINED
 
 /**
  * A cell standing for many objects: half of the heap dump, or every instance of one class under the
@@ -132,7 +160,51 @@ private fun ObjectGroupDetails(
     Text(summary.explanation(), style = MaterialTheme.typography.bodySmall)
   }
   Detail("Retained together", formatByteSize(summary.retainedSize))
-  Detail("Objects", formatObjectCount(summary.objectCount))
+  Detail(OBJECTS, formatObjectCount(summary.objectCount))
+}
+
+/**
+ * One row of the classes view: what it gathers, how much of the heap that comes to, and the column it is
+ * part of — every row of which leads back to itself, so this is also the way down a column.
+ *
+ * No chain up to a GC root beside it, unlike an object: a row is a pile of objects held as many ways as it
+ * has objects in it. See [RootPathPanel].
+ */
+@Composable
+private fun RowDetails(
+  summary: ReverseNodeSummary,
+  coloring: CellColoring,
+  onOpen: (Long) -> Unit
+) {
+  Text(summary.label, style = MaterialTheme.typography.titleMedium)
+  summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Box(Modifier.size(SWATCH_SIZE).background(legendColor(coloring, summary.strength)))
+    Text(summary.strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
+  }
+  Text(summary.explanation(), style = MaterialTheme.typography.bodySmall)
+  Detail(ACCOUNTS_FOR, formatByteSize(summary.byteCount))
+  Detail(OBJECTS, formatObjectCount(summary.objectCount))
+  if (summary.column.isEmpty()) {
+    return
+  }
+  // Which is the question this view is for: these bytes are held by this, which is held by that. Nearest
+  // first, so the list reads the way the rows under it do on screen, going down.
+  Text(COLUMN_BELOW, style = MaterialTheme.typography.labelSmall)
+  summary.column.forEach { step ->
+    Inspectable(step.label, step.nodeId, onOpen)
+  }
+}
+
+/** What kind of row it is, in as many words: two of the four are where a column stops. */
+private fun ReverseNodeSummary.explanation(): String = when (kind) {
+  ReverseNodeKind.WHOLE_HEAP_DUMP -> WHOLE_HEAP_DUMP_ROW_EXPLANATION
+  ReverseNodeKind.CLASS -> CLASS_ROW_EXPLANATION
+  ReverseNodeKind.NO_OWNER -> NO_OWNER_ROW_EXPLANATION
+  ReverseNodeKind.UNCOLLECTED_GARBAGE -> GARBAGE_ROW_EXPLANATION
 }
 
 /** What a pile of objects is called wherever it is described: here, and on the card at the pointer. */
@@ -176,7 +248,7 @@ private fun ObjectDetails(
     Box(Modifier.size(SWATCH_SIZE).background(legendColor(coloring, summary.strength)))
     Text(summary.strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
   }
-  Detail("Retained", formatByteSize(summary.retainedSize))
+  Detail(RETAINED, formatByteSize(summary.retainedSize))
   Detail("Retained objects", summary.retainedCount.toString())
   Detail("Shallow", formatByteSize(summary.shallowSize))
   Detail("Dominates", "${summary.dominatedObjectCount} objects")
@@ -314,6 +386,38 @@ internal const val CLASS_GROUP_EXPLANATION =
 private const val GROUP_EXPLANATION =
   "Too small or too many to draw one by one in the rectangle they belong to. Clicking them roots the " +
     "map at what holds them, which gives it the whole view to draw them in."
+
+/** The same pile in the classes view, where what didn't fit along a row is rows rather than objects. */
+private const val ROW_GROUP_EXPLANATION =
+  "Too narrow or too many to draw one by one on the row above the one they belong to. Clicking them " +
+    "roots the view at that row, which gives them the whole width."
+
+/** What the row across the bottom of the classes view is. */
+internal const val WHOLE_HEAP_DUMP_ROW_EXPLANATION =
+  "Every object of the heap dump counted in its own bytes, which is what the rows above are shares of."
+
+internal const val CLASS_ROW_EXPLANATION =
+  "Not one object: the objects of this class that dominate what the row below stands for, as wide as " +
+    "the bytes of it they account for. The row above splits those bytes by what dominates these."
+
+/** Where a column stops. See [shark.explorer.ReverseNodeKind.NO_OWNER]. */
+internal const val NO_OWNER_ROW_EXPLANATION =
+  "Where the column stops: nothing in particular dominates these objects. Each of them is held from " +
+    "more than one place, so no single object of the heap dump would free it."
+
+/** And the other way it stops, which is the garbage getting there first. */
+internal const val GARBAGE_ROW_EXPLANATION =
+  "Where the column stops: what dominates these objects is uncollected garbage, so nothing a GC root " +
+    "reaches holds them. The next collection would take all of it."
+
+/** The rows a row stands on, listed under it: the column read downwards. */
+internal const val COLUMN_BELOW = "Held by, going down"
+
+/** What a row's width is, which is not what it retains: see [shark.explorer.ReverseNodeSummary]. */
+internal const val ACCOUNTS_FOR = "Accounts for"
+
+internal const val RETAINED = "Retained"
+private const val OBJECTS = "Objects"
 
 /** What the pixels of the selected bitmap are, to anything that can't look at them. */
 internal const val BITMAP_DESCRIPTION = "The pixels of the selected bitmap."

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -43,8 +43,10 @@ import shark.explorer.CellSubject
 import shark.explorer.DeviceHeapDumps
 import shark.explorer.ExplorerScreen
 import shark.explorer.HeapDominatorTreemap
+import shark.explorer.HeapExplorer
 import shark.explorer.HeapObjectKind
 import shark.explorer.HeapSizes
+import shark.explorer.HeapTree
 import shark.explorer.LayoutCell
 import shark.explorer.NativeBitmapPixels
 import shark.explorer.NavigationHistory
@@ -53,6 +55,7 @@ import shark.explorer.ObjectList
 import shark.explorer.ObjectListFilter
 import shark.explorer.RadialLayout
 import shark.explorer.RadialPresentation
+import shark.explorer.ReverseDominatorTree
 import shark.explorer.RootPath
 import shark.explorer.RootPathWay
 import shark.explorer.StackLayout
@@ -164,6 +167,9 @@ internal fun HeapDumpExplorer(
   val treemapLayout = rememberTreemapLayout()
   val radialLayout = rememberRadialLayout()
   val stackLayout = rememberStackLayout()
+  // The same layout the other way up, which is what the classes view is: its rows grow from the whole heap
+  // dump along the bottom rather than down from it. See [StackLayout].
+  val classesLayout = rememberStackLayout(rowsGoUp = true)
   // In pixels, like everything a layout is measured in, so that how small is too small for an image to be
   // worth drawing is the same size on every display. See MIN_BITMAP_DRAW_SIZE.
   val minBitmapDrawSize = with(LocalDensity.current) { MIN_BITMAP_DRAW_SIZE.toPx() }
@@ -173,12 +179,17 @@ internal fun HeapDumpExplorer(
   // nothing to lay out for.
   val viewRequest = viewportSize.takeIf { it != IntSize.Zero }?.let { size ->
     ViewRequest(
-      navigation = navigation,
+      // The whole heap dump when the shape being switched to draws the other of the heap dump's two trees,
+      // which is the one node they share. Substituted in the request rather than in the history, so that
+      // the path into the tree being left is still there to come back to: what the effect below replaces
+      // the history with, it only replaces when the request is what the window is already showing.
+      navigation = navigation.takeIf { shape.draws(it.current) } ?: TreemapNavigation(ROOT_NODE),
       viewportSize = size,
       shape = shape,
       treemapLayout = treemapLayout,
       radialLayout = radialLayout,
-      stackLayout = stackLayout
+      stackLayout = stackLayout,
+      classesLayout = classesLayout
     )
   }
 
@@ -194,7 +205,7 @@ internal fun HeapDumpExplorer(
     }
     isLayingOut = true
     view = session.read(viewRequest.description()) { explorer ->
-      val tree = explorer.tree
+      val tree = explorer.treeOf(viewRequest.shape)
       val requested = viewRequest.navigation
       // An object zoomed into may no longer be dominated by the one above it on the path.
       val reachablePath = requested.retainingWhere { it in tree }
@@ -227,6 +238,14 @@ internal fun HeapDumpExplorer(
             StackPresentation.of(
               tree,
               viewRequest.stackLayout,
+              viewRequest.viewport,
+              reachablePath.current
+            )
+          )
+          ViewShape.CLASSES -> ViewPresentation.Stack(
+            StackPresentation.of(
+              tree,
+              viewRequest.classesLayout,
               viewRequest.viewport,
               reachablePath.current
             )
@@ -283,14 +302,16 @@ internal fun HeapDumpExplorer(
   }
 
   // Reading what a cell stands for is a heap dump read too, so the panels fill in a beat after the click.
-  // Keyed on the request, so that nothing else clears them.
+  // Keyed on the request, so that nothing else clears them — the shape included, though the cell is read as
+  // whatever the view it was clicked in draws: switching shape leaves the panels on what they were saying,
+  // and re-reading a cell of the view being left would be asking one tree about the other tree's node.
   LaunchedEffect(session, clicked?.request) {
     val clickedRequest = clicked?.request
     if (clickedRequest == null) {
       clickedDetails = null
       return@LaunchedEffect
     }
-    session.describing(clickedRequest) { clickedDetails = it }
+    session.describing(clickedRequest, shape) { clickedDetails = it }
   }
 
   // The same for the cell under the pointer, once it has stayed on one long enough to be looking at it.
@@ -303,7 +324,7 @@ internal fun HeapDumpExplorer(
       return@LaunchedEffect
     }
     delay(HOVER_SETTLE_MILLIS)
-    session.describing(hoveredRequest) { hoveredDetails = it }
+    session.describing(hoveredRequest, shape) { hoveredDetails = it }
   }
 
   // The panel shows the bitmap it describes as big as the panel is wide, so its pixels are read again at
@@ -382,13 +403,13 @@ internal fun HeapDumpExplorer(
     isListing = false
   }
 
-  // Where the treemap draws a node takes walking up its dominators, so showing what a panel line or a row
+  // Where the view draws a node takes walking up its dominators, so showing what a panel line or a row
   // of a list leads to is a heap dump read as well.
   LaunchedEffect(session, nodeToOpen) {
     val move = nodeToOpen ?: return@LaunchedEffect
     val openNodeId = move.nodeId
     val path = session.read("where the map draws ${nodeIdText(openNodeId)}") { explorer ->
-      explorer.tree.pathToOpen(openNodeId)
+      explorer.treeOf(openNodeId).pathToOpen(openNodeId)
     }
     if (openNodeId != ROOT_NODE && path == listOf(ROOT_NODE)) {
       // Clicking a field or a row led to an object the tree has no node for, so the map has nowhere to
@@ -622,10 +643,13 @@ private fun DescribedObject(selection: Selection?) {
       selection.summary.className ?: HeapDominatorTreemap.UNREACHABLE_LABEL,
       style = MaterialTheme.typography.bodyMedium
     )
-    is Selection.Group -> Text(
-      "${selection.nodeCount} smaller objects",
+    // The class the row gathers, which is what it is about, and what it says of itself for the rows that
+    // gather no class: the whole heap dump, and the two ways a column stops.
+    is Selection.Row -> Text(
+      selection.summary.className ?: selection.summary.label,
       style = MaterialTheme.typography.bodyMedium
     )
+    is Selection.Group -> Text(selection.title(), style = MaterialTheme.typography.bodyMedium)
   }
 }
 
@@ -794,16 +818,23 @@ private fun rememberRadialLayout(): RadialLayout<Long> {
   }
 }
 
-/** And the stack layout, whose row height is a line of text and so is scaled like the rest of them. */
+/**
+ * And the stack layout, whose row height is a line of text and so is scaled like the rest of them.
+ *
+ * One of these per direction rather than one asked which way to go per layout, because which way a stack
+ * grows is as much a part of how a shape is laid out as its thresholds are: [ViewShape.STACK] and
+ * [ViewShape.CLASSES] are two shapes, and a view is laid out again when the shape changes.
+ */
 @Composable
-private fun rememberStackLayout(): StackLayout<Long> {
+private fun rememberStackLayout(rowsGoUp: Boolean = false): StackLayout<Long> {
   val density = LocalDensity.current
-  return remember(density) {
+  return remember(density, rowsGoUp) {
     with(density) {
       StackLayout(
         rowHeight = STACK_ROW_HEIGHT.toPx().toDouble(),
         minSubdivideWidth = MIN_SUBDIVIDE_STACK_WIDTH.toPx().toDouble(),
-        minDrawWidth = MIN_DRAW_STACK_WIDTH.toPx().toDouble()
+        minDrawWidth = MIN_DRAW_STACK_WIDTH.toPx().toDouble(),
+        rowsGoUp = rowsGoUp
       )
     }
   }
@@ -827,7 +858,9 @@ private data class ViewRequest(
   val shape: ViewShape,
   val treemapLayout: TreemapLayout<Long>,
   val radialLayout: RadialLayout<Long>,
-  val stackLayout: StackLayout<Long>
+  val stackLayout: StackLayout<Long>,
+  /** The stack laid out the other way up, which is the classes view. See [StackLayout]. */
+  val classesLayout: StackLayout<Long>
 ) {
   val viewport: TreemapRect
     get() = TreemapRect(
@@ -947,38 +980,18 @@ private class CellDetails(
  */
 private suspend fun HeapDumpSession.describing(
   request: SelectionRequest,
+  shape: ViewShape,
   onDetails: (CellDetails) -> Unit
 ) {
-  val cellDetails = read(request.description()) { explorer ->
-    val tree = explorer.tree
-    val selection = when (request) {
-      is SelectionRequest.Object -> {
-        val group = tree.groupOrNull(request.objectId)
-        when {
-          group != null -> Selection.ObjectGroup(group)
-          request.objectId in tree -> Selection.Object(tree.summarize(request.objectId))
-          // Which is why the panel goes back to saying nothing is selected.
-          else -> {
-            SharkLog.d {
-              "Nothing to describe for ${nodeIdText(request.objectId)}: it is no node of the tree"
-            }
-            null
-          }
-        }
-      }
-      is SelectionRequest.Group -> Selection.Group(
-        nodeCount = request.nodeCount,
-        byteCount = request.byteCount,
-        parentLabel = tree.label(request.parentObjectId)
-      )
-    }
+  val cellDetails = read(request.description(shape)) { explorer ->
+    val selection = explorer.selectionOf(request, shape)
     // The tree already knows what dominates what, so this is a read of one label rather than a search,
     // and it belongs in the same read: two of them means the panel showing a dominator a beat late.
     val objectId = (selection as? Selection.Object)?.summary?.objectId
     CellDetails(
       request = request,
       selection = selection,
-      dominator = objectId?.let { tree.dominatorOf(it) },
+      dominator = objectId?.let { explorer.tree.dominatorOf(it) },
       rootPath = null
     )
   }
@@ -996,6 +1009,68 @@ private suspend fun HeapDumpSession.describing(
     )
   )
 }
+
+/**
+ * What one cell of the view [shape] draws is: a row of the classes view, or an object of the tree read from
+ * the roots down and the two kinds of pile that view has.
+ *
+ * The shape rather than the node says which, because the node can't: the whole heap dump is the row across
+ * the bottom of one view and the root of the other, being the one node both of the heap dump's trees have.
+ * See [HeapTree].
+ *
+ * Null for a cell whose node has left the tree, which is what a click on a field or a list row can reach —
+ * and why the panel goes back to saying nothing is selected.
+ */
+private fun HeapExplorer.selectionOf(
+  request: SelectionRequest,
+  shape: ViewShape
+): Selection? {
+  val rows = if (shape == ViewShape.CLASSES) tree.reverseTree else null
+  return when (request) {
+    is SelectionRequest.Object -> if (rows != null) {
+      if (request.objectId in rows) {
+        Selection.Row(rows.summarize(request.objectId))
+      } else {
+        SharkLog.d {
+          "Nothing to describe for ${nodeIdText(request.objectId)}: it is no row of the classes view"
+        }
+        null
+      }
+    } else {
+      val group = tree.groupOrNull(request.objectId)
+      when {
+        group != null -> Selection.ObjectGroup(group)
+        request.objectId in tree -> Selection.Object(tree.summarize(request.objectId))
+        else -> {
+          SharkLog.d {
+            "Nothing to describe for ${nodeIdText(request.objectId)}: it is no node of the tree"
+          }
+          null
+        }
+      }
+    }
+    is SelectionRequest.Group -> Selection.Group(
+      isRows = rows != null,
+      nodeCount = request.nodeCount,
+      byteCount = request.byteCount,
+      parentLabel = (rows ?: tree).label(request.parentObjectId)
+    )
+  }
+}
+
+/**
+ * Which of the heap dump's two trees a node belongs to, which its own id says. See [HeapTree].
+ *
+ * The other tree is built on first use and costs a pass over every object of the heap dump, so it is only
+ * ever asked for a node that is one of its own. The whole heap dump belongs to both, and both answer the
+ * same for it, so which of them is asked about it doesn't matter here — unlike in [selectionOf].
+ */
+private fun HeapExplorer.treeOf(nodeId: Long): HeapTree =
+  if (ReverseDominatorTree.isReverseNode(nodeId)) tree.reverseTree else tree
+
+/** And which of them a shape draws, which is what one view is laid out from. */
+private fun HeapExplorer.treeOf(shape: ViewShape): HeapTree =
+  if (shape == ViewShape.CLASSES) tree.reverseTree else tree
 
 /** A cell the panels have been asked about, before the heap dump has been read for it. */
 private sealed interface SelectionRequest {
@@ -1019,9 +1094,15 @@ private sealed interface SelectionRequest {
 }
 
 /** What the panel is being filled in for, for the log. See [HeapDumpSession.read]. */
-private fun SelectionRequest.description(): String = when (this) {
+private fun SelectionRequest.description(shape: ViewShape): String = when (this) {
   is SelectionRequest.Object -> "what ${nodeIdText(objectId)} is"
-  is SelectionRequest.Group -> "what the $nodeCount objects under ${nodeIdText(parentObjectId)} are"
+  // The classes view is made of rows and every other view of objects, and which of the two a line of the
+  // log is about is the difference between a pile of a hundred bitmaps and a hundred classes of them.
+  is SelectionRequest.Group -> if (shape == ViewShape.CLASSES) {
+    "what the $nodeCount rows above ${nodeIdText(parentObjectId)} are"
+  } else {
+    "what the $nodeCount objects under ${nodeIdText(parentObjectId)} are"
+  }
 }
 
 private const val ROOT_NODE = HeapDominatorTreemap.ROOT_OBJECT_ID
@@ -1044,10 +1125,11 @@ internal const val FORWARD_ARROW = "→"
 internal const val FETCH_BITMAPS = "Fetch the pixels of"
 
 /**
- * What the tree looks like to anything that can't look at it, a screen reader or a test.
+ * What the view looks like to anything that can't look at it, a screen reader or a test.
  *
- * The same for every [ViewShape], because it says what is drawn rather than how: only one of the three
- * draws a cell inside the one that holds it.
+ * The same for every [ViewShape], because it says what is drawn rather than how: only one of the four
+ * draws a cell inside the one that holds it, and only one of them draws piles of objects rather than
+ * objects — so what they have in common is domination, and a cell being as big as its share of the heap.
  */
 internal const val VIEW_DESCRIPTION =
-  "The dominator tree of the heap dump: every cell is an object, as big as what it retains."
+  "What retains what in the heap dump: every cell is as big as its share of the heap."

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PointerCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import shark.explorer.HeapObjectSummary
 import shark.explorer.ObjectGroupSummary
 import shark.explorer.ReachabilityStrength
+import shark.explorer.ReverseNodeSummary
 import shark.explorer.formatByteSize
 import shark.explorer.formatObjectCount
 
@@ -61,6 +62,7 @@ internal fun PointerCard(
       when (selection) {
         is Selection.Object -> ObjectLines(selection.summary, coloring)
         is Selection.ObjectGroup -> ObjectGroupLines(selection.summary, coloring)
+        is Selection.Row -> RowLines(selection.summary, coloring)
         is Selection.Group -> GroupLines(selection)
       }
     }
@@ -107,19 +109,44 @@ private fun ObjectGroupLines(
   Text(PILE_OF_OBJECTS, style = MaterialTheme.typography.bodySmall)
 }
 
+/**
+ * One row of the classes view, which is the pile a reader points at most: the row is named by a count and
+ * a simple class name, and which class that is, is the whole question it raises.
+ *
+ * How much of the heap it accounts for rather than what it retains, which is what its width is: see
+ * [shark.explorer.ReverseNodeSummary.byteCount].
+ */
+@Composable
+private fun RowLines(
+  summary: ReverseNodeSummary,
+  coloring: CellColoring
+) {
+  Text(summary.label, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Bold)
+  summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+  StrengthLine(summary.strength, coloring)
+  Text(summary.accountsForText(), style = MaterialTheme.typography.bodySmall)
+  Text(ROW_OF_OBJECTS, style = MaterialTheme.typography.bodySmall)
+}
+
 /** The children of a rectangle that its subdivision had no room for. See [shark.explorer.CellSubject.Group]. */
 @Composable
 private fun GroupLines(selection: Selection.Group) {
   Text(
-    "${selection.nodeCount} smaller objects",
+    selection.title(),
     style = MaterialTheme.typography.bodyMedium,
     fontWeight = FontWeight.Bold
   )
-  // Which rectangle they were left out of, since they have nothing else in common: that is the object to
-  // go to if any of them is worth finding.
+  // Which cell they were left out of, since they have nothing else in common: that is where to go if any
+  // of them is worth finding.
   Text("Held by ${selection.parentLabel}", style = MaterialTheme.typography.bodySmall)
-  Text("Retains ${formatByteSize(selection.byteCount)}", style = MaterialTheme.typography.bodySmall)
-  Text(LEFTOVER_OBJECTS, style = MaterialTheme.typography.bodySmall)
+  Text(
+    "${selection.byteCountName} ${formatByteSize(selection.byteCount)}",
+    style = MaterialTheme.typography.bodySmall
+  )
+  Text(
+    if (selection.isRows) LEFTOVER_ROWS else LEFTOVER_OBJECTS,
+    style = MaterialTheme.typography.bodySmall
+  )
 }
 
 /** How firmly what the pointer is on is held, beside the colour the map drew it in. */
@@ -146,6 +173,9 @@ private fun HeapObjectSummary.shallowText(): String =
 private fun ObjectGroupSummary.retainedText(): String =
   "Retains ${formatByteSize(retainedSize)} in ${formatObjectCount(objectCount)}"
 
+/** How much of the heap a row is as wide as, which is not what the objects on it retain. */
+private fun ReverseNodeSummary.accountsForText(): String = "$ACCOUNTS_FOR ${formatByteSize(byteCount)}"
+
 /**
  * What a pile of objects has to say for itself in one line, because a rectangle full of them looks exactly
  * like one object until something says otherwise. The details panel spells out which kind of pile it is.
@@ -156,6 +186,13 @@ private fun ObjectGroupSummary.retainedText(): String =
 internal const val PILE_OF_OBJECTS = "Not one object. Click it to reach the objects it stands for."
 
 /**
+ * The same for a row of the classes view, where clicking leads to the rows above rather than to objects:
+ * the objects a row gathers are of one class, and every class is a row of that view already.
+ */
+internal const val ROW_OF_OBJECTS =
+  "Not one object. Click it to give what dominates these the whole width."
+
+/**
  * The other kind of pile: what a rectangle's subdivision had no room for. It is no node of the tree, so
  * there is nothing to go into and the promise [PILE_OF_OBJECTS] makes would be a lie here. What a click
  * does instead is root the map at the rectangle they were left out of, which is where there is the room
@@ -163,6 +200,14 @@ internal const val PILE_OF_OBJECTS = "Not one object. Click it to reach the obje
  */
 internal const val LEFTOVER_OBJECTS =
   "Not one object. Click it for what holds them, where there is room to draw them one by one."
+
+/**
+ * And the classes left off a row of the classes view, where a click leads the other way: the row they
+ * belong to is above the one they were left out of, so what gives them the width is rooting the view at
+ * the row below them. See [DetailsPanel]'s `ROW_GROUP_EXPLANATION`.
+ */
+internal const val LEFTOVER_ROWS =
+  "Not one class. Click it to root the view at the row below, where there is room to draw them one by one."
 
 /**
  * Where a card of [cardSize] goes for a pointer at [pointer] in a view of [viewSize]: below and to the right

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StackView.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StackView.kt
@@ -1,6 +1,7 @@
 package shark.explorer.app
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -57,6 +58,12 @@ import shark.explorer.formatByteSize
  * Every block that has the width for it carries its own name and size, which the treemap can't do — a
  * rectangle there is covered by its children, and naming every level of it was unreadable. Here a level
  * is a row of its own, so there is nothing to cover and nothing to leave out.
+ *
+ * **A stack laid out the other way up scrolls the other way round**, which is the classes view: its rows
+ * grow up from the row across the bottom, so that is the end a view of it opens on and the end a window
+ * being resized keeps. Compose does that with [verticalScroll]'s `reverseScrolling`, which places the
+ * content by its end and leaves the scroll counting from there — hence [offsetInto], which is what the
+ * pointer's coordinates and the blocks are apart whichever way the rows go.
  */
 @Composable
 internal fun StackView(
@@ -82,8 +89,9 @@ internal fun StackView(
     presentation.cells.map { it.measure(colors, textMeasurer, density, dots) }
   }
   val scrollState = rememberScrollState()
-  // A move re-roots the stack, and the new one starts at its own top: the row someone had scrolled down
-  // to belonged to the tree they have just left. Resizing keeps the scroll, since the tree is the same.
+  // A move re-roots the stack, and the new one starts where it is rooted: the row someone had scrolled
+  // away to belonged to the tree they have just left. Zero is that end whichever way the rows go, since a
+  // stack growing up is scrolled from its bottom. Resizing keeps the scroll, since the tree is the same.
   LaunchedEffect(presentation.rootNode) {
     scrollState.scrollTo(0)
   }
@@ -93,10 +101,14 @@ internal fun StackView(
   // Scrolling moves the blocks under a pointer that hasn't moved, and so does being laid out again, and
   // neither sends a pointer event: without this the panes would keep describing the row that was there.
   LaunchedEffect(presentation, blocks, scrollState.value) {
-    onHover(pointerOffset?.let { presentation.pointedAt(it, scrollState.value) })
+    val offset = scrollState.offsetInto(presentation)
+    onHover(pointerOffset?.let { presentation.pointedAt(it, offset) })
   }
   Box(modifier) {
-    Box(Modifier.fillMaxSize().verticalScroll(scrollState)) {
+    Box(
+      Modifier.fillMaxSize()
+        .verticalScroll(scrollState, reverseScrolling = presentation.layout.rowsGoUp)
+    ) {
       Canvas(
         Modifier.fillMaxWidth()
           // As tall as the stack came out, which is what there is to scroll through. The layout works in
@@ -113,9 +125,10 @@ internal fun StackView(
                   PointerEventType.Move -> {
                     // The scroll is read here rather than keyed on, so that scrolling doesn't restart
                     // the gesture loop, and it is read live so that a wheel between two moves counts.
-                    val offset = event.changes.first().position.inTheView(scrollState.value)
+                    val scroll = scrollState.offsetInto(presentation)
+                    val offset = event.changes.first().position.inTheView(scroll)
                     pointerOffset = offset
-                    onHover(presentation.pointedAt(offset, scrollState.value))
+                    onHover(presentation.pointedAt(offset, scroll))
                   }
                   PointerEventType.Exit -> {
                     pointerOffset = null
@@ -128,8 +141,8 @@ internal fun StackView(
           .pointerInput(presentation, blocks) {
             detectTapGestures(
               onPress = { offset ->
-                presentation.cellAt(offset.inTheView(scrollState.value), scrollState.value)
-                  ?.let(onClick)
+                val scroll = scrollState.offsetInto(presentation)
+                presentation.cellAt(offset.inTheView(scroll), scroll)?.let(onClick)
               }
             )
           }
@@ -163,11 +176,13 @@ internal fun StackView(
       }
     }
     // The one shape that has more than it can show, so the one that needs saying so: nothing else in
-    // this window scrolls without a pane around it to make that obvious.
+    // this window scrolls without a pane around it to make that obvious. Laid out the other way up, so
+    // that the thumb is at the end of the bar the rows the view opens on are at.
     if (scrollState.maxValue > 0) {
       VerticalScrollbar(
         rememberScrollbarAdapter(scrollState),
-        Modifier.align(Alignment.CenterEnd).fillMaxHeight()
+        Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+        reverseLayout = presentation.layout.rowsGoUp
       )
     }
     NotExpandedBadge(presentation.truncatedNodeCount)
@@ -176,6 +191,17 @@ internal fun StackView(
 
 /** Where the pointer is in the view, given where it is on the stack: the stack scrolls, the view doesn't. */
 private fun Offset.inTheView(scroll: Int): Offset = Offset(x, y - scroll)
+
+/**
+ * How far down the stack the top of the view is, which is what everything the pointer reports has to be
+ * shifted by.
+ *
+ * The scroll's own value for rows going down, and counted the other way for rows going up, because
+ * `reverseScrolling` leaves zero meaning the end of the content rather than the start of it: the blocks
+ * are laid out from the top of what there is to scroll, so this is the one place that difference lives.
+ */
+private fun ScrollState.offsetInto(presentation: StackPresentation): Int =
+  if (presentation.layout.rowsGoUp) maxValue - value else value
 
 private fun StackPresentation.cellAt(
   /** In the view, which is [scroll] pixels down the stack. */

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ClassesViewTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ClassesViewTest.kt
@@ -1,0 +1,202 @@
+package shark.explorer.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+
+/**
+ * The window with the heap dump read from the classes up, which is a view of piles rather than of objects:
+ * every cell of it stands for the objects of one class at one point of a column, so what the panels say
+ * about one is not what they say anywhere else.
+ *
+ * The geometry is the other thing only a window shows. This view's rows grow **up** from the whole heap
+ * dump, so the row across the bottom is the one it opens on — see `StackLayoutTest` for the arithmetic and
+ * [classesRow] for how a test points at a row of it.
+ *
+ * The tree itself is unit tested by `ReverseDominatorTreeTest` in `shark-explorer-core`.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ClassesViewTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  /** Every UI test here records what Shark logged. See [RecordedLog]. */
+  @get:Rule val logged = RecordedLog()
+
+  @Test fun `the row across the bottom is the whole heap dump`() {
+    explorerUiTest {
+      openHeapDump(oneClassPerPayloadHeapDump())
+      showTheClassesView()
+
+      clickAt(classesRow(WHOLE_HEAP_DUMP_ROW))
+
+      // Which is what makes the view readable without scrolling it: the row every column stands on is the
+      // one always in front of the reader, and the classes are the row above it.
+      waitUntilAtLeastOneExists(hasText(WHOLE_HEAP_DUMP_ROW_EXPLANATION), OPEN_TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `pointing at a row says which class it gathers`() {
+    explorerUiTest {
+      openHeapDump(oneClassPerPayloadHeapDump())
+      showTheClassesView()
+
+      hoverAt(classesRow(CLASS_ROW, WIDEST_CELL_X))
+
+      // The row has room for `250 × Object[]` and no more, so which `Object[]` that is arrives at the
+      // pointer, as it does for a pile of objects on the map.
+      waitUntilAtLeastOneExists(hasText(OBJECT_ARRAY_CLASS_NAME), OPEN_TIMEOUT_MILLIS)
+      // And that it is a pile at all, said the way this view means it: a click gives what dominates these
+      // the width rather than reaching the objects, which are on this very row already.
+      onNodeWithText(ROW_OF_OBJECTS).assertIsDisplayed()
+    }
+  }
+
+  @Test fun `clicking a row says what holds it, going down`() {
+    explorerUiTest {
+      openHeapDump(oneClassPerPayloadHeapDump())
+      showTheClassesView()
+
+      clickAt(classesRow(CLASS_ROW, WIDEST_CELL_X))
+
+      // Which is the question the view is for, and the one thing the map beside it can't answer: these
+      // bytes are held by this, which is held by that, down to the whole heap dump.
+      waitUntilAtLeastOneExists(hasText(CLASS_ROW_EXPLANATION), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText(COLUMN_BELOW).assertIsDisplayed()
+      // How wide it is rather than what it retains, which for a row of arrays is not the same number.
+      onNodeWithText(ACCOUNTS_FOR, substring = true).assertIsDisplayed()
+      assertThat(onAllNodesWithText(OBJECT_ARRAY_CLASS_NAME).fetchSemanticsNodes()).isNotEmpty()
+    }
+  }
+
+  @Test fun `pointing at the classes a row had no room for says they are classes`() {
+    explorerUiTest {
+      // A class per payload, more of them than a row draws one by one, so the row above the arrays has a
+      // cell standing for the ones it left out.
+      openHeapDump(oneClassPerPayloadHeapDump())
+      showTheClassesView()
+
+      hoverAt(classesRow(DOMINATOR_ROW, LEFTOVER_CELL_X))
+
+      waitUntilAtLeastOneExists(hasText(SMALLER_ROWS, substring = true), OPEN_TIMEOUT_MILLIS)
+      // Rows rather than objects, and a click that leads down rather than up: everything a pile of
+      // siblings says on the map is the other way round here.
+      onNodeWithText(LEFTOVER_ROWS).assertIsDisplayed()
+    }
+  }
+
+  /** Switches the view to the classes and waits for that tree to be laid out. */
+  private fun ComposeUiTest.showTheClassesView() {
+    shapeOption(ViewShape.CLASSES).performClick()
+    // Reading the classes off the heap dump is a pass over every object of it, so the view comes back a
+    // beat later — and on a first switch, several of them.
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+  }
+
+  /** The radio button for [shape] above the view. */
+  private fun ComposeUiTest.shapeOption(shape: ViewShape): SemanticsNodeInteraction =
+    onNode(hasText(shape.displayName) and isSelectable())
+
+  private fun ComposeUiTest.hoverAt(offset: Offset) {
+    onRoot().performMouseInput { hover(offset) }
+  }
+
+  private fun ComposeUiTest.clickAt(offset: Offset) {
+    onRoot().performMouseInput { click(offset) }
+  }
+
+  private fun ComposeUiTest.openHeapDump(heapDumpFile: File) {
+    setContent {
+      MaterialTheme {
+        var shown: File? by remember { mutableStateOf(heapDumpFile) }
+        ExplorerApp(shown, onHeapDumpChosen = { file, _ -> shown = file })
+      }
+    }
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+  }
+
+  /**
+   * A heap dump of [HOLDER_COUNT] payload arrays of one array class, each held by an instance of a class of
+   * its own: so the arrays are one row across almost the whole view, and the row above it is one cell per
+   * holder class — more of them than a row has room to draw.
+   */
+  private fun oneClassPerPayloadHeapDump(): File {
+    val file = testFolder.newFile("one-class-per-payload.hprof")
+    file.dump {
+      // Declared once, so that the payloads share a class and therefore a row. The holders don't: the
+      // `instance { }` shorthand writes a class per instance, which is what gives this dump its crowd.
+      val objectArrayClassId = arrayClass("java.lang.Object")
+      repeat(HOLDER_COUNT) { index ->
+        val holder = "com.example.Holder$index" instance {
+          field["payload"] =
+            ReferenceHolder(objectArray(objectArrayClassId, LongArray(HOLDER_PAYLOAD_LENGTH)))
+        }
+        gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = index.toLong()))
+      }
+    }
+    return file
+  }
+
+  companion object {
+    /** Past `StackLayout.maxChildrenPerNode`, which is 200, so a level of it has to leave some out. */
+    private const val HOLDER_COUNT = 250
+
+    /** Big enough that the arrays are nearly the whole dump, so their row is nearly the whole width. */
+    private const val HOLDER_PAYLOAD_LENGTH = 1024
+
+    /** The row this view opens on, counting from the bottom, which is what every column stands on. */
+    private const val WHOLE_HEAP_DUMP_ROW = 0
+
+    /** And the row above it, which is one cell per class of the objects of the heap dump. */
+    private const val CLASS_ROW = 1
+
+    /** And the row above that, which splits a class row by what dominates the objects on it. */
+    private const val DOMINATOR_ROW = 2
+
+    /** Well inside the widest cell of a row, which a stack lays out first and therefore leftmost. */
+    private const val WIDEST_CELL_X = 0.05f
+
+    /**
+     * And where the cell standing for the classes that didn't fit is: at the far end of the row, since it
+     * is what is left after the ones drawn one by one.
+     *
+     * The holders weigh the same as each other, so the fifty left out are a fifth of the row's width and
+     * the row is nearly the whole view: the last tenth of it is inside that cell with room to spare.
+     */
+    private const val LEFTOVER_CELL_X = 0.9f
+
+    /** What the payloads' class is called in full, which is the line only the pointer has room for. */
+    private const val OBJECT_ARRAY_CLASS_NAME = "java.lang.Object[]"
+
+    /** How a pile of rows names itself, whatever a level had no room for. See [Selection.Group.title]. */
+    private const val SMALLER_ROWS = "smaller rows"
+
+    /** Opening a heap dump and laying a tree out both happen on another thread. */
+    private const val OPEN_TIMEOUT_MILLIS = 10_000L
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerUiTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerUiTest.kt
@@ -65,6 +65,22 @@ internal fun ComposeUiTest.stackRow(
 }
 
 /**
+ * The middle of a row of the classes view, counting from the one across the *bottom*: that view's rows grow
+ * up from the whole heap dump, which is where it is rooted and the end it opens on. See [stackRow].
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun ComposeUiTest.classesRow(
+  row: Int,
+  xFraction: Float = 0.5f
+): Offset {
+  val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
+  return Offset(
+    x = view.left + view.width * xFraction,
+    y = view.bottom - STACK_ROW_HEIGHT.value * (row + 0.5f)
+  )
+}
+
+/**
  * Moves the pointer onto [offset] the way a mouse gets anywhere: from a pixel away.
  *
  * The first move a view is sent is an enter rather than a move, and the views only describe what the

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TreeLayoutTest.kt
@@ -83,6 +83,22 @@ class TreeLayoutTest {
   }
 
   /**
+   * And the classes view, which is the other of the heap dump's two trees: laying it out reads that tree for
+   * the first time, so a second layout of it would be a second pass over every object of the dump.
+   */
+  @Test fun `switching to the classes view lays the tree out once more`() {
+    explorerUiTest {
+      openHeapDump()
+
+      shapeOption(ViewShape.CLASSES).performClick()
+      settleTheHeapDumpThread(ViewShape.CLASSES)
+    }
+
+    assertThat(treeLayoutsOf(ViewShape.CLASSES)).hasSize(1)
+    assertThat(treeLayoutsOf(ViewShape.TREEMAP)).hasSize(1)
+  }
+
+  /**
    * Waits for a heap dump read that isn't a layout, which is what makes counting the layouts sound rather
    * than a race: reads queue on the heap dump's one thread in the order they were asked for, so a layout
    * queued behind the one that drew what the window is showing is in the log by the time this comes back.
@@ -101,9 +117,13 @@ class TreeLayoutTest {
         Offset(view.left + view.width * CELL_X, view.top + view.height * CELL_Y)
       }
       ViewShape.STACK -> stackRow(CELL_ROW, CELL_X)
+      // Whose rows are counted from the bottom of the view rather than from the top of it.
+      ViewShape.CLASSES -> classesRow(CELL_ROW, CELL_X)
     }
     onRoot().performMouseInput { hover(cell) }
-    waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { logged.any { it.startsWith(HOVER_READ) } }
+    // A row of the classes view has no one chain holding it, so what is read for one is the row itself.
+    val read = if (shape == ViewShape.CLASSES) ROW_READ else HOVER_READ
+    waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { logged.any { it.startsWith(read) } }
   }
 
   /** Every layout of the tree as [shape] the window has asked for, one line per read of the heap dump. */
@@ -164,5 +184,8 @@ class TreeLayoutTest {
 
     /** How the log says the chain holding the cell under the pointer was read. */
     private const val HOVER_READ = "Read what holds"
+
+    /** And how it says a row of the classes view was, which is all there is to read for one. */
+    private const val ROW_READ = "Read what the class row"
   }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ByteSizeFormat.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ByteSizeFormat.kt
@@ -32,10 +32,14 @@ fun formatByteSize(byteCount: Long): String {
  * both would leave the eye nothing exact to hold on to. Always [Locale.US], for the same reason
  * [formatByteSize] is.
  */
-fun formatObjectCount(objectCount: Int): String {
-  val count = String.format(Locale.US, "%,d", objectCount)
-  return if (objectCount == 1) "$count object" else "$count objects"
-}
+fun formatObjectCount(objectCount: Int): String = "${formatCount(objectCount)} " +
+  if (objectCount == 1) "object" else "objects"
+
+/**
+ * The same count with nothing after it, e.g. `807,231`, for where saying what is being counted is somebody
+ * else's job: a cell label reading `807,231 × byte[]` has already said it.
+ */
+internal fun formatCount(count: Int): String = String.format(Locale.US, "%,d", count)
 
 private const val UNIT = 1024
 private val UNITS = listOf("KB", "MB", "GB", "TB")

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/GroupingClasses.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/GroupingClasses.kt
@@ -1,0 +1,55 @@
+package shark.explorer
+
+import shark.HeapGraph
+import shark.HeapObject
+import shark.HeapObject.HeapClass
+import shark.HeapObject.HeapInstance
+import shark.HeapObject.HeapObjectArray
+import shark.HeapObject.HeapPrimitiveArray
+import shark.SharkLog
+
+/**
+ * The class an object is gathered under wherever the explorer gathers objects by class: the classes the
+ * root's children are drawn as in [HeapDominatorTreemap], and the row every object starts on in
+ * [ReverseDominatorTree].
+ *
+ * One of these per heap dump rather than one per tree, because a class name is expensive to look up and both
+ * trees look up the same ones: [HeapGraph.findClassByName] performs two linear scans over every string of the
+ * dump, and asking it per object of a production dump — once for every class object, once for every `byte[]`
+ * — took the best part of a minute. So an answer is remembered whether or not there was one.
+ */
+internal class GroupingClasses(private val graph: HeapGraph) {
+
+  private val classIdByName = mutableMapOf<String, Long?>()
+
+  /**
+   * The class [heapObject] is gathered under, or null for one that isn't gathered: a class object, unless
+   * the dump has `java.lang.Class` for them all to gather under, which every Android heap dump does.
+   */
+  fun classIdOf(heapObject: HeapObject): Long? = when (heapObject) {
+    is HeapInstance -> heapObject.instanceClassId
+    is HeapObjectArray -> heapObject.arrayClassId
+    // Not [HeapPrimitiveArray.arrayClass], which goes through findClassByName every time it's asked.
+    is HeapPrimitiveArray -> classIdOf(heapObject.arrayClassName)
+    is HeapClass -> classIdOf(JAVA_LANG_CLASS)
+  }
+
+  /** The id of a class by name, looked up once per name however many objects are asked about. */
+  fun classIdOf(className: String): Long? {
+    if (className in classIdByName) {
+      return classIdByName[className]
+    }
+    val classId = graph.findClassByName(className)?.objectId
+    if (classId == null) {
+      // Which leaves the objects of that class ungathered — a cell each under the dominator tree's root,
+      // one row for all of them in the tree read from the classes up — so it's worth a line saying so.
+      SharkLog.d { "No class named $className in the heap dump, so nothing groups by it" }
+    }
+    classIdByName[className] = classId
+    return classId
+  }
+
+  private companion object {
+    const val JAVA_LANG_CLASS = "java.lang.Class"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -67,6 +67,8 @@ import shark.ValueHolder.ShortHolder
  * or the garbage's children are gathered under. [isPileId] is which, and they're allocated per tree, so
  * they mean nothing to another tree of the same heap dump.
  *
+ * [reverseTree] is the same domination read the other way round, from the classes up.
+ *
  * Reads the heap dump, so not from the UI thread. See [HeapExplorer].
  */
 // Everything the UI asks about one heap dump: the tree, what a cell of it says, and how an object is held.
@@ -83,7 +85,7 @@ class HeapDominatorTreemap internal constructor(
   private val gcRootProvider: GcRootProvider,
   private val dominatorTree: HeapDominatorTree,
   private val nodes: Map<Long, DominatorNode>
-) : TreemapTree<Long> {
+) : HeapTree {
 
   override val root: Long get() = NULL_REFERENCE
 
@@ -93,6 +95,21 @@ class HeapDominatorTreemap internal constructor(
    * dump has six figures worth of them.
    */
   private val topLevel: TopLevel by lazy { splitRootChildren() }
+
+  /** The classes objects are gathered under, shared with [reverseTree] so a class is looked up once. */
+  private val groupingClasses = GroupingClasses(graph)
+
+  /**
+   * The same domination read from the classes up rather than from the roots down, which is the other
+   * question a dominator tree answers: not what this object retains, but what dominates every `byte[]` of
+   * the dump.
+   *
+   * Built on first use, off the same nodes this tree draws, so that the two agree to the byte and the reader
+   * who never asks pays nothing. See [ReverseDominatorTree].
+   */
+  val reverseTree: ReverseDominatorTree by lazy {
+    ReverseDominatorTree(graph, reachability, dominatorTree, nodes, groupingClasses)
+  }
 
   /**
    * The references this tree was built by following, which is what a path up to a GC root has to follow
@@ -157,11 +174,11 @@ class HeapDominatorTreemap internal constructor(
     "$nodeId is no node of this tree, which has ${nodes.size} of them. Ask contains() first."
   }
 
-  /** Whether [objectId] is a node of this tree, which every object of the heap dump is. */
-  operator fun contains(objectId: Long): Boolean = if (isPileId(objectId)) {
-    objectId in topLevel.groups
+  /** Whether [nodeId] is a node of this tree, which every object of the heap dump is. */
+  override operator fun contains(nodeId: Long): Boolean = if (isPileId(nodeId)) {
+    nodeId in topLevel.groups
   } else {
-    objectId in nodes
+    nodeId in nodes
   }
 
   /**
@@ -303,40 +320,6 @@ class HeapDominatorTreemap internal constructor(
     return ids
   }
 
-  /**
-   * The class an object is grouped under, or null for one that isn't grouped: a class object, unless the
-   * dump has `java.lang.Class` for them all to gather under, which every Android heap dump does.
-   */
-  private fun HeapObject.groupingClassId(): Long? = when (this) {
-    is HeapInstance -> instanceClassId
-    is HeapObjectArray -> arrayClassId
-    // Not [HeapPrimitiveArray.arrayClass], which goes through findClassByName every time it's asked.
-    is HeapPrimitiveArray -> classIdOf(arrayClassName)
-    is HeapClass -> classIdOf(JAVA_LANG_CLASS)
-  }
-
-  /**
-   * The id of a class by name, looked up once per name and remembered whether it was found or not:
-   * [HeapGraph.findClassByName] performs two linear scans over every string of the heap dump, and asking
-   * it per object of a production dump — once for every class object, once for every `byte[]` — took the
-   * best part of a minute.
-   */
-  private fun classIdOf(className: String): Long? {
-    if (className in classIdByName) {
-      return classIdByName[className]
-    }
-    val classId = graph.findClassByName(className)?.objectId
-    if (classId == null) {
-      // Which leaves every object of that class as a rectangle of its own under the root rather than
-      // gathered with its siblings, so it's worth a line saying so.
-      SharkLog.d { "No class named $className in the heap dump, so nothing groups by it" }
-    }
-    classIdByName[className] = classId
-    return classId
-  }
-
-  private val classIdByName = mutableMapOf<String, Long?>()
-
   /** How strongly the garbage collector holds on to [node], or to what a group of objects holds. */
   fun strengthOf(node: Long): ReachabilityStrength = when {
     node == root -> ReachabilityStrength.STRONG
@@ -348,7 +331,7 @@ class HeapDominatorTreemap internal constructor(
    *
    * Cheap enough to call for every visible rectangle, unlike [summarize].
    */
-  fun label(node: Long): String {
+  override fun label(node: Long): String {
     if (node == root) {
       return ROOT_LABEL
     }
@@ -697,7 +680,7 @@ class HeapDominatorTreemap internal constructor(
    * Stops at the last node that has children: zooming into an object that dominates nothing would draw an
    * empty view, so the caller ends up looking at what holds it, with it selected inside.
    */
-  fun pathToOpen(node: Long): List<Long> {
+  override fun pathToOpen(node: Long): List<Long> {
     if (node == root) {
       return listOf(root)
     }
@@ -1022,16 +1005,7 @@ class HeapDominatorTreemap internal constructor(
     return (target as? HeapInstance)?.readAsJavaString()?.let { "\"$it\"" } ?: label(objectId)
   }
 
-  /**
-   * Reads a label and a strength for every one of [cells]: everything the UI needs to draw a laid out
-   * shape of this tree without touching the heap dump itself.
-   *
-   * What shape they are is no business of this, which is why there is one of these rather than one per
-   * shape — a `TreemapCell`, a `RadialCell` and a `StackCell` are all a [CellSubject] with geometry, and
-   * a name is read off the subject. Pairing a layout with this is [TreemapPresentation.of] and its two
-   * siblings, so a fourth shape needs nothing here.
-   */
-  fun <C : LayoutCell<Long>> present(cells: List<C>): List<PresentedCell<C>> =
+  override fun <C : LayoutCell<Long>> present(cells: List<C>): List<PresentedCell<C>> =
     cells.map { it.presented() }
 
   private fun <C : LayoutCell<Long>> C.presented(): PresentedCell<C> = when (val subject = subject) {
@@ -1155,7 +1129,7 @@ class HeapDominatorTreemap internal constructor(
     ) {
       childIds += heapObject.objectId
       this.retainedSize += retainedSize
-      val classId = heapObject.groupingClassId()
+      val classId = groupingClasses.classIdOf(heapObject)
       if (classId == null) {
         ungroupedIds += heapObject.objectId
       } else {
@@ -1218,8 +1192,6 @@ class HeapDominatorTreemap internal constructor(
      * all fit on screen, and a level of classes to click through would be in the way.
      */
     const val MIN_CHILDREN_TO_GROUP_BY_CLASS = 200
-
-    private const val JAVA_LANG_CLASS = "java.lang.Class"
 
     /**
      * Whether [nodeId] stands for a pile of objects rather than for one object of the heap dump: the two

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapTree.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapTree.kt
@@ -1,0 +1,50 @@
+package shark.explorer
+
+/**
+ * A tree of one heap dump the explorer can draw and navigate.
+ *
+ * There are two: [HeapDominatorTreemap], which is what retains what read from the GC roots down, and
+ * [ReverseDominatorTree], which is the same domination read from the classes up. Two trees rather than two
+ * shapes of one, because a node of the first is an object of the heap dump and a node of the second is a pile
+ * of them at one point of a column — so what a cell says, and what a click on it can lead to, is different.
+ *
+ * What they have in common is everything a laid out view needs, which is this: what a node weighs, what to
+ * call it, where it is drawn, and whether it is in the tree at all.
+ *
+ * **They share their root**, [HeapDominatorTreemap.ROOT_OBJECT_ID], because the whole heap dump is the whole
+ * heap dump in either reading. Which is what lets the UI keep one navigation path for both: a path at the
+ * root is a path of either tree, and a path zoomed into one of them is dropped by the other's [contains].
+ *
+ * Reads the heap dump, so not from the UI thread. See [HeapExplorer].
+ */
+interface HeapTree : TreemapTree<Long> {
+
+  /** Whether [nodeId] is a node of this tree. */
+  operator fun contains(nodeId: Long): Boolean
+
+  /**
+   * A short name for [nodeId], to draw on its cell.
+   *
+   * Cheap enough to call for every visible cell, unlike whatever this tree summarises one with.
+   */
+  fun label(nodeId: Long): String
+
+  /**
+   * The nodes to zoom through so that [nodeId] is drawn, the root first.
+   *
+   * Stops at the last node that has children: zooming into a node with nothing under it would draw an empty
+   * view, so the caller ends up looking at what holds it with it selected inside.
+   */
+  fun pathToOpen(nodeId: Long): List<Long>
+
+  /**
+   * Reads a label and a strength for every one of [cells]: everything the UI needs to draw a laid out shape
+   * of this tree without touching the heap dump itself.
+   *
+   * What shape they are is no business of a tree, which is why there is one of these rather than one per
+   * shape — a `TreemapCell`, a `RadialCell` and a `StackCell` are all a [CellSubject] with geometry, and a
+   * name is read off the subject. Pairing a layout with a tree is [TreemapPresentation.of] and its two
+   * siblings, so a fourth shape needs nothing here.
+   */
+  fun <C : LayoutCell<Long>> present(cells: List<C>): List<PresentedCell<C>>
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NodeIds.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NodeIds.kt
@@ -17,15 +17,17 @@ fun hexObjectId(objectId: Long): String {
 }
 
 /**
- * How a node of a [HeapDominatorTreemap] reads in a message: the address of an object, or which pile of
- * objects it is.
+ * How a node of either of a heap dump's two trees reads in a message: the address of an object, which pile of
+ * objects it is, or which row of the tree read from the classes up.
  *
- * A pile is no object of the heap dump, so it has no address to name it by. See
- * [HeapDominatorTreemap.isPileId].
+ * Neither a pile nor a row is an object of the heap dump, so neither has an address to name it by. See
+ * [HeapDominatorTreemap.isPileId] and [ReverseDominatorTree.isReverseNode].
  */
 fun nodeIdText(nodeId: Long): String = when {
   nodeId == ROOT_OBJECT_ID -> "the whole heap dump"
   nodeId == UNREACHABLE_NODE_ID -> "the uncollected garbage"
+  ReverseDominatorTree.isReverseNode(nodeId) ->
+    "the class row ${ReverseDominatorTree.FIRST_REVERSE_NODE_ID - nodeId}"
   HeapDominatorTreemap.isPileId(nodeId) -> "the class pile ${nodeId - UNREACHABLE_NODE_ID}"
   else -> hexObjectId(nodeId)
 }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReverseDominatorTree.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReverseDominatorTree.kt
@@ -1,0 +1,548 @@
+package shark.explorer
+
+import androidx.collection.MutableLongLongMap
+import androidx.collection.MutableLongObjectMap
+import java.util.concurrent.TimeUnit.NANOSECONDS
+import shark.HeapDominatorTree
+import shark.HeapGraph
+import shark.ObjectDominators.DominatorNode
+import shark.SharkLog
+import shark.ValueHolder.Companion.NULL_REFERENCE
+
+/**
+ * A heap dump's domination read from the classes up: every object of the dump on the row of its class, and
+ * above each row the classes of the objects dominating it.
+ *
+ * [HeapDominatorTreemap] draws the same domination from the roots down, and answers "what is this object
+ * keeping alive". This is the other direction: **take every `byte[]` of the dump — what dominates them, by
+ * class?** The bottom row of a column is one class, as wide as what its objects take up, and the row above it
+ * splits that width by the class of whatever dominates each of them. So a column reads `byte[]` at the
+ * bottom, `Bitmap` above it, `ImageView` above that, and how wide it is says how much of the heap's `byte[]`
+ * bytes that accounts for.
+ *
+ * **A row is weighed by the objects at the bottom of its column, in their own bytes.** Which is the one
+ * weighting that makes the rows comparable: retained size would count an object's bytes again on every row
+ * above it, so the rows would add up to several times the heap and "a fifth of the dump" would mean nothing.
+ * Shallow bytes add up to the dump exactly once, so [root] weighs what the dominator tree's root weighs, a
+ * row's width is its share of the whole heap dump at every level, and a row's children cover it to the byte.
+ *
+ * A column stops where the objects it names are dominated by nothing in particular — see
+ * [ReverseNodeKind.NO_OWNER] — or by uncollected garbage alone, [ReverseNodeKind.UNCOLLECTED_GARBAGE]. Both
+ * are rows of their own rather than width left over, which is what keeps a row's children covering it.
+ *
+ * Built as it is read, like the tree it reverses. The classes cost one pass over every object of the dump, and
+ * a row above one costs a read per object that row gathers: its dominator, for the class to put it under. What
+ * it holds in memory between reads is **at most one entry per object of the heap dump in total**, however many
+ * levels have been opened, because expanding a row hands its entries to the rows above it and drops its own.
+ * See [ReverseNode.entries].
+ *
+ * Nodes are ids of its own, out of the range no object id can land in: the other end of the one
+ * [HeapDominatorTreemap] takes its pile ids from. [isReverseNode] is which. The exception is [root], which
+ * the two trees share — the whole heap dump is the whole heap dump in either reading.
+ *
+ * Reads the heap dump, so not from the UI thread. See [HeapExplorer].
+ */
+class ReverseDominatorTree internal constructor(
+  private val graph: HeapGraph,
+  private val reachability: HeapReachability,
+  private val dominatorTree: HeapDominatorTree,
+  /** The dominator tree's nodes, for the shallow size of an object and for which objects are folded. */
+  private val nodes: Map<Long, DominatorNode>,
+  private val groupingClasses: GroupingClasses
+) : HeapTree {
+
+  /** The whole heap dump, which both trees of it hang off. See [HeapDominatorTreemap.ROOT_OBJECT_ID]. */
+  override val root: Long get() = HeapDominatorTreemap.ROOT_OBJECT_ID
+
+  /** Every row handed out so far, by its id. The root isn't one: it belongs to both trees and to neither. */
+  private val rowsById = MutableLongObjectMap<ReverseNode>()
+
+  private var nextId = FIRST_REVERSE_NODE_ID
+
+  /**
+   * The bottom row of every column: one per class, with every object of the dump on the one for its own
+   * class.
+   *
+   * Computed on first use, because it is a pass over every object of the heap dump — seconds on a large one —
+   * and the reader who never opens this view shouldn't pay for it.
+   */
+  private val classRows: ClassRows by lazy { gatherByClass() }
+
+  override fun weight(node: Long): Long =
+    if (node == root) classRows.byteCount else rowOf(node).weight
+
+  override fun children(node: Long): List<Long> =
+    if (node == root) classRows.ids else rowsAbove(rowOf(node))
+
+  override fun contains(nodeId: Long): Boolean = when {
+    nodeId == root -> true
+    isReverseNode(nodeId) -> nodeId in rowsById
+    else -> false
+  }
+
+  override fun label(nodeId: Long): String =
+    if (nodeId == root) HeapDominatorTreemap.ROOT_LABEL else rowOf(nodeId).label()
+
+  override fun pathToOpen(nodeId: Long): List<Long> {
+    if (!contains(nodeId) || nodeId == root) {
+      return listOf(root)
+    }
+    val row = rowOf(nodeId)
+    val column = ArrayDeque(row.columnUp().map { it.id })
+    // A row nothing holds has no row above it, so rooting the view there would draw one row and nothing
+    // else: the view stops at the row under it with it selected inside, as [HeapDominatorTreemap.pathToOpen]
+    // does for an object that dominates nothing. Every other row has children — a class row is the classes
+    // of what dominates its objects, and one of those two is what a column with no classes left ends at.
+    if (row.kind.stopsAColumn) {
+      column.removeLast()
+    }
+    return listOf(root) + column
+  }
+
+  /**
+   * Everything the details panel shows about one row: what it gathers, how much of the heap that is, and
+   * the column it is part of.
+   *
+   * Cheap, unlike [HeapDominatorTreemap.summarize]: a row was read when it was laid out, so this is what
+   * was already worked out plus the labels of the rows under it.
+   */
+  fun summarize(nodeId: Long): ReverseNodeSummary {
+    if (nodeId == root) {
+      return ReverseNodeSummary(
+        nodeId = root,
+        kind = ReverseNodeKind.WHOLE_HEAP_DUMP,
+        label = HeapDominatorTreemap.ROOT_LABEL,
+        className = null,
+        strength = ReachabilityStrength.STRONG,
+        objectCount = classRows.objectCount,
+        byteCount = classRows.byteCount,
+        column = emptyList()
+      )
+    }
+    val row = rowOf(nodeId)
+    return ReverseNodeSummary(
+      nodeId = nodeId,
+      kind = row.kind,
+      label = row.label(),
+      className = row.className,
+      strength = row.strength,
+      objectCount = row.objectCount,
+      byteCount = row.weight,
+      // The rows under it, nearest first — the order they are read in on screen, going down from this one —
+      // and the whole heap dump at the end of them, which every column stands on.
+      column = row.columnUp().dropLast(1).reversed().map { ReverseColumnStep(it.id, it.label()) } +
+        ReverseColumnStep(root, HeapDominatorTreemap.ROOT_LABEL)
+    )
+  }
+
+  override fun <C : LayoutCell<Long>> present(cells: List<C>): List<PresentedCell<C>> =
+    cells.map { it.presented() }
+
+  private fun <C : LayoutCell<Long>> C.presented(): PresentedCell<C> = when (val subject = subject) {
+    is CellSubject.Node -> presentedRow(subject.node)
+    is CellSubject.Group -> PresentedCell(
+      cell = this,
+      // Rows rather than objects, which is what the row above one is made of: its classes.
+      label = "${subject.nodeCount} smaller ${if (subject.nodeCount == 1) "row" else "rows"}",
+      content = CellContent.Leftover(strengthOf(subject.parent))
+    )
+    // Never reached: a row's children cover what it weighs, so no row has width of its own left over. Here
+    // because the layout is free to ask, and answering with the row itself is what that width would be.
+    is CellSubject.Own -> presentedRow(subject.node)
+  }
+
+  /**
+   * Every row of this tree stands for a pile of objects rather than for one, the root included — which is
+   * what a view draws differently, and the whole point of reading the tree this way.
+   */
+  private fun <C : LayoutCell<Long>> C.presentedRow(nodeId: Long): PresentedCell<C> {
+    if (nodeId == root) {
+      return PresentedCell(
+        cell = this,
+        label = HeapDominatorTreemap.ROOT_LABEL,
+        content = CellContent.ObjectRow(
+          kind = ReverseNodeKind.WHOLE_HEAP_DUMP,
+          strength = ReachabilityStrength.STRONG,
+          objectCount = classRows.objectCount
+        )
+      )
+    }
+    val row = rowOf(nodeId)
+    return PresentedCell(
+      cell = this,
+      label = row.label(),
+      content = CellContent.ObjectRow(row.kind, row.strength, row.objectCount)
+    )
+  }
+
+  private fun strengthOf(nodeId: Long): ReachabilityStrength =
+    if (nodeId == root) ReachabilityStrength.STRONG else rowOf(nodeId).strength
+
+  /**
+   * This tree's row for [nodeId].
+   *
+   * Not [MutableLongObjectMap.get] with a `!!`, whose bare NullPointerException is what asking this tree
+   * about a node of the dominator tree beside it reads as, several frames below whatever asked.
+   */
+  private fun rowOf(nodeId: Long): ReverseNode = requireNotNull(rowsById[nodeId]) {
+    "${nodeIdText(nodeId)} is no row of this tree, which has handed out ${rowsById.size} of them. Ask " +
+      "contains() first."
+  }
+
+  /**
+   * Puts every object of the heap dump on the row of its own class, weighed by what it takes up itself.
+   *
+   * Over [HeapGraph.objects] rather than over [nodes], because an object's class comes off the index it is
+   * read from and looking it up again per object is what made the first version of this take minutes. The
+   * objects with no node are the folded ones — a string's characters, an object array's elements where the
+   * array is what owns them — whose bytes are counted in the object holding them, so counting them here
+   * would count them twice.
+   */
+  private fun gatherByClass(): ClassRows {
+    val startNanos = System.nanoTime()
+    val builders = LinkedHashMap<Long, RowBuilder>()
+    var objectCount = 0
+    graph.objects.forEach { heapObject ->
+      val node = nodes[heapObject.objectId] ?: return@forEach
+      objectCount++
+      val classId = groupingClasses.classIdOf(heapObject) ?: NO_CLASS_ID
+      builders.getOrPut(classId) { RowBuilder(ReverseNodeKind.CLASS, classId) }
+        .add(heapObject.objectId, node.shallowSize, reachability.strengthOf(heapObject))
+    }
+    val ids = register(builders.values, parentId = root, depth = 1)
+    val byteCount = ids.sumOf { rowOf(it).weight }
+    SharkLog.d {
+      "Gathered ${formatObjectCount(objectCount)} onto ${ids.size} class rows, " +
+        "${formatByteSize(byteCount)}, in ${NANOSECONDS.toMillis(System.nanoTime() - startNanos)} ms"
+    }
+    return ClassRows(ids = ids, byteCount = byteCount, objectCount = objectCount)
+  }
+
+  /**
+   * The row above [row]: what dominates the objects it gathers, gathered by class in turn, plus the columns
+   * that stop here.
+   *
+   * A read of one object per entry — its dominator, for the class to put it under — so this is what a level
+   * of this tree costs. Worked out once per row and kept, and the entries it was worked out from are dropped:
+   * a row that has been expanded is a row on screen and nothing more.
+   *
+   * Nothing is registered until the whole row is built, so that a read given up on half way leaves the tree
+   * as it was rather than holding half a row. See the module's AGENTS.md on cancellation.
+   */
+  private fun rowsAbove(row: ReverseNode): List<Long> {
+    row.children?.let { return it }
+    val entries = row.entries
+    if (entries == null) {
+      row.children = emptyList()
+      return emptyList()
+    }
+    val builders = LinkedHashMap<Long, RowBuilder>()
+    // The two rows that stop a column are kept apart from the classes rather than under a made up class id,
+    // because every long is somebody's address: an object id can be negative, and zero is the only one no
+    // object has. See [HeapDominatorTreemap.isPileId].
+    var noOwner: RowBuilder? = null
+    var garbage: RowBuilder? = null
+    entries.forEach { objectId, weight ->
+      val dominatorId = dominatorTree.immediateDominatorOf(objectId)
+      if (dominatorId == root) {
+        // The column stops here: what holds the object is the whole heap dump, which is what the dominator
+        // tree says when nothing in particular does, or nothing at all when the object is garbage.
+        val strength = reachability.strengthOf(objectId)
+        val builder = if (strength == ReachabilityStrength.UNREACHABLE) {
+          garbage ?: RowBuilder(ReverseNodeKind.UNCOLLECTED_GARBAGE, NO_CLASS_ID).also { garbage = it }
+        } else {
+          noOwner ?: RowBuilder(ReverseNodeKind.NO_OWNER, NO_CLASS_ID).also { noOwner = it }
+        }
+        builder.add(objectId, weight, strength)
+      } else {
+        val dominator = graph.findObjectById(dominatorId)
+        val classId = groupingClasses.classIdOf(dominator) ?: NO_CLASS_ID
+        builders.getOrPut(classId) { RowBuilder(ReverseNodeKind.CLASS, classId) }
+          .add(dominatorId, weight, reachability.strengthOf(dominator))
+      }
+    }
+    val children = register(
+      builders = builders.values + listOfNotNull(noOwner, garbage),
+      parentId = row.id,
+      depth = row.depth + 1
+    )
+    row.children = children
+    row.entries = null
+    return children
+  }
+
+  /**
+   * Turns the rows worked out for one level into rows of this tree, heaviest first — the order every level
+   * of the tree beside it is handed out in.
+   */
+  private fun register(
+    builders: Collection<RowBuilder>,
+    parentId: Long,
+    depth: Int
+  ): List<Long> {
+    val built = builders
+      .map { builder -> builder.build(nextRowId(), parentId, depth) }
+      .sortedByDescending { it.weight }
+    built.forEach { rowsById[it.id] = it }
+    return built.map { it.id }
+  }
+
+  /** The next id to hand a row, out of the half of the pile id range this tree owns. */
+  private fun nextRowId(): Long {
+    val rowId = nextId--
+    check(rowId >= SMALLEST_REVERSE_NODE_ID) {
+      "This tree has handed out every row id there is room for between $SMALLEST_REVERSE_NODE_ID and " +
+        "$FIRST_REVERSE_NODE_ID, which takes more rows than a heap dump has objects"
+    }
+    return rowId
+  }
+
+  private fun RowBuilder.build(
+    nodeId: Long,
+    parentId: Long,
+    depth: Int
+  ): ReverseNode {
+    val heapClass = if (classId == NO_CLASS_ID) {
+      null
+    } else {
+      checkNotNull(graph.findObjectById(classId).asClass) {
+        "The class $objectCount objects were gathered under, ${hexObjectId(classId)}, is no class of the " +
+          "heap dump"
+      }
+    }
+    return ReverseNode(
+      id = nodeId,
+      kind = kind,
+      parentId = parentId,
+      depth = depth,
+      className = heapClass?.name,
+      simpleClassName = heapClass?.simpleName,
+      strength = strength,
+      objectCount = objectCount,
+      weight = weight,
+      entries = entries
+    )
+  }
+
+  /** The rows of a column from [ReverseNode] up, which is what a row's own path down to the root is. */
+  private fun ReverseNode.columnUp(): List<ReverseNode> {
+    val column = ArrayDeque<ReverseNode>()
+    var row: ReverseNode? = this
+    while (row != null) {
+      column.addFirst(row)
+      row = if (row.parentId == root) null else rowOf(row.parentId)
+    }
+    return column
+  }
+
+  private fun ReverseNode.label(): String = when (kind) {
+    ReverseNodeKind.WHOLE_HEAP_DUMP -> HeapDominatorTreemap.ROOT_LABEL
+    // "1,204 × byte[]" rather than "byte[]": a count and a multiplication sign say this row is a pile of
+    // objects and not one of them, on a block with room for nothing else.
+    ReverseNodeKind.CLASS ->
+      "${formatCount(objectCount)} ${HeapDominatorTreemap.CLASS_GROUP_LABEL_SEPARATOR} " +
+        (simpleClassName ?: CLASS_OBJECTS_LABEL)
+    ReverseNodeKind.NO_OWNER -> NO_OWNER_LABEL
+    ReverseNodeKind.UNCOLLECTED_GARBAGE -> HeapDominatorTreemap.UNREACHABLE_LABEL
+  }
+
+  /** What [children] and [weight] answer for the root, worked out by the pass that gathers the classes. */
+  private class ClassRows(
+    val ids: List<Long>,
+    /** Every object of the heap dump in its own bytes, which is the whole dump. */
+    val byteCount: Long,
+    val objectCount: Int
+  )
+
+  /**
+   * One row of this tree: the objects of one class at one point of a column, or one of the two ways a column
+   * stops.
+   *
+   * A row is drawn as wide as [weight], names itself with [objectCount] and [simpleClassName], and knows the
+   * row under it so that a column can be read back down. Everything else about it is [entries].
+   */
+  private class ReverseNode(
+    val id: Long,
+    val kind: ReverseNodeKind,
+    /** The row under this one, and [root] for a class row at the bottom of a column. */
+    val parentId: Long,
+    /** How many rows are under it: 1 for a class row of the objects themselves. */
+    val depth: Int,
+    val className: String?,
+    val simpleClassName: String?,
+    /** The strength most of [weight] is held at. See [RowBuilder.strength]. */
+    val strength: ReachabilityStrength,
+    /** How many objects this row gathers, which is what its label counts. */
+    val objectCount: Int,
+    val weight: Long,
+    /**
+     * The objects this row gathers, by how many of the bytes below it each of them holds.
+     *
+     * What the row above is worked out from, and dropped once it has been: which is what bounds this tree to
+     * one live entry per object of the heap dump. An expanded row's entries are split among its children by
+     * the class of their dominator, so the entries alive at any moment stand for disjoint sets of the objects
+     * at the bottom of the columns — at most one entry each, whatever levels are open.
+     *
+     * Null for a row that stops a column, which has nothing above it to work out.
+     */
+    var entries: MutableLongLongMap?,
+    /** Worked out on the first [rowsAbove] and kept: laying the view out again asks for it every time. */
+    var children: List<Long>? = null
+  )
+
+  /**
+   * One row of a level being worked out: what its objects add up to, and which of them they are.
+   *
+   * Built up as the level's objects are read and turned into a [ReverseNode] once they all have been, so
+   * that a class is read for its name once per row rather than once per object gathered on it.
+   */
+  private class RowBuilder(
+    val kind: ReverseNodeKind,
+    /** The class the row gathers, and [NO_CLASS_ID] for the two kinds that gather none. */
+    val classId: Long
+  ) {
+    /** Null for a row that stops a column: there is nothing above it for entries to be worked out for. */
+    val entries: MutableLongLongMap? =
+      if (kind.stopsAColumn) null else MutableLongLongMap()
+
+    var weight = 0L
+      private set
+
+    private var stoppedObjectCount = 0
+
+    private val bytesByStrength = LongArray(STRENGTHS.size)
+
+    /** How many objects the row gathers, which for a row of one class is how many distinct ones. */
+    val objectCount: Int get() = entries?.size ?: stoppedObjectCount
+
+    /**
+     * How firmly the row is held, which is the strength holding most of its bytes.
+     *
+     * One answer for many objects, because a row is one block of one colour. The objects of one class at one
+     * point of a column are usually held the same way, and where they aren't, the bytes are what a reader is
+     * looking at.
+     */
+    val strength: ReachabilityStrength
+      get() {
+        var strongest = 0
+        for (index in 1 until bytesByStrength.size) {
+          if (bytesByStrength[index] > bytesByStrength[strongest]) {
+            strongest = index
+          }
+        }
+        return STRENGTHS[strongest]
+      }
+
+    /** Puts [objectId] on this row with [weight] of the bytes below it. */
+    fun add(
+      objectId: Long,
+      weight: Long,
+      strength: ReachabilityStrength
+    ) {
+      this.weight += weight
+      bytesByStrength[strength.ordinal] += weight
+      val entries = entries
+      if (entries == null) {
+        stoppedObjectCount++
+      } else {
+        // Two objects of one row can have the same dominator, and then that dominator is one object of the
+        // row above holding both of their bytes.
+        entries[objectId] = entries.getOrDefault(objectId, 0L) + weight
+      }
+    }
+  }
+
+  companion object {
+    /**
+     * The first of the ids this tree hands out to its rows, which count down from there.
+     *
+     * The other end of the range [HeapDominatorTreemap] takes its pile ids from: those count up from
+     * [Long.MIN_VALUE] and these down from just below the smallest id an object of a heap dump can have, so
+     * that telling one tree's nodes from the other's stays a range check. See
+     * [HeapDominatorTreemap.isPileId] for why it can't be a look at the sign.
+     */
+    internal const val FIRST_REVERSE_NODE_ID = Int.MIN_VALUE.toLong() - 1L
+
+    /** And the last of them, which leaves the other half of the range to the dominator tree's piles. */
+    private const val SMALLEST_REVERSE_NODE_ID = Long.MIN_VALUE / 2
+
+    /** Whether [nodeId] is a row of a tree read from the classes up rather than a node of a dominator tree. */
+    fun isReverseNode(nodeId: Long): Boolean =
+      nodeId in SMALLEST_REVERSE_NODE_ID..FIRST_REVERSE_NODE_ID
+
+    /**
+     * What a row of objects nothing in particular holds is called.
+     *
+     * Not "whole heap dump", though that is what the dominator tree says holds them, because the whole heap
+     * dump is already the row across the bottom of this view and two rows of one name read as one thing.
+     */
+    const val NO_OWNER_LABEL = "Nothing in particular"
+
+    /**
+     * What the row of the objects no class gathers is called: class objects in a heap dump without
+     * `java.lang.Class`, which no Android dump is. See [GroupingClasses.classIdOf].
+     */
+    private const val CLASS_OBJECTS_LABEL = "class objects"
+
+    /** No class of the heap dump, since no object of one is at address zero. */
+    private const val NO_CLASS_ID = NULL_REFERENCE
+
+    private val STRENGTHS = ReachabilityStrength.values()
+  }
+}
+
+/** What the UI knows about one row of a [ReverseDominatorTree]. See [ReverseDominatorTree.summarize]. */
+data class ReverseNodeSummary(
+  /** What the tree knows this row by, e.g. to zoom into it. Not an object id. */
+  val nodeId: Long,
+  val kind: ReverseNodeKind,
+  /** Short name, as drawn on the row. */
+  val label: String,
+  /** Fully qualified class name, or array type, for [ReverseNodeKind.CLASS] only. */
+  val className: String?,
+  /** How firmly the objects it gathers are held: the strength most of [byteCount] is at. */
+  val strength: ReachabilityStrength,
+  /** How many objects this row gathers. */
+  val objectCount: Int,
+  /**
+   * The bytes the row is as wide as: what the objects at the bottom of its column take up, of the ones these
+   * objects dominate. Their own bytes, for a row at the bottom of a column.
+   */
+  val byteCount: Long,
+  /** The rows under this one, the one it stands on first, down to the whole heap dump. */
+  val column: List<ReverseColumnStep>
+) {
+
+  /** How far up its column this row is: 0 for the whole heap dump, 1 for a row of objects of one class. */
+  val depth: Int get() = column.size
+}
+
+/** One row under a [ReverseNodeSummary]: what that row says, and what to zoom back out to it by. */
+data class ReverseColumnStep(
+  val nodeId: Long,
+  val label: String
+)
+
+/** Which kind of row a [ReverseNodeSummary] is about. */
+enum class ReverseNodeKind {
+
+  /** The whole heap dump, at the bottom of every column, which the class rows are gathered on. */
+  WHOLE_HEAP_DUMP,
+
+  /** Objects of one class: their own row, or the row of what dominates the objects below them. */
+  CLASS,
+
+  /**
+   * Where a column stops because nothing in particular holds the objects below it — the dominator tree hangs
+   * them off the whole heap dump, because they are held from more than one place and no one of those would
+   * free them. See [DominatorKind.WHOLE_HEAP_DUMP].
+   */
+  NO_OWNER,
+
+  /** And where it stops because only uncollected garbage does. */
+  UNCOLLECTED_GARBAGE;
+
+  /** Whether this is where a column ends, which is a row with nothing above it. */
+  internal val stopsAColumn: Boolean
+    get() = this == NO_OWNER || this == UNCOLLECTED_GARBAGE
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/StackLayout.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/StackLayout.kt
@@ -30,15 +30,18 @@ class StackLayoutResult<N>(
   val rowCount: Int,
   /** How tall one row is, in the pixels the viewport was measured in. */
   val rowHeight: Double,
-  /** See [TreemapLayoutResult.truncatedNodeCount]. */
-  val truncatedNodeCount: Int
-) {
-
   /**
    * How tall everything laid out is, which is what a view of it has to scroll through: a stack is as
    * deep as the tree it drew, and that is regularly deeper than a viewport.
+   *
+   * [rowCount] rows' worth, and never less than the viewport when [rowsGoUp]. See [StackLayout].
    */
-  val contentHeight: Double get() = rowCount * rowHeight
+  val contentHeight: Double,
+  /** Whether the rows go up from the node the stack is rooted at rather than down. See [StackLayout]. */
+  val rowsGoUp: Boolean,
+  /** See [TreemapLayoutResult.truncatedNodeCount]. */
+  val truncatedNodeCount: Int
+) {
 
   /** The block [point] falls in, or null where the stack has none: past its last row, or in a notch. */
   fun cellAt(point: TreemapPoint): StackCell<N>? = cells.firstOrNull { point in it.rect }
@@ -68,6 +71,9 @@ class StackLayoutResult<N>(
  * up to. What the parent holds on its own is the width left over at the right end of the row, drawn as
  * a [CellSubject.Own] block, so a bitmap reads as a wide block with almost nothing under it and every
  * row of the stack can be compared with every other.
+ *
+ * [rowsGoUp] draws the same stack the other way up, which is what a tree read from the classes up is
+ * drawn as: see [ReverseDominatorTree].
  */
 class StackLayout<N>(
   /** How tall one row is. A row holds a line of text and nothing else, so this is a text height. */
@@ -88,7 +94,18 @@ class StackLayout<N>(
   private val maxCells: Int = 5000,
   private val maxChildrenPerNode: Int = 200,
   /** And how many for the node the stack is rooted at, which has the whole width. See [TreemapLayout]. */
-  private val maxRootChildren: Int = maxCells / 2
+  private val maxRootChildren: Int = maxCells / 2,
+  /**
+   * Which way the levels go from the node the stack is rooted at: down the view for a tree read from the
+   * roots down, up it for one read from the classes up.
+   *
+   * Which makes the two readings of a heap dump's domination look like the mirror images they are, and
+   * puts the row everything is a share of — the whole heap dump — along the edge a reader starts at. The
+   * only thing it changes is where a row is drawn, so it is done to the finished rows: a row's place is
+   * its depth counted from the far end of the stack, and how far away that is isn't known until the last
+   * row has been placed.
+   */
+  private val rowsGoUp: Boolean = false
 ) {
 
   fun layout(
@@ -105,7 +122,7 @@ class StackLayout<N>(
     )
     val cells = mutableListOf(rootCell)
     if (viewport.width <= 0.0 || rowHeight <= 0.0) {
-      return StackLayoutResult(cells, rowCount = 1, rowHeight = rowHeight, truncatedNodeCount = 0)
+      return result(cells, viewport, rowCount = 1, truncatedNodeCount = 0)
     }
 
     // Widest first, so that the budget is spent where a row has the room to be read. Ties broken by
@@ -202,10 +219,43 @@ class StackLayout<N>(
       }
     }
 
-    return StackLayoutResult(
+    return result(
       cells = cells,
+      viewport = viewport,
       rowCount = cells.maxOf { it.depth } + 1,
+      truncatedNodeCount = truncatedNodeCount
+    )
+  }
+
+  /**
+   * The stack as laid out, with every row flipped when [rowsGoUp]: depth 0 along the bottom edge of what
+   * there is to scroll through, and the deepest row at the top of it.
+   *
+   * Which is as tall as the rows come to, and **never less than the viewport when the rows go up**,
+   * because the bottom row is then the one a view opens on: a stack of six rows in a window with room for
+   * forty has to hang off the bottom of it, and a view scrolls what it is given from the top.
+   */
+  private fun result(
+    cells: List<StackCell<N>>,
+    viewport: TreemapRect,
+    rowCount: Int,
+    truncatedNodeCount: Int
+  ): StackLayoutResult<N> {
+    val stackHeight = rowCount * rowHeight
+    val contentHeight = if (rowsGoUp) maxOf(stackHeight, viewport.height) else stackHeight
+    return StackLayoutResult(
+      cells = if (!rowsGoUp) {
+        cells
+      } else {
+        cells.map { cell ->
+          val top = viewport.top + contentHeight - (cell.depth + 1) * rowHeight
+          cell.copy(rect = cell.rect.copy(top = top, bottom = top + rowHeight))
+        }
+      },
+      rowCount = rowCount,
       rowHeight = rowHeight,
+      contentHeight = contentHeight,
+      rowsGoUp = rowsGoUp,
       truncatedNodeCount = truncatedNodeCount
     )
   }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
@@ -23,12 +23,12 @@ class TreemapPresentation(
     /**
      * Lays [tree] out into [viewport] rooted at [root] and reads what it takes to draw the result.
      *
-     * Here rather than in [HeapDominatorTreemap] — as is every shape's — because which shapes there are
-     * is not something a heap dump reader should have to know: it labels cells, and pairing that with a
-     * layout is this side of the line. See [HeapDominatorTreemap.present].
+     * Here rather than in [HeapTree] — as is every shape's — because which shapes there are is not
+     * something a heap dump reader should have to know: it labels cells, and pairing that with a layout
+     * is this side of the line. See [HeapTree.present].
      */
     fun of(
-      tree: HeapDominatorTreemap,
+      tree: HeapTree,
       layout: TreemapLayout<Long>,
       viewport: TreemapRect,
       root: Long = tree.root
@@ -53,7 +53,7 @@ class RadialPresentation(
   companion object {
     /** See [TreemapPresentation.of]. */
     fun of(
-      tree: HeapDominatorTreemap,
+      tree: HeapTree,
       layout: RadialLayout<Long>,
       viewport: TreemapRect,
       root: Long = tree.root
@@ -78,7 +78,7 @@ class StackPresentation(
   companion object {
     /** See [TreemapPresentation.of]. */
     fun of(
-      tree: HeapDominatorTreemap,
+      tree: HeapTree,
       layout: StackLayout<Long>,
       viewport: TreemapRect,
       root: Long = tree.root
@@ -104,12 +104,13 @@ class PresentedCell<out C : LayoutCell<Long>>(
   val strength: ReachabilityStrength get() = when (val content = content) {
     is CellContent.Object -> content.strength
     is CellContent.ObjectGroup -> content.strength
+    is CellContent.ObjectRow -> content.strength
     is CellContent.Leftover -> content.strength
   }
 }
 
 /**
- * What a presented cell stands for, which is what decides how it's drawn: two of the three aren't an
+ * What a presented cell stands for, which is what decides how it's drawn: three of the four aren't an
  * object of the heap dump, and a view that drew them like one would be lying about the heap.
  */
 sealed interface CellContent {
@@ -132,6 +133,23 @@ sealed interface CellContent {
   data class ObjectGroup(
     val kind: ObjectGroupKind,
     /** How firmly the objects in it are held, which they all are the same way. */
+    val strength: ReachabilityStrength,
+    val objectCount: Int
+  ) : CellContent
+
+  /**
+   * One row of the tree read from the classes up: see [ReverseDominatorTree].
+   *
+   * A pile of objects too, but not one drawn among objects — **every** cell of that tree is one of these,
+   * so what marks a pile out in a treemap says nothing here. Which is why it isn't an [ObjectGroup]: a
+   * view that washed all of them out and dashed all of their edges would spend the whole picture saying
+   * something no cell of it contradicts, and lose the colours that make a column readable. The count each
+   * row is named by is what says it instead.
+   */
+  data class ObjectRow(
+    /** Which kind of row, which is what a view draws a column's two ways of stopping differently by. */
+    val kind: ReverseNodeKind,
+    /** How firmly the objects it gathers are held: the strength most of its bytes are at. */
     val strength: ReachabilityStrength,
     val objectCount: Int
   ) : CellContent

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NodeIdsTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NodeIdsTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import shark.explorer.HeapDominatorTreemap.Companion.ROOT_OBJECT_ID
 import shark.explorer.HeapDominatorTreemap.Companion.UNREACHABLE_NODE_ID
+import shark.explorer.ReverseDominatorTree.Companion.FIRST_REVERSE_NODE_ID
 
 class NodeIdsTest {
 
@@ -23,5 +24,12 @@ class NodeIdsTest {
     assertThat(nodeIdText(UNREACHABLE_NODE_ID)).isEqualTo("the uncollected garbage")
     // A class pile is one of however many a tree hands out, so there is no name to give it but its number.
     assertThat(nodeIdText(UNREACHABLE_NODE_ID + 1)).isEqualTo("the class pile 1")
+  }
+
+  @Test fun `a row of the classes view reads as which row it is`() {
+    // Counted up from the first row a tree read from the classes up hands out, whose own ids count down:
+    // a message about the third row it made should say three rather than a nine digit negative number.
+    assertThat(nodeIdText(FIRST_REVERSE_NODE_ID)).isEqualTo("the class row 0")
+    assertThat(nodeIdText(FIRST_REVERSE_NODE_ID - 2)).isEqualTo("the class row 2")
   }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ReverseDominatorTreeTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ReverseDominatorTreeTest.kt
@@ -1,0 +1,271 @@
+package shark.explorer
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+
+/**
+ * The heap dump's domination read from the classes up: every object on the row of its class, and above each
+ * row the classes of what dominates it.
+ *
+ * Asserted on a dump of three payload arrays, two of them held by instances of one class and one by an
+ * instance of another, so that the arrays are one row and the row above it splits that row's width two ways.
+ * Which is the whole shape of this tree in the smallest dump that has it.
+ */
+class ReverseDominatorTreeTest {
+
+  @get:Rule
+  val testFolder = TemporaryFolder()
+
+  @Test fun `the rows are the classes of every object of the heap dump`() {
+    classRows { explorer, rows ->
+      val classRows = rows.children(rows.root)
+
+      // Heaviest first, as every level of either tree is handed out. The class objects are a row of their
+      // own because this dump has no `java.lang.Class` for them to gather under, as no Android dump does.
+      assertThat(rows.labelsOf(classRows)).containsExactly(
+        "3 × Object[]",
+        "$CLASS_OBJECT_COUNT × class objects",
+        "2 × Tile",
+        "1 × Solo"
+      )
+      assertThat(rows.summarize(rows.root).objectCount)
+        .isEqualTo(classRows.sumOf { rows.summarize(it).objectCount })
+      assertThat(explorer.tree.reverseTree).isSameAs(rows)
+    }
+  }
+
+  @Test fun `the rows add up to the whole heap dump`() {
+    classRows { explorer, rows ->
+      // What makes a row's width its share of the heap: shallow bytes count every object exactly once, so
+      // the bottom row of every column together is the whole dump — which is what the tree beside it
+      // weighs at its own root. This dump has no object counted inside another, so it is exact here.
+      assertThat(rows.weight(rows.root)).isEqualTo(explorer.tree.weight(explorer.tree.root))
+      assertThat(rows.children(rows.root).sumOf { rows.weight(it) }).isEqualTo(rows.weight(rows.root))
+    }
+  }
+
+  @Test fun `a class row is as wide as what its objects take up themselves`() {
+    classRows { explorer, rows ->
+      val arrays = explorer.tree.allSummaries().filter { it.label == "Object[]" }
+      assertThat(arrays).hasSize(3)
+
+      assertThat(rows.weight(rows.rowOf(rows.root, "3 × Object[]")))
+        .isEqualTo(arrays.sumOf { it.shallowSize })
+    }
+  }
+
+  @Test fun `the row above one is what dominates its objects, split by class`() {
+    classRows { _, rows ->
+      val arrays = rows.rowOf(rows.root, "3 × Object[]")
+      val dominators = rows.children(arrays)
+
+      assertThat(rows.labelsOf(dominators)).containsExactly("2 × Tile", "1 × Solo")
+      // Two thirds of the arrays' bytes are held by the two tiles and the last third by the one other
+      // instance, which is what makes this row a reading of where those bytes go.
+      val payload = rows.weight(arrays) / 3
+      assertThat(dominators.map { rows.weight(it) }).containsExactly(2 * payload, payload)
+    }
+  }
+
+  @Test fun `a row's children cover it to the byte`() {
+    classRows { _, rows ->
+      // Every level of every column, which is what lets a row be read as a share of the row under it: a
+      // stack drawn from this tree has no width left over anywhere.
+      rows.everyRow().forEach { row ->
+        val children = rows.children(row)
+        if (children.isNotEmpty()) {
+          assertThat(children.sumOf { rows.weight(it) })
+            .describedAs(rows.label(row))
+            .isEqualTo(rows.weight(row))
+        }
+      }
+    }
+  }
+
+  @Test fun `a column stops where nothing in particular holds the objects`() {
+    classRows { _, rows ->
+      val tiles = rows.rowOf(rows.rowOf(rows.root, "3 × Object[]"), "2 × Tile")
+
+      // Each tile is a GC root of its own, so what holds it is the heap dump rather than an object of it.
+      val terminal = rows.children(tiles).single()
+      assertThat(rows.label(terminal)).isEqualTo(ReverseDominatorTree.NO_OWNER_LABEL)
+      assertThat(rows.summarize(terminal).kind).isEqualTo(ReverseNodeKind.NO_OWNER)
+      // A row of its own rather than width left over, which is what keeps the row below it covered, and
+      // the end of the column: there is nothing above what nothing holds.
+      assertThat(rows.weight(terminal)).isEqualTo(rows.weight(tiles))
+      assertThat(rows.children(terminal)).isEmpty()
+    }
+  }
+
+  @Test fun `a column stops at the uncollected garbage as well`() {
+    HeapExplorer.open(testFolder.uncollectedGarbageHeapDump()).use { explorer ->
+      val rows = explorer.tree.reverseTree
+
+      val payload = rows.rowOf(rows.root, "1 × Object[]")
+      val forgotten = rows.rowOf(payload, "1 × Forgotten")
+      val terminal = rows.children(forgotten).single()
+      assertThat(rows.label(terminal)).isEqualTo(HeapDominatorTreemap.UNREACHABLE_LABEL)
+      assertThat(rows.summarize(terminal).kind).isEqualTo(ReverseNodeKind.UNCOLLECTED_GARBAGE)
+      assertThat(rows.summarize(terminal).strength).isEqualTo(ReachabilityStrength.UNREACHABLE)
+      assertThat(rows.children(terminal)).isEmpty()
+    }
+  }
+
+  @Test fun `a row knows the column it stands on, nearest first`() {
+    classRows { _, rows ->
+      val arrays = rows.rowOf(rows.root, "3 × Object[]")
+      val tiles = rows.rowOf(arrays, "2 × Tile")
+
+      val summary = rows.summarize(tiles)
+      assertThat(summary.column.map { it.label })
+        .containsExactly("3 × Object[]", HeapDominatorTreemap.ROOT_LABEL)
+      assertThat(summary.column.map { it.nodeId }).containsExactly(arrays, rows.root)
+      assertThat(summary.depth).isEqualTo(2)
+      assertThat(summary.kind).isEqualTo(ReverseNodeKind.CLASS)
+      assertThat(summary.className).isEqualTo("com.example.Tile")
+      assertThat(summary.objectCount).isEqualTo(2)
+      assertThat(summary.byteCount).isEqualTo(rows.weight(tiles))
+    }
+  }
+
+  @Test fun `the whole heap dump is what every column stands on`() {
+    classRows { explorer, rows ->
+      val summary = rows.summarize(rows.root)
+
+      assertThat(summary.kind).isEqualTo(ReverseNodeKind.WHOLE_HEAP_DUMP)
+      assertThat(summary.label).isEqualTo(HeapDominatorTreemap.ROOT_LABEL)
+      assertThat(summary.byteCount).isEqualTo(explorer.tree.weight(explorer.tree.root))
+      assertThat(summary.column).isEmpty()
+    }
+  }
+
+  @Test fun `a row is opened by zooming through the rows under it`() {
+    classRows { _, rows ->
+      val arrays = rows.rowOf(rows.root, "3 × Object[]")
+      val tiles = rows.rowOf(arrays, "2 × Tile")
+
+      assertThat(rows.pathToOpen(tiles)).containsExactly(rows.root, arrays, tiles)
+      // A row nothing holds has nothing above it, so rooting the view there would draw one row and nothing
+      // else: the view stops at the row under it, with it drawn inside.
+      assertThat(rows.pathToOpen(rows.children(tiles).single()))
+        .containsExactly(rows.root, arrays, tiles)
+      assertThat(rows.pathToOpen(rows.root)).containsExactly(rows.root)
+    }
+  }
+
+  @Test fun `a node of the tree read from the roots down is no node of this one`() {
+    classRows { explorer, rows ->
+      val objectId = explorer.tree.findByLabel("Solo").objectId
+      val arrays = rows.rowOf(rows.root, "3 × Object[]")
+
+      assertThat(objectId in rows).isFalse()
+      assertThat(arrays in rows).isTrue()
+      // The one node the two trees share, so that a path at the root is a path of either of them.
+      assertThat(rows.root in rows).isTrue()
+      assertThat(rows.root).isEqualTo(explorer.tree.root)
+      assertThat(ReverseDominatorTree.isReverseNode(arrays)).isTrue()
+      assertThat(ReverseDominatorTree.isReverseNode(objectId)).isFalse()
+    }
+  }
+
+  @Test fun `asking this tree about an object says that it has no such row`() {
+    classRows { explorer, rows ->
+      val objectId = explorer.tree.findByLabel("Solo").objectId
+
+      assertThatThrownBy { rows.weight(objectId) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("is no row of this tree")
+    }
+  }
+
+  @Test fun `every cell of a stack laid out from it is a pile of objects`() {
+    classRows { _, rows ->
+      val result = StackLayout<Long>(rowsGoUp = true)
+        .layout(rows, TreemapRect(0.0, 0.0, 1000.0, 800.0))
+
+      val presented = rows.present(result.cells)
+      // Which is what makes this a view of its own rather than another shape of the tree beside it: not one
+      // cell here is an object whose fields can be read.
+      assertThat(presented.map { it.content }).allMatch { it is CellContent.ObjectRow }
+      assertThat(presented.map { it.label })
+        .contains(HeapDominatorTreemap.ROOT_LABEL, "3 × Object[]", "2 × Tile")
+    }
+  }
+
+  /** Opens [classRowsHeapDump] and hands the test its tree read from the classes up. */
+  private fun classRows(block: (HeapExplorer, ReverseDominatorTree) -> Unit) {
+    HeapExplorer.open(testFolder.classRowsHeapDump()).use { explorer ->
+      block(explorer, explorer.tree.reverseTree)
+    }
+  }
+
+  /** The one row above [below] with [rowLabel] on it, which is how these tests walk up a column. */
+  private fun ReverseDominatorTree.rowOf(
+    below: Long,
+    rowLabel: String
+  ): Long = children(below).single { label(it) == rowLabel }
+
+  private fun ReverseDominatorTree.labelsOf(nodeIds: List<Long>): List<String> =
+    nodeIds.map { label(it) }
+
+  /** Every row of the tree, which reading them all is what expands them all. */
+  private fun ReverseDominatorTree.everyRow(): List<Long> {
+    val rows = mutableListOf<Long>()
+    val toVisit = ArrayDeque(children(root))
+    while (toVisit.isNotEmpty()) {
+      val row = toVisit.removeFirst()
+      rows += row
+      toVisit += children(row)
+    }
+    return rows
+  }
+
+  /**
+   * A heap dump where two instances of one class and one of another each hold an object array of the same
+   * size, all three of one array class: so the arrays are one class row, and the row above it is two.
+   */
+  private fun TemporaryFolder.classRowsHeapDump(): File {
+    val file = newFile("class-rows.hprof")
+    file.dump {
+      // One class for all three arrays, declared once: the `arrayClass` shorthand writes a class record
+      // every time it is called, and three of those would be three classes and therefore three rows.
+      val objectArrayClassId = arrayClass("java.lang.Object")
+      val tileClassId = clazz(
+        className = "com.example.Tile",
+        fields = listOf("payload" to ReferenceHolder::class)
+      )
+      repeat(TILE_INSTANCE_COUNT) { index ->
+        val payload = ReferenceHolder(objectArray(objectArrayClassId, LongArray(PAYLOAD_ELEMENT_COUNT)))
+        val tile = instance(tileClassId, listOf(payload))
+        gcRoot(JniGlobal(id = tile.value, jniGlobalRefId = index.toLong()))
+      }
+      val solo = "com.example.Solo" instance {
+        field["payload"] =
+          ReferenceHolder(objectArray(objectArrayClassId, LongArray(PAYLOAD_ELEMENT_COUNT)))
+      }
+      gcRoot(JniGlobal(id = solo.value, jniGlobalRefId = TILE_INSTANCE_COUNT.toLong()))
+    }
+    return file
+  }
+
+  private companion object {
+    /** Two of them, so that the row above the arrays is one row of two objects and one of one. */
+    const val TILE_INSTANCE_COUNT = 2
+
+    /**
+     * Every class the dump has an object of but the array class the payloads share: the two declared here,
+     * and what the `dump { }` DSL writes whether or not anything of it is used.
+     *
+     * Asserted on because the row they land on is real — a heap dump without `java.lang.Class` has no class
+     * for its class objects, which is a row of this tree like any other. See `GroupingClasses.classIdOf`.
+     */
+    const val CLASS_OBJECT_COUNT = 7
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/StackLayoutTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/StackLayoutTest.kt
@@ -284,6 +284,59 @@ class StackLayoutTest {
     assertThat(second.cells).isEqualTo(first.cells)
   }
 
+  @Test fun `going up, the root is the row across the bottom`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 10), Node("b", 5))))
+
+    val result = StackLayout<Node>(rowHeight = 20.0, rowsGoUp = true).layout(tree, viewport)
+
+    // Sitting on the bottom edge of the viewport rather than of the two rows it drew: a stack growing up
+    // has to be as tall as what it is drawn in, or the rows would start in the middle of the view and the
+    // reader would be scrolling to reach the one thing that is always there.
+    assertThat(result.contentHeight).isEqualTo(viewport.height)
+    assertThat(result.cellOf("root").rect).isEqualTo(TreemapRect(0.0, 780.0, 1000.0, 800.0))
+    assertThat(result.cellOf("a").rect.top).isEqualTo(760.0)
+  }
+
+  @Test fun `going up, a stack taller than the viewport starts at its own bottom`() {
+    val tree = NodeTree(chain(60))
+
+    val result = StackLayout<Node>(rowHeight = 20.0, rowsGoUp = true).layout(tree, viewport)
+
+    // Past the viewport's height, so there is nothing to fill and the rows are the whole of it: what the
+    // view scrolls through, with the row it opens on at the very bottom. See [StackLayoutResult.rowsGoUp].
+    assertThat(result.contentHeight).isEqualTo(result.rowCount * 20.0)
+    assertThat(result.cellOf("chain.0").rect.bottom).isEqualTo(result.contentHeight)
+  }
+
+  @Test fun `going up changes nothing but where a row is`() {
+    val tree = NodeTree(uniformTree("root", depth = 3, breadth = 2, leafWeight = 1_000_000))
+    val down = StackLayout<Node>(rowHeight = 20.0).layout(tree, viewport)
+
+    val up = StackLayout<Node>(rowHeight = 20.0, rowsGoUp = true).layout(tree, viewport)
+
+    // The same cells in the same order at the same width: which way the rows go is done to the finished
+    // layout, so a block being where a reader can read it is decided once for both.
+    assertThat(up.names).isEqualTo(down.names)
+    assertThat(up.cells.map { it.rect.left to it.rect.right })
+      .isEqualTo(down.cells.map { it.rect.left to it.rect.right })
+    // And every row as far from the bottom of the content as it was from the top.
+    up.cells.zip(down.cells).forEach { (upCell, downCell) ->
+      assertThat(up.contentHeight - upCell.rect.bottom).isEqualTo(downCell.rect.top)
+    }
+  }
+
+  @Test fun `going up, hit testing finds the block a point falls in`() {
+    val tree = NodeTree(Node("root", children = listOf(Node("a", 30), Node("b", 10))))
+
+    val result = StackLayout<Node>(rowHeight = 20.0, rowsGoUp = true).layout(tree, viewport)
+
+    assertThat(result.cellAt(TreemapPoint(500.0, 790.0))).isEqualTo(result.cellOf("root"))
+    assertThat(result.cellAt(TreemapPoint(500.0, 770.0))).isEqualTo(result.cellOf("a"))
+    assertThat(result.cellAt(TreemapPoint(800.0, 770.0))).isEqualTo(result.cellOf("b"))
+    // Above the rows is the empty part of a viewport the stack didn't fill, which is no block of it.
+    assertThat(result.cellAt(TreemapPoint(500.0, 700.0))).isNull()
+  }
+
   @Test fun `laying out a subtree puts it across the top`() {
     val tree = NodeTree(uniformTree("root", depth = 3, breadth = 2, leafWeight = 1_000_000))
     val subtree = tree.root.children.first()


### PR DESCRIPTION
A fourth view in Shark Explorer, and the first one that isn't the dominator tree read from the roots down: **every object of the heap dump on the row of its class along the bottom, and above each row the classes of the objects dominating it.** An icicle chart of a reverse call tree, with "what retains this" in place of "who called this".

A column reads `byte[]` at the bottom, `Bitmap` above it, `LruCache` above that, and how wide it is says how much of the heap's `byte[]` bytes that accounts for.

Which is the question the other three views can't answer. They start from one object and walk out, so "what holds all the `byte[]` arrays, by class" means finding 16,730 rectangles scattered over the picture and adding them up by eye. Here it's the widest row, and what holds them is the row above it.

## What the picture looks like

`large-dump.hprof`, 39 MB, 387,971 objects — the opening view of the classes tab:

- `16,730 × byte[]` — 10 MB, a third of the heap
- above it, `151 × Bitmap` accounting for 7.7 MB of those bytes, and `14,874 × Class` for 2.2 MB
- above the bitmaps, `2 × LinkedHashMap$LinkedHashMapEntry`, `1 × LinkedHashMap` and `1 × LruCache`, each holding 3.9 MB of them
- and where a column stops: `Nothing in particular`, the objects the dominator tree hangs off the whole heap dump because they're held from more than one place

Six rows of one column, in the picture the view opens on, with no chain walked and nothing clicked.

## The weighting, which is the whole design

**A row is weighed by the objects at the bottom of its column, in their own bytes.** That's the one weighting that makes rows comparable: retained size would count an object's bytes again on every row above it, so the rows would add up to several times the heap and "a fifth of the dump" would mean nothing.

Shallow bytes add up to the dump exactly once, so:

- the reverse root weighs exactly what the dominator tree's root weighs (asserted)
- a row's width is its share of the whole heap dump at every level
- a row's children cover it to the byte

Two kinds of row stop a column rather than leaving width over: objects nothing in particular dominates, and objects only uncollected garbage does.

## What it costs

No second dominator computation — only `immediateDominatorOf`, one object at a time, plus the tree's nodes for shallow sizes and to know what Shark folded. And nothing at all until the view is opened. On `large-dump.hprof`, which takes 2.4 s to open:

| | |
| --- | --- |
| Gathering every object onto its class row | 0.20 s, 8,679 rows |
| The level above the widest row | 0.01 s, 44 rows |

What it holds between reads is **at most one entry per object of the heap dump**, however many levels are open: expanding a row hands its entries to the rows above it and drops its own, so the live entries stand for disjoint sets of the objects at the bottom of the columns.

## Three decisions worth reviewing

**Going up is done to the finished layout.** `StackLayout` gains a `rowsGoUp` flag and flips every row once `rowCount` is known, because a row's distance from the *bottom* isn't known until the last row has been placed. `contentHeight` is clamped to the viewport when growing up, so the root row sits on the bottom edge of the view rather than of the rows, and `StackView` scrolls it with `reverseScrolling` so `scrollTo(0)` still means "where it opens".

**The two trees share the root node id**, so switching shape substitutes the root *in the view request* rather than in the history — which is what leaves the path into the tree being left there to come back to. Every other node is told apart by a range check at the far end of the range the treemap takes its pile ids from.

**Every cell here is a pile of objects, including the root**, so a row is coloured and outlined like an object instead of like a pile: washing all of them out and dashing all of their edges would spend the whole picture saying something no cell of it contradicts, and lose the hues that make a column readable. The count in the label (`151 × Bitmap`) says "pile" instead, and the two rows that stop a column keep their own look — slate and dashed for `Nothing in particular`, purple for the garbage.

That shared root is also the one thing a node id can't answer for, so **what a clicked cell is, is read off the shape being drawn**: the whole heap dump is a row of this view and the root of the other, and the classes a row had no room for are named after the cell they were left out of, which on a dump with 8,679 classes is that very node.

## Tests

- `ReverseDominatorTreeTest` — 13 cases on the tree: the rows gather by class weighed by shallow bytes, they add up to what the forward root weighs, the row above one is its dominators split by class in proportion, every row's children cover it exactly, both kinds of terminal row, `pathToOpen`, the column read nearest-first, and that a node of one tree is no node of the other.
- `StackLayoutTest` — four upward cases: the root row across the bottom with `contentHeight` clamped to the viewport, a stack taller than the viewport starting at its own bottom, "going up changes nothing but where a row is", and hit testing.
- `ClassesViewTest` — the window: the bottom row is the whole heap dump, pointing at a row says which class it gathers, clicking one says what holds it going down, and the classes a row had no room for say they're classes.
- `TreeLayoutTest` — switching to the classes view lays the tree out exactly once, since that first layout is a pass over every object of the dump.

`notes/treemap-rendering.md` and `notes/dominator-tree.md` carry the design and the numbers; the module's `AGENTS.md` gains the one trap — the shared root node.

Try it:

```bash
./gradlew :shark:shark-explorer:shark-explorer-app:run \
  --args="--title=\"Classes view\" leakcanary/leakcanary-android-instrumentation/src/androidTest/assets/large-dump.hprof"
```

Pick **Classes** in the Shape row, then read up a column: click a row to give what dominates it the whole width, and the details panel lists the rows under it, nearest first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
