### PR TITLE
Draw the activities an app is running under the thread running them

### DIFF
--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -224,11 +224,10 @@ view bindings and `StandardRowSpec$StandardViewHolder.itemView`.
 `OwnerReferences` applies a curated list of `OwnerRule`s: a class whose instances something owns, plus the
 references that own them — named fields, or the virtual references a class's instances hand out. Three
 today — `android.view.View` owned by the `ViewGroup` that reads it as a child (see below) and by
-`Activity.mDecor` or `Dialog.mDecor`, and `android.app.Activity` owned by
-`ActivityThread$ActivityClientRecord.activity`. After: **every one of the 277 child views is under its
-parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity` retains
-18 MB under the record the framework runs it from, which is the second largest rectangle under the GC
-roots.
+`Activity.mDecor` or `Dialog.mDecor`, and `android.app.Activity` owned by the `ActivityThread` that reads
+it as one it's running (see below too). After: **every one of the 277 child views is under its parent**,
+the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity` retains 18 MB under
+the thread running it, which is the second largest rectangle under the GC roots.
 
 **A rule is parked, not dropped, and that's the whole design.** The walk in
 `HeapReachability.walkFromGcRoots` keeps a second queue per strength and only takes from it once the main
@@ -261,14 +260,26 @@ Two things to know before adding a rule:
   own. An *array* can only be named by its type, which is what the first version of the view rule did —
   every `android.view.View[]` element owned what it pointed at — and a type says nothing about whose
   children the array holds, so an app's own `View[]` of views it merely points at claimed them too. Hence
-  the reader below.
+  the readers below.
+- **Name the thing that holds it, not the slot it's in.** `ActivityClientRecord.activity` is perfectly
+  nameable and was the activity rule for a while, and it still put a map's `ArrayMap`, `Object[]` and
+  record between the thread running a screen and the screen. Nameable is the floor, not the bar: ask what
+  you would say holds the object out loud, and if that isn't the reference, the reader has one to add.
 
 Ownership is **not** a `ReachabilityStrength` and can't be: strength is a min over the references of a
 path, while owning is a property of the last reference alone. It's a separate binary verdict per object,
 gated in the same place — `WeakeningAwareReferenceReader`, which the dominator tree, the referrer index
 and the path search all read through, so all three see one edge set.
 
-### A `ViewGroup` points at its children: the one virtual reference the explorer adds
+### The two virtual references the explorer adds
+
+A rule can only claim ownership through something nameable, and the framework's own structure often has
+nothing to name — so the reader below each rule adds the reference the rule is about, and the dominator
+tree is what then collapses the levels the real structure went through. Both are **additive**, both are
+read from `ReferenceStrengthReader.retainingReferencesOf`, and both are bounded by the count the framework
+keeps rather than by the capacity of the array behind it.
+
+#### A `ViewGroup` points at its children
 
 `ViewChildReferenceReader` gives a `ViewGroup` one reference per child, named by index and marked virtual,
 which is what the view `OwnerRule` claims ownership through. It reads `mChildren` bounded by
@@ -298,6 +309,44 @@ Three things make it safe, and each one is a decision:
 Byte counts are untouched by all of it, which is the check that no object moved out of the graph: 83.83 MB
 strong, 2.05 MB thread local, 28 B local, 2.6 KB finalizer, 190 KB unreachable, 1,019,837 objects, before
 and after.
