### PR TITLE
Hold a decor view through its window, and the window through its screen

### DIFF
--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -250,13 +250,14 @@ itself and retained 4.2 KB and 3.9 KB instead of their windows. The damaging ref
 view bindings and `StandardRowSpec$StandardViewHolder.itemView`.
 
 `OwnerReferences` applies a curated list of `OwnerRule`s, each one a class taking the graph and answering
-which of an owner's references own what they point at — `ownerRulesFor` in `OwnerRules.kt`. Seven today: a
-`View` owned by the `ViewGroup` that reads it as a child (see below), a decor view owned by `Activity.mDecor`
-or `Dialog.mDecor`, an `Activity` owned by the `ActivityThread` that reads it as one it's running (see below
-too), the three Compose ones in the section on Compose below, and a dependency injection singleton owned by
-the provider caching it (see `notes/dependency-injection.md`). After: **every one of the 277 child views is
-under its parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity`
-retains 18 MB under the thread running it, which is the second largest rectangle under the GC roots.
+which of an owner's references own what they point at — `ownerRulesFor` in `OwnerRules.kt`. Eight today: a
+`View` owned by the `ViewGroup` that reads it as a child (see below), a decor view owned by the `mDecor` of
+the window it is the decor of, that window owned by the `Activity` or `Dialog` it is the window of, an
+`Activity` owned by the `ActivityThread` that reads it as one it's running (see below too), the three
+Compose ones in the section on Compose below, and a dependency injection singleton owned by the provider
+caching it (see `notes/dependency-injection.md`). After: **every one of the 277 child views is under its
+parent**, the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity` retains
+18 MB under the thread running it, which is the second largest rectangle under the GC roots.
 
 **Which objects are owned is derived from those references rather than declared beside them**, and that
 distinction is load-bearing rather than tidiness. The rules used to name a class whose instances were owned —
