### PR TITLE
Say that docs/api is git ignored rather than committed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,11 @@ Java 8 have to be able to use the artifacts.
 ./gradlew siteDokka                   # regenerate docs/api
 ```
 
+`docs/api/` — the `siteDokka` output — is git ignored, not committed. The release process
+regenerates it just before publishing the site (see `docs/releasing.md`), so a public API change
+means updating the ABI dump and nothing else. If you do run `siteDokka`, don't edit what it writes;
+fix the KDoc in the source.
+
 Instrumentation tests need a device or emulator and only cover `leakcanary-android`,
 `leakcanary-android-core`, `leakcanary-android-instrumentation` and `leakcanary-android-test`. CI
 runs them on one emulator per major Android release, from the minSdk to the newest API level with a
@@ -66,9 +71,6 @@ pair is what Kotlin's own ABI validation documentation calls these tasks, but he
 from KGP and therefore exist *only on the JVM modules* — they silently skip every Android library
 module, which is most of the published ones. A green `updateLegacyAbi` means less than half the repo
 was covered.
-
-**`docs/api/` is generated.** It's Dokka output committed to the repo, produced by
-`./gradlew siteDokka`. Never hand-edit those files; fix the KDoc in the source instead.
 
 **Some dependency versions are deliberately old.** The `compileOnly` AndroidX versions in
 `gradle/libs.versions.toml` are pinned to the *lowest* version LeakCanary supports, so that apps


### PR DESCRIPTION
AGENTS.md claimed `docs/api` was Dokka output committed to the repo. It has been git ignored since `5abae5d77` ("Prepare 2.9 release", April 2022), which untracked every `docs/api` file and added the directory to `.gitignore` in the same commit. `git ls-files docs/api` returns nothing and the directory does not exist in a fresh clone.

Both release guides already have this right — `docs/releasing.md:155` and `docs/releasing-shark-explorer.md:81` run `rm -rf docs/api && ./gradlew siteDokka` before `mkdocs gh-deploy` precisely because the directory is not there, and the shark-explorer guide states the reason in prose. Only AGENTS.md misstated it, so this is a docs correction, not a build change.

That line sent me looking for a directory to regenerate after the public API change in #2938 — the exact failure this file exists to prevent.

### Why it moved out of "Things that will bite you"

Nothing about a generated, git-ignored directory is surprising once stated, so it is not a bite. The moment the fact is actually useful is when you have just changed the public API and are deciding what to regenerate — which is next to `updateKotlinAbi` in the command list. The contrast is the point: `updateKotlinAbi` produces something you commit, `siteDokka` does not. The half of the old warning that still holds — fix the KDoc, not the generated pages — is kept.

### Rest of the file

Checked every other factual claim for the same kind of drift; all still hold:

- `checkKotlinAbi`/`updateKotlinAbi`/`siteDokka`/`installGitHooks` all exist in the root `build.gradle.kts`, and the two-mechanism explanation matches the Android hand-rolled tasks there.
- `modulesWithoutPublicApi` exists and is the exemption list described.
- Layout table matches `settings.gradle` and the directories on disk.
- Java 8 source/target compatibility repo wide; CI runs `./gradlew build`.
- `HprofRetainedHeapPerfTest` and `HprofIOPerfTest` are both in `shark-android`.
- detekt config at `config/detekt-config.yml`, hook installed from `assemble` and `clean`.
- Changelog legend still has 💥 as crash fix and ⚠️ as breaking change.
- `assertjCore.android` pinned to 3.15.0 with the API 24 explanation in the catalog.
- `shark/shark-explorer` is the one scoped guide, paired `AGENTS.md` + `CLAUDE.md` as documented.

One thing I noticed but did not change: the instrumentation-test sentence names four modules, and `samples/leakcanary-android-sample` also has an `androidTest` source set (one test). CI does not run `connectedCheck` on it — `.github/workflows/main.yml:108` runs exactly the four modules listed — so the sentence is right about what CI covers. Flagging it in case you want the wording to distinguish "has instrumentation tests" from "CI runs them".

🤖 Generated with [Claude Code](https://claude.com/claude-code)