+
+#### An `ActivityThread` points at the activities it's running
+
+`RunningActivityReferenceReader` gives the `ActivityThread` one reference per activity, named `activities`
+and marked virtual, which is what the activity `OwnerRule` claims ownership through. It reads the values of
+`mActivities` — an `ArrayMap` from an activity's token to its `ActivityClientRecord`, so a key at every even
+slot of `mArray` and a record at the odd one after it — bounded by `mSize`, and takes each record's
+`activity`.
+
+The rule used to name `ActivityClientRecord.activity` instead, which is a slot of that map rather than the
+thing running the activity, and it left the map, its `Object[]` and the record between the thread and every
+screen. Measured on `large-dump.hprof`, which is running two activities:
+
+| | Before | After |
+| --- | --- | --- |
+| `MainActivity` dominator | `ActivityClientRecord` | `ActivityThread` |
+| GC root chain to `MainActivity` | 6 steps | **3 steps** |
+| Record holding `MainActivity` retains | 2,125,170 B | **381 B** |
+| Record holding `PaymentActivity` retains | 14,552 B | **361 B** |
+| `mActivities` `ArrayMap` retains | 2,139,795 B | **815 B** |
+
+The two activities' own retained sizes don't move — 2,124,789 B and 11,995 B either way — because a record
+retained little beyond the activity in it. What moves is where those bytes are drawn: two screens side by
+side under the thread, instead of two piles of map bookkeeping. Chains into an activity's internals get a
+step shorter too, and a better first step: the shortest way to the `Bundle`s under `MainActivity` used to
+run through a *leaked* `SquareActivity.foot → ArrayList → Object[]`, since that was fewer steps than the map.
+
+Byte counts are again identical before and after, which is the check that no object left the graph:
+30,090,032 B strong, 28,302 B thread local, 1,444 B soft, 261 B weak, 9,353 B finalizer, 631,761 B
+unreachable, 387,971 objects. Opening the dump costs at most 2% more — median of five steady state opens
+2.02 s with the reader against 1.98 s without, ranges overlapping — which is the fourth sequence
+concatenation `retainingReferencesOf` now does per object, since the reader itself is one class id
+comparison for everything that isn't the activity thread.
+
+`mActivities` has been an `ArrayMap` since Lollipop, seven releases before the oldest one LeakCanary
+supports, so the `HashMap` it was before that is deliberately not read: a dump that doesn't have the
+`ArrayMap` shape logs a line and reads as a thread running nothing, which leaves its activities held by
+whatever points at them.
 
 ## What holds an object: one chain, with the dominators on it marked
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
@@ -213,16 +213,22 @@ internal class OwnerReferences private constructor(
           "android.app.Dialog" to setOf("mDecor")
         )
       ),