@@ -271,6 +272,36 @@ all the way to the root. Derived, an object nothing owns is simply not owned: `P
 decor view the ordinary way, each view below it is still owned by its parent, and that `PhoneWindow` retains
 1.68 MB. Across the eight real dumps in the repo the change moved 0 to 53 objects of 34 K to 340 K, all of
 them windows and views, with the object set and every total byte count identical.
+
+**The screen a hierarchy belongs to is reached through its window, not straight from the activity.** Which is
+the other half of that `Activity.mDecor` measurement: the field is null on a live activity because
+`ActivityThread.handleResumeActivity` is the only place that writes it and does so under
+`if (r.window == null && !a.mFinished && willBeVisible)` — once per `ActivityClientRecord`, not once per
+`Activity`, so a screen recreated on a configuration change is visible, resumed and has a null `mDecor` for
+the rest of its life. `PhoneWindow.mDecor` has no such gap: every decor view in the seven real dumps here has
+exactly one referrer through it (1 of 1 in `compose_leak.hprof`, 3 of 3 in `leak_asynctask_m.hprof`, and so on).
+
+It is a decor view and not a root view, though — most root views have no window at all. 14 of the 15 in
+`compose_leak.hprof`, 9 of the 10 in `leak_asynctask_m.hprof` and 22 of the 23 in `gcroot_unknown_object.hprof`
+are `Toast` views, `PopupWindow.mContentView`, `TextView$MagnifierView`s, `Toolbar.mNavButtonView` image
+buttons and fragment roots, each held the ordinary way by whatever made it.
+
+**So the window needs a rule of its own, or moving the decor view one step down loses the screen.** A window
+has 6 to 9 referrers in these dumps, most of them its own inner classes and its decor's, and the external ones
+— `WindowManagerImpl.mParentWindow`, `ActivityThread$ActivityClientRecord.window`, `DecorView.mWindow` reached
+from a `ViewRootImpl` — put 6 of the 16 windows at the top of the tree. With only the decor rule that costs
+more than it used to, because the hierarchy now hangs off the window and floats with it:
+`gcroot_unknown_object.hprof`'s `PhoneWindow` went from 14 KB at the root to 3.09 MB there, and
+`large-dump.hprof`'s from 12 KB to 2.14 MB. With `Activity.mWindow` and `Dialog.mWindow` owning it, every
+decor view in every dump is under its window and every window of a screen that is up is under its screen.
+
+**That rule is the one exception to the paragraph below: it reads the state of its owner.** `Activity.mWindow`
+is set in `attach` and never cleared and `Dialog.mWindow` is final, so a destroyed activity and a dismissed
+dialog both go on pointing at a window they have nothing to do with — the framework expresses this one in a
+field rather than in references, `Activity.mDestroyed` and the `Dialog.mDecor` that `dismiss` nulls. Owning it
+regardless is what the check is worth: it took the window of a leaked screen away from whatever else was
+holding it, and `HeapLeaksTest` went from two leaks to one, hiding the reference that would still have been
+there after the activity was fixed.
 
 Deriving costs a record read per possible owner where declaring cost none: **4 ms to 26 ms** against 12 ms to
 32 ms, of the 1.5 s it takes to open these dumps. It buys the hot path back — asking whether a reference is a
@@ -291,19 +322,23 @@ rule the 82 MB dump comes out at exactly the same numbers as before — 80 MB st
 missing when you read `OwnerRules.kt`. "The parent owns an *attached* view" needs no attachment test, because a
 detached hierarchy isn't held by whatever holds the window: if the parent isn't reachable, no owner
 reference reaches the child and the fallback handles it. "Unless the activity is destroyed" needs no
-`mDestroyed` test either — `ActivityThread.handleDestroyActivity` sets `mDecor = null` and takes the
-`ActivityClientRecord` out of `mActivities`, so the framework has already removed both references the
-rules are about. The state a rule seems to need is expressed by which references exist, and a leaked
-destroyed activity therefore falls back on whatever is leaking it — which is the one thing you'd want to
-read its bytes under.
+`mDestroyed` test either — `ActivityThread.handleDestroyActivity` takes the `ActivityClientRecord` out of
+`mActivities`, so the framework has already removed the reference that rule is about. The state a rule seems
+to need is expressed by which references exist, and a leaked destroyed activity therefore falls back on
+whatever is leaking it — which is the one thing you'd want to read its bytes under.
+
+Which is the test to apply to a new rule, rather than a promise that no rule reads state: ask whether the
+framework drops the reference, and only reach for a field when it demonstrably doesn't. `ActivityWindowRule`
+is where it doesn't, and the paragraph above says what that cost when the check wasn't there.
 
 Two things to know before adding a rule:
 
 - **One owner per construct.** Two owner references are two ways of owning, so the object ends up
-  dominated by whatever dominates both. `PhoneWindow.mDecor` was in the list at first and cost the
-  activity all 18 MB of its hierarchy: a `JankStatsMonitor` held the window from a GC root of its own, so
-  the decor view's dominator became the top of the tree. Pick the one reference you'd want to read the
-  bytes under.
+  dominated by whatever dominates both. `PhoneWindow.mDecor` and `Activity.mDecor` were both in the list at
+  first and cost the activity all 18 MB of its hierarchy: a `JankStatsMonitor` held the window from a GC root
+  of its own, so the decor view's dominator became the top of the tree. Pick the one reference you'd want to
+  read the bytes under — here the window's, with the window owned in turn, which is a chain of single owners
+  rather than two owners of one object.
 - **An owner has to be nameable.** A rule names a field on a class, or a class whose virtual references
   own. An *array* can only be named by its type, which is what the first version of the view rule did —
   every `android.view.View[]` element owned what it pointed at — and a type says nothing about whose

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerRules.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerRules.kt
@@ -16,6 +16,7 @@ import shark.ValueHolder
 internal fun ownerRulesFor(graph: HeapGraph): List<OwnerRule> = listOf(
   ViewParentRule(graph),
   WindowDecorRule(),
+  ActivityWindowRule(),
   RunningActivityRule(graph),
   LayoutNodeParentRule(graph),
   ComposeUiRootNodeRule(),
@@ -47,21 +48,69 @@ internal class ViewParentRule(graph: HeapGraph) : OwnerRule {
 }
 
 /**
- * The root view of a hierarchy has no parent to own it, and belongs to whatever the hierarchy is for.
- * Attributing a window's views to the `Activity` or `Dialog` they're for is the whole point: otherwise they
- * land under the `WindowManagerGlobal` that holds every window of the process, which tells you nothing
- * about which screen is expensive.
+ * The decor view at the top of a hierarchy has no parent to own it, and is held by the window it is the
+ * decor of.
  *
- * The framework nulls `Activity.mDecor` when it destroys the activity, and that is the whole of "unless the
- * activity is destroyed": a rule needs no state check when the field is already gone.
+ * Not by the `Activity` or `Dialog`, which is what this rule used to say. `Activity.mDecor` is written in
+ * one place, `ActivityThread.handleResumeActivity`, guarded by the activity's record having no window yet —
+ * so it is set once per `ActivityClientRecord` rather than once per activity, and an activity recreated on a
+ * configuration change is visible, resumed, and has a null `mDecor` for the rest of its life. Which is most
+ * of the activities in the heap dumps here. Worse than useless: with the decor view declared owned and no
+ * owner reaching it, every rival counted, and a window's whole hierarchy was drawn flat at the top of the
+ * tree.
  *
- * Not `PhoneWindow.mDecor`, which also holds the decor view and is set whether the activity is destroyed or
- * not. Two owners are two ways of owning, so the decor view would end up dominated by whatever dominates
- * both, and on a real app dump that's the top of the tree: a jank monitor held the window from a GC root of
- * its own, which cost the activity all 18 MB of its hierarchy. One owner per construct, and it should be
- * the one you'd want to read the bytes under.
+ * The window holds it whether the activity is destroyed or not, so this rule leans on [ActivityWindowRule]
+ * for the fallback the field used to give: it is the *window* that stops being owned when its activity goes,
+ * and the hierarchy comes with it.
+ *
+ * One owner and not both, though — a decor view owned by its window *and* its activity is dominated by
+ * whatever dominates the two, and on a real app dump that's the top of the tree: a jank monitor held the
+ * window from a GC root of its own, which cost the activity all 18 MB of its hierarchy.
  */
 internal class WindowDecorRule : OwnerRule {
+
+  override val ownerClassNames = setOf(WINDOW_CLASS_NAME)
+
+  override fun forEachOwnedObject(
+    owner: HeapInstance,
+    onOwned: (Long) -> Unit
+  ) {
+    // By field name rather than by declaring class, because the class declaring it is internal and has
+    // moved: com.android.internal.policy.impl.PhoneWindow before Lollipop, com.android.internal.policy
+    // .PhoneWindow since. Reading the fields of a window costs the record read this rule makes anyway.
+    owner.readFields()
+      .firstOrNull { it.name == DECOR_FIELD_NAME }
+      ?.value
+      ?.asNonNullObjectId
+      ?.let(onOwned)
+  }
+
+  companion object {
+    private const val WINDOW_CLASS_NAME = "android.view.Window"
+    private const val DECOR_FIELD_NAME = "mDecor"
+  }
+}
+
+/**
+ * A window is held by the `Activity` or `Dialog` it is the window of. Everything else pointing at one is
+ * something that needs to reach the window: the `WindowManagerImpl` that added it, an
+ * `AppCompatDelegateImpl`, a `DecorContext`, a menu callback, the window's own inner classes.
+ *
+ * Attributing a window to what it is for is what makes the rest of these rules land somewhere worth reading.
+ * Its decor view is nearly all of its bytes ([WindowDecorRule]), and a window with several referrers is
+ * otherwise dominated by whatever dominates all of them — measured on the heap dumps here, 6 of 16 windows
+ * were drawn at the top of the tree, taking their hierarchy with them.
+ *
+ * The one rule here that reads the state of its owner, because this is the one place the framework doesn't
+ * express it in references. `Activity.mWindow` is set in `attach` and never cleared, and `Dialog.mWindow` is
+ * final, so a destroyed activity and a dismissed dialog both still point at a window they have nothing to do
+ * with. Owning it anyway would take the only honest answer away from the one case that needs it: a leaked
+ * screen whose window something else holds as well is two things to fix, and it reads as one if the leak owns
+ * the window. So a destroyed activity owns nothing, and neither does a dismissed dialog — which the framework
+ * says by nulling `Dialog.mDecor`, the field that used to be this rule and is a reliable signal for a dialog
+ * even though it isn't one for an activity ([WindowDecorRule]).
+ */
+internal class ActivityWindowRule : OwnerRule {
 
   override val ownerClassNames = setOf(ACTIVITY_CLASS_NAME, DIALOG_CLASS_NAME)
 
@@ -69,14 +118,32 @@ internal class WindowDecorRule : OwnerRule {
     owner: HeapInstance,
     onOwned: (Long) -> Unit
   ) {
-    ownerClassNames.forEach { className ->
-      owner[className, DECOR_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+    if (!owner.isScreenThatIsUp()) {
+      return
     }
+    ownerClassNames.forEach { className ->
+      owner[className, WINDOW_FIELD_NAME]?.value?.asNonNullObjectId?.let(onOwned)
+    }
+  }
+
+  /** Whether the framework hasn't finished with [this] screen yet. */
+  private fun HeapInstance.isScreenThatIsUp(): Boolean {
+    // A dialog says so with its own mDecor: show sets it, dismiss nulls it. Asked first because having the
+    // field is also what tells a dialog from an activity — an activity has no android.app.Dialog.mDecor.
+    val dialogDecor = this[DIALOG_CLASS_NAME, DECOR_FIELD_NAME]
+    if (dialogDecor != null) {
+      return dialogDecor.value.asNonNullObjectId != null
+    }
+    // An activity says so with mDestroyed, which API 17 introduced — a dump too old to have the field is not
+    // a dump of destroyed screens.
+    return this[ACTIVITY_CLASS_NAME, DESTROYED_FIELD_NAME]?.value?.asBoolean != true
   }
 
   companion object {
     private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
     private const val DIALOG_CLASS_NAME = "android.app.Dialog"
+    private const val WINDOW_FIELD_NAME = "mWindow"
+    private const val DESTROYED_FIELD_NAME = "mDestroyed"
     private const val DECOR_FIELD_NAME = "mDecor"
   }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
@@ -29,9 +29,16 @@ class OwnerReferencesTest {
       // A fallback event handler and an InputMethodManager both point at a view they don't hold, and both
       // are one step from a GC root while the activity is two. Counting those as ways of holding a view is
       // what scatters a window's hierarchy across whatever happens to be closest to a root.
-      assertThat(tree.dominatorOf(decor.objectId)!!.label).isEqualTo("MainActivity")
+      //
+      // The window rather than the activity, whose mDecor points at this decor view as well: two owners
+      // would put it under whatever dominates both, and a window is the one that always has it.
+      assertThat(tree.dominatorOf(decor.objectId)!!.label).isEqualTo("PhoneWindow")
       assertThat(tree.independentPathsBelowDominator(decor.objectId).paths.map { it.stepLabels() })
         .containsExactly(listOf("mDecor → DecorView"))
+      // And the window under the activity it is the window of, so the hierarchy still reads under the screen
+      // it belongs to — one step further down than it used to.
+      assertThat(tree.dominatorOf(tree.findByLabel("PhoneWindow").objectId)!!.label)
+        .isEqualTo("MainActivity")
       // Its parent, not the View[] the parent keeps it in: the parent points at each of its children
       // itself — see [ViewChildReferenceReader] — so the array is no step on the way down to a view, and
       // the one step there is names the child's index on the parent's own class.
@@ -81,27 +88,53 @@ class OwnerReferencesTest {
     }
   }
 
-  @Test fun `a hierarchy whose root nothing owns still nests inside its root`() {
-    HeapExplorer.open(windowWithoutActivityDecorHeapDump()).use { explorer ->
+  @Test fun `the window of a screen the framework is done with is held by whatever leaks it`() {
+    HeapExplorer.open(destroyedActivityWindowHeapDump()).use { explorer ->
       val tree = explorer.tree
 
-      // `Activity.mDecor` is a field of the framework that is null on a live activity more often than not —
-      // measured null for the only activity of compose_leak.hprof, for two of the three in
-      // leak_asynctask_m.hprof and for two of the four in large-dump.hprof — because what holds a decor
-      // view is the window. So the rule about that field mostly doesn't fire, and what a hierarchy hangs
-      // off has to be right without it.
+      // A destroyed activity still points at its window — mWindow is set in attach and never cleared, unlike
+      // the mDecor this rule used to be about — so this is the one rule that reads the state of its owner. It
+      // has to: a window an owner keeps for ever is a window whose real holder the tree can never show, and
+      // for a leaked screen that holder is the answer being looked for.
+      assertThat(tree.dominatorOf(tree.findByLabel("PhoneWindow").objectId)!!.label)
+        .isEqualTo("MainActivity")
+      assertThat(tree.dominatorOf(tree.findByLabel("MainActivity").objectId)!!.label)
+        .isEqualTo("Leaker")
+      // And the hierarchy under the window nests as it always did, each layer under its own parent, with the
+      // bytes at the bottom counted all the way up. Declaring a view owned when nothing owns it used to cost
+      // exactly this: every rival counted, and a window's hierarchy was drawn as a flat pile under whatever
+      // dominated all of them.
       assertThat(tree.dominatorOf(tree.findByLabel("DecorView").objectId)!!.label)
         .isEqualTo("PhoneWindow")
-      // Each layer under its own parent, and the bytes at the bottom counted all the way up. Declaring
-      // every view owned whether or not an owner points at one used to cost exactly this: with nothing
-      // owning the root, every view of the window became held as a last resort, every rival counted, and
-      // the hierarchy was drawn as a flat pile under whatever dominated all of them.
       assertThat(tree.dominatorOf(tree.findByLabel("ContentFrame").objectId)!!.label)
         .isEqualTo("DecorView")
       assertThat(tree.dominatorOf(tree.findByLabel("ContentView").objectId)!!.label)
         .isEqualTo("ContentFrame")
       assertThat(tree.weight(tree.findByLabel("PhoneWindow").objectId))
         .isGreaterThan(tree.weight(tree.findByLabel("ContentView").objectId))
+    }
+  }
+
+  @Test fun `a dialog that is up holds its window and one that has been dismissed doesn't`() {
+    HeapExplorer.open(dialogWindowsHeapDump()).use { explorer ->
+      val tree = explorer.tree
+
+      // A dialog's window is final, so the field that says whether the dialog is still up is its own mDecor:
+      // show sets it, dismiss nulls it. Which is the field this rule used to be about, and the one place it
+      // was a reliable signal.
+      assertThat(tree.dominatorOf(tree.findByLabel("ShowingDialogWindow").objectId)!!.label)
+        .isEqualTo("ShowingDialog")
+      // Nothing owns the dismissed one's window, so the jank monitor holding it counts and the tree says
+      // there are two ways to it rather than attributing it to the dialog that is done with it. Which is the
+      // point of the state check: that other reference is the reason the window is still in memory, and a
+      // rule that owned it anyway would have drawn it as the dialog's own bytes and hidden the one thing to
+      // fix.
+      val dismissed = tree.findByLabel("DismissedDialogWindow").objectId
+      assertThat(tree.independentPathsBelowDominator(dismissed).paths.map { it.stepLabels() })
+        .containsExactlyInAnyOrder(
+          listOf("JankMonitor", "dismissedWindow → DismissedDialogWindow"),
+          listOf("DismissedDialog", "mWindow → DismissedDialogWindow")
+        )
     }
   }
 
