### PR TITLE
Hold a dependency injection singleton by the provider caching it

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,9 @@ workManager = "2.7.0"
 detekt = "1.23.8"
 dokka = "2.2.0"
 hilt = "2.60.1"
+# Metro's runtime, used by no module's production code. Only the Shark explorer's tests depend on it,
+# to build the very providers a generated Metro graph builds — see DependencyInjectionOwnerTest.
+metro = "1.4.0"
 sqldelight = "2.3.2"
 androidMinSdk = "24"
 androidCompileSdk = "36"
@@ -52,6 +55,12 @@ kotlin-abi-tools = { module = "org.jetbrains.kotlin:abi-tools", version.ref = "k
 
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+
+# The two dependency injection runtimes the explorer has an owner rule about, on the test classpath of
+# shark-explorer-core and nowhere else. Runtimes only: neither annotation processor nor compiler plugin
+# runs in this build, see DependencyInjectionOwnerTest.
+dagger-runtime = { module = "com.google.dagger:dagger", version.ref = "hilt" }
+metro-runtime = { module = "dev.zacsweers.metro:runtime-jvm", version.ref = "metro" }
 
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -452,6 +452,8 @@ Design decisions and findings, kept current as the work proceeds:
   treemap
 - `notes/bitmaps.md` — which Android versions put a bitmap's pixels in the heap dump, and the two ways
   the ones that don't are fetched off the device
+- `notes/dependency-injection.md` — what Dagger and Metro leave in a heap dump, why the owner rule is
+  about the provider rather than the component, and how to dump really generated code
 
 Update these in the same change that makes them stale. They're for agents, so keep them short and
 skip anything derivable from the code.

--- a/shark/shark-explorer/notes/dependency-injection.md
+++ b/shark/shark-explorer/notes/dependency-injection.md
@@ -1,0 +1,110 @@
+# Dependency injection singletons
+
+What a heap dump of an app using Dagger or Metro actually contains, measured by generating both with
+real code generation and dumping the result. This is what the owner rule in `OwnerReferences` was
+written from, and what to re-measure against when either framework moves.
+
+Measured against **Dagger 2.60.1** and **Metro 1.4.0**.
+
+## Nothing in a heap dump says which object is a component
+
+Which is the finding that shaped the rule. The tempting design — a virtual reference from a component
+to each of its singletons, the way `ViewChildReferenceReader` gives a `ViewGroup` one per child —
+needs to be able to point at the component, and neither framework leaves a mark to point at.
+
+| | Generated component | Generated child |
+| --- | --- | --- |
+| Dagger | `DaggerProbeDaggerComponent$ProbeDaggerComponentImpl` | `DaggerProbeDaggerComponent$ProbeDaggerSubcomponentImpl` |
+| Metro | `ProbeMetroGraph$Impl` | `ProbeMetroGraph$Impl$ProbeMetroGraphExtensionImpl` |
+
+Dagger's is at least guessable from the name, though only by a convention it doesn't promise. Metro's
+is an `Impl` nested in the app's own graph interface: no marker interface, no annotation retained at
+runtime, no name to match on. `ProbeMetroGraph$Impl` and any other `Foo$Impl` in the app are the same
+shape.
+
+So **the rule is about the provider, not the component**. A provider is a class of the framework, by
+name, and the component collects the singleton's bytes anyway — one step further down the tree, since
+it is what holds every provider.
+
+## The providers
+
+Both frameworks memoize a scoped binding in a `DoubleCheck`, and both leave one shared sentinel object
+in the instance field until something first asks. Verified from the jars with `javap -p`:
+
+| | Class holding the instance | Instance field | Sentinel |
+| --- | --- | --- | --- |
+| Dagger | `dagger.internal.DoubleCheck` | `instance` | `dagger.internal.DoubleCheck.UNINITIALIZED` |
+| Metro | `dev.zacsweers.metro.internal.BaseDoubleCheck` | `_value` | `dev.zacsweers.metro.internal.BaseDoubleCheckKt.UNINITIALIZED` |
+
+Three things there are worth knowing before editing the rule:
+
+- **Metro declares the field on the superclass.** `dev.zacsweers.metro.internal.DoubleCheck` is what
+  generated code instantiates, `BaseDoubleCheck` is where `_value` lives, and the rule names the
+  superclass so that both it and anything else extending it are covered.
+- **Metro's sentinel is on a different class from the field.** `BaseDoubleCheckKt` is the file facade
+  for `BaseDoubleCheck.kt`, which is where a top level `private val UNINITIALIZED` ends up. Dagger's is
+  a static on `DoubleCheck` itself. That's why the rule carries a holder class name per framework
+  rather than assuming the sentinel is on the provider.
+- **Both null out `provider` once initialised**, so the unscoped factory a provider was built from is
+  not in the dump once the singleton exists, and can't be used to identify anything.
+
+## Neither framework's code generation runs in this build
+
+`DependencyInjectionOwnerTest` builds providers through `DoubleCheck.provider` and writes the
+components by hand. Dagger's annotation processor could run here — it's KSP, which this repo already
+has — but **Metro's cannot**: its Gradle plugin and compiler plugin are Java 21 bytecode, and both
+this repo and CI are Java 17, so the Kotlin compiler here can't load it
+(`UnsupportedClassVersionError: … class file version 65.0 … only recognizes up to 61.0`). Making it
+possible would mean moving the build's Kotlin daemon to JDK 21, which is a repo-wide decision for one
+test's sake.
+
+Since the rule names no generated class, hand-writing the components costs the test nothing: what it
+has to get right is the provider, and those are the frameworks' own.
+
+## Taking another dump of really generated code
+
+A throwaway Gradle project outside the repo, which is how the tables above were measured. Both
+frameworks in one project so that one dump answers for both:
+
+```kotlin
+// build.gradle.kts
+plugins {
+  kotlin("jvm") version "2.4.10"
+  id("com.google.devtools.ksp") version "2.3.10"
+  id("dev.zacsweers.metro") version "1.4.0"
+  application
+}
+kotlin { jvmToolchain(21) }
+application { mainClass.set("probe.MainKt") }
+dependencies {
+  implementation("com.google.dagger:dagger:2.60.1")
+  ksp("com.google.dagger:dagger-compiler:2.60.1")
+}
+```
+
+```properties
+# gradle.properties — jvmToolchain(21) alone isn't enough, the Kotlin daemon still starts on the
+# JVM Gradle runs on, and Metro's compiler plugin won't load there.
+kotlin.compiler.execution.strategy=in-process
+```
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 21) gradle --no-daemon -q run --args="/tmp/di-probe.hprof"
+```
+
+`main` keeps every object it asks for in a list, then dumps with
+`HotSpotDiagnosticMXBean.dumpHeap(path, false)`. Two things to get right in the fixtures:
+
+- **`@Singleton` goes on the binding, not only on the component.** A component annotated `@Singleton`
+  whose bindings aren't generates no `DoubleCheck` at all, and the dump looks like the framework
+  doesn't memoize.
+- **Give one scoped binding a dependency on another**, which is what makes Dagger emit a
+  `SwitchingProvider` rather than a direct factory, and one injection site an `@Inject Provider<Foo>`
+  field, which is the case where something other than the component holds the provider too.
+
+Open the result the usual way:
+
+```bash
+./gradlew :shark:shark-explorer:shark-explorer-app:runNamed \
+  --args="--title=\"DI probe\" /tmp/di-probe.hprof"
+```

--- a/shark/shark-explorer/shark-explorer-core/build.gradle.kts
+++ b/shark/shark-explorer/shark-explorer-core/build.gradle.kts
@@ -12,4 +12,9 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.assertjCore)
   testImplementation(projects.shark.sharkHprofTest)
+  // So that the owner rule about dependency injection singletons is tested against the providers Dagger
+  // and Metro really build, rather than against this repo's idea of them. Runtimes only — no annotation
+  // processor and no compiler plugin run here, see DependencyInjectionOwnerTest.
+  testImplementation(libs.dagger.runtime)
+  testImplementation(libs.metro.runtime)
 }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
@@ -9,6 +9,8 @@ import shark.HeapObject
 import shark.HeapObject.HeapClass
 import shark.HeapObject.HeapInstance
 import shark.Reference
+import shark.explorer.OwnedObjects.HeldByScopedProviders
+import shark.explorer.OwnedObjects.InstancesOf
 
 /**
  * A construct where one reference is the one that really holds an object, and every other reference to
@@ -28,8 +30,8 @@ import shark.Reference
  * expressed by which references exist.
  */
 internal class OwnerRule(
-  /** The class whose instances something owns, subclasses included. */
-  val ownedClassName: String,
+  /** Which objects of a heap dump the rule is about. */
+  val ownedObjects: OwnedObjects,
   /**
    * The fields that own what they point at, by the name of the class declaring them. Read against the
    * whole class hierarchy of the referring object, so a rule on a base class covers every subclass.
@@ -44,6 +46,55 @@ internal class OwnerRule(
    * whichever slot of whichever array each one is really in.
    */
   val ownerVirtualClassNames: Set<String> = emptySet()
+)
+
+/**
+ * How an [OwnerRule] says which objects of a heap dump it is about.
+ *
+ * Two ways, because the cheap one doesn't always apply. Naming a class is a scan of two indexes and no
+ * object record, so it's the one to reach for — but it needs the owned objects to have a class in
+ * common, and the objects of some constructs have nothing in common but where they're held.
+ */
+internal sealed class OwnedObjects {
+
+  /** Every instance of [className] and of its subclasses, which the heap dump index answers on its own. */
+  class InstancesOf(val className: String) : OwnedObjects()
+
+  /**
+   * Whatever the [providers] are holding, whatever its class — for a dependency injection singleton,
+   * which is any type at all. What makes an object one is a provider caching it, so there is nothing
+   * about the object itself to recognise, and this reads the providers to find out.
+   */
+  class HeldByScopedProviders(val providers: List<ScopedProvider>) : OwnedObjects()
+}
+
+/**
+ * A dependency injection framework's scoped provider: the object a generated component keeps a binding's
+ * instance in, so that every injection point of that scope is handed the same one.
+ *
+ * Named per framework rather than found by shape, since a provider is an ordinary class with an ordinary
+ * field and nothing in a heap dump marks it. Each entry is four names, and all four are checkable against
+ * a dump of an app using the framework — a wrong one doesn't fail, it silently stops finding singletons.
+ */
+internal class ScopedProvider(
+  /**
+   * The provider class, subclasses included, so that naming Metro's `BaseDoubleCheck` covers the
+   * `DoubleCheck` its generated code really instantiates.
+   */
+  val className: String,
+  /** The field the provider caches the instance in, once something has asked it for one. */
+  val instanceFieldName: String,
+  /** The class declaring the static field below, which is the provider's own only for Dagger. */
+  val uninitializedHolderClassName: String,
+  /**
+   * The static field holding what [instanceFieldName] points at until something asks: one sentinel object
+   * the framework shares between every provider in the process.
+   *
+   * Which has to be skipped rather than ignored, because it is a real object that real fields point at.
+   * Counting it as owned would hand a bare `Object` to whichever provider hadn't been asked yet and take
+   * the static field that does hold it out of the tree.
+   */
+  val uninitializedFieldName: String
 )
 
 /**
@@ -178,6 +229,31 @@ internal class OwnerReferences private constructor(
     private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
 
     /**
+     * The scoped providers of the dependency injection frameworks the explorer knows about, read off a
+     * heap dump of an app built with each — see `notes/dependency-injection.md`.
+     *
+     * Both frameworks null the provider's own `provider` field once it has produced the instance, so a
+     * live provider points at nothing but its singleton.
+     */
+    private val SCOPED_PROVIDERS = listOf(
+      // Dagger keeps the sentinel on the provider class itself.
+      ScopedProvider(
+        className = "dagger.internal.DoubleCheck",
+        instanceFieldName = "instance",
+        uninitializedHolderClassName = "dagger.internal.DoubleCheck",
+        uninitializedFieldName = "UNINITIALIZED"
+      ),
+      // Metro's is a top level property of the file declaring the class, so it lives on the file's facade
+      // class rather than on the provider — which is why this needs a class name of its own.
+      ScopedProvider(
+        className = "dev.zacsweers.metro.internal.BaseDoubleCheck",
+        instanceFieldName = "_value",
+        uninitializedHolderClassName = "dev.zacsweers.metro.internal.BaseDoubleCheckKt",
+        uninitializedFieldName = "UNINITIALIZED"
+      )
+    )
+
+    /**
      * The constructs the explorer knows about. Curated: each one is a claim that a reference is *the* way
      * an object is held, and getting that wrong moves bytes to the wrong place in the tree.
      */
@@ -190,7 +266,7 @@ internal class OwnerReferences private constructor(
       // so a rule about View[] also hands ownership to an app's own array of views it merely points at,
       // and it leaves a hierarchy hanging off an unnamed array at every level of the tree.
       OwnerRule(
-        ownedClassName = VIEW_CLASS_NAME,
+        ownedObjects = InstancesOf(VIEW_CLASS_NAME),
         ownerVirtualClassNames = setOf(ViewChildReferenceReader.VIEW_GROUP_CLASS_NAME)
       ),
       // The root view of a hierarchy has no parent to own it, and belongs to whatever the hierarchy is
@@ -207,7 +283,7 @@ internal class OwnerReferences private constructor(
       // monitor held the window from a GC root of its own, which cost the activity all 18 MB of its
       // hierarchy. One owner per construct, and it should be the one you'd want to read the bytes under.
       OwnerRule(
-        ownedClassName = VIEW_CLASS_NAME,
+        ownedObjects = InstancesOf(VIEW_CLASS_NAME),
         ownerFieldsByClassName = mapOf(
           ACTIVITY_CLASS_NAME to setOf("mDecor"),
           "android.app.Dialog" to setOf("mDecor")
@@ -227,8 +303,32 @@ internal class OwnerReferences private constructor(
       // screen spends three of its steps on a map's bookkeeping and the thread's own rectangle is a pile of
       // records rather than a row of screens to compare.
       OwnerRule(
-        ownedClassName = ACTIVITY_CLASS_NAME,
+        ownedObjects = InstancesOf(ACTIVITY_CLASS_NAME),
         ownerVirtualClassNames = setOf(RunningActivityReferenceReader.ACTIVITY_THREAD_CLASS_NAME)
+      ),
+      // A dependency injection singleton is held by the provider its component caches it in, and every
+      // other reference to one is an injection site the component handed it to. Which is nearly always a
+      // lot of them, all over the app, so without this rule a singleton is dominated by whatever dominates
+      // the whole graph of things that were injected with it — the top of the tree. Measured on a JVM dump
+      // of a Dagger and a Metro component: every scoped instance came out under the root, and under this
+      // rule every one of them came out under its own component.
+      //
+      // The provider and not the component, though the component is what you'd want to read the bytes
+      // under, because **nothing in a heap dump says which object is a component**. Dagger's generated one
+      // is a `DaggerAppComponent$AppComponentImpl`, which a name could just about catch; Metro's is an
+      // `AppGraph$Impl`, an `Impl` nested in the interface the app declared, with no marker of any kind.
+      // A rule about the provider needs no such guess, and the component still collects the bytes, one
+      // step further down: it is what holds every provider.
+      //
+      // Self-clearing in the way the rest of these are. A provider never lets go of its instance, so there
+      // is no state to check: while the component is reachable so is the provider, and once the component
+      // is gone the provider is gone with it, no owner reaches the singleton, and whatever is still
+      // pointing at it is both how it's held and what's leaking it.
+      OwnerRule(
+        ownedObjects = HeldByScopedProviders(SCOPED_PROVIDERS),
+        ownerFieldsByClassName = SCOPED_PROVIDERS.associate {
+          it.className to setOf(it.instanceFieldName)
+        }
       )
     )
 
@@ -243,43 +343,97 @@ internal class OwnerReferences private constructor(
      */
     fun computeFor(graph: HeapGraph): OwnerReferences {
       val ownedClassIds = MutableLongSet()
-      RULES.mapTo(mutableSetOf()) { it.ownedClassName }.forEach { className ->
-        graph.findClassByName(className)?.let { ownedClassIds += it.objectId }
+      RULES.mapNotNullTo(mutableSetOf()) { (it.ownedObjects as? InstancesOf)?.className }
+        .forEach { className ->
+          graph.findClassByName(className)?.let { ownedClassIds += it.objectId }
+        }
+      val scopedProviders = RULES.flatMap {
+        (it.ownedObjects as? HeldByScopedProviders)?.providers.orEmpty()
       }
       return OwnerReferences(
         graph = graph,
-        ownedObjectIds = ownedObjectIdsOf(graph, ownedClassIds),
+        ownedObjectIds = ownedObjectIdsOf(graph, ownedClassIds, scopedProviders),
         ownerFieldsByClassName = ownerFieldsByClassName(),
         ownerVirtualClassNames = RULES.flatMapTo(mutableSetOf()) { it.ownerVirtualClassNames }
       )
     }
 
     /**
-     * The instances of [ownedClassIds] and of their subclasses, by object id.
+     * The instances of [ownedClassIds] and of their subclasses, plus what the [scopedProviders] found in
+     * the same pass are holding, by object id.
      *
-     * Reads no object record: an instance's class comes from the heap dump index, and so does the
-     * superclass of a class, so this is a scan of two indexes.
+     * The class half reads no object record: an instance's class comes from the heap dump index, and so
+     * does the superclass of a class, so it is a scan of two indexes. The provider half then reads one
+     * record per provider, which is one per binding a component has been asked for rather than one per
+     * object — a few thousand at the very most, against the millions the index pass walks past.
      */
     private fun ownedObjectIdsOf(
       graph: HeapGraph,
-      ownedClassIds: LongSet
+      ownedClassIds: LongSet,
+      scopedProviders: List<ScopedProvider>
     ): LongSet {
       val ownedObjectIds = MutableLongSet()
-      if (ownedClassIds.isEmpty()) {
-        return ownedObjectIds
-      }
-      val subclassIds = MutableLongSet()
-      graph.classes.forEach { heapClass ->
-        if (heapClass.classHierarchy.any { ownedClassIds.contains(it.objectId) }) {
-          subclassIds += heapClass.objectId
+      // Only the frameworks the heap dump has classes for, so an app using neither pays one class lookup
+      // per framework and nothing else.
+      val providerByDeclaringClassId = MutableLongObjectMap<ScopedProvider>()
+      scopedProviders.forEach { provider ->
+        graph.findClassByName(provider.className)?.let {
+          providerByDeclaringClassId[it.objectId] = provider
         }
       }
+      if (ownedClassIds.isEmpty() && providerByDeclaringClassId.isEmpty()) {
+        return ownedObjectIds
+      }
+      // Both halves need the subclasses of a named class, so both read them out of the one pass:
+      // HeapClass.subclasses is a scan of every class of the dump, and there are several names here.
+      val subclassIds = MutableLongSet()
+      val providerByClassId = MutableLongObjectMap<ScopedProvider>()
+      graph.classes.forEach { heapClass ->
+        heapClass.classHierarchy.forEach { superclass ->
+          if (ownedClassIds.contains(superclass.objectId)) {
+            subclassIds += heapClass.objectId
+          }
+          providerByDeclaringClassId[superclass.objectId]?.let {
+            providerByClassId[heapClass.objectId] = it
+          }
+        }
+      }
+      val providerInstances = mutableListOf<HeapInstance>()
       graph.instances.forEach { instance ->
         if (subclassIds.contains(instance.instanceClassId)) {
           ownedObjectIds += instance.objectId
         }
+        if (providerByClassId.containsKey(instance.instanceClassId)) {
+          providerInstances += instance
+        }
+      }
+      val uninitializedValueIds = uninitializedValueIdsOf(graph, providerByDeclaringClassId)
+      providerInstances.forEach { providerInstance ->
+        val provider = providerByClassId[providerInstance.instanceClassId]!!
+        val heldObjectId = providerInstance[provider.className, provider.instanceFieldName]
+          ?.value
+          ?.asNonNullObjectId
+        if (heldObjectId != null && !uninitializedValueIds.contains(heldObjectId)) {
+          ownedObjectIds += heldObjectId
+        }
       }
       return ownedObjectIds
+    }
+
+    /** The sentinel each of the frameworks present in [graph] leaves in a provider nothing has asked yet. */
+    private fun uninitializedValueIdsOf(
+      graph: HeapGraph,
+      providerByDeclaringClassId: MutableLongObjectMap<ScopedProvider>
+    ): LongSet {
+      val uninitializedValueIds = MutableLongSet()
+      providerByDeclaringClassId.forEachValue { provider ->
+        graph.findClassByName(provider.uninitializedHolderClassName)
+          ?.get(provider.uninitializedFieldName)
+          ?.value
+          ?.asNonNullObjectId
+          ?.let { uninitializedValueIds += it }
+      }
+      return uninitializedValueIds
     }
 
     /** [RULES]' owner fields merged, so that two rules on the same class both hold. */

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/DependencyInjectionOwnerTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/DependencyInjectionOwnerTest.kt
@@ -1,0 +1,303 @@
+package shark.explorer
+
+import com.sun.management.HotSpotDiagnosticMXBean
+import dagger.internal.DoubleCheck as DaggerDoubleCheck
+import dev.zacsweers.metro.internal.DoubleCheck as MetroDoubleCheck
+import java.io.File
+import java.lang.management.ManagementFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import shark.explorer.ReachabilityStrength.UNREACHABLE
+import dagger.internal.Provider as DaggerProvider
+import dev.zacsweers.metro.Provider as MetroProvider
+
+/**
+ * What the explorer makes of a dependency injection singleton, in a heap dump of a real JVM holding real
+ * Dagger and real Metro providers — the class names, the field names and the sentinel a provider holds
+ * before anything has asked it are each framework's own rather than this repo's idea of them.
+ *
+ * **The providers are built the way generated code builds them**, through `DoubleCheck.provider`, but the
+ * components holding them are written here rather than generated. That is the point rather than a
+ * shortcut: the rule in [OwnerReferences] never names a component, because nothing in a heap dump says
+ * which object is one — Dagger's generated component is a `DaggerAppComponent$AppComponentImpl`, Metro's
+ * is an `AppGraph$Impl`, an `Impl` nested in the app's own interface with no marker of any kind. What the
+ * rule does depend on is the provider, and these are the frameworks' own.
+ *
+ * Neither framework's code generation runs in this build. Dagger's could: it is an annotation processor
+ * and this repo already runs KSP. **Metro's cannot** — its compiler plugin is Java 21 bytecode and this
+ * repo builds with Java 17, so the Kotlin compiler here can't load it. `notes/dependency-injection.md`
+ * records a dump of really generated code from both frameworks, and how to take another one.
+ *
+ * The dump is written without collecting first and left in `build/heap-dumps`, for the reasons
+ * [JvmReferenceStrengthTest] gives. To open the explorer on the same heap dump these assertions ran
+ * against:
+ *
+ * ```
+ * ./gradlew :shark:shark-explorer:shark-explorer-app:runNamed --args="--title=\"DI singletons\" \
+ *   shark/shark-explorer/shark-explorer-core/build/heap-dumps/dependency-injection.hprof"
+ * ```
+ */
+class DependencyInjectionOwnerTest {
+
+  @Test fun `a Dagger singleton is held by the provider its component caches it in`() {
+    val singleton = explorer.tree.onlyInstanceOf("DaggerSingleton")
+
+    // Two other objects point at it, both closer to a GC root than the component is, which is the shape of
+    // an injected singleton: whatever was injected with one usually hangs off something nearer a root than
+    // the component, and none of those collaborators is where the singleton's bytes belong.
+    assertThat(explorer.tree.dominatorOf(singleton.objectId)!!.label).isEqualTo("DoubleCheck")
+    assertThat(explorer.tree.rootPathTo(singleton.objectId).stepLabels().takeLast(2)).containsExactly(
+      "singletonProvider → DoubleCheck",
+      "instance → DaggerSingleton"
+    )
+  }
+
+  @Test fun `a Metro singleton is held by the provider its graph caches it in`() {
+    val singleton = explorer.tree.onlyInstanceOf("MetroSingleton")
+
+    assertThat(explorer.tree.dominatorOf(singleton.objectId)!!.label).isEqualTo("DoubleCheck")
+    // `_value`, not `instance`: Metro declares the field on `BaseDoubleCheck`, which is why the rule names
+    // a class and a field per framework rather than assuming one shape covers both.
+    assertThat(explorer.tree.rootPathTo(singleton.objectId).stepLabels().takeLast(2)).containsExactly(
+      "singletonProvider → DoubleCheck",
+      "_value → MetroSingleton"
+    )
+  }
+
+  @Test fun `a component collects the bytes of every singleton it caches`() {
+    // Which is what the rule is for. Without it each of these is dominated by the whole heap dump, because
+    // the injection sites are spread over everything the component built.
+    listOf(
+      "DaggerComponent" to "DaggerSingleton",
+      "MetroGraph" to "MetroSingleton"
+    ).forEach { (componentName, singletonName) ->
+      val component = explorer.tree.onlyInstanceOf(componentName)
+      val singleton = explorer.tree.onlyInstanceOf(singletonName)
+
+      // The provider is a node between the two, holding its own handful of bytes, so the component
+      // retains the singleton one step further down rather than immediately.
+      assertThat(explorer.tree.dominatorLabelsOf(singleton.objectId))
+        .startsWith("DoubleCheck", componentName)
+      assertThat(explorer.tree.weight(component.objectId))
+        .isGreaterThan(explorer.tree.weight(singleton.objectId))
+    }
+  }
+
+  @Test fun `a singleton whose provider something else holds too is held by neither`() {
+    val shared = explorer.tree.onlyInstanceOf("SharedProviderSingleton")
+
+    // An `@Inject Provider<Foo>` field is handed the component's own provider, so two objects hold it and
+    // the tree says what is true: neither of them is where the singleton's bytes belong. The rule stops
+    // the sites holding the *instance* from scattering it and claims nothing beyond that.
+    assertThat(explorer.tree.dominatorOf(shared.objectId)!!.label).isEqualTo("DoubleCheck")
+    assertThat(explorer.tree.dominatorLabelsOf(shared.objectId)).doesNotContain("DaggerComponent")
+  }
+
+  @Test fun `a provider nothing has asked yet holds no singleton of its own`() {
+    // Until something asks, both frameworks leave one sentinel object in the field, shared by every
+    // provider in the process. One provider per framework here was never asked, so both sentinels are in
+    // the dump with a provider pointing at them.
+    val sentinelIds = explorer.tree.instancesOf("DoubleCheck")
+      .mapNotNull { doubleCheck ->
+        explorer.tree.summarize(doubleCheck.objectId)
+          .fields
+          .single { it.name == "instance" || it.name == "_value" }
+          .inspectableObjectId
+      }
+      .filter { explorer.tree.label(it) == "Object" }
+
+    assertThat(sentinelIds).hasSize(2)
+    sentinelIds.forEach { sentinelId ->
+      // Counting a sentinel as a singleton would hand a bare Object to whichever provider reached it
+      // first, and take the static field that really holds it out of the tree.
+      assertThat(explorer.tree.dominatorOf(sentinelId)!!.label).isNotEqualTo("DoubleCheck")
+      assertThat(explorer.tree.independentPathsFromRoots(sentinelId).paths.map { it.stepLabels().last() })
+        .contains("UNINITIALIZED → Object")
+    }
+  }
+
+  @Test fun `a singleton whose component is gone is held by what points at it after all`() {
+    // The dump is written without collecting, so the dropped component is still in it, and the explorer
+    // draws it as what it is: nothing reaches it from a GC root, so neither its bytes nor its provider's
+    // are attributed to anything.
+    assertThat(explorer.tree.onlyInstanceOf("DroppedComponent").strength).isEqualTo(UNREACHABLE)
+    val dropped = explorer.tree.onlyInstanceOf("DroppedSingleton")
+
+    // Which is the whole of "unless the component is destroyed", and is why the rule needs no state
+    // check: a provider never lets go of its instance, so the way a component stops owning its
+    // singletons is by being collected, provider and all. The owner reference then never turns up
+    // during the walk, and what is still pointing at the singleton is both how it's held and what's
+    // leaking it — which is exactly what there is to be shown.
+    assertThat(explorer.tree.dominatorOf(dropped.objectId)!!.label).isEqualTo("DroppedInjectionSite")
+    assertThat(explorer.tree.rootPathTo(dropped.objectId).stepLabels().takeLast(2)).containsExactly(
+      "droppedSite → DroppedInjectionSite",
+      "singleton → DroppedSingleton"
+    )
+  }
+
+  companion object {
+
+    private val HEAP_DUMP_FILE = File("build/heap-dumps", "dependency-injection.hprof")
+
+    /** One heap dump for the whole class, as in [JvmReferenceStrengthTest]. */
+    private lateinit var explorer: HeapExplorer
+
+    @BeforeClass @JvmStatic fun openHeapDumpOfThisJvm() {
+      Components.build()
+      // Everything the tests that ran before left behind goes now, so that the dump is the live set and
+      // these components rather than a hundred megabytes of somebody else's garbage.
+      System.gc()
+      // After the collection rather than before it, so that one component and its provider are in the
+      // dump as garbage, the way a destroyed component is in a heap dump taken from an app. Fragile in
+      // the way [JvmReferenceStrengthTest] describes: a collection between here and the dump takes it.
+      Components.dropped = null
+
+      HEAP_DUMP_FILE.parentFile.mkdirs()
+      // Left behind by the last run, and the MBean refuses to overwrite a file.
+      HEAP_DUMP_FILE.delete()
+      val mBean = ManagementFactory.newPlatformMXBeanProxy(
+        ManagementFactory.getPlatformMBeanServer(),
+        "com.sun.management:type=HotSpotDiagnostic",
+        HotSpotDiagnosticMXBean::class.java
+      )
+      mBean.dumpHeap(HEAP_DUMP_FILE.absolutePath, false)
+      explorer = HeapExplorer.open(HEAP_DUMP_FILE)
+    }
+
+    @AfterClass @JvmStatic fun closeHeapDump() {
+      explorer.close()
+    }
+  }
+}
+
+/*
+ * What the heap dump holds, one top level class per thing so that each is found by its own name and drawn
+ * as its own rectangle, the way [JvmReferenceStrengthTest] does it.
+ */
+
+/**
+ * Where all of it is held from: a Kotlin object, so a field here is a field of a singleton its own class's
+ * static points at, which is a GC root.
+ *
+ * The injection sites hang off here too, and are therefore each closer to a GC root than the component is.
+ * That is the difficulty the owner rule exists for, and it is how a real app looks.
+ */
+private object Components {
+  @JvmField var dagger: DaggerComponent? = null
+  @JvmField var metro: MetroGraph? = null
+  @JvmField var daggerSite: DaggerInjectionSite? = null
+  @JvmField var metroSite: MetroInjectionSite? = null
+  @JvmField var providerSite: ProviderInjectionSite? = null
+
+  /** Set to null once the heap is collected, so that the dump holds a component nothing reaches. */
+  @JvmField var dropped: DroppedComponent? = null
+  @JvmField var droppedSite: DroppedInjectionSite? = null
+
+  fun build() {
+    val daggerComponent = DaggerComponent()
+    val metroGraph = MetroGraph()
+    val droppedComponent = DroppedComponent()
+    dagger = daggerComponent
+    metro = metroGraph
+    dropped = droppedComponent
+    // Asking a provider is what makes it cache an instance, which is the state the rule is about. The two
+    // deliberately left unasked are `neverAskedProvider` on each component.
+    val daggerSingleton = daggerComponent.singletonProvider.get()
+    val metroSingleton = metroGraph.singletonProvider()
+    val sharedSingleton = daggerComponent.sharedProvider.get()
+    // Two sites per singleton rather than one, so that no singleton has a single rival that could dominate
+    // it on its own — what the tree has to fall back on is a lowest common dominator of several.
+    daggerSite = DaggerInjectionSite(daggerSingleton, DaggerInjectionSite(daggerSingleton, null))
+    metroSite = MetroInjectionSite(metroSingleton, MetroInjectionSite(metroSingleton, null))
+    providerSite = ProviderInjectionSite(daggerComponent.sharedProvider, sharedSingleton)
+    droppedSite = DroppedInjectionSite(droppedComponent.singletonProvider.get())
+  }
+}
+
+private const val KB = 1024
+
+/** A singleton, which in a heap dump is any object at all: what makes it one is a provider caching it. */
+private class DaggerSingleton {
+  @JvmField val bytes = ByteArray(64 * KB)
+}
+
+private class MetroSingleton {
+  @JvmField val bytes = ByteArray(48 * KB)
+}
+
+/** The one whose provider an injection site holds as well, the way an `@Inject Provider<Foo>` field does. */
+private class SharedProviderSingleton {
+  @JvmField val bytes = ByteArray(32 * KB)
+}
+
+private class NeverAskedSingleton
+
+/** The one whose component is collected before the dump, leaving the injection site holding it alone. */
+private class DroppedSingleton {
+  @JvmField val bytes = ByteArray(16 * KB)
+}
+
+/**
+ * Stands in for the class Dagger generates: one `DoubleCheck` field per scoped binding, built with the
+ * call the generated code makes.
+ */
+private class DaggerComponent {
+  @JvmField val singletonProvider: DaggerProvider<DaggerSingleton> =
+    DaggerDoubleCheck.provider<DaggerSingleton>(newDaggerProvider { DaggerSingleton() })
+
+  @JvmField val sharedProvider: DaggerProvider<SharedProviderSingleton> =
+    DaggerDoubleCheck.provider<SharedProviderSingleton>(newDaggerProvider { SharedProviderSingleton() })
+
+  @JvmField val neverAskedProvider: DaggerProvider<NeverAskedSingleton> =
+    DaggerDoubleCheck.provider<NeverAskedSingleton>(newDaggerProvider { NeverAskedSingleton() })
+}
+
+/** A component of its own class, so that collecting it doesn't take a second [DaggerComponent] with it. */
+private class DroppedComponent {
+  @JvmField val singletonProvider: DaggerProvider<DroppedSingleton> =
+    DaggerDoubleCheck.provider<DroppedSingleton>(newDaggerProvider { DroppedSingleton() })
+}
+
+/** The same for Metro, whose generated graph is an `Impl` nested in the app's own graph interface. */
+private class MetroGraph {
+  @JvmField val singletonProvider: MetroProvider<MetroSingleton> =
+    MetroDoubleCheck.provider(newMetroProvider { MetroSingleton() })
+
+  @JvmField val neverAskedProvider: MetroProvider<NeverAskedSingleton> =
+    MetroDoubleCheck.provider(newMetroProvider { NeverAskedSingleton() })
+}
+
+/**
+ * The unscoped provider a `DoubleCheck` wraps, written out rather than built with either framework's own
+ * helper: Dagger's `Provider` is a Java interface reached through two overloads Kotlin can't tell apart,
+ * and Metro's `provider { }` is an inline function compiled for Java 11, which won't inline into the Java
+ * 8 bytecode every module here but the desktop app is built as.
+ */
+private fun <T : Any> newDaggerProvider(create: () -> T) = object : DaggerProvider<T> {
+  override fun get(): T = create()
+}
+
+private fun <T : Any> newMetroProvider(create: () -> T) = object : MetroProvider<T> {
+  override fun invoke(): T = create()
+}
+
+private class DaggerInjectionSite(
+  @JvmField val singleton: DaggerSingleton,
+  @JvmField val alsoHere: DaggerInjectionSite?
+)
+
+private class MetroInjectionSite(
+  @JvmField val singleton: MetroSingleton,
+  @JvmField val alsoHere: MetroInjectionSite?
+)
+
+/** One rival and no other, so that what holds the singleton once its component is gone is unambiguous. */
+private class DroppedInjectionSite(@JvmField val singleton: DroppedSingleton)
+
+/** Holds the component's own provider rather than the instance, the way `@Inject Provider<Foo>` does. */
+private class ProviderInjectionSite(
+  @JvmField val sharedProvider: DaggerProvider<SharedProviderSingleton>,
+  @JvmField val singleton: SharedProviderSingleton
+)

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapReading.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapReading.kt
@@ -22,6 +22,17 @@ internal fun HeapDominatorTreemap.instancesOf(simpleClassName: String): List<Obj
 internal fun HeapDominatorTreemap.onlyInstanceOf(simpleClassName: String): ObjectListEntry =
   instancesOf(simpleClassName).single()
 
+/** Every object the tree has between [objectId] and its root, nearest first. */
+internal fun HeapDominatorTreemap.dominatorLabelsOf(objectId: Long): List<String> {
+  val labels = mutableListOf<String>()
+  var dominator = dominatorOf(objectId)
+  while (dominator != null) {
+    labels += dominator.label
+    dominator = if (dominator.kind == DominatorKind.OBJECT) dominatorOf(dominator.nodeId) else null
+  }
+  return labels
+}
+
 /** Every object of the tree, walked past the groups, which stand for objects rather than being one. */
 internal fun HeapDominatorTreemap.allSummaries(): List<HeapObjectSummary> {
   val summaries = mutableListOf<HeapObjectSummary>()


### PR DESCRIPTION
An owner rule for the explorer: a dependency injection singleton is held by the provider its component caches it in, and every other reference to one is an injection site the component handed it to.

Without it a singleton is dominated by whatever dominates the whole graph of things that were injected with it — which on a real app is the top of the tree. Measured on a JVM dump of a Dagger and a Metro component: every scoped instance came out under the root, and under this rule every one of them came out under its own component.

### Why the provider and not the component

The component is what you'd want to read the bytes under, and the tempting design is a virtual reference from it to each of its singletons, the way `ViewChildReferenceReader` gives a `ViewGroup` one per child. That needs to be able to point at the component, and **nothing in a heap dump says which object is one**:

| | Generated component | Generated child |
| --- | --- | --- |
| Dagger | `DaggerAppComponent$AppComponentImpl` | `DaggerAppComponent$AppSubcomponentImpl` |
| Metro | `AppGraph$Impl` | `AppGraph$Impl$AppExtensionImpl` |

Dagger's is guessable from the name, by a convention it doesn't promise. Metro's is an `Impl` nested in the interface the app declared — no marker interface, no runtime annotation, no name to match on, indistinguishable from any other `Foo$Impl` in the app.

A rule about the provider needs no such guess, and the component still collects the bytes one step further down, being what holds every provider. The cost is one `DoubleCheck` node between the two.

Both frameworks memoize in a `DoubleCheck`, and both leave a shared sentinel in the instance field until first use, which the rule skips by reading the framework's own static field rather than by a heuristic:

| | Class holding the instance | Instance field | Sentinel |
| --- | --- | --- | --- |
| Dagger 2.60.1 | `dagger.internal.DoubleCheck` | `instance` | `dagger.internal.DoubleCheck.UNINITIALIZED` |
| Metro 1.4.0 | `dev.zacsweers.metro.internal.BaseDoubleCheck` | `_value` | `dev.zacsweers.metro.internal.BaseDoubleCheckKt.UNINITIALIZED` |

Metro declares the field on the superclass and puts the sentinel on the file facade of the file declaring it, which is why an entry is four names rather than two.

### Self-clearing, like the rest of the rules

An owner rule says nothing about the state of the owned object — that's what makes it cheap and what makes it right. A provider never lets go of its instance, so there is no "unless the component is destroyed" check to write: while the component is reachable so is the provider, and once the component is collected the provider goes with it, no owner reaches the singleton, and what is still pointing at it is both how it's held and what's leaking it. `a singleton whose component is gone is held by what points at it after all` covers exactly that, dropping a component after the collection so it's in the dump as garbage.

### Cost

The provider half piggybacks on the passes `OwnerReferences` already makes: the same class pass that collects subclass ids of the owned classes now also maps provider classes, and the same instance pass collects the providers. It then reads one record per provider, which is one per scoped binding that's been asked for. A heap dump with neither framework in it pays two class lookups and nothing else.

### Tests

`DependencyInjectionOwnerTest` asserts against a heap dump of the JVM running it, holding real Dagger and real Metro providers built the way generated code builds them, through `DoubleCheck.provider`. The components are written by hand, which is the point rather than a shortcut: the rule never names a component, and what it does depend on is the frameworks' own.

Neither framework's code generation runs in this build. Dagger's could — it's an annotation processor and this repo already runs KSP — but **Metro's cannot**: its Gradle plugin and compiler plugin are Java 21 bytecode and this repo and CI are Java 17, so the Kotlin compiler here can't load it. `shark/shark-explorer/notes/dependency-injection.md` records a throwaway project that runs both for real, what its dump contains, and how to take another one.

No changelog entry: the explorer's log is still a single "Initial release".