-      // An activity belongs to the list of activities the process is running, and everything else that
-      // points at one — a context wrapper, a view, a fragment, a presenter, a callback — is something the
-      // activity brought along. Self-clearing in the same way: ActivityThread.handleDestroyActivity takes
-      // the record out of mActivities, so a destroyed activity has no owner left and falls back on
-      // whatever is leaking it, which is exactly what you want its bytes drawn under.
+      // An activity belongs to the thread running it, through the virtual reference
+      // [RunningActivityReferenceReader] reads from an ActivityThread to each activity in mActivities.
+      // Everything else that points at one — a context wrapper, a view, a fragment, a presenter, a
+      // callback — is something the activity brought along. Self-clearing in the same way:
+      // ActivityThread.handleDestroyActivity takes the record out of mActivities, so a destroyed activity
+      // has no owner left and falls back on whatever is leaking it, which is exactly what you want its
+      // bytes drawn under.
+      //
+      // Not ActivityClientRecord.activity, which is what this rule used to say. A record is a slot of the
+      // ArrayMap the thread keeps its activities in, and naming the slot leaves the map, its Object[] and
+      // the record itself between the thread and every activity, so the chain from a GC root down to a
+      // screen spends three of its steps on a map's bookkeeping and the thread's own rectangle is a pile of
+      // records rather than a row of screens to compare.
       OwnerRule(
         ownedClassName = ACTIVITY_CLASS_NAME,
-        ownerFieldsByClassName = mapOf(
-          "android.app.ActivityThread\$ActivityClientRecord" to setOf("activity")
-        )
+        ownerVirtualClassNames = setOf(RunningActivityReferenceReader.ACTIVITY_THREAD_CLASS_NAME)
       )
     )
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -70,8 +70,9 @@ internal class WeakeningReference(
  *
  * Where a structure is worth presenting the way you think about it anyway, the reference is **added**
  * rather than swapped in: [ViewChildReferenceReader] gives a `ViewGroup` a reference to each of its
- * children, and the `View[]` they really live in is still reached through `mChildren` and still a node of
- * its own.
+ * children and [RunningActivityReferenceReader] gives an `ActivityThread` one to each activity the app is
+ * running, and the `View[]` and the `ArrayMap` they really live in are still reached through their fields
+ * and still nodes of their own.
  */
 internal class ReferenceStrengthReader(private val graph: HeapGraph) {
 
@@ -79,6 +80,8 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
     ActualMatchingReferenceReaderFactory(WEAKENING_REFERENCE_MATCHERS).createFor(graph)
 
   private val viewChildReader = ViewChildReferenceReader(graph)
+
+  private val runningActivityReader = RunningActivityReferenceReader(graph)
 
   /**
    * Which fields of a class hold their value without retaining it, by class object id. Cached because
@@ -98,7 +101,8 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
   /** The references from [source] that keep their target alive. */
   fun retainingReferencesOf(source: HeapObject): Sequence<Reference> =
     retainingReader.read(source) + classMetadataReferencesOf(source) +
-      viewChildReader.childReferencesOf(source)
+      viewChildReader.childReferencesOf(source) +
+      runningActivityReader.activityReferencesOf(source)
 
   /**
    * The arrays ART hangs off a class object to hold what it embeds — its method tables in

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RunningActivityReferenceReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RunningActivityReferenceReader.kt
@@ -1,0 +1,123 @@
+package shark.explorer
+
+import shark.HeapGraph
+import shark.HeapObject
+import shark.HeapObject.HeapInstance
+import shark.Reference
+import shark.Reference.LazyDetails
+import shark.ReferenceLocationType.INSTANCE_FIELD
+import shark.SharkLog
+import shark.ValueHolder
+
+/**
+ * The activities an app is running, as one reference from its `ActivityThread` straight to each of them,
+ * under a name the framework has no field for: `activities`.
+ *
+ * The framework keeps them in `mActivities`, an `ArrayMap` from an activity's token to the
+ * `ActivityClientRecord` it runs it from, so the way from the thread to an activity really reads
+ * `ActivityThread.mActivities → ArrayMap.mArray → Object[][1] → ActivityClientRecord.activity`: five
+ * objects to say the app is running a screen, three of them a map's bookkeeping. That costs the same two
+ * things reading a `ViewGroup`'s children out of its `View[]` costs — see [ViewChildReferenceReader] — a
+ * path nobody reads all of, and an owner that is a slot of a map rather than the thing running the
+ * activity.
+ *
+ * So this adds one virtual reference per activity, and [OwnerReferences] names this class to say that an
+ * `ActivityThread` owns what they point at. **Additive** — the map, its `Object[]` and every record are
+ * still reached through `mActivities` and still nodes holding their own bytes, because the explorer needs
+ * every object of a heap dump to be a node exactly once (see [ReferenceStrengthReader]). What takes the map
+ * back out of the middle of the tree is the dominator tree rather than this: both ways to an activity now
+ * start at the `ActivityThread`, so it dominates the activity and the map is left retaining its own
+ * entries.
+ *
+ * Named `activities` rather than `mActivities`, which would be two references of that name out of one
+ * `ActivityThread` pointing at different things — the map, and each activity in it — with nothing in a path
+ * or a referrer list to tell them apart. A virtual reference is named by what it is rather than by the
+ * field it was read out of, the same way a `ViewGroup`'s children are.
+ */
+internal class RunningActivityReferenceReader(private val graph: HeapGraph) {
+
+  /**
+   * The class id of `ActivityThread`, resolved once: [HeapGraph.findClassByName] scans every string of the
+   * heap dump, and an instance's class comes from the index, so this turns "is this the activity thread"
+   * into a comparison. Never a real object id for a heap dump that has no `ActivityThread` in it, which is
+   * every dump of a JVM.
+   */
+  private val activityThreadClassId: Long by lazy {
+    graph.findClassByName(ACTIVITY_THREAD_CLASS_NAME)?.objectId ?: ValueHolder.NULL_REFERENCE
+  }
+
+  /** The activities [source] is running when it's the `ActivityThread`, and nothing at all for the rest. */
+  fun activityReferencesOf(source: HeapObject): Sequence<Reference> {
+    if (source !is HeapInstance || source.instanceClassId != activityThreadClassId) {
+      return emptySequence()
+    }
+    return runningActivityIdsOf(source).map { activityObjectId ->
+      Reference(
+        valueObjectId = activityObjectId,
+        isLowPriority = false,
+        lazyDetailsResolver = {
+          LazyDetails(
+            name = ACTIVITIES_NAME,
+            locationClassObjectId = activityThreadClassId,
+            locationType = INSTANCE_FIELD,
+            isVirtual = true,
+            matchedLibraryLeak = null
+          )
+        }
+      )
+    }
+  }
+
+  /** The activities the records in `ActivityThread.mActivities` are running, by object id. */
+  private fun runningActivityIdsOf(activityThread: HeapInstance): Sequence<Long> {
+    val activities = activityThread[ACTIVITY_THREAD_CLASS_NAME, ACTIVITIES_FIELD_NAME]?.valueAsInstance
+      ?: return emptySequence()
+    val entries = activities[ARRAY_MAP_CLASS_NAME, ARRAY_MAP_ARRAY_FIELD_NAME]?.valueAsObjectArray
+    val entryCount = activities[ARRAY_MAP_CLASS_NAME, ARRAY_MAP_SIZE_FIELD_NAME]?.value?.asInt
+    if (entries == null || entryCount == null) {
+      // An ArrayMap here since Lollipop, seven releases before the oldest one LeakCanary supports, so this
+      // is a dump from before that or from a fork that changed the field. Reads as an activity thread
+      // running nothing, which leaves every activity of the dump held by whatever points at it.
+      SharkLog.d {
+        "$ACTIVITY_THREAD_CLASS_NAME.$ACTIVITIES_FIELD_NAME is a ${activities.instanceClassName} rather " +
+          "than an $ARRAY_MAP_CLASS_NAME, so no activity is read as one the app is running"
+      }
+      return emptySequence()
+    }
+    val elementIds = entries.readRecord().elementIds
+    // An ArrayMap holds a key at every even index and its value at the odd one after it, bounded by the
+    // count it keeps rather than by the length of the array, which is a capacity it grows and shrinks in
+    // chunks. `ArrayMap.removeAt` nulls the pair it gives up, so the tail is null anyway and the bound
+    // looks like belt and braces — but a slot the map doesn't count is not an entry, and calling one an
+    // activity the app is running attributes an activity the framework has let go of to the framework,
+    // which is exactly the leak you'd be looking for. A heap dump also catches threads mid-method, and
+    // `ArrayMap.put` fills the pair before it counts it.
+    val valueIndexes = 1 until (entryCount * 2).coerceIn(0, elementIds.size) step 2
+    return valueIndexes.asSequence()
+      .mapNotNull { index -> graph.findObjectByIdOrNull(elementIds[index]) as? HeapInstance }
+      .mapNotNull { record ->
+        record[ACTIVITY_CLIENT_RECORD_CLASS_NAME, ACTIVITY_FIELD_NAME]?.value?.asNonNullObjectId
+      }
+  }
+
+  companion object {
+    /** Also what an [OwnerRule] names to say that the thread owns the activities read here. */
+    const val ACTIVITY_THREAD_CLASS_NAME = "android.app.ActivityThread"
+
+    /** What every reference read here is called, which is no field of `ActivityThread`. */
+    private const val ACTIVITIES_NAME = "activities"
+
+    private const val ACTIVITIES_FIELD_NAME = "mActivities"
+
+    private const val ACTIVITY_CLIENT_RECORD_CLASS_NAME =
+      "android.app.ActivityThread\$ActivityClientRecord"
+
+    private const val ACTIVITY_FIELD_NAME = "activity"
+
+    private const val ARRAY_MAP_CLASS_NAME = "android.util.ArrayMap"
+
+    private const val ARRAY_MAP_ARRAY_FIELD_NAME = "mArray"
+
+    private const val ARRAY_MAP_SIZE_FIELD_NAME = "mSize"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import shark.GcRoot.JniGlobal
 import shark.ReferenceLocationType.ARRAY_ENTRY
+import shark.ReferenceLocationType.INSTANCE_FIELD
 import shark.ValueHolder
 import shark.ValueHolder.BooleanHolder
 import shark.ValueHolder.IntHolder
@@ -80,18 +81,55 @@ class OwnerReferencesTest {
     }
   }
 
-  @Test fun `an activity the framework hasn't destroyed is held by the framework`() {
+  @Test fun `an activity the framework hasn't destroyed is held by the thread running it`() {
     HeapExplorer.open(viewHierarchyHeapDump()).use { explorer ->
       val tree = explorer.tree
       val activity = tree.findByLabel("MainActivity")
 
-      // Something else holding a live activity is holding what the framework is running, so the record in
-      // ActivityThread.mActivities is where its bytes belong. Once the framework destroys it that record
-      // is gone, and then the thing still pointing at it is both its owner and its leak.
-      assertThat(tree.dominatorOf(activity.objectId)!!.label)
-        .isEqualTo("ActivityThread\$ActivityClientRecord")
+      // Something else holding a live activity is holding what the framework is running, so the thread
+      // running it is where its bytes belong. Straight from the thread rather than through the ArrayMap it
+      // keeps its activities in — see [RunningActivityReferenceReader] — so the map, its array and the
+      // record are no steps on the way down to a screen, and the one step there is names the thread's own
+      // class.
+      assertThat(tree.dominatorOf(activity.objectId)!!.label).isEqualTo("ActivityThread")
       assertThat(tree.independentPathsBelowDominator(activity.objectId).paths.map { it.stepLabels() })
-        .containsExactly(listOf("activity → MainActivity"))
+        .containsExactly(listOf("activities → MainActivity"))
+      val activityReference = tree.independentPathsBelowDominator(activity.objectId)
+        .paths
+        .single()
+        .steps
+        .single()
+        .reference!!
+      assertThat(activityReference.ownerClassName).isEqualTo("ActivityThread")
+      assertThat(activityReference.locationType).isEqualTo(INSTANCE_FIELD)
+    }
+  }
+
+  @Test fun `an activity in a slot the map doesn't count is not one the app is running`() {
+    HeapExplorer.open(viewHierarchyHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val uncounted = tree.findByLabel("UncountedActivity")
+
+      // What the thread runs is what mSize covers, not what its array has room for. A pair past the count
+      // is an entry the map has let go of or hasn't taken yet, so nothing owns the activity in it and the
+      // record that points at it holds it as a last resort.
+      assertThat(tree.dominatorOf(uncounted.objectId)!!.label)
+        .isEqualTo("ActivityThread\$ActivityClientRecord")
+    }
+  }
+
+  @Test fun `an activity the framework has destroyed is held by whatever leaks it`() {
+    HeapExplorer.open(viewHierarchyHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val destroyed = tree.findByLabel("DestroyedActivity")
+
+      // handleDestroyActivity takes the record out of mActivities, so the reference the ownership rule
+      // waits on never turns up and the rival is how the activity is held. Which is the leak, and it's the
+      // one thing you'd want its bytes drawn under.
+      assertThat(destroyed.strength).isEqualTo(STRONG)
+      assertThat(tree.dominatorOf(destroyed.objectId)!!.label).isEqualTo("Leaker")
+      assertThat(tree.independentPathsBelowDominator(destroyed.objectId).paths.map { it.stepLabels() })
+        .containsExactly(listOf("destroyedActivity → DestroyedActivity"))
     }
   }
 
@@ -105,11 +143,14 @@ class OwnerReferencesTest {
     }
   }
   /**
-   * A heap dump shaped like the view hierarchies of a running app: an activity holding its decor view, the
-   * decor view holding a child through the array a `ViewGroup` keeps its children in — plus a view in a
-   * slot of that array it doesn't count — and two things pointing at views they don't hold, a
-   * `ViewRootImpl` and an `InputMethodManager`, each a GC root of its own so that both are closer to a
-   * root than the activity is.
+   * A heap dump shaped like the view hierarchies of a running app: an `ActivityThread` running an activity
+   * through the `ArrayMap` of records it keeps them in, the activity holding its decor view, the decor view
+   * holding a child through the array a `ViewGroup` keeps its children in — plus a view in a slot of that
+   * array it doesn't count — and two things pointing at views they don't hold, a `ViewRootImpl` and an
+   * `InputMethodManager`, each a GC root of its own so that both are closer to a root than the activity is.
+   *
+   * Plus the two shapes of something the framework isn't running: a destroyed activity only a leaker keeps
+   * in memory, and an activity in a pair of the map past the count it keeps.
    *
    * Plus a hierarchy that was taken off its window and is only still in memory because the input method
    * manager kept a reference into it, which is the shape of a real view leak.
@@ -146,17 +187,18 @@ class OwnerReferencesTest {
         className = "com.android.internal.policy.DecorView",
         superclassId = viewGroupClassId
       )
+      val activityClassId = clazz(
+        className = "android.app.Activity",
+        fields = listOf(
+          "mDecor" to ReferenceHolder::class,
+          "mDestroyed" to BooleanHolder::class
+        )
+      )
       // The owner field is declared by android.app.Activity and the instance is a subclass of it, which is
       // how a real dump looks and what makes this cover the class hierarchy walk.
       val mainActivityClassId = clazz(
         className = "com.example.MainActivity",
-        superclassId = clazz(
-          className = "android.app.Activity",
-          fields = listOf(
-            "mDecor" to ReferenceHolder::class,
-            "mDestroyed" to BooleanHolder::class
-          )
-        )
+        superclassId = activityClassId
       )
       // Views point back at their parent, at their hierarchy's root and at their activity, so their ids
       // have to exist before the objects they point at are written.
@@ -210,11 +252,44 @@ class OwnerReferencesTest {
         objectId = detachedRootId
       )
       instance(mainActivityClassId, listOf(decor, BooleanHolder(false)), objectId = activityId)
-      // What the framework runs the activity from, and something outside it that also points at it.
-      val activityRecord = "android.app.ActivityThread\$ActivityClientRecord" instance {
-        field["activity"] = activityId
+      // The activity the framework has destroyed, and one in a pair of the map past the count it keeps —
+      // neither of them something the app is running, reached by two different ways of not being in it.
+      val destroyedActivity = instance(
+        clazz(className = "com.example.DestroyedActivity", superclassId = activityClassId),
+        listOf(NO_REFERENCE, BooleanHolder(true))
+      )
+      val uncountedActivity = instance(
+        clazz(className = "com.example.UncountedActivity", superclassId = activityClassId),
+        listOf(NO_REFERENCE, BooleanHolder(false))
+      )
+      // What the framework runs each activity from. One class for both records, because the shorthand that
+      // declares a class per instance would put two ActivityClientRecord classes in a dump that no real one
+      // has.
+      val activityRecordClassId = clazz(
+        className = "android.app.ActivityThread\$ActivityClientRecord",
+        fields = listOf("activity" to ReferenceHolder::class)
+      )
+      // A token per record, which is what the map is keyed by.
+      val tokenClassId = clazz(className = "android.os.BinderProxy")
+      val activityThread = "android.app.ActivityThread" instance {
+        field["mActivities"] = "android.util.ArrayMap" instance {
+          // An ArrayMap holds a key at every even slot and its value at the odd one after it, in an array
+          // with room to spare: two pairs of capacity, and mSize says one of them is an entry.
+          field["mArray"] = objectArray(
+            instance(tokenClassId),
+            instance(activityRecordClassId, listOf(activityId)),
+            instance(tokenClassId),
+            instance(activityRecordClassId, listOf(uncountedActivity))
+          )
+          field["mSize"] = IntHolder(1)
+        }
       }
-      val leaker = "com.example.Leaker" instance { field["activity"] = activityId }
+      // Something outside the framework pointing at the activity it's running, and something pointing at
+      // the one it has destroyed, which is a leak.
+      val leaker = "com.example.Leaker" instance {
+        field["activity"] = activityId
+        field["destroyedActivity"] = destroyedActivity
+      }
       val fallbackHandler = "com.android.internal.policy.PhoneFallbackEventHandler" instance {
         field["mView"] = decor
       }
@@ -222,7 +297,7 @@ class OwnerReferencesTest {
         field["mServedView"] = leaf
         field["mNextServedView"] = detachedRootId
       }
-      gcRoot(JniGlobal(id = activityRecord.value, jniGlobalRefId = 0))
+      gcRoot(JniGlobal(id = activityThread.value, jniGlobalRefId = 0))
       gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 1))
       gcRoot(JniGlobal(id = fallbackHandler.value, jniGlobalRefId = 2))
       gcRoot(JniGlobal(id = inputMethodManager.value, jniGlobalRefId = 3))


### PR DESCRIPTION
## What

Adds a virtual `activities` reference from `ActivityThread` to each activity in `mActivities`, and moves the activity `OwnerRule` onto it.

`ActivityThread` keeps its activities in `mActivities`, an `ArrayMap` from an activity's token to the `ActivityClientRecord` it runs it from, so the way from the thread down to a screen really reads:

```
ActivityThread.mActivities → ArrayMap.mArray → Object[][1] → ActivityClientRecord.activity
```

Five objects to say the app is running a screen, three of them a map's bookkeeping. The rule named `ActivityClientRecord.activity` as the owner, which is a slot of that map rather than the thing running the activity, so all three stayed between the thread and every activity.

`RunningActivityReferenceReader` now adds one virtual reference per activity and the rule claims ownership through that instead. **Additive**, like `ViewChildReferenceReader`: the map, its `Object[]` and every record are still reached through `mActivities` and still nodes holding their own bytes. It's the dominator tree that takes them out of the middle, both ways to an activity now starting at the thread.

It's named `activities` rather than `mActivities` because a virtual reference borrowing a real field's name would be two references called `mActivities` out of one `ActivityThread` pointing at different things — the map, and each activity in it — with nothing in a path or a referrer list to tell them apart.

## Measured on `large-dump.hprof`, which is running two activities

| | Before | After |
| --- | --- | --- |
| `MainActivity` dominator | `ActivityClientRecord` | `ActivityThread` |
| GC root chain to `MainActivity` | 6 steps | **3 steps** |
| Record holding `MainActivity` retains | 2,125,170 B | **381 B** |
| Record holding `PaymentActivity` retains | 14,552 B | **361 B** |
| `mActivities` `ArrayMap` retains | 2,139,795 B | **815 B** |

The activities' own retained sizes don't move — 2,124,789 B and 11,995 B either way — because a record retained little beyond the activity in it. What moves is where those bytes are drawn: two screens side by side under the thread instead of two piles of map bookkeeping.

Chains into an activity's internals also get a step shorter and a better first step. The shortest way to the `Bundle`s under `MainActivity` used to run through a *leaked* `SquareActivity.foot → ArrayList → Object[]`, that being fewer steps than the map; it now runs `Thread → ActivityThread, activities → MainActivity`.

Byte counts are identical before and after, which is the check that no object left the graph: 30,090,032 B strong, 28,302 B thread local, 1,444 B soft, 261 B weak, 9,353 B finalizer, 631,761 B unreachable, 387,971 objects.

Opening the dump costs at most 2% more — median of five steady state opens 2.02 s with the reader against 1.98 s without, ranges overlapping. That's the fourth sequence concatenation `retainingReferencesOf` now does per object; the reader itself is one class id comparison for everything that isn't the activity thread.

## Details worth a look in review

- **Bounded by `mSize`, not by the length of `mArray`.** Same reason `ViewChildReferenceReader` bounds by `mChildrenCount`: `ArrayMap.removeAt` nulls the pair it gives up so the tail is null anyway, but a heap dump catches threads mid-method and `ArrayMap.put` fills a pair before it counts it. Calling an uncounted pair an activity the app is running would attribute an activity the framework has let go of to the framework, which is exactly the leak you'd be looking for.
- **The record's field is no longer an owner**, so it's a rival like any other reference — which is what makes the two "not running" shapes fall back correctly: a destroyed activity (`handleDestroyActivity` takes its record out of `mActivities`) lands under whatever leaks it, and one in an uncounted pair lands under the record pointing at it. Both pinned by new tests.
- **One owner per construct**, so this replaces the old rule rather than joining it. Keeping both would show two paths from the thread to every activity, one direct and one through the map.
- **`ArrayMap` only.** `mActivities` has been one since Lollipop, seven releases before LeakCanary's `minSdk` of 24, so the `HashMap` it was before that is deliberately not read: a dump without the `ArrayMap` shape logs a line and reads as a thread running nothing.

No changelog entry: this is Shark Explorer, whose `Unreleased` section is still just *"Initial release"*.

`notes/dominator-tree.md` gains the section for this reader and the numbers above; its `OwnerRule` section grows a *"name the thing that holds it, not the slot it's in"* bullet, since nameable turned out to be the floor rather than the bar.

## Test plan

- `./gradlew :shark:shark-explorer:shark-explorer-core:check :shark:shark-explorer:shark-explorer-app:check :shark:shark-explorer:shark-explorer-jdwp:check` — green, detekt included.
- Three tests in `OwnerReferencesTest`: an activity the framework hasn't destroyed is held by the thread running it (with the reference read back as an `INSTANCE_FIELD` named `activities` on `ActivityThread`), one in a slot the map doesn't count isn't, and a destroyed one is held by whatever leaks it.
- Opened `large-dump.hprof` in the app and read the numbers in the table off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)