@@ -168,10 +201,11 @@ class OwnerReferencesTest {
   }
   /**
    * A heap dump shaped like the view hierarchies of a running app: an `ActivityThread` running an activity
-   * through the `ArrayMap` of records it keeps them in, the activity holding its decor view, the decor view
-   * holding a child through the array a `ViewGroup` keeps its children in — plus a view in a slot of that
-   * array it doesn't count — and two things pointing at views they don't hold, a `ViewRootImpl` and an
-   * `InputMethodManager`, each a GC root of its own so that both are closer to a root than the activity is.
+   * through the `ArrayMap` of records it keeps them in, the activity holding its window, the window holding
+   * its decor view, the decor view holding a child through the array a `ViewGroup` keeps its children in —
+   * plus a view in a slot of that array it doesn't count — and two things pointing at views they don't hold,
+   * a `ViewRootImpl` and an `InputMethodManager`, each a GC root of its own so that both are closer to a root
+   * than the activity is.
    *
    * Plus the two shapes of something the framework isn't running: a destroyed activity only a leaker keeps
    * in memory, and an activity in a pair of the map past the count it keeps.
@@ -211,11 +245,23 @@ class OwnerReferencesTest {
         className = "com.android.internal.policy.DecorView",
         superclassId = viewGroupClassId
       )
+      val windowClassId = clazz(
+        className = "com.android.internal.policy.PhoneWindow",
+        // Declared by the internal subclass rather than by android.view.Window, which is where the framework
+        // declares it and so what makes this cover a rule that has to find the field without naming the class
+        // that has it.
+        superclassId = clazz(
+          className = "android.view.Window",
+          fields = listOf("mDestroyed" to BooleanHolder::class)
+        ),
+        fields = listOf("mDecor" to ReferenceHolder::class)
+      )
       val activityClassId = clazz(
         className = "android.app.Activity",
         fields = listOf(
           "mDecor" to ReferenceHolder::class,
-          "mDestroyed" to BooleanHolder::class
+          "mDestroyed" to BooleanHolder::class,
+          "mWindow" to ReferenceHolder::class
         )
       )
       // The owner field is declared by android.app.Activity and the instance is a subclass of it, which is
@@ -275,16 +321,20 @@ class OwnerReferencesTest {
         ),
         objectId = detachedRootId
       )
-      instance(mainActivityClassId, listOf(decor, BooleanHolder(false)), objectId = activityId)
+      // The window the decor view really hangs off. The activity's own mDecor is left pointing at it too,
+      // because the framework sets that field for the first activity of a record and this is what says the
+      // decor view is drawn under the window all the same.
+      val window = instance(windowClassId, listOf(decor, BooleanHolder(false)))
+      instance(mainActivityClassId, listOf(decor, BooleanHolder(false), window), objectId = activityId)
       // The activity the framework has destroyed, and one in a pair of the map past the count it keeps —
       // neither of them something the app is running, reached by two different ways of not being in it.
       val destroyedActivity = instance(
         clazz(className = "com.example.DestroyedActivity", superclassId = activityClassId),
-        listOf(NO_REFERENCE, BooleanHolder(true))
+        listOf(NO_REFERENCE, BooleanHolder(true), NO_REFERENCE)
       )
       val uncountedActivity = instance(
         clazz(className = "com.example.UncountedActivity", superclassId = activityClassId),
-        listOf(NO_REFERENCE, BooleanHolder(false))
+        listOf(NO_REFERENCE, BooleanHolder(false), NO_REFERENCE)
       )
       // What the framework runs each activity from. One class for both records, because the shorthand that
       // declares a class per instance would put two ActivityClientRecord classes in a dump that no real one
@@ -330,12 +380,11 @@ class OwnerReferencesTest {
   }
 
   /**
-   * A window of an activity whose `mDecor` is null, which is how a live activity looks in most real dumps:
-   * three views deep, with something pointing at the middle of the hierarchy the way an app's own field
-   * does.
+   * A destroyed activity that a leaker keeps in memory, still pointing at its window: three views deep, with
+   * something pointing at the middle of the hierarchy the way an app's own field does.
    */
-  private fun windowWithoutActivityDecorHeapDump(): File {
-    val file = testFolder.newFile("window-without-activity-decor.hprof")
+  private fun destroyedActivityWindowHeapDump(): File {
+    val file = testFolder.newFile("destroyed-activity-window.hprof")
     file.dump {
       val viewClassId = clazz(
         className = "android.view.View",
@@ -357,7 +406,10 @@ class OwnerReferencesTest {
       val viewArrayClassId = arrayClass("android.view.View")
       val activityClassId = clazz(
         className = "android.app.Activity",
-        fields = listOf("mDecor" to ReferenceHolder::class)
+        fields = listOf(
+          "mDestroyed" to BooleanHolder::class,
+          "mWindow" to ReferenceHolder::class
+        )
       )
       val decorId = reserveObjectId()
       val activityId = reserveObjectId()
@@ -399,30 +451,92 @@ class OwnerReferencesTest {
         ),
         objectId = decorId
       )
-      // The window really holding the decor view, and the activity's own field left null.
-      val window = "com.android.internal.policy.PhoneWindow" instance {
-        field["mDecor"] = decorId
-      }
-      instance(activityClassId, listOf(NO_REFERENCE), objectId = activityId)
-      val activityRecordClassId = clazz(
-        className = "android.app.ActivityThread\$ActivityClientRecord",
-        fields = listOf("activity" to ReferenceHolder::class)
+      // The window holding the decor view, and the destroyed activity still pointing at the window.
+      val window = instance(
+        clazz(
+          className = "com.android.internal.policy.PhoneWindow",
+          superclassId = clazz(
+            className = "android.view.Window",
+            fields = listOf("mDestroyed" to BooleanHolder::class)
+          ),
+          fields = listOf("mDecor" to ReferenceHolder::class)
+        ),
+        listOf(decorId, BooleanHolder(true))
       )
-      val activityThread = "android.app.ActivityThread" instance {
-        field["mActivities"] = "android.util.ArrayMap" instance {
-          field["mArray"] = objectArray(
-            instance(clazz(className = "android.os.BinderProxy")),
-            instance(activityRecordClassId, listOf(activityId))
-          )
-          field["mSize"] = IntHolder(1)
-        }
-        // Whatever the app hangs off the thread, the window among it.
-        field["mWindow"] = window
+      instance(
+        clazz(className = "com.example.MainActivity", superclassId = activityClassId),
+        listOf(BooleanHolder(true), window),
+        objectId = activityId
+      )
+      // What keeps the destroyed screen in memory, plus a rival into the middle of the hierarchy, one step
+      // from a GC root while the decor view is three.
+      val leaker = "com.example.Leaker" instance {
+        field["activity"] = activityId
+        field["frame"] = contentFrame
       }
-      // A rival into the middle of the hierarchy, one step from a GC root while the decor view is three.
-      val leaker = "com.example.Leaker" instance { field["frame"] = contentFrame }
-      gcRoot(JniGlobal(id = activityThread.value, jniGlobalRefId = 0))
-      gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 1))
+      gcRoot(JniGlobal(id = leaker.value, jniGlobalRefId = 0))
+    }
+    return file
+  }
+
+  /**
+   * Two dialogs, each holding a window of its own, one of them dismissed — and a jank monitor holding both
+   * windows from a GC root of its own, which is what makes where each of them lands a question.
+   */
+  private fun dialogWindowsHeapDump(): File {
+    val file = testFolder.newFile("dialog-windows.hprof")
+    file.dump {
+      val windowClassId = clazz(
+        className = "android.view.Window",
+        // mDestroyed because the object inspector for a window reads it and would throw without it. False
+        // for both: the framework only sets it on the window of an activity it destroys.
+        fields = listOf(
+          "mDestroyed" to BooleanHolder::class,
+          "payload" to ReferenceHolder::class
+        )
+      )
+      val dialogClassId = clazz(
+        className = "android.app.Dialog",
+        fields = listOf(
+          "mDecor" to ReferenceHolder::class,
+          "mWindow" to ReferenceHolder::class
+        )
+      )
+      // Named for what each of them is, since a window is told from another by its label in the tree.
+      val showingWindow = instance(
+        clazz(className = "com.example.ShowingDialogWindow", superclassId = windowClassId),
+        listOf(
+          BooleanHolder(false),
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT)))
+        )
+      )
+      val dismissedWindow = instance(
+        clazz(className = "com.example.DismissedDialogWindow", superclassId = windowClassId),
+        listOf(
+          BooleanHolder(false),
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_ELEMENT_COUNT)))
+        )
+      )
+      // Dialog.show reads the decor view off the window and keeps it; Dialog.dismiss puts the field back to
+      // null and leaves mWindow where it was.
+      val showingDialog = instance(
+        clazz(className = "com.example.ShowingDialog", superclassId = dialogClassId),
+        listOf(
+          instance(clazz(className = "com.android.internal.policy.DecorView")),
+          showingWindow
+        )
+      )
+      val dismissedDialog = instance(
+        clazz(className = "com.example.DismissedDialog", superclassId = dialogClassId),
+        listOf(NO_REFERENCE, dismissedWindow)
+      )
+      val jankMonitor = "com.example.JankMonitor" instance {
+        field["showingWindow"] = showingWindow
+        field["dismissedWindow"] = dismissedWindow
+      }
+      gcRoot(JniGlobal(id = showingDialog.value, jniGlobalRefId = 0))
+      gcRoot(JniGlobal(id = dismissedDialog.value, jniGlobalRefId = 1))
+      gcRoot(JniGlobal(id = jankMonitor.value, jniGlobalRefId = 2))
     }
     return file
   }


### PR DESCRIPTION
Stacked on #2941. The question this answers: is there always a window when there's a decor view, and if so, should the rule be `PhoneWindow.mDecor` rather than `Activity.mDecor`?

## Is there always a window?

Yes, for a *decor view*: every one in the seven real dumps in the repo is pointed at by exactly one `PhoneWindow.mDecor` (1 of 1 in `compose_leak.hprof`, 3 of 3 in `leak_asynctask_m.hprof`, and so on).

Not for a *root view*, which is the distinction that matters: 14 of the 15 root views in `compose_leak.hprof`, 9 of the 10 in `leak_asynctask_m.hprof` and 22 of the 23 in `gcroot_unknown_object.hprof` have no window anywhere. They're `Toast` views, `PopupWindow.mContentView`, `TextView$MagnifierView`s, `Toolbar.mNavButtonView` image buttons and fragment roots, each held the ordinary way by whatever made it. So the rule is window → decor view, and the rest need nothing.

## Why `Activity.mDecor` had to go

`ActivityThread.handleResumeActivity` is the only place that writes it, guarded by `if (r.window == null && !a.mFinished && willBeVisible)` — so it is set once per `ActivityClientRecord`, not once per `Activity`. A screen recreated on a configuration change is resumed, visible, and has a null `mDecor` for the rest of its life. It also inverted the nesting where it *was* set: in `leak_asynctask_m.hprof` a `PhoneWindow` was drawn under its own `DecorView`, through `DecorView.this$0`.

