### PR TITLE
Make an owner rule code, and hold a screen's views through its window

### DIFF
--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -250,13 +250,14 @@ itself and retained 4.2 KB and 3.9 KB instead of their windows. The damaging ref
 view bindings and `StandardRowSpec$StandardViewHolder.itemView`.
 
 `OwnerReferences` applies a curated list of `OwnerRule`s, each one a class taking the graph and answering
-which of an owner's references own what they point at — `ownerRulesFor` in `OwnerRules.kt`. Seven today: a
-`View` owned by the `ViewGroup` that reads it as a child (see below), a decor view owned by `Activity.mDecor`
-or `Dialog.mDecor`, an `Activity` owned by the `ActivityThread` that reads it as one it's running (see below
-too), the three Compose ones in the section on Compose below, and a dependency injection singleton owned by
-the provider caching it (see `notes/dependency-injection.md`). After: **every one of the 277 child views is
-under its parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity`
-retains 18 MB under the thread running it, which is the second largest rectangle under the GC roots.
+which of an owner's references own what they point at — `ownerRulesFor` in `OwnerRules.kt`. Eight today: a
+`View` owned by the `ViewGroup` that reads it as a child (see below), a decor view owned by the `mDecor` of
+the window it is the decor of, that window owned by the `Activity` or `Dialog` it is the window of, an
+`Activity` owned by the `ActivityThread` that reads it as one it's running (see below too), the three
+Compose ones in the section on Compose below, and a dependency injection singleton owned by the provider
+caching it (see `notes/dependency-injection.md`). After: **every one of the 277 child views is under its
+parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity` retains
+18 MB under the thread running it, which is the second largest rectangle under the GC roots.
 
 **Which objects are owned is derived from those references rather than declared beside them**, and that
 distinction is load-bearing rather than tidiness. The rules used to name a class whose instances were owned —
@@ -271,6 +272,45 @@ all the way to the root. Derived, an object nothing owns is simply not owned: `P
 decor view the ordinary way, each view below it is still owned by its parent, and that `PhoneWindow` retains
 1.68 MB. Across the eight real dumps in the repo the change moved 0 to 53 objects of 34 K to 340 K, all of
 them windows and views, with the object set and every total byte count identical.
+
+**The screen a hierarchy belongs to is reached through its window, not straight from the activity.** Which is
+the other half of that `Activity.mDecor` measurement: the field is null on a live activity because
+`ActivityThread.handleResumeActivity` is the only place that writes it and does so under
+`if (r.window == null && !a.mFinished && willBeVisible)` — once per `ActivityClientRecord`, not once per
+`Activity`, so a screen recreated on a configuration change is visible, resumed and has a null `mDecor` for
+the rest of its life. `PhoneWindow.mDecor` has no such gap: every decor view in the seven real dumps here has
+exactly one referrer through it (1 of 1 in `compose_leak.hprof`, 3 of 3 in `leak_asynctask_m.hprof`, and so on).
+
+It is a decor view and not a root view, though — most root views have no window at all. 14 of the 15 in
+`compose_leak.hprof`, 9 of the 10 in `leak_asynctask_m.hprof` and 22 of the 23 in `gcroot_unknown_object.hprof`
+are `Toast` views, `PopupWindow.mContentView`, `TextView$MagnifierView`s, `Toolbar.mNavButtonView` image
+buttons and fragment roots, each held the ordinary way by whatever made it.
+
+**So the window needs a rule of its own, or moving the decor view one step down loses the screen.** A window
+has 6 to 9 referrers in these dumps, most of them its own inner classes and its decor's, and the external ones
+— `WindowManagerImpl.mParentWindow`, `ActivityThread$ActivityClientRecord.window`, `DecorView.mWindow` reached
+from a `ViewRootImpl` — put 6 of the 16 windows at the top of the tree. With only the decor rule that costs
+more than it used to, because the hierarchy now hangs off the window and floats with it:
+`gcroot_unknown_object.hprof`'s `PhoneWindow` went from 14 KB at the root to 3.09 MB there, and
+`large-dump.hprof`'s from 12 KB to 2.14 MB. With `Activity.mWindow` and `Dialog.mWindow` owning it, every
+decor view in every dump is under its window and every window of a screen that is up is under its screen.
+
+**That rule is the one whose owning reference outlives the construct it is about.** `Activity.mWindow` is set
+in `attach` and never cleared and `Dialog.mWindow` is final, so a destroyed activity and a dismissed dialog
+both go on pointing at a window they have nothing left to do with. Owning it regardless takes the window of a
+leaked screen away from whatever else is holding it: `HeapLeaksTest` went from two leaks to one, hiding the
+reference that would still have been there after the activity was fixed.
+
+So the rule owns through `mWindow` and asks whether the screen is up of *another* reference, one the framework
+does drop — the same self-clearing signal the other rules own by, borrowed from beside the one this rule owns
+through. A dialog is dropped from its own `mDecor`, which `show` sets and `dismiss` nulls; an activity is
+dropped from `ActivityThread.mActivities`, which `handleDestroyActivity` removes the record from and which the
+activity rule already owns activities by. Measured: reading the map rather than `Activity.mDestroyed` gives
+byte-identical trees and leak lists on all eight real dumps, `mActivities.size` matching the count of
+non-destroyed activities in every one of them. They fail in opposite directions, which is the reason to
+prefer the map — an `mDestroyed` a dump doesn't have reads as a screen that is up and keeps ownership, an
+`mActivities` this can't read reads as a thread running nothing and gives ownership up, which is the fallback
+every other rule already has.
 
 Deriving costs a record read per possible owner where declaring cost none: **4 ms to 26 ms** against 12 ms to
 32 ms, of the 1.5 s it takes to open these dumps. It buys the hot path back — asking whether a reference is a
@@ -291,19 +331,26 @@ rule the 82 MB dump comes out at exactly the same numbers as before — 80 MB st
 missing when you read `OwnerRules.kt`. "The parent owns an *attached* view" needs no attachment test, because a
 detached hierarchy isn't held by whatever holds the window: if the parent isn't reachable, no owner
 reference reaches the child and the fallback handles it. "Unless the activity is destroyed" needs no
-`mDestroyed` test either — `ActivityThread.handleDestroyActivity` sets `mDecor = null` and takes the
-`ActivityClientRecord` out of `mActivities`, so the framework has already removed both references the
-rules are about. The state a rule seems to need is expressed by which references exist, and a leaked
-destroyed activity therefore falls back on whatever is leaking it — which is the one thing you'd want to
-read its bytes under.
+`mDestroyed` test either — `ActivityThread.handleDestroyActivity` takes the `ActivityClientRecord` out of
+`mActivities`, so the framework has already removed the reference that rule is about. The state a rule seems
+to need is expressed by which references exist, and a leaked destroyed activity therefore falls back on
+whatever is leaking it — which is the one thing you'd want to read its bytes under.
+
+Which is the test to apply to a new rule: **ask which reference the framework drops, and own by that one or
+read it.** `ActivityWindowRule` is the case where the two are not the same reference — a record in a map is
+no owner worth putting between a thread and a screen, see the reader below — so it owns through one and reads
+the other. What no rule does is read a *field* saying what was true when the dump was taken: a boolean has no
+fallback, since a dump that doesn't carry it reads as the state that keeps ownership, and it says nothing
+about what is still pointing at what, which is the only thing parking can act on.
 
 Two things to know before adding a rule:
 
 - **One owner per construct.** Two owner references are two ways of owning, so the object ends up
-  dominated by whatever dominates both. `PhoneWindow.mDecor` was in the list at first and cost the
-  activity all 18 MB of its hierarchy: a `JankStatsMonitor` held the window from a GC root of its own, so
-  the decor view's dominator became the top of the tree. Pick the one reference you'd want to read the
-  bytes under.
+  dominated by whatever dominates both. `PhoneWindow.mDecor` and `Activity.mDecor` were both in the list at
+  first and cost the activity all 18 MB of its hierarchy: a `JankStatsMonitor` held the window from a GC root
+  of its own, so the decor view's dominator became the top of the tree. Pick the one reference you'd want to
+  read the bytes under — here the window's, with the window owned in turn, which is a chain of single owners
+  rather than two owners of one object.
 - **An owner has to be nameable.** A rule names a field on a class, or a class whose virtual references
   own. An *array* can only be named by its type, which is what the first version of the view rule did —
   every `android.view.View[]` element owned what it pointed at — and a type says nothing about whose

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -249,14 +249,33 @@ itself and retained 4.2 KB and 3.9 KB instead of their windows. The damaging ref
 `PhoneFallbackEventHandler.mView`, `RealWorkflowLifecycleOwner.view`, `ComposeToastServiceImpl.rootView`,
 view bindings and `StandardRowSpec$StandardViewHolder.itemView`.
 
-`OwnerReferences` applies a curated list of `OwnerRule`s: a class whose instances something owns, plus the
-references that own them — named fields, or the virtual references a class's instances hand out. Six
-today — `android.view.View` owned by the `ViewGroup` that reads it as a child (see below) and by
-`Activity.mDecor` or `Dialog.mDecor`, `android.app.Activity` owned by the `ActivityThread` that reads it
-as one it's running (see below too), and the three Compose ones in the section on Compose below. After: **every one of
-the 277 child views is under its parent**, the dialog's `DecorView` is dominated by the
-`PartialModalDialog`, and `MainActivity` retains 18 MB under the thread running it, which is the second
-largest rectangle under the GC roots.
+`OwnerReferences` applies a curated list of `OwnerRule`s, each one a class taking the graph and answering
+which of an owner's references own what they point at — `ownerRulesFor` in `OwnerRules.kt`. Seven today: a
+`View` owned by the `ViewGroup` that reads it as a child (see below), a decor view owned by `Activity.mDecor`
+or `Dialog.mDecor`, an `Activity` owned by the `ActivityThread` that reads it as one it's running (see below
+too), the three Compose ones in the section on Compose below, and a dependency injection singleton owned by
+the provider caching it (see `notes/dependency-injection.md`). After: **every one of the 277 child views is
+under its parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity`
+retains 18 MB under the thread running it, which is the second largest rectangle under the GC roots.
+
+**Which objects are owned is derived from those references rather than declared beside them**, and that
+distinction is load-bearing rather than tidiness. The rules used to name a class whose instances were owned —
+"every `View`" — and separately name the references that own one. So a view no owner pointed at was still
+owned, which made it held as a last resort, which made *every* rival into it count. `Activity.mDecor` is
+null on a live activity more often than not (measured null for the only activity of `compose_leak.hprof`,
+two of the three in `leak_asynctask_m.hprof`, one of the two in `gcroot_unknown_object.hprof` and two of the
+four in `large-dump.hprof` — what holds a decor view is the window), so that is the ordinary case, and a
+whole window's hierarchy was drawn as a flat pile: on `large-dump.hprof` a `PhoneWindow` retained 20 KB with
+1.6 MB of its own views hanging off the activity beside it, and in a synthetic dump the decor view floated
+all the way to the root. Derived, an object nothing owns is simply not owned: `PhoneWindow.mDecor` holds the
+decor view the ordinary way, each view below it is still owned by its parent, and that `PhoneWindow` retains
+1.68 MB. Across the eight real dumps in the repo the change moved 0 to 53 objects of 34 K to 340 K, all of
+them windows and views, with the object set and every total byte count identical.
+
+Deriving costs a record read per possible owner where declaring cost none: **4 ms to 26 ms** against 12 ms to
+32 ms, of the 1.5 s it takes to open these dumps. It buys the hot path back — asking whether a reference is a
+rival is one hash lookup rather than resolving the reference's name — and it makes a rule two members instead
+of a schema, so a rule can't be paired with the wrong owned objects.
 
 **A rule is parked, not dropped, and that's the whole design.** The walk in
 `HeapReachability.walkFromGcRoots` keeps a second queue per strength and only takes from it once the main
@@ -269,7 +288,7 @@ rule the 82 MB dump comes out at exactly the same numbers as before — 80 MB st
 28 B local, 2.6 KB finalizer, 186 KB unreachable.
 
 **Parking is also why a rule needs no check on the state of the object**, which is the thing that looks
