### PR TITLE
Warn that gh pr merge --auto merges immediately here

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,22 @@ before adjusting the expected values, and say in the PR why the new number is co
 via the `assemble` and `clean` tasks, so a fresh clone gets it after the first build. Run `detekt`
 before pushing rather than discovering it at push time.
 
+**`gh pr merge --auto` does not wait for CI here — it merges on the spot.** Auto-merge is enabled on
+the repo, but `main` is deliberately left unprotected, so there are no required status checks for
+auto-merge to gate on. GitHub sees a mergeable pull request with nothing to wait for and merges
+immediately, exiting zero and printing nothing, which reads exactly like it armed. Nothing in the
+repo will stop a merge while CI is red — `main` is open on purpose — so waiting for green is your
+job, not the platform's. Wait explicitly and let the exit code decide:
+
+```bash
+gh pr checks <number> --watch --fail-fast && gh pr merge <number> --merge
+```
+
+`gh pr checks` exits zero only once every check has passed, so the `&&` is what makes this safe;
+`--fail-fast` returns as soon as one fails instead of sitting through the rest. A run takes 9 to 13
+minutes, nearly all of it the emulator matrix, so start that command detached — a foreground call
+that gives up at ten minutes will usually be killed just before the last emulator reports.
+
 ## Changelog
 
 Entries go in `docs/changelog.md` under `## Unreleased`, each starting with one of the markers from


### PR DESCRIPTION
Follow-up to #2940, where I merged with eleven emulator jobs still pending.

`gh pr merge --auto` looked like the right way to land a PR on green. It is not, on this repo:

- `main` is deliberately unprotected — `gh api repos/square/leakcanary/branches/main/protection` returns 404, "Branch not protected" — so there are no required status checks.
- Auto-merge is enabled at the repo level (`allow_auto_merge: true`), so the flag is accepted rather than rejected.
- With a mergeable PR and nothing to gate on, GitHub merges immediately. The command exits zero and prints nothing, which is indistinguishable from having armed auto-merge.

Leaving `main` open is deliberate and worth keeping — it is the escape hatch — so the fix is to document the wait that actually works, not to protect the branch:

```bash
gh pr checks <number> --watch --fail-fast && gh pr merge <number> --merge
```

`gh pr checks` exits zero only once every check has passed, so the `&&` carries the safety. The 9 to 13 minute figure is measured from the last eight completed `main.yml` runs; it matters because it straddles the ten minute timeout an agent typically has on a foreground command, so the wait has to be started detached or it gets killed just before the last emulator reports.

This PR is being merged with that command, so the recipe is tested by its own landing rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)