## Why the window then needs a rule of its own

A window has 6 to 9 referrers in these dumps. Most are its own inner classes and its decor's, but the external ones — `WindowManagerImpl.mParentWindow`, `ActivityThread$ActivityClientRecord.window`, `DecorView.mWindow` reached from a `ViewRootImpl` — put **6 of the 16 windows at the top of the tree**. Moving the decor view under the window makes that worse than it was, because the hierarchy now floats with it: `gcroot_unknown_object.hprof`'s `PhoneWindow` went from 14 KB at the root to 3.09 MB there, `large-dump.hprof`'s from 12 KB to 2.14 MB. With `Activity.mWindow` / `Dialog.mWindow` owning it, every decor view in every dump is under its window and every window of a screen that is up is under that screen.

## The one state check

`ActivityWindowRule` reads `Activity.mDestroyed` and `Dialog.mDecor`, which no other rule here needs. It has to: `Activity.mWindow` is set in `attach` and never cleared, and `Dialog.mWindow` is final, so a destroyed activity and a dismissed dialog go on pointing at a window they have nothing to do with. Owning it regardless took the window of a leaked screen away from whatever else was holding it and turned two leaks into one on the list — the reference that would still have been there after the activity was fixed stopped being reported. `HeapLeaksTest` covers that, and `notes/dominator-tree.md` now records it as the test to apply to a new rule.

## Conserved

Bytes conserved on all eight dumps, no object joins or leaves the tree, 0 to 16 objects of 34 K to 340 K move. `shark-explorer-core:check` and `shark-explorer-app:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)