-missing when you read `RULES`. "The parent owns an *attached* view" needs no attachment test, because a
+missing when you read `OwnerRules.kt`. "The parent owns an *attached* view" needs no attachment test, because a
 detached hierarchy isn't held by whatever holds the window: if the parent isn't reachable, no owner
 reference reaches the child and the fallback handles it. "Unless the activity is destroyed" needs no
 `mDestroyed` test either — `ActivityThread.handleDestroyActivity` sets `mDecor = null` and takes the

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapReachability.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapReachability.kt
@@ -243,10 +243,9 @@ internal class HeapReachability private constructor(
           if (isLastResort) {
             ownerReferences.markLastResortHeld(heapObject)
           }
-          val ownership = ownerReferences.ownershipOf(heapObject)
           // A reference that retains its target doesn't weaken the path it's on.
           strengthReader.retainingReferencesOf(heapObject).forEach { reference ->
-            if (ownerReferences.isRivalReference(ownership, reference)) {
+            if (ownerReferences.isRivalReference(heapObject.objectId, reference)) {
               parked += reference.valueObjectId
             } else {
               queue += reference.valueObjectId
@@ -395,9 +394,8 @@ internal class HeapReachability private constructor(
       block: (HeapObject) -> Unit
     ) {
       val source = graph.findObjectById(objectId)
-      val ownership = ownerReferences.ownershipOf(source)
       val referentIds = strengthReader.retainingReferencesOf(source)
-        .filter { ownerReferences.isHeldThrough(ownership, it) }
+        .filter { ownerReferences.isHeldThrough(objectId, it) }
         .map { it.valueObjectId } +
         strengthReader.weakeningReferencesOf(source).map { it.valueObjectId }
       referentIds.forEach { referentId ->

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
@@ -1,20 +1,17 @@
 package shark.explorer
 
-import androidx.collection.LongSet
+import androidx.collection.LongObjectMap
 import androidx.collection.MutableLongObjectMap
 import androidx.collection.MutableLongSet
 import java.util.BitSet
 import shark.HeapGraph
 import shark.HeapObject
-import shark.HeapObject.HeapClass
 import shark.HeapObject.HeapInstance
 import shark.Reference
-import shark.explorer.OwnedObjects.HeldByScopedProviders
-import shark.explorer.OwnedObjects.InstancesOf
 
 /**
- * A construct where one reference is the one that really holds an object, and every other reference to
- * it is a rival that happens to point at it.
+ * A construct where one reference is the one that really holds an object, and every other reference to it
+ * is a rival that happens to point at it.
  *
  * A view that's part of a hierarchy is the example to think with. Dozens of things end up pointing at
  * it — an input method manager, a fallback event handler, a view binding, a lifecycle owner, a view
@@ -23,90 +20,43 @@ import shark.explorer.OwnedObjects.InstancesOf
  * dominator tree built without this rule scatters a window's views across whatever happened to be
  * closest to a GC root.
  *
- * A rule says nothing about the state the owned object is in, which is what makes it cheap and what
- * makes it right. "The parent owns an *attached* view" needs no attachment check: a detached hierarchy
- * isn't held by whatever holds the window, so if its parent isn't reachable, no owner reaches the child
- * and [OwnerReferences] falls back on the rivals by itself. The state the rule seems to need is already
+ * A rule says nothing about the state the owned object is in, which is what makes it cheap and what makes
+ * it right. "The parent owns an *attached* view" needs no attachment check: a detached hierarchy isn't held
+ * by whatever holds the window, so if its parent isn't reachable, no owner reaches the child and
+ * [OwnerReferences] falls back on the rivals by itself. The state the rule seems to need is already
  * expressed by which references exist.
- */
-internal class OwnerRule(
-  /** Which objects of a heap dump the rule is about. */
-  val ownedObjects: OwnedObjects,
-  /**
-   * The fields that own what they point at, by the name of the class declaring them. Read against the
-   * whole class hierarchy of the referring object, so a rule on a base class covers every subclass.
-   */
-  val ownerFieldsByClassName: Map<String, Set<String>> = emptyMap(),
-  /**
-   * The classes whose virtual references own what they point at, subclasses included.
-   *
-   * Those are the references the explorer adds itself, to present a structure the way you think about it
-   * instead of the way it's built, and an owner named that way is named by what it is rather than by a
-   * field it holds the object in: a `ViewGroup` owns the children [ViewChildReferenceReader] reads for it,
-   * whichever slot of whichever array each one is really in.
-   */
-  val ownerVirtualClassNames: Set<String> = emptySet()
-)
-
-/**
- * How an [OwnerRule] says which objects of a heap dump it is about.
  *
- * Two ways, because the cheap one doesn't always apply. Naming a class is a scan of two indexes and no
- * object record, so it's the one to reach for — but it needs the owned objects to have a class in
- * common, and the objects of some constructs have nothing in common but where they're held.
+ * A rule is code rather than a pattern because two of these — which references own, and which objects are
+ * owned — are one question. See [OwnerReferences.computeFor], and [ownerRulesFor] for the rules themselves.
  */
-internal sealed class OwnedObjects {
-
-  /** Every instance of [className] and of its subclasses, which the heap dump index answers on its own. */
-  class InstancesOf(val className: String) : OwnedObjects()
+internal interface OwnerRule {
 
   /**
-   * Whatever the [providers] are holding, whatever its class — for a dependency injection singleton,
-   * which is any type at all. What makes an object one is a provider caching it, so there is nothing
-   * about the object itself to recognise, and this reads the providers to find out.
+   * The classes whose instances can own something, subclasses included, so that the pass below reads the
+   * objects that can own and no others. A rule naming a class the heap dump doesn't have owns nothing.
    */
-  class HeldByScopedProviders(val providers: List<ScopedProvider>) : OwnedObjects()
+  val ownerClassNames: Set<String>
+
+  /**
+   * Reports to [onOwned] every object [owner] owns, [owner] being an instance of one of
+   * [ownerClassNames] or of a subclass of one.
+   */
+  fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  )
 }
 
 /**
- * A dependency injection framework's scoped provider: the object a generated component keeps a binding's
- * instance in, so that every injection point of that scope is handed the same one.
- *
- * Named per framework rather than found by shape, since a provider is an ordinary class with an ordinary
- * field and nothing in a heap dump marks it. Each entry is four names, and all four are checkable against
- * a dump of an app using the framework — a wrong one doesn't fail, it silently stops finding singletons.
- */
-internal class ScopedProvider(
-  /**
-   * The provider class, subclasses included, so that naming Metro's `BaseDoubleCheck` covers the
-   * `DoubleCheck` its generated code really instantiates.
-   */
-  val className: String,
-  /** The field the provider caches the instance in, once something has asked it for one. */
-  val instanceFieldName: String,
-  /** The class declaring the static field below, which is the provider's own only for Dagger. */
-  val uninitializedHolderClassName: String,
-  /**
-   * The static field holding what [instanceFieldName] points at until something asks: one sentinel object
-   * the framework shares between every provider in the process.
-   *
-   * Which has to be skipped rather than ignored, because it is a real object that real fields point at.
-   * Counting it as owned would hand a bare `Object` to whichever provider hadn't been asked yet and take
-   * the static field that does hold it out of the tree.
-   */
-  val uninitializedFieldName: String
-)
-
-/**
- * Which objects of a heap dump something owns, and which references are the owning ones — the
- * [OwnerRule] list applied to one heap dump.
+ * Which objects of a heap dump something owns, and which references are the owning ones — [ownerRulesFor]
+ * applied to one heap dump.
  *
  * The rule this exists to apply: **a reference into an object something else owns is not one of the ways
- * that object is held, unless nothing that owns it reached it.** A walk therefore parks a rival
- * reference instead of dropping it, and only takes a parked one once it has nothing else left to
- * follow — see [HeapReachability.walkFromGcRoots]. That's what makes the rule safe to apply without
- * knowing anything about the state of the objects: when the owner turns out not to be there, the walk
- * calls [markLastResortHeld] and the rivals count after all.
+ * that object is held, unless nothing that owns it reached it.** A walk therefore parks a rival reference
+ * instead of dropping it, and only takes a parked one once it has nothing else left to follow — see
+ * [HeapReachability.walkFromGcRoots]. That's what makes the rule safe to apply without knowing anything
+ * about the state of the objects: when the owner turns out not to be there, the walk calls
+ * [markLastResortHeld] and the rivals count after all.
  *
  * Filled in by the walk, then read by everything that needs the same edges the walk followed:
  * [WeakeningAwareReferenceReader], and so the dominator tree, the referrer index and the path search.
@@ -114,18 +64,16 @@ internal class ScopedProvider(
  */
 internal class OwnerReferences private constructor(
   private val graph: HeapGraph,
-  /** Every object of the heap dump an [OwnerRule] applies to, however it turns out to be held. */
-  private val ownedObjectIds: LongSet,
-  private val ownerFieldsByClassName: Map<String, Set<String>>,
-  private val ownerVirtualClassNames: Set<String>
-) {
-
   /**
-   * What the instances of a class own, by class object id. Cached because it takes a class hierarchy walk
-   * to work out and a heap dump has far more instances than classes, the same way
-   * [ReferenceStrengthReader] caches its weakening fields.
+   * Who owns each owned object of the heap dump, which is both halves of a rule at once: an object is owned
+   * because something owns it, and the reference that owns it is the one from that something.
+   *
+   * Usually one owner. More than one is a construct with two ways of owning, and the tree then draws the
+   * object under whatever dominates all of them, which is the honest answer and not a good place for bytes
+   * to land — see [WindowDecorRule] for the one that taught us that.
    */
-  private val ownershipByClassId = MutableLongObjectMap<Ownership>()
+  private val ownersByOwnedObjectId: LongObjectMap<MutableLongSet>
+) {
 
   /**
    * The owned objects nothing that owns them reached, so that what points at them is how they're held
@@ -134,18 +82,21 @@ internal class OwnerReferences private constructor(
    */
   private val lastResortHeldObjectIndexes = BitSet(graph.objectCount)
 
-  /** What [source] owns, worked out once per object rather than once per reference out of it. */
-  fun ownershipOf(source: HeapObject): Ownership =
-    if (source is HeapInstance) ownershipOfInstancesOf(source.instanceClass) else OWNS_NOTHING
-
   /**
-   * Whether [reference] out of an object with [sourceOwnership] points at an object something else owns,
+   * Whether [reference] out of the object with [sourceObjectId] points at an object something else owns,
    * which is a reference a walk parks until it turns out to be the only one there is.
+   *
+   * One hash lookup for nearly every reference of a heap dump, which is what this being asked per reference
+   * needs it to be: the objects a rule is about number in the thousands against the millions of references
+   * a walk reads, and a reference into none of them is answered by the map not having the key.
    */
   fun isRivalReference(
-    sourceOwnership: Ownership,
+    sourceObjectId: Long,
     reference: Reference
-  ): Boolean = ownedObjectIds.contains(reference.valueObjectId) && !sourceOwnership.owns(reference)
+  ): Boolean {
+    val owners = ownersByOwnedObjectId[reference.valueObjectId] ?: return false
+    return !owners.contains(sourceObjectId)
+  }
 
   /**
    * Records that nothing that owns [heapObject] reached it, so [isHeldThrough] answers true for every
@@ -156,7 +107,7 @@ internal class OwnerReferences private constructor(
   }
 
   /**
-   * Whether [reference] out of an object with [sourceOwnership] is one of the ways its target is held.
+   * Whether [reference] out of the object with [sourceObjectId] is one of the ways its target is held.
    *
    * True for everything but a rival reference into an object an owner reached. Nothing is lost by it:
    * every object was reached either through a reference this keeps, or from the parked references, and
@@ -164,335 +115,89 @@ internal class OwnerReferences private constructor(
    * every object of the heap dump in it, reachable and garbage alike.
    */
   fun isHeldThrough(
-    sourceOwnership: Ownership,
+    sourceObjectId: Long,
     reference: Reference
   ): Boolean {
-    if (!isRivalReference(sourceOwnership, reference)) {
+    if (!isRivalReference(sourceObjectId, reference)) {
       return true
     }
     val target = graph.findObjectByIdOrNull(reference.valueObjectId) ?: return true
     return lastResortHeldObjectIndexes.get(target.objectIndex)
   }
 
-  /** Every instance of a class owns the same fields and the same virtual references. */
-  private fun ownershipOfInstancesOf(instanceClass: HeapClass): Ownership =
-    ownershipByClassId.getOrPut(instanceClass.objectId) {
-      val hierarchy = instanceClass.classHierarchy.toList()
-      // Superclass first, so that a subclass adding an owner field keeps the ones it inherits: an
-      // Activity subclass owns its decor view through the field android.app.Activity declares.
-      val ownerFieldNames = hierarchy
-        .asReversed()
-        .fold(emptySet<String>()) { inherited, heapClass ->
-          ownerFieldsByClassName[heapClass.name]?.let { inherited + it } ?: inherited
-        }
-      // Against the hierarchy for the same reason: a LinearLayout owns its children through the rule on
-      // android.view.ViewGroup.
-      val ownsEveryVirtualReference = hierarchy.any { it.name in ownerVirtualClassNames }
-      if (ownerFieldNames.isEmpty() && !ownsEveryVirtualReference) {
-        OWNS_NOTHING
-      } else {
-        Ownership(ownerFieldNames, ownsEveryVirtualReference)
-      }
-    }
-
-  /**
-   * What one object owns: the values of a set of named fields, and whether the virtual references the
-   * explorer reads for it own what they point at. For nearly every object of a heap dump, nothing at all.
-   */
-  internal class Ownership(
-    private val ownerFieldNames: Set<String>,
-    private val ownsEveryVirtualReference: Boolean
-  ) {
-
-    /**
-     * Whether [reference] is the owning one. Only ever asked about a reference into an owned object, so
-     * resolving the details of one to read its name stays rare — it's the names that cost, and an object
-     * that owns nothing never gets that far.
-     */
-    fun owns(reference: Reference): Boolean {
-      if (ownerFieldNames.isEmpty() && !ownsEveryVirtualReference) {
-        return false
-      }
-      val details = reference.lazyDetailsResolver.resolve()
-      return if (details.isVirtual) {
-        ownsEveryVirtualReference
-      } else {
-        details.name in ownerFieldNames
-      }
-    }
-  }
-
   companion object {
 
-    private const val VIEW_CLASS_NAME = "android.view.View"
-
-    private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
-
-    private const val MODIFIER_NODE_CLASS_NAME = "androidx.compose.ui.Modifier\$Node"
-
     /**
-     * The scoped providers of the dependency injection frameworks the explorer knows about, read off a
-     * heap dump of an app built with each — see `notes/dependency-injection.md`.
+     * Applies [ownerRulesFor] to [graph], which takes one pass over its classes and one over its instances.
      *
-     * Both frameworks null the provider's own `provider` field once it has produced the instance, so a
-     * live provider points at nothing but its singleton.
-     */
-    private val SCOPED_PROVIDERS = listOf(
-      // Dagger keeps the sentinel on the provider class itself.
-      ScopedProvider(
-        className = "dagger.internal.DoubleCheck",
-        instanceFieldName = "instance",
-        uninitializedHolderClassName = "dagger.internal.DoubleCheck",
-        uninitializedFieldName = "UNINITIALIZED"
-      ),
-      // Metro's is a top level property of the file declaring the class, so it lives on the file's facade
-      // class rather than on the provider — which is why this needs a class name of its own.
-      ScopedProvider(
-        className = "dev.zacsweers.metro.internal.BaseDoubleCheck",
-        instanceFieldName = "_value",
-        uninitializedHolderClassName = "dev.zacsweers.metro.internal.BaseDoubleCheckKt",
-        uninitializedFieldName = "UNINITIALIZED"
-      )
-    )
-
-    /**
-     * The constructs the explorer knows about. Curated: each one is a claim that a reference is *the* way
-     * an object is held, and getting that wrong moves bytes to the wrong place in the tree.
-     */
-    private val RULES = listOf(
-      // A view of a hierarchy is held by its parent, through the virtual reference
-      // [ViewChildReferenceReader] reads from a ViewGroup to each of its children.
-      //
-      // Not through the View[] the framework really keeps them in, which is what this rule used to say.
-      // An array owns by its type or not at all — there is nothing on it to say whose children it holds —
-      // so a rule about View[] also hands ownership to an app's own array of views it merely points at,
-      // and it leaves a hierarchy hanging off an unnamed array at every level of the tree.
-      OwnerRule(
-        ownedObjects = InstancesOf(VIEW_CLASS_NAME),
-        ownerVirtualClassNames = setOf(ViewChildReferenceReader.VIEW_GROUP_CLASS_NAME)
-      ),
-      // The root view of a hierarchy has no parent to own it, and belongs to whatever the hierarchy is
-      // for. Attributing a window's views to the Activity or Dialog they're for is the whole point:
-      // otherwise they land under the WindowManagerGlobal that holds every window of the process, which
-      // tells you nothing about which screen is expensive.
-      //
-      // The framework nulls Activity.mDecor when it destroys the activity, and that is the whole of
-      // "unless the activity is destroyed": a rule needs no state check when the field is already gone.
-      //
-      // Not PhoneWindow.mDecor, which also holds the decor view and is set whether the activity is
-      // destroyed or not. Two owner references are two ways of owning, so the decor view ends up
-      // dominated by whatever dominates both, and on a real app dump that's the top of the tree: a jank
-      // monitor held the window from a GC root of its own, which cost the activity all 18 MB of its
-      // hierarchy. One owner per construct, and it should be the one you'd want to read the bytes under.
-      OwnerRule(
-        ownedObjects = InstancesOf(VIEW_CLASS_NAME),
-        ownerFieldsByClassName = mapOf(
-          ACTIVITY_CLASS_NAME to setOf("mDecor"),
-          "android.app.Dialog" to setOf("mDecor")
-        )
-      ),
-      // An activity belongs to the thread running it, through the virtual reference
-      // [RunningActivityReferenceReader] reads from an ActivityThread to each activity in mActivities.
-      // Everything else that points at one — a context wrapper, a view, a fragment, a presenter, a
-      // callback — is something the activity brought along. Self-clearing in the same way:
-      // ActivityThread.handleDestroyActivity takes the record out of mActivities, so a destroyed activity
-      // has no owner left and falls back on whatever is leaking it, which is exactly what you want its
-      // bytes drawn under.
-      //
-      // Not ActivityClientRecord.activity, which is what this rule used to say. A record is a slot of the
-      // ArrayMap the thread keeps its activities in, and naming the slot leaves the map, its Object[] and
-      // the record itself between the thread and every activity, so the chain from a GC root down to a
-      // screen spends three of its steps on a map's bookkeeping and the thread's own rectangle is a pile of
-      // records rather than a row of screens to compare.
-      OwnerRule(
-        ownedObjects = InstancesOf(ACTIVITY_CLASS_NAME),
-        ownerVirtualClassNames = setOf(RunningActivityReferenceReader.ACTIVITY_THREAD_CLASS_NAME)
-      ),
-      // A Compose UI is a tree of LayoutNodes and the same rule applies to it, through the virtual
-      // reference [LayoutNodeChildReferenceReader] reads from a parent to each child.
-      //
-      // It needs saying louder here than for a view, because Compose keeps a flat registry of every node
-      // of a window — `AndroidComposeView.layoutNodes`, by semantics id — so *every* node of a UI is one
-      // reference from the view that hosts it, and the tree of a screen is a list until this rule turns
-      // it back into a tree. The rest of the rivals are Compose's own graphs pointing sideways: the nodes
-      // waiting to be measured, the ones waiting to be positioned, a focus listener the input method
-      // manager holds, a modifier node's coordinator.
-      OwnerRule(
-        ownedObjects = InstancesOf(LayoutNodeChildReferenceReader.LAYOUT_NODE_CLASS_NAME),
-        ownerVirtualClassNames = setOf(LayoutNodeChildReferenceReader.LAYOUT_NODE_CLASS_NAME)
-      ),
-      // The node at the top of a window has no parent node, and belongs to the view hosting it — the same
-      // rule as a decor view belonging to its Activity, and what puts a Compose UI's bytes inside the
-      // hierarchy of the screen showing it.
-      //
-      // The composition holds that node too, in a slot of its table, and this is deliberately the owner
-      // instead: a composition is one flat store per window, so owning from there would be the registry
-      // problem again. See [SlotTableReferenceReader] for what a slot reference is.
-      OwnerRule(
-        ownedObjects = InstancesOf(LayoutNodeChildReferenceReader.LAYOUT_NODE_CLASS_NAME),
-        ownerFieldsByClassName = mapOf(
-          "androidx.compose.ui.platform.AndroidComposeView" to setOf("root")
-        )
-      ),
-      // What a node of a Compose UI is made of belongs to that node: its modifiers are a chain hanging
-      // off its `NodeChain`, from the outermost through each one's `child` to the tail.
-      //
-      // Without this the chain is a way *into* the UI rather than a part of it, and that is measurable:
-      // Compose's modifier nodes point back at their coordinators, which point back at their layers and
-      // at each other, so a single reference into any one of them reaches the lot. A heap dump taken on
-      // API 36 has three such references from outside — a focus listener the input method manager reaches
-      // through the window's `ViewTreeObserver`, the snapshot observer's static list of what it observes,
-      // and the `Recomposer` — so every modifier of every screen was held from a GC root of its own, and
-      // the images the UI draws were dominated by the top of the heap rather than by the UI showing them.
-      //
-      // `child` and not `parent`: a chain has to be owned in one direction, and it reads outermost first,
-      // the way the modifiers were written.
-      OwnerRule(
-        ownedObjects = InstancesOf(MODIFIER_NODE_CLASS_NAME),
-        ownerFieldsByClassName = mapOf(
-          "androidx.compose.ui.node.NodeChain" to setOf("head"),
-          MODIFIER_NODE_CLASS_NAME to setOf("child")
-        )
-      ),
-      // A dependency injection singleton is held by the provider its component caches it in, and every
-      // other reference to one is an injection site the component handed it to. Which is nearly always a
-      // lot of them, all over the app, so without this rule a singleton is dominated by whatever dominates
-      // the whole graph of things that were injected with it — the top of the tree. Measured on a JVM dump
-      // of a Dagger and a Metro component: every scoped instance came out under the root, and under this
-      // rule every one of them came out under its own component.
-      //
-      // The provider and not the component, though the component is what you'd want to read the bytes
-      // under, because **nothing in a heap dump says which object is a component**. Dagger's generated one
-      // is a `DaggerAppComponent$AppComponentImpl`, which a name could just about catch; Metro's is an
-      // `AppGraph$Impl`, an `Impl` nested in the interface the app declared, with no marker of any kind.
-      // A rule about the provider needs no such guess, and the component still collects the bytes, one
-      // step further down: it is what holds every provider.
-      //
-      // Self-clearing in the way the rest of these are. A provider never lets go of its instance, so there
-      // is no state to check: while the component is reachable so is the provider, and once the component
-      // is gone the provider is gone with it, no owner reaches the singleton, and whatever is still
-      // pointing at it is both how it's held and what's leaking it.
-      OwnerRule(
-        ownedObjects = HeldByScopedProviders(SCOPED_PROVIDERS),
-        ownerFieldsByClassName = SCOPED_PROVIDERS.associate {
-          it.className to setOf(it.instanceFieldName)
-        }
-      )
-    )
-
-    private val OWNS_NOTHING = Ownership(emptySet(), false)
-
-    /**
-     * Applies [RULES] to [graph], which takes one pass over its classes and one over its instances.
+     * Reading which objects are owned up front is what buys a hash lookup per reference later on, and it
+     * has to be up front: a rival reference is one a walk has to recognise before anything has reached its
+     * target.
      *
-     * The pass over the instances is what buys a hash lookup per reference later on, instead of a class
-     * hierarchy walk: reading which objects are owned up front costs one index scan, and a heap dump has
-     * millions of references but only thousands of views.
+     * The class pass reads no object record — an instance's class comes from the heap dump index, and so
+     * does the superclass of a class — and it is what holds the instance pass to the objects that can own
+     * something. Which is a few thousand of the millions in a dump, so asking each of those for what it
+     * owns costs a record read per possible owner rather than per object: measured against naming the owned
+     * classes instead, 4 ms to 26 ms of the 1.5 s it takes to open the heap dumps in this repo.
      */
     fun computeFor(graph: HeapGraph): OwnerReferences {
-      val ownedClassIds = MutableLongSet()
-      RULES.mapNotNullTo(mutableSetOf()) { (it.ownedObjects as? InstancesOf)?.className }
-        .forEach { className ->
-          graph.findClassByName(className)?.let { ownedClassIds += it.objectId }
+      val rules = ownerRulesFor(graph)
+      val rulesByOwnerClassId = rulesByOwnerClassIdOf(graph, rules)
+      val ownersByOwnedObjectId = MutableLongObjectMap<MutableLongSet>()
+      if (rulesByOwnerClassId.isNotEmpty()) {
+        graph.instances.forEach { instance ->
+          rulesByOwnerClassId[instance.instanceClassId]?.forEach { rule ->
+            rule.forEachOwnedObject(instance) { ownedObjectId ->
+              ownersByOwnedObjectId
+                .getOrPut(ownedObjectId) { MutableLongSet(initialCapacity = 1) }
+                .plusAssign(instance.objectId)
+            }
+          }
         }
-      val scopedProviders = RULES.flatMap {
-        (it.ownedObjects as? HeldByScopedProviders)?.providers.orEmpty()
       }
       return OwnerReferences(
         graph = graph,
-        ownedObjectIds = ownedObjectIdsOf(graph, ownedClassIds, scopedProviders),
-        ownerFieldsByClassName = ownerFieldsByClassName(),
-        ownerVirtualClassNames = RULES.flatMapTo(mutableSetOf()) { it.ownerVirtualClassNames }
+        ownersByOwnedObjectId = ownersByOwnedObjectId
       )
     }
 
     /**
-     * The instances of [ownedClassIds] and of their subclasses, plus what the [scopedProviders] found in
-     * the same pass are holding, by object id.
+     * Which rules the instances of a class can own something through, for the classes whose instances can,
+     * so that reading an instance's own class id is enough to tell.
      *
-     * The class half reads no object record: an instance's class comes from the heap dump index, and so
-     * does the superclass of a class, so it is a scan of two indexes. The provider half then reads one
-     * record per provider, which is one per binding a component has been asked for rather than one per
-     * object — a few thousand at the very most, against the millions the index pass walks past.
+     * Empty for a heap dump none of the rules names a class of, which is what keeps a rule about Android
+     * from costing anything on a dump of a JVM.
      */
-    private fun ownedObjectIdsOf(
+    private fun rulesByOwnerClassIdOf(
       graph: HeapGraph,
-      ownedClassIds: LongSet,
-      scopedProviders: List<ScopedProvider>
-    ): LongSet {
-      val ownedObjectIds = MutableLongSet()
-      // Only the frameworks the heap dump has classes for, so an app using neither pays one class lookup
-      // per framework and nothing else.
-      val providerByDeclaringClassId = MutableLongObjectMap<ScopedProvider>()
-      scopedProviders.forEach { provider ->
-        graph.findClassByName(provider.className)?.let {
-          providerByDeclaringClassId[it.objectId] = provider
+      rules: List<OwnerRule>
+    ): LongObjectMap<List<OwnerRule>> {
+      val rulesByDeclaredClassId = MutableLongObjectMap<MutableList<OwnerRule>>()
+      rules.forEach { rule ->
+        rule.ownerClassNames.forEach { className ->
+          graph.findClassByName(className)?.let { ownerClass ->
+            rulesByDeclaredClassId.getOrPut(ownerClass.objectId) { mutableListOf() } += rule
+          }
         }
       }
-      if (ownedClassIds.isEmpty() && providerByDeclaringClassId.isEmpty()) {
-        return ownedObjectIds
+      val rulesByOwnerClassId = MutableLongObjectMap<List<OwnerRule>>()
+      if (rulesByDeclaredClassId.isEmpty()) {
+        return rulesByOwnerClassId
       }
-      // Both halves need the subclasses of a named class, so both read them out of the one pass:
-      // HeapClass.subclasses is a scan of every class of the dump, and there are several names here.
-      val subclassIds = MutableLongSet()
-      val providerByClassId = MutableLongObjectMap<ScopedProvider>()
       graph.classes.forEach { heapClass ->
+        var rulesForClass: MutableList<OwnerRule>? = null
         heapClass.classHierarchy.forEach { superclass ->
-          if (ownedClassIds.contains(superclass.objectId)) {
-            subclassIds += heapClass.objectId
+          rulesByDeclaredClassId[superclass.objectId]?.let { declaredRules ->
+            // Superclass first would be the other order, and either does: a class inheriting an owner rule
+            // owns through it as well, and a rule appears once however many of its classes are in the
+            // hierarchy.
+            val rulesSoFar = rulesForClass ?: mutableListOf<OwnerRule>().also { rulesForClass = it }
+            declaredRules.forEach { if (it !in rulesSoFar) rulesSoFar += it }
           }
-          providerByDeclaringClassId[superclass.objectId]?.let {
-            providerByClassId[heapClass.objectId] = it
-          }
         }
+        rulesForClass?.let { rulesByOwnerClassId[heapClass.objectId] = it }
       }
-      val providerInstances = mutableListOf<HeapInstance>()
-      graph.instances.forEach { instance ->
-        if (subclassIds.contains(instance.instanceClassId)) {
-          ownedObjectIds += instance.objectId
-        }
-        if (providerByClassId.containsKey(instance.instanceClassId)) {
-          providerInstances += instance
-        }
-      }
-      val uninitializedValueIds = uninitializedValueIdsOf(graph, providerByDeclaringClassId)
-      providerInstances.forEach { providerInstance ->
-        val provider = providerByClassId[providerInstance.instanceClassId]!!
-        val heldObjectId = providerInstance[provider.className, provider.instanceFieldName]
-          ?.value
-          ?.asNonNullObjectId
-        if (heldObjectId != null && !uninitializedValueIds.contains(heldObjectId)) {
-          ownedObjectIds += heldObjectId
-        }
-      }
-      return ownedObjectIds
-    }
-
-    /** The sentinel each of the frameworks present in [graph] leaves in a provider nothing has asked yet. */
-    private fun uninitializedValueIdsOf(
-      graph: HeapGraph,
-      providerByDeclaringClassId: MutableLongObjectMap<ScopedProvider>
-    ): LongSet {
-      val uninitializedValueIds = MutableLongSet()
-      providerByDeclaringClassId.forEachValue { provider ->
-        graph.findClassByName(provider.uninitializedHolderClassName)
-          ?.get(provider.uninitializedFieldName)
-          ?.value
-          ?.asNonNullObjectId
-          ?.let { uninitializedValueIds += it }
-      }
-      return uninitializedValueIds
-    }
-
-    /** [RULES]' owner fields merged, so that two rules on the same class both hold. */
-    private fun ownerFieldsByClassName(): Map<String, Set<String>> {
-      val merged = mutableMapOf<String, Set<String>>()
-      RULES.forEach { rule ->
-        rule.ownerFieldsByClassName.forEach { (className, fieldNames) ->
-          merged[className] = merged[className].orEmpty() + fieldNames
-        }
-      }
-      return merged
+      return rulesByOwnerClassId
     }
   }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerRules.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerRules.kt
@@ -1,0 +1,306 @@
+package shark.explorer
+
+import shark.HeapGraph
+import shark.HeapObject.HeapInstance
+import shark.ValueHolder
+
+/**
+ * The constructs the explorer knows about. Curated: each one is a claim that a reference is *the* way an
+ * object is held, and getting that wrong moves bytes to the wrong place in the tree.
+ *
+ * Created per heap dump, so a rule resolves the class it is about once and answers off the index from
+ * there, the way [ViewChildReferenceReader] and [RunningActivityReferenceReader] do. A rule whose classes
+ * aren't in the dump names no owner and therefore owns nothing, which is what keeps a rule about Android
+ * from costing anything on a dump of a JVM.
+ */
+internal fun ownerRulesFor(graph: HeapGraph): List<OwnerRule> = listOf(
+  ViewParentRule(graph),
+  WindowDecorRule(),
+  RunningActivityRule(graph),
+  LayoutNodeParentRule(graph),
+  ComposeUiRootNodeRule(),
+  ModifierChainRule(),
+  ScopedProviderRule(graph)
+)
+
+/**
+ * A view of a hierarchy is held by its parent, through the virtual reference [ViewChildReferenceReader]
+ * reads from a `ViewGroup` to each of its children.
+ *
+ * Not through the `View[]` the framework really keeps them in, which is what this rule used to say. An
+ * array owns by its type or not at all — there is nothing on it to say whose children it holds — so a rule
+ * about `View[]` also hands ownership to an app's own array of views it merely points at, and it leaves a
+ * hierarchy hanging off an unnamed array at every level of the tree.
+ */
+internal class ViewParentRule(graph: HeapGraph) : OwnerRule {
+
+  private val childReferenceReader = ViewChildReferenceReader(graph)
+
+  override val ownerClassNames = setOf(ViewChildReferenceReader.VIEW_GROUP_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    childReferenceReader.childReferencesOf(owner).forEach { onOwned(it.valueObjectId) }
+  }
+}
+
+/**
+ * The root view of a hierarchy has no parent to own it, and belongs to whatever the hierarchy is for.
+ * Attributing a window's views to the `Activity` or `Dialog` they're for is the whole point: otherwise they
+ * land under the `WindowManagerGlobal` that holds every window of the process, which tells you nothing
+ * about which screen is expensive.
+ *
+ * The framework nulls `Activity.mDecor` when it destroys the activity, and that is the whole of "unless the
+ * activity is destroyed": a rule needs no state check when the field is already gone.
+ *
+ * Not `PhoneWindow.mDecor`, which also holds the decor view and is set whether the activity is destroyed or
+ * not. Two owners are two ways of owning, so the decor view would end up dominated by whatever dominates
+ * both, and on a real app dump that's the top of the tree: a jank monitor held the window from a GC root of
+ * its own, which cost the activity all 18 MB of its hierarchy. One owner per construct, and it should be
+ * the one you'd want to read the bytes under.
+ */
+internal class WindowDecorRule : OwnerRule {
+
+  override val ownerClassNames = setOf(ACTIVITY_CLASS_NAME, DIALOG_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    ownerClassNames.forEach { className ->
+      owner[className, DECOR_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+    }
+  }
+
+  companion object {
+    private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
+    private const val DIALOG_CLASS_NAME = "android.app.Dialog"
+    private const val DECOR_FIELD_NAME = "mDecor"
+  }
+}
+
+/**
+ * An activity belongs to the thread running it, through the virtual reference
+ * [RunningActivityReferenceReader] reads from an `ActivityThread` to each activity in `mActivities`.
+ * Everything else that points at one — a context wrapper, a view, a fragment, a presenter, a callback — is
+ * something the activity brought along.
+ *
+ * Self-clearing in the same way as the rest: `ActivityThread.handleDestroyActivity` takes the record out of
+ * `mActivities`, so a destroyed activity has no owner left and falls back on whatever is leaking it, which
+ * is exactly what you want its bytes drawn under.
+ */
+internal class RunningActivityRule(graph: HeapGraph) : OwnerRule {
+
+  private val activityReferenceReader = RunningActivityReferenceReader(graph)
+
+  override val ownerClassNames = setOf(RunningActivityReferenceReader.ACTIVITY_THREAD_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    activityReferenceReader.activityReferencesOf(owner).forEach { onOwned(it.valueObjectId) }
+  }
+}
+
+/**
+ * A Compose UI is a tree of `LayoutNode`s and [ViewParentRule] applies to it too, through the virtual
+ * reference [LayoutNodeChildReferenceReader] reads from a parent to each child.
+ *
+ * It needs saying louder than for a view, because Compose keeps a flat registry of every node of a window —
+ * `AndroidComposeView.layoutNodes`, by semantics id — so *every* node of a UI is one reference from the view
+ * that hosts it, and the tree of a screen is a list until this rule turns it back into a tree. The rest of
+ * the rivals are Compose's own graphs pointing sideways: the nodes waiting to be measured, the ones waiting
+ * to be positioned, a focus listener the input method manager holds, a modifier node's coordinator.
+ */
+internal class LayoutNodeParentRule(graph: HeapGraph) : OwnerRule {
+
+  private val childReferenceReader = LayoutNodeChildReferenceReader(graph)
+
+  override val ownerClassNames = setOf(LayoutNodeChildReferenceReader.LAYOUT_NODE_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    childReferenceReader.childReferencesOf(owner).forEach { onOwned(it.valueObjectId) }
+  }
+}
+
+/**
+ * The node at the top of a window has no parent node, and belongs to the view hosting it — the same rule as
+ * a decor view belonging to its `Activity` ([WindowDecorRule]), and what puts a Compose UI's bytes inside
+ * the hierarchy of the screen showing it.
+ *
+ * The composition holds that node too, in a slot of its table, and this is deliberately the owner instead: a
+ * composition is one flat store per window, so owning from there would be the registry problem
+ * [LayoutNodeParentRule] describes. See [SlotTableReferenceReader] for what a slot reference is.
+ */
+internal class ComposeUiRootNodeRule : OwnerRule {
+
+  override val ownerClassNames = setOf(ANDROID_COMPOSE_VIEW_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    owner[ANDROID_COMPOSE_VIEW_CLASS_NAME, ROOT_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+  }
+
+  companion object {
+    private const val ANDROID_COMPOSE_VIEW_CLASS_NAME = "androidx.compose.ui.platform.AndroidComposeView"
+    private const val ROOT_FIELD_NAME = "root"
+  }
+}
+
+/**
+ * What a node of a Compose UI is made of belongs to that node: its modifiers are a chain hanging off its
+ * `NodeChain`, from the outermost through each one's `child` to the tail.
+ *
+ * Without this the chain is a way *into* the UI rather than a part of it, and that is measurable: Compose's
+ * modifier nodes point back at their coordinators, which point back at their layers and at each other, so a
+ * single reference into any one of them reaches the lot. A heap dump taken on API 36 has three such
+ * references from outside — a focus listener the input method manager reaches through the window's
+ * `ViewTreeObserver`, the snapshot observer's static list of what it observes, and the `Recomposer` — so
+ * every modifier of every screen was held from a GC root of its own, and the images the UI draws were
+ * dominated by the top of the heap rather than by the UI showing them.
+ *
+ * `child` and not `parent`: a chain has to be owned in one direction, and it reads outermost first, the way
+ * the modifiers were written.
+ */
+internal class ModifierChainRule : OwnerRule {
+
+  override val ownerClassNames = setOf(NODE_CHAIN_CLASS_NAME, MODIFIER_NODE_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    owner[NODE_CHAIN_CLASS_NAME, HEAD_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+    owner[MODIFIER_NODE_CLASS_NAME, CHILD_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+  }
+
+  companion object {
+    private const val NODE_CHAIN_CLASS_NAME = "androidx.compose.ui.node.NodeChain"
+    private const val MODIFIER_NODE_CLASS_NAME = "androidx.compose.ui.Modifier\$Node"
+    private const val HEAD_FIELD_NAME = "head"
+    private const val CHILD_FIELD_NAME = "child"
+  }
+}
+
+/**
+ * A dependency injection singleton is held by the provider its component caches it in, and every other
+ * reference to one is an injection site the component handed it to. Which is nearly always a lot of them,
+ * all over the app, so without this rule a singleton is dominated by whatever dominates the whole graph of
+ * things that were injected with it — the top of the tree.
+ *
+ * The provider and not the component, though the component is what you'd want to read the bytes under,
+ * because **nothing in a heap dump says which object is a component**. Dagger's generated one is a
+ * `DaggerAppComponent$AppComponentImpl`, which a name could just about catch; Metro's is an `AppGraph$Impl`,
+ * an `Impl` nested in the interface the app declared, with no marker of any kind. A rule about the provider
+ * needs no such guess, and the component still collects the bytes, one step further down: it is what holds
+ * every provider.
+ *
+ * Self-clearing in the way the rest of these are. A provider never lets go of its instance, so there is no
+ * state to check: while the component is reachable so is the provider, and once the component is gone the
+ * provider is gone with it, no owner reaches the singleton, and whatever is still pointing at it is both how
+ * it's held and what's leaking it.
+ *
+ * `notes/dependency-injection.md` records where every name below was read off a heap dump of an app built
+ * with each framework, and how to take another dump.
+ */
+internal class ScopedProviderRule(private val graph: HeapGraph) : OwnerRule {
+
+  /**
+   * One dependency injection framework's scoped provider: the object a generated component keeps a
+   * binding's instance in, so that every injection point of that scope is handed the same one.
+   *
+   * Both frameworks null the provider's own `provider` field once it has produced the instance, so a live
+   * provider points at nothing but its singleton.
+   */
+  private class ScopedProvider(
+    /**
+     * The class declaring the field below, so that naming Metro's `BaseDoubleCheck` covers the
+     * `DoubleCheck` its generated code really instantiates.
+     */
+    val className: String,
+    /** The field the provider caches the instance in, once something has asked it for one. */
+    val instanceFieldName: String,
+    /**
+     * What [instanceFieldName] points at until something asks: one sentinel object the framework shares
+     * between every provider in the process, read out of the static field holding it.
+     *
+     * Skipped rather than ignored, because it is a real object that real fields point at. Counting it as
+     * owned would hand a bare `Object` to whichever provider hadn't been asked yet and take the static
+     * field that does hold it out of the tree.
+     */
+    val uninitializedObjectId: Long
+  )
+
+  /**
+   * Only the frameworks the heap dump has, resolved once: [HeapGraph.findClassByName] scans every string of
+   * the dump, and reading a field off an instance of a class that isn't in its hierarchy answers null, so a
+   * dump built with neither framework pays these lookups and nothing else.
+   */
+  private val scopedProviders: List<ScopedProvider> by lazy {
+    listOfNotNull(
+      // Dagger keeps the sentinel on the provider class itself.
+      scopedProviderOrNull(
+        className = "dagger.internal.DoubleCheck",
+        instanceFieldName = "instance",
+        uninitializedHolderClassName = "dagger.internal.DoubleCheck"
+      ),
+      // Metro's is a top level property of the file declaring the class, so it lives on that file's facade
+      // class rather than on the provider.
+      scopedProviderOrNull(
+        className = "dev.zacsweers.metro.internal.BaseDoubleCheck",
+        instanceFieldName = "_value",
+        uninitializedHolderClassName = "dev.zacsweers.metro.internal.BaseDoubleCheckKt"
+      )
+    )
+  }
+
+  override val ownerClassNames = setOf(
+    "dagger.internal.DoubleCheck",
+    "dev.zacsweers.metro.internal.BaseDoubleCheck"
+  )
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    scopedProviders.forEach { provider ->
+      val heldObjectId = owner[provider.className, provider.instanceFieldName]
+        ?.value
+        ?.asNonNullObjectId
+      if (heldObjectId != null && heldObjectId != provider.uninitializedObjectId) {
+        onOwned(heldObjectId)
+      }
+    }
+  }
+
+  private fun scopedProviderOrNull(
+    className: String,
+    instanceFieldName: String,
+    uninitializedHolderClassName: String
+  ): ScopedProvider? {
+    if (graph.findClassByName(className) == null) {
+      return null
+    }
+    return ScopedProvider(
+      className = className,
+      instanceFieldName = instanceFieldName,
+      uninitializedObjectId = graph.findClassByName(uninitializedHolderClassName)
+        ?.get(UNINITIALIZED_FIELD_NAME)
+        ?.value
+        ?.asNonNullObjectId
+        ?: ValueHolder.NULL_REFERENCE
+    )
+  }
+
+  companion object {
+    private const val UNINITIALIZED_FIELD_NAME = "UNINITIALIZED"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerRules.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerRules.kt
@@ -1,5 +1,6 @@
 package shark.explorer
 
+import androidx.collection.LongSet
 import shark.HeapGraph
 import shark.HeapObject.HeapInstance
 import shark.ValueHolder
@@ -13,15 +14,21 @@ import shark.ValueHolder
  * aren't in the dump names no owner and therefore owns nothing, which is what keeps a rule about Android
  * from costing anything on a dump of a JVM.
  */
-internal fun ownerRulesFor(graph: HeapGraph): List<OwnerRule> = listOf(
-  ViewParentRule(graph),
-  WindowDecorRule(),
-  RunningActivityRule(graph),
-  LayoutNodeParentRule(graph),
-  ComposeUiRootNodeRule(),
-  ModifierChainRule(),
-  ScopedProviderRule(graph)
-)
+internal fun ownerRulesFor(graph: HeapGraph): List<OwnerRule> {
+  // One reader between the two rules that read the activities the app is running: they ask it for the same
+  // thing, from either end of it — which activities the thread owns, and which of them own their window.
+  val runningActivities = RunningActivityReferenceReader(graph)
+  return listOf(
+    ViewParentRule(graph),
+    WindowDecorRule(),
+    ActivityWindowRule(runningActivities),
+    RunningActivityRule(runningActivities),
+    LayoutNodeParentRule(graph),
+    ComposeUiRootNodeRule(),
+    ModifierChainRule(),
+    ScopedProviderRule(graph)
+  )
+}
 
 /**
  * A view of a hierarchy is held by its parent, through the virtual reference [ViewChildReferenceReader]
@@ -47,21 +54,81 @@ internal class ViewParentRule(graph: HeapGraph) : OwnerRule {
 }
 
 /**
- * The root view of a hierarchy has no parent to own it, and belongs to whatever the hierarchy is for.
- * Attributing a window's views to the `Activity` or `Dialog` they're for is the whole point: otherwise they
- * land under the `WindowManagerGlobal` that holds every window of the process, which tells you nothing
- * about which screen is expensive.
+ * The decor view at the top of a hierarchy has no parent to own it, and is held by the window it is the
+ * decor of.
  *
- * The framework nulls `Activity.mDecor` when it destroys the activity, and that is the whole of "unless the
- * activity is destroyed": a rule needs no state check when the field is already gone.
+ * Not by the `Activity` or `Dialog`, which is what this rule used to say. `Activity.mDecor` is written in
+ * one place, `ActivityThread.handleResumeActivity`, guarded by the activity's record having no window yet —
+ * so it is set once per `ActivityClientRecord` rather than once per activity, and an activity recreated on a
+ * configuration change is visible, resumed, and has a null `mDecor` for the rest of its life. Which is most
+ * of the activities in the heap dumps here. Worse than useless: with the decor view declared owned and no
+ * owner reaching it, every rival counted, and a window's whole hierarchy was drawn flat at the top of the
+ * tree.
  *
- * Not `PhoneWindow.mDecor`, which also holds the decor view and is set whether the activity is destroyed or
- * not. Two owners are two ways of owning, so the decor view would end up dominated by whatever dominates
- * both, and on a real app dump that's the top of the tree: a jank monitor held the window from a GC root of
- * its own, which cost the activity all 18 MB of its hierarchy. One owner per construct, and it should be
- * the one you'd want to read the bytes under.
+ * The window holds it whether the activity is destroyed or not, so this rule leans on [ActivityWindowRule]
+ * for the fallback the field used to give: it is the *window* that stops being owned when its activity goes,
+ * and the hierarchy comes with it.
+ *
+ * One owner and not both, though — a decor view owned by its window *and* its activity is dominated by
+ * whatever dominates the two, and on a real app dump that's the top of the tree: a jank monitor held the
+ * window from a GC root of its own, which cost the activity all 18 MB of its hierarchy.
  */
 internal class WindowDecorRule : OwnerRule {
+
+  override val ownerClassNames = setOf(WINDOW_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    // By field name rather than by declaring class, because the class declaring it is internal and has
+    // moved: com.android.internal.policy.impl.PhoneWindow before Lollipop, com.android.internal.policy
+    // .PhoneWindow since. Reading the fields of a window costs the record read this rule makes anyway.
+    owner.readFields()
+      .firstOrNull { it.name == DECOR_FIELD_NAME }
+      ?.value
+      ?.asNonNullObjectId
+      ?.let(onOwned)
+  }
+
+  companion object {
+    private const val WINDOW_CLASS_NAME = "android.view.Window"
+    private const val DECOR_FIELD_NAME = "mDecor"
+  }
+}
+
+/**
+ * A window is held by the `Activity` or `Dialog` it is the window of. Everything else pointing at one is
+ * something that needs to reach the window: the `WindowManagerImpl` that added it, an
+ * `AppCompatDelegateImpl`, a `DecorContext`, a menu callback, the window's own inner classes.
+ *
+ * Attributing a window to what it is for is what makes the rest of these rules land somewhere worth reading.
+ * Its decor view is nearly all of its bytes ([WindowDecorRule]), and a window with several referrers is
+ * otherwise dominated by whatever dominates all of them — measured on the heap dumps here, 6 of 16 windows
+ * were drawn at the top of the tree, taking their hierarchy with them.
+ *
+ * The one rule whose owning reference outlives the construct it is about, and the whole of the difficulty
+ * here. `Activity.mWindow` is set in `attach` and never cleared, and `Dialog.mWindow` is final, so a
+ * destroyed activity and a dismissed dialog go on pointing at a window they have nothing left to do with.
+ * Owning it anyway takes the only honest answer away from the case that needs it: a leaked screen whose
+ * window something else holds as well is two things to fix, and it reads as one if the leak owns the window.
+ *
+ * So this rule owns through `mWindow` and reads whether the screen is up off *another* reference, one the
+ * framework does drop — the same self-clearing signal the rest of these rules own by, borrowed from beside
+ * the one they own through. A dialog is dropped from its decor view, which `show` sets and `dismiss` nulls;
+ * an activity is dropped from `ActivityThread.mActivities`, which `handleDestroyActivity` removes the record
+ * from and which [RunningActivityRule] already owns activities by. Nothing here reads the state of an
+ * object: a screen the framework is done with owns its window for exactly as long as the framework holds it.
+ */
+internal class ActivityWindowRule(runningActivities: RunningActivityReferenceReader) : OwnerRule {
+
+  /**
+   * The activities the app is running, which is the reference `handleDestroyActivity` drops.
+   *
+   * Read once for the heap dump rather than per activity, because the read starts at the thread and not at
+   * the activity: there is no way from an activity back to the record running it.
+   */
+  private val runningActivityIds: LongSet by lazy { runningActivities.runningActivityIds() }
 
   override val ownerClassNames = setOf(ACTIVITY_CLASS_NAME, DIALOG_CLASS_NAME)
 
@@ -69,14 +136,29 @@ internal class WindowDecorRule : OwnerRule {
     owner: HeapInstance,
     onOwned: (Long) -> Unit
   ) {
-    ownerClassNames.forEach { className ->
-      owner[className, DECOR_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+    if (!owner.isScreenTheFrameworkStillHolds()) {
+      return
     }
+    ownerClassNames.forEach { className ->
+      owner[className, WINDOW_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+    }
+  }
+
+  /** Whether the framework is still holding [this] screen, read off what it lets go of. */
+  private fun HeapInstance.isScreenTheFrameworkStillHolds(): Boolean {
+    // Asked of the dialog first because having the field is also what tells a dialog from an activity — an
+    // activity has no android.app.Dialog.mDecor, and a dialog is in no ActivityThread.
+    val dialogDecor = this[DIALOG_CLASS_NAME, DECOR_FIELD_NAME]
+    if (dialogDecor != null) {
+      return dialogDecor.value.asNonNullObjectId != null
+    }
+    return runningActivityIds.contains(objectId)
   }
 
   companion object {
     private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
     private const val DIALOG_CLASS_NAME = "android.app.Dialog"
+    private const val WINDOW_FIELD_NAME = "mWindow"
     private const val DECOR_FIELD_NAME = "mDecor"
   }
 }
@@ -91,9 +173,9 @@ internal class WindowDecorRule : OwnerRule {
  * `mActivities`, so a destroyed activity has no owner left and falls back on whatever is leaking it, which
  * is exactly what you want its bytes drawn under.
  */
-internal class RunningActivityRule(graph: HeapGraph) : OwnerRule {
-
-  private val activityReferenceReader = RunningActivityReferenceReader(graph)
+internal class RunningActivityRule(
+  private val activityReferenceReader: RunningActivityReferenceReader
+) : OwnerRule {
 
   override val ownerClassNames = setOf(RunningActivityReferenceReader.ACTIVITY_THREAD_CLASS_NAME)
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -462,9 +462,8 @@ internal class WeakeningAwareReferenceReader(
 
   override fun read(source: HeapObject): Sequence<Reference> {
     val pathStrength = reachability.strengthOf(source)
-    val ownership = ownerReferences.ownershipOf(source)
     val retaining = strengthReader.retainingReferencesOf(source)
-      .filter { ownerReferences.isHeldThrough(ownership, it) }
+      .filter { ownerReferences.isHeldThrough(source.objectId, it) }
       .let { references ->
         // Nothing to weigh when the path here is strong, which it is for nearly every object of a dump.
         if (pathStrength == STRONG) {

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RunningActivityReferenceReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RunningActivityReferenceReader.kt
@@ -1,5 +1,7 @@
 package shark.explorer
 
+import androidx.collection.LongSet
+import androidx.collection.MutableLongSet
 import shark.HeapGraph
 import shark.HeapObject
 import shark.HeapObject.HeapInstance
@@ -44,6 +46,22 @@ internal class RunningActivityReferenceReader(private val graph: HeapGraph) {
    */
   private val activityThreadClassId: Long by lazy {
     graph.findClassByName(ACTIVITY_THREAD_CLASS_NAME)?.objectId ?: ValueHolder.NULL_REFERENCE
+  }
+
+  /**
+   * Every activity the app is running, whichever `ActivityThread` runs it, by object id.
+   *
+   * The same read as [activityReferencesOf] asked of the whole heap dump rather than of one thread, for
+   * [ActivityWindowRule], which needs to know whether the framework is still running a screen and has only
+   * this to read it off: an activity it has finished with is out of `mActivities` and says so nowhere else
+   * in its references.
+   */
+  fun runningActivityIds(): LongSet {
+    val activityIds = MutableLongSet()
+    graph.findClassByName(ACTIVITY_THREAD_CLASS_NAME)?.instances?.forEach { activityThread ->
+      runningActivityIdsOf(activityThread).forEach { activityIds += it }
+    }
+    return activityIds
   }
 
   /** The activities [source] is running when it's the `ActivityThread`, and nothing at all for the rest. */

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
@@ -29,9 +29,16 @@ class OwnerReferencesTest {
       // A fallback event handler and an InputMethodManager both point at a view they don't hold, and both
       // are one step from a GC root while the activity is two. Counting those as ways of holding a view is
       // what scatters a window's hierarchy across whatever happens to be closest to a root.
-      assertThat(tree.dominatorOf(decor.objectId)!!.label).isEqualTo("MainActivity")
+      //
+      // The window rather than the activity, whose mDecor points at this decor view as well: two owners
+      // would put it under whatever dominates both, and a window is the one that always has it.
+      assertThat(tree.dominatorOf(decor.objectId)!!.label).isEqualTo("PhoneWindow")
       assertThat(tree.independentPathsBelowDominator(decor.objectId).paths.map { it.stepLabels() })
         .containsExactly(listOf("mDecor → DecorView"))
+      // And the window under the activity it is the window of, so the hierarchy still reads under the screen
+      // it belongs to — one step further down than it used to.
+      assertThat(tree.dominatorOf(tree.findByLabel("PhoneWindow").objectId)!!.label)
+        .isEqualTo("MainActivity")
       // Its parent, not the View[] the parent keeps it in: the parent points at each of its children
       // itself — see [ViewChildReferenceReader] — so the array is no step on the way down to a view, and
       // the one step there is names the child's index on the parent's own class.
@@ -81,27 +88,72 @@ class OwnerReferencesTest {
     }
   }
 
-  @Test fun `a hierarchy whose root nothing owns still nests inside its root`() {
-    HeapExplorer.open(windowWithoutActivityDecorHeapDump()).use { explorer ->
+  @Test fun `the window of a screen the framework is done with is held by whatever leaks it`() {
+    HeapExplorer.open(destroyedActivityWindowHeapDump()).use { explorer ->
       val tree = explorer.tree
 
-      // `Activity.mDecor` is a field of the framework that is null on a live activity more often than not —
-      // measured null for the only activity of compose_leak.hprof, for two of the three in
-      // leak_asynctask_m.hprof and for two of the four in large-dump.hprof — because what holds a decor
-      // view is the window. So the rule about that field mostly doesn't fire, and what a hierarchy hangs
-      // off has to be right without it.
+      // A destroyed activity still points at its window — mWindow is set in attach and never cleared, unlike
+      // the mDecor this rule used to be about — and nothing else here does, so the window lands under it all
+      // the same. What the rule saves is the case below, where something else points at the window too.
+      assertThat(tree.dominatorOf(tree.findByLabel("PhoneWindow").objectId)!!.label)
+        .isEqualTo("MainActivity")
+      assertThat(tree.dominatorOf(tree.findByLabel("MainActivity").objectId)!!.label)
+        .isEqualTo("Leaker")
+      // And the hierarchy under the window nests as it always did, each layer under its own parent, with the
+      // bytes at the bottom counted all the way up. Declaring a view owned when nothing owns it used to cost
+      // exactly this: every rival counted, and a window's hierarchy was drawn as a flat pile under whatever
+      // dominated all of them.
       assertThat(tree.dominatorOf(tree.findByLabel("DecorView").objectId)!!.label)
         .isEqualTo("PhoneWindow")
-      // Each layer under its own parent, and the bytes at the bottom counted all the way up. Declaring
-      // every view owned whether or not an owner points at one used to cost exactly this: with nothing
-      // owning the root, every view of the window became held as a last resort, every rival counted, and
-      // the hierarchy was drawn as a flat pile under whatever dominated all of them.
       assertThat(tree.dominatorOf(tree.findByLabel("ContentFrame").objectId)!!.label)
         .isEqualTo("DecorView")
       assertThat(tree.dominatorOf(tree.findByLabel("ContentView").objectId)!!.label)
         .isEqualTo("ContentFrame")
       assertThat(tree.weight(tree.findByLabel("PhoneWindow").objectId))
         .isGreaterThan(tree.weight(tree.findByLabel("ContentView").objectId))
+    }
+  }
+
+  @Test fun `a dialog that is up holds its window and one that has been dismissed doesn't`() {
+    HeapExplorer.open(dialogWindowsHeapDump()).use { explorer ->
+      val tree = explorer.tree
+
+      // A dialog's window is final, so the field that says whether the dialog is still up is its own mDecor:
+      // show sets it, dismiss nulls it. Which is the field this rule used to be about, and the one place it
+      // was a reliable signal.
+      assertThat(tree.dominatorOf(tree.findByLabel("ShowingDialogWindow").objectId)!!.label)
+        .isEqualTo("ShowingDialog")
+      // Nothing owns the dismissed one's window, so the jank monitor holding it counts and the tree says
+      // there are two ways to it rather than attributing it to the dialog that is done with it. Which is the
+      // whole point: that other reference is the reason the window is still in memory, and a rule that owned
+      // it anyway would have drawn it as the dialog's own bytes and hidden the one thing to fix.
+      val dismissed = tree.findByLabel("DismissedDialogWindow").objectId
+      assertThat(tree.independentPathsBelowDominator(dismissed).paths.map { it.stepLabels() })
+        .containsExactlyInAnyOrder(
+          listOf("JankMonitor", "dismissedWindow → DismissedDialogWindow"),
+          listOf("DismissedDialog", "mWindow → DismissedDialogWindow")
+        )
+    }
+  }
+
+  @Test fun `an activity the app is running holds its window and one it has let go of doesn't`() {
+    HeapExplorer.open(activityWindowsHeapDump()).use { explorer ->
+      val tree = explorer.tree
+
+      // An activity's window is never taken off it, so what says whether the screen is still up is the
+      // record in ActivityThread.mActivities, which handleDestroyActivity removes. The activity that still
+      // has one owns its window, and the jank monitor pointing at it as well costs it nothing.
+      assertThat(tree.dominatorOf(tree.findByLabel("RunningActivityWindow").objectId)!!.label)
+        .isEqualTo("RunningActivity")
+      // Nothing owns the window of the activity the framework has finished with, so the tree says there are
+      // two ways to it rather than drawing it as the bytes of an activity that has nothing left to do with
+      // it — and one of those two ways is why it is still in memory.
+      val destroyed = tree.findByLabel("DestroyedActivityWindow").objectId
+      assertThat(tree.independentPathsBelowDominator(destroyed).paths.map { it.stepLabels() })
+        .containsExactlyInAnyOrder(
+          listOf("JankMonitor", "destroyedWindow → DestroyedActivityWindow"),
+          listOf("Leaker", "activity → DestroyedActivity", "mWindow → DestroyedActivityWindow")
+        )
     }
   }
 
@@ -168,10 +220,11 @@ class OwnerReferencesTest {
   }
   /**
    * A heap dump shaped like the view hierarchies of a running app: an `ActivityThread` running an activity
-   * through the `ArrayMap` of records it keeps them in, the activity holding its decor view, the decor view
-   * holding a child through the array a `ViewGroup` keeps its children in — plus a view in a slot of that
-   * array it doesn't count — and two things pointing at views they don't hold, a `ViewRootImpl` and an
-   * `InputMethodManager`, each a GC root of its own so that both are closer to a root than the activity is.
+   * through the `ArrayMap` of records it keeps them in, the activity holding its window, the window holding
+   * its decor view, the decor view holding a child through the array a `ViewGroup` keeps its children in —
+   * plus a view in a slot of that array it doesn't count — and two things pointing at views they don't hold,
+   * a `ViewRootImpl` and an `InputMethodManager`, each a GC root of its own so that both are closer to a root
+   * than the activity is.
    *
    * Plus the two shapes of something the framework isn't running: a destroyed activity only a leaker keeps
    * in memory, and an activity in a pair of the map past the count it keeps.
@@ -211,11 +264,23 @@ class OwnerReferencesTest {
         className = "com.android.internal.policy.DecorView",
         superclassId = viewGroupClassId
       )
+      val windowClassId = clazz(
+        className = "com.android.internal.policy.PhoneWindow",
+        // Declared by the internal subclass rather than by android.view.Window, which is where the framework
+        // declares it and so what makes this cover a rule that has to find the field without naming the class
+        // that has it.
+        superclassId = clazz(
+          className = "android.view.Window",
+          fields = listOf("mDestroyed" to BooleanHolder::class)
+        ),
+        fields = listOf("mDecor" to ReferenceHolder::class)
+      )
       val activityClassId = clazz(
         className = "android.app.Activity",
         fields = listOf(
           "mDecor" to ReferenceHolder::class,
-          "mDestroyed" to BooleanHolder::class
+          "mDestroyed" to BooleanHolder::class,
+          "mWindow" to ReferenceHolder::class
         )
       )
       // The owner field is declared by android.app.Activity and the instance is a subclass of it, which is
@@ -275,16 +340,20 @@ class OwnerReferencesTest {
         ),
         objectId = detachedRootId
       )
-      instance(mainActivityClassId, listOf(decor, BooleanHolder(false)), objectId = activityId)
+      // The window the decor view really hangs off. The activity's own mDecor is left pointing at it too,
+      // because the framework sets that field for the first activity of a record and this is what says the
+      // decor view is drawn under the window all the same.
+      val window = instance(windowClassId, listOf(decor, BooleanHolder(false)))
+      instance(mainActivityClassId, listOf(decor, BooleanHolder(false), window), objectId = activityId)
       // The activity the framework has destroyed, and one in a pair of the map past the count it keeps —
       // neither of them something the app is running, reached by two different ways of not being in it.
       val destroyedActivity = instance(
         clazz(className = "com.example.DestroyedActivity", superclassId = activityClassId),
-        listOf(NO_REFERENCE, BooleanHolder(true))
+        listOf(NO_REFERENCE, BooleanHolder(true), NO_REFERENCE)
       )
       val uncountedActivity = instance(
         clazz(className = "com.example.UncountedActivity", superclassId = activityClassId),
-        listOf(NO_REFERENCE, BooleanHolder(false))
+        listOf(NO_REFERENCE, BooleanHolder(false), NO_REFERENCE)
       )
       // What the framework runs each activity from. One class for both records, because the shorthand that
       // declares a class per instance would put two ActivityClientRecord classes in a dump that no real one
@@ -330,12 +399,11 @@ class OwnerReferencesTest {
   }
 
   /**
-   * A window of an activity whose `mDecor` is null, which is how a live activity looks in most real dumps:
-   * three views deep, with something pointing at the middle of the hierarchy the way an app's own field
-   * does.
+   * A destroyed activity that a leaker keeps in memory, still pointing at its window: three views deep, with
+   * something pointing at the middle of the hierarchy the way an app's own field does.
    */
-  private fun windowWithoutActivityDecorHeapDump(): File {
-    val file = testFolder.newFile("window-without-activity-decor.hprof")
+  private fun destroyedActivityWindowHeapDump(): File {
+    val file = testFolder.newFile("destroyed-activity-window.hprof")
     file.dump {
       val viewClassId = clazz(
         className = "android.view.View",
@@ -357,7 +425,10 @@ class OwnerReferencesTest {
       val viewArrayClassId = arrayClass("android.view.View")
       val activityClassId = clazz(
         className = "android.app.Activity",
-        fields = listOf("mDecor" to ReferenceHolder::class)
+        fields = listOf(
+          "mDestroyed" to BooleanHolder::class,
+          "mWindow" to ReferenceHolder::class
+        )
       )
       val decorId = reserveObjectId()
       val activityId = reserveObjectId()
@@ -399,30 +470,169 @@ class OwnerReferencesTest {
         ),
         objectId = decorId
       )
-      // The window really holding the decor view, and the activity's own field left null.
-      val window = "com.android.internal.policy.PhoneWindow" instance {
-        field["mDecor"] = decorId
+      // The window holding the decor view, and the destroyed activity still pointing at the window.
+      val window = instance(
+        clazz(
+          className = "com.android.internal.policy.PhoneWindow",
+          superclassId = clazz(
+            className = "android.view.Window",
+            fields = listOf("mDestroyed" to BooleanHolder::class)
+          ),
+          fields = listOf("mDecor" to ReferenceHolder::class)
+        ),
+        listOf(decorId, BooleanHolder(true))
+      )
+      instance(
+        clazz(className = "com.example.MainActivity", superclassId = activityClassId),
+        listOf(BooleanHolder(true), window),
+        objectId = activityId
+      )
+      // What keeps the destroyed screen in memory, plus a rival into the middle of the hierarchy, one step
+      // from a GC root while the decor view is three.
+      val leaker = "com.example.Leaker" instance {
+        field["activity"] = activityId
+        field["frame"] = contentFrame
       }
-      instance(activityClassId, listOf(NO_REFERENCE), objectId = activityId)
-      val activityRecordClassId = clazz(
-        className = "android.app.ActivityThread\$ActivityClientRecord",
-        fields = listOf("activity" to ReferenceHolder::class)
+      gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 0))
+    }
+    return file
+  }
+
+  /**
+   * Two dialogs, each holding a window of its own, one of them dismissed — and a jank monitor holding both
+   * windows from a GC root of its own, which is what makes where each of them lands a question.
+   */
+  private fun dialogWindowsHeapDump(): File {
+    val file = testFolder.newFile("dialog-windows.hprof")
+    file.dump {
+      val windowClassId = clazz(
+        className = "android.view.Window",
+        // mDestroyed because the object inspector for a window reads it and would throw without it. False
+        // for both: the framework only sets it on the window of an activity it destroys.
+        fields = listOf(
+          "mDestroyed" to BooleanHolder::class,
+          "payload" to ReferenceHolder::class
+        )
+      )
+      val dialogClassId = clazz(
+        className = "android.app.Dialog",
+        fields = listOf(
+          "mDecor" to ReferenceHolder::class,
+          "mWindow" to ReferenceHolder::class
+        )
+      )
+      // Named for what each of them is, since a window is told from another by its label in the tree.
+      val showingWindow = instance(
+        clazz(className = "com.example.ShowingDialogWindow", superclassId = windowClassId),
+        listOf(
+          BooleanHolder(false),
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT)))
+        )
+      )
+      val dismissedWindow = instance(
+        clazz(className = "com.example.DismissedDialogWindow", superclassId = windowClassId),
+        listOf(
+          BooleanHolder(false),
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT)))
+        )
+      )
+      // Dialog.show reads the decor view off the window and keeps it; Dialog.dismiss puts the field back to
+      // null and leaves mWindow where it was.
+      val showingDialog = instance(
+        clazz(className = "com.example.ShowingDialog", superclassId = dialogClassId),
+        listOf(
+          instance(clazz(className = "com.android.internal.policy.DecorView")),
+          showingWindow
+        )
+      )
+      val dismissedDialog = instance(
+        clazz(className = "com.example.DismissedDialog", superclassId = dialogClassId),
+        listOf(NO_REFERENCE, dismissedWindow)
+      )
+      val jankMonitor = "com.example.JankMonitor" instance {
+        field["showingWindow"] = showingWindow
+        field["dismissedWindow"] = dismissedWindow
+      }
+      gcRoot(JniGlobal(id = showingDialog.value, jniGlobalRefId = 0))
+      gcRoot(JniGlobal(id = dismissedDialog.value, jniGlobalRefId = 1))
+      gcRoot(JniGlobal(id = jankMonitor.value, jniGlobalRefId = 2))
+    }
+    return file
+  }
+
+  /**
+   * Two activities, each holding a window of its own, one of them gone from the `ActivityThread` running the
+   * app — and a jank monitor holding both windows from a GC root of its own, which is what makes where each
+   * of them lands a question.
+   */
+  private fun activityWindowsHeapDump(): File {
+    val file = testFolder.newFile("activity-windows.hprof")
+    file.dump {
+      val windowClassId = clazz(
+        className = "android.view.Window",
+        // mDestroyed because the object inspector for a window reads it and would throw without it.
+        fields = listOf(
+          "mDestroyed" to BooleanHolder::class,
+          "payload" to ReferenceHolder::class
+        )
+      )
+      val activityClassId = clazz(
+        className = "android.app.Activity",
+        fields = listOf(
+          "mDestroyed" to BooleanHolder::class,
+          "mWindow" to ReferenceHolder::class
+        )
+      )
+      // Named for what each of them is, since a window is told from another by its label in the tree.
+      val runningWindow = instance(
+        clazz(className = "com.example.RunningActivityWindow", superclassId = windowClassId),
+        listOf(
+          BooleanHolder(false),
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT)))
+        )
+      )
+      val destroyedWindow = instance(
+        clazz(className = "com.example.DestroyedActivityWindow", superclassId = windowClassId),
+        listOf(
+          BooleanHolder(true),
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT)))
+        )
+      )
+      // Activity.mWindow is set in attach and never cleared, so both of them point at their window and the
+      // difference between the two is only in what the thread below still runs.
+      val runningActivity = instance(
+        clazz(className = "com.example.RunningActivity", superclassId = activityClassId),
+        listOf(BooleanHolder(false), runningWindow)
+      )
+      val destroyedActivity = instance(
+        clazz(className = "com.example.DestroyedActivity", superclassId = activityClassId),
+        listOf(BooleanHolder(true), destroyedWindow)
       )
       val activityThread = "android.app.ActivityThread" instance {
         field["mActivities"] = "android.util.ArrayMap" instance {
+          // A key at the even slot and its record at the odd one after it, for the one activity left.
           field["mArray"] = objectArray(
             instance(clazz(className = "android.os.BinderProxy")),
-            instance(activityRecordClassId, listOf(activityId))
+            instance(
+              clazz(
+                className = "android.app.ActivityThread\$ActivityClientRecord",
+                fields = listOf("activity" to ReferenceHolder::class)
+              ),
+              listOf(runningActivity)
+            )
           )
           field["mSize"] = IntHolder(1)
         }
-        // Whatever the app hangs off the thread, the window among it.
-        field["mWindow"] = window
       }
-      // A rival into the middle of the hierarchy, one step from a GC root while the decor view is three.
-      val leaker = "com.example.Leaker" instance { field["frame"] = contentFrame }
+      val jankMonitor = "com.example.JankMonitor" instance {
+        field["runningWindow"] = runningWindow
+        field["destroyedWindow"] = destroyedWindow
+      }
+      // What keeps the destroyed screen in memory, the thread being what keeps the other one.
+      val leaker = "com.example.Leaker" instance { field["activity"] = destroyedActivity }
       gcRoot(JniGlobal(id = activityThread.value, jniGlobalRefId = 0))
       gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 1))
+      gcRoot(JniGlobal(id = jankMonitor.value, jniGlobalRefId = 2))
     }
     return file
   }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
@@ -81,6 +81,30 @@ class OwnerReferencesTest {
     }
   }
 
+  @Test fun `a hierarchy whose root nothing owns still nests inside its root`() {
+    HeapExplorer.open(windowWithoutActivityDecorHeapDump()).use { explorer ->
+      val tree = explorer.tree
+
+      // `Activity.mDecor` is a field of the framework that is null on a live activity more often than not —
+      // measured null for the only activity of compose_leak.hprof, for two of the three in
+      // leak_asynctask_m.hprof and for two of the four in large-dump.hprof — because what holds a decor
+      // view is the window. So the rule about that field mostly doesn't fire, and what a hierarchy hangs
+      // off has to be right without it.
+      assertThat(tree.dominatorOf(tree.findByLabel("DecorView").objectId)!!.label)
+        .isEqualTo("PhoneWindow")
+      // Each layer under its own parent, and the bytes at the bottom counted all the way up. Declaring
+      // every view owned whether or not an owner points at one used to cost exactly this: with nothing
+      // owning the root, every view of the window became held as a last resort, every rival counted, and
+      // the hierarchy was drawn as a flat pile under whatever dominated all of them.
+      assertThat(tree.dominatorOf(tree.findByLabel("ContentFrame").objectId)!!.label)
+        .isEqualTo("DecorView")
+      assertThat(tree.dominatorOf(tree.findByLabel("ContentView").objectId)!!.label)
+        .isEqualTo("ContentFrame")
+      assertThat(tree.weight(tree.findByLabel("PhoneWindow").objectId))
+        .isGreaterThan(tree.weight(tree.findByLabel("ContentView").objectId))
+    }
+  }
+
   @Test fun `an activity the framework hasn't destroyed is held by the thread running it`() {
     HeapExplorer.open(viewHierarchyHeapDump()).use { explorer ->
       val tree = explorer.tree
@@ -301,6 +325,104 @@ class OwnerReferencesTest {
       gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 1))
       gcRoot(JniGlobal(id = fallbackHandler.value, jniGlobalRefId = 2))
       gcRoot(JniGlobal(id = inputMethodManager.value, jniGlobalRefId = 3))
+    }
+    return file
+  }
+
+  /**
+   * A window of an activity whose `mDecor` is null, which is how a live activity looks in most real dumps:
+   * three views deep, with something pointing at the middle of the hierarchy the way an app's own field
+   * does.
+   */
+  private fun windowWithoutActivityDecorHeapDump(): File {
+    val file = testFolder.newFile("window-without-activity-decor.hprof")
+    file.dump {
+      val viewClassId = clazz(
+        className = "android.view.View",
+        fields = listOf(
+          "mParent" to ReferenceHolder::class,
+          "mWindowAttachCount" to IntHolder::class,
+          "mAttachInfo" to ReferenceHolder::class,
+          "mContext" to ReferenceHolder::class
+        )
+      )
+      val viewGroupClassId = clazz(
+        className = "android.view.ViewGroup",
+        superclassId = viewClassId,
+        fields = listOf(
+          "mChildren" to ReferenceHolder::class,
+          "mChildrenCount" to IntHolder::class
+        )
+      )
+      val viewArrayClassId = arrayClass("android.view.View")
+      val activityClassId = clazz(
+        className = "android.app.Activity",
+        fields = listOf("mDecor" to ReferenceHolder::class)
+      )
+      val decorId = reserveObjectId()
+      val activityId = reserveObjectId()
+      val attachInfo = "android.view.View\$AttachInfo" instance { field["mRootView"] = decorId }
+      val contentView = instance(
+        clazz(
+          className = "com.example.ContentView",
+          superclassId = viewClassId,
+          fields = listOf("payload" to ReferenceHolder::class)
+        ),
+        listOf(
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT))),
+          NO_REFERENCE,
+          IntHolder(1),
+          attachInfo,
+          activityId
+        )
+      )
+      val contentFrame = instance(
+        clazz(className = "com.example.ContentFrame", superclassId = viewGroupClassId),
+        listOf(
+          ReferenceHolder(objectArray(viewArrayClassId, longArrayOf(contentView.value))),
+          IntHolder(1),
+          decorId,
+          IntHolder(1),
+          attachInfo,
+          activityId
+        )
+      )
+      instance(
+        clazz(className = "com.android.internal.policy.DecorView", superclassId = viewGroupClassId),
+        listOf(
+          ReferenceHolder(objectArray(viewArrayClassId, longArrayOf(contentFrame.value))),
+          IntHolder(1),
+          NO_REFERENCE,
+          IntHolder(1),
+          attachInfo,
+          activityId
+        ),
+        objectId = decorId
+      )
+      // The window really holding the decor view, and the activity's own field left null.
+      val window = "com.android.internal.policy.PhoneWindow" instance {
+        field["mDecor"] = decorId
+      }
+      instance(activityClassId, listOf(NO_REFERENCE), objectId = activityId)
+      val activityRecordClassId = clazz(
+        className = "android.app.ActivityThread\$ActivityClientRecord",
+        fields = listOf("activity" to ReferenceHolder::class)
+      )
+      val activityThread = "android.app.ActivityThread" instance {
+        field["mActivities"] = "android.util.ArrayMap" instance {
+          field["mArray"] = objectArray(
+            instance(clazz(className = "android.os.BinderProxy")),
+            instance(activityRecordClassId, listOf(activityId))
+          )
+          field["mSize"] = IntHolder(1)
+        }
+        // Whatever the app hangs off the thread, the window among it.
+        field["mWindow"] = window
+      }
+      // A rival into the middle of the hierarchy, one step from a GC root while the decor view is three.
+      val leaker = "com.example.Leaker" instance { field["frame"] = contentFrame }
+      gcRoot(JniGlobal(id = activityThread.value, jniGlobalRefId = 0))
+      gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 1))
     }
     return file
   }


### PR DESCRIPTION
Follow-up to #2937. The `OwnerRule` schema grew a second vocabulary when the dependency injection rule landed — a sealed `OwnedObjects` class and a four-name `ScopedProvider` — and that turned out to be a symptom rather than an inconvenience.

## What was wrong with the schema

**It said the same thing twice.** Every rule named a class whose instances are owned *and* the references that own them. For a DI singleton the only way to name the owned objects **is** the owner reference — `DoubleCheck.instance` — so the sealed class existed to express a tautology.

**It had no room for "and not this object".** `ScopedProvider.uninitializedHolderClassName` and `uninitializedFieldName` were a sub-vocabulary for one exclusion that in code is `heldObjectId != provider.uninitializedObjectId`.

**It lost which rule a field belonged to.** `ownerFieldsByClassName()` merged every rule's fields into one map and every rule's virtual class names into one set, and `Ownership` carried no rule identity — so nothing checked that the field that owns matches the objects it owns. Sound today only by luck: the next virtual reference reader whose source class is also a `ViewGroup` would have silently made that `ViewGroup` own what the new reader reads.

## What a rule is now

A class taking the graph, resolving its classes once and answering off the index — the same shape `ViewChildReferenceReader` and `RunningActivityReferenceReader` already have. Two members:

```kotlin
internal interface OwnerRule {
  val ownerClassNames: Set<String>
  fun forEachOwnedObject(owner: HeapInstance, onOwned: (Long) -> Unit)
}
```

Which objects are owned is derived from what those report. Deleted: `OwnedObjects`, `ScopedProvider`'s two sentinel fields, the merged field and virtual-class maps, the per-class `Ownership` cache, and the lazy name resolution the hot path did for every reference into an owned object. Asking whether a reference is a rival is now one hash lookup into a single map.

Consumers are unchanged apart from passing an object id where they passed an `Ownership`.

## Deriving turned out to be a fix

I expected this to be behaviour-preserving and captured a signature of every node of every real dump in the repo beforehand to prove it. It isn't, and the difference is a bug the schema was hiding.

Declaring "every `View` is owned" meant a view **no owner points at** was still owned, so it was held as a last resort, so *every* rival into it counted. And `Activity.mDecor` is null on a live activity more often than not — measured null for the only activity of `compose_leak.hprof`, two of the three in `leak_asynctask_m.hprof`, one of the two in `gcroot_unknown_object.hprof` and two of the four in `large-dump.hprof`, because what holds a decor view is the window. So the ordinary case was: no owner reaches the decor view, the whole hierarchy becomes last-resort held, and the window's views are drawn as a flat pile.

On `large-dump.hprof` a `PhoneWindow` retained 20 KB with 1.6 MB of its own views hanging off the activity beside it. Derived, that `PhoneWindow` retains 1.68 MB and each layout layer nests under the one above it. In the new synthetic fixture the old code floats the decor view all the way to `"Whole heap dump"` — I ran the new test against the old rule code to confirm it fails there.

## Measurements

Signature of every node — id, retained size, dominator, dominator kind — over the eight real dumps, before and after:

| | |
| --- | --- |
| Object set | identical in all eight |
| Total retained bytes | identical in all eight |
| Objects that changed dominator | 0 to 53, of 34 K to 340 K |
| What moved | windows and views, nothing else |

`unloaded_classes-stripped.hprof` (5.5 GB of retained heap, 314 K objects) is byte-for-byte identical. The two nodes that vanish from `leak_asynctask_m.hprof` are synthetic group nodes, not objects: a flat pile of same-class views needed grouping and a nested hierarchy doesn't.

Cost of the pass, measured per dump: **4 ms to 26 ms** derived against **12 ms to 32 ms** declared, of the ~1.5 s it takes to open these dumps. Deriving reads a record per possible owner where declaring read none, and buys back the name resolution the hot path was doing per reference.

`notes/dominator-tree.md` records all of it.

No changelog entry: the explorer's log is still a single "Initial release".

---

# Second commit: hold a decor view through its window, and the window through its screen

Which was #2943 until it turned out to be one change with the first commit rather than a follow-up.
The question it answers: is there always a window when there's a decor view, and if so, should the
rule be `PhoneWindow.mDecor` rather than `Activity.mDecor`?

## Is there always a window?

Yes, for a *decor view*: every one in the seven real dumps in the repo is pointed at by exactly one `PhoneWindow.mDecor` (1 of 1 in `compose_leak.hprof`, 3 of 3 in `leak_asynctask_m.hprof`, and so on).

Not for a *root view*, which is the distinction that matters: 14 of the 15 root views in `compose_leak.hprof`, 9 of the 10 in `leak_asynctask_m.hprof` and 22 of the 23 in `gcroot_unknown_object.hprof` have no window anywhere. They're `Toast` views, `PopupWindow.mContentView`, `TextView$MagnifierView`s, `Toolbar.mNavButtonView` image buttons and fragment roots, each held the ordinary way by whatever made it. So the rule is window → decor view, and the rest need nothing.

## Why `Activity.mDecor` had to go

`ActivityThread.handleResumeActivity` is the only place that writes it, guarded by `if (r.window == null && !a.mFinished && willBeVisible)` — so it is set once per `ActivityClientRecord`, not once per `Activity`. A screen recreated on a configuration change is resumed, visible, and has a null `mDecor` for the rest of its life. It also inverted the nesting where it *was* set: in `leak_asynctask_m.hprof` a `PhoneWindow` was drawn under its own `DecorView`, through `DecorView.this$0`.

## Why the window then needs a rule of its own

A window has 6 to 9 referrers in these dumps. Most are its own inner classes and its decor's, but the external ones — `WindowManagerImpl.mParentWindow`, `ActivityThread$ActivityClientRecord.window`, `DecorView.mWindow` reached from a `ViewRootImpl` — put **6 of the 16 windows at the top of the tree**. Moving the decor view under the window makes that worse than it was, because the hierarchy now floats with it: `gcroot_unknown_object.hprof`'s `PhoneWindow` went from 14 KB at the root to 3.09 MB there, `large-dump.hprof`'s from 12 KB to 2.14 MB. With `Activity.mWindow` / `Dialog.mWindow` owning it, every decor view in every dump is under its window and every window of a screen that is up is under that screen.

## The rule whose owning reference outlives what it is about

`Activity.mWindow` is set in `attach` and never cleared, and `Dialog.mWindow` is final, so a destroyed activity and a dismissed dialog go on pointing at a window they have nothing left to do with. Owning it regardless took the window of a leaked screen away from whatever else was holding it and turned two leaks into one on the list — the reference that would still have been there after the activity was fixed stopped being reported. `HeapLeaksTest` covers that.

So `ActivityWindowRule` owns through `mWindow` and asks whether the screen is up of **another reference, one the framework does drop** — the same self-clearing signal every other rule owns by, borrowed from beside the one this rule owns through:

- A dialog is dropped from its own `mDecor`, which `show` sets and `dismiss` nulls.
- An activity is dropped from `ActivityThread.mActivities`, which `handleDestroyActivity` removes the record from — and which `RunningActivityRule` already owns activities by, so the two rules now share one `RunningActivityReferenceReader`.

No rule reads the state of an object. The first draft of this one read `Activity.mDestroyed`; swapping it for the map gives **byte-identical trees and leak lists on all eight real dumps**, with `mActivities.size` matching the count of non-destroyed activities in every one of them. They also fail in opposite directions, which is the reason to prefer the map: an `mDestroyed` a dump doesn't carry reads as a screen that is up and *keeps* ownership, where an `mActivities` this can't read reads as a thread running nothing and *gives ownership up*, which is the fallback every other rule already has.

`notes/dominator-tree.md` records this as the test to apply to a new rule: ask which reference the framework drops, and own by that one or read it.

## Conserved

Bytes conserved on all eight dumps, no object joins or leaves the tree, 0 to 16 objects of 34 K to 340 K move. `shark-explorer-core:check` and `shark-explorer-app:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
