### PR TITLE
Read a Compose UI as a UI, and what it remembers as the UI's

### DIFF
--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -389,8 +389,10 @@ whatever points at them.
 
 Everything above is about views, and none of it fires on a Compose screen: the tree is `LayoutNode`s, the
 children are in a vector rather than a `View[]`, and there is no `mChildrenCount`. So the same two
-mechanisms again, plus the ownership rules — measured on a dump of `leakcanary-android-sample` taken off
-an API 36 emulator, since every heap dump in the repo predates Compose.
+mechanisms again, plus the ownership rules — measured on a dump of `leakcanary-app` taken off an API 36
+emulator, since every heap dump in the repo predates Compose and the sample app has none of it. The images
+the numbers below move around came from a screen added to that app for the measurement and deleted again,
+so reproducing them means a screen that remembers a few large images, not a dump of the app as it stands.
 
 `LayoutNodeChildReferenceReader` is `ViewChildReferenceReader` for a node, and the array it collapses is
 further down: `LayoutNode._foldedChildren` → `MutableVectorWithMutationTracking.vector` →
@@ -429,8 +431,8 @@ hangs off them, so there's no rule here worth the risk of a wrong claim.
 A composition keeps its state in one `Object[]` per window — every `remember` of every composable in it,
 every composition local map, every lambda, every `LayoutNode`, side by side — plus an `int[]` describing
 that array. So a bitmap one screen remembers is held by the same array as a bitmap five screens away, and
-the dominator answer for either is the composition rather than a piece of UI. On the sample app's dump
-that array was the single thing holding the images of every screen.
+the dominator answer for either is the composition rather than a piece of UI. On that app's dump the
+array was the single thing holding the images of every screen.
 
 `SlotTableReferenceReader` reads the `int[]` and hands each element out from the node whose composable is
 inside. The layout, read off Compose 1.11.4's bytecode and confirmed against a real dump: **five ints a
@@ -459,7 +461,7 @@ Three things about it are decisions rather than mechanics:
   its slots in chunks rather than one array and is refused for the same reason: it isn't decodable from
   these four fields.
 
-Measured, the two commits together, on that API 36 sample app dump: `AndroidComposeView` retains
+Measured, the two commits together, on that API 36 dump of `leakcanary-app`: `AndroidComposeView` retains
 **10,368,941 B where it retained 2,619,473 B**, its root `LayoutNode` **7,744,454 B where it retained
 8,895 B**, and the `BitmapPainter`s and `AndroidImageBitmap`s of a screen are dominated by a `LayoutNode`
 under `AndroidComposeView` → `ComposeView` → … → `DecorView` → `MainActivity` →

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -375,8 +375,8 @@ run through a *leaked* `SquareActivity.foot → ArrayList → Object[]`, since t
 Byte counts are again identical before and after, which is the check that no object left the graph:
 30,090,032 B strong, 28,302 B thread local, 1,444 B soft, 261 B weak, 9,353 B finalizer, 631,761 B
 unreachable, 387,971 objects. Opening the dump costs at most 2% more — median of five steady state opens
-2.02 s with the reader against 1.98 s without, ranges overlapping — which is the fourth sequence
-concatenation `retainingReferencesOf` now does per object, since the reader itself is one class id
+2.02 s with the reader against 1.98 s without, ranges overlapping — which is one more sequence
+concatenation `retainingReferencesOf` does per object, since the reader itself is one class id
 comparison for everything that isn't the activity thread.
 
 `mActivities` has been an `ArrayMap` since Lollipop, seven releases before the oldest one LeakCanary

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -250,12 +250,13 @@ itself and retained 4.2 KB and 3.9 KB instead of their windows. The damaging ref
 view bindings and `StandardRowSpec$StandardViewHolder.itemView`.
 
 `OwnerReferences` applies a curated list of `OwnerRule`s: a class whose instances something owns, plus the
-references that own them — named fields, or the virtual references a class's instances hand out. Three
+references that own them — named fields, or the virtual references a class's instances hand out. Six
 today — `android.view.View` owned by the `ViewGroup` that reads it as a child (see below) and by
-`Activity.mDecor` or `Dialog.mDecor`, and `android.app.Activity` owned by the `ActivityThread` that reads
-it as one it's running (see below too). After: **every one of the 277 child views is under its parent**,
-the dialog's `DecorView` is dominated by the `PartialModalDialog`, and `MainActivity` retains 18 MB under
-the thread running it, which is the second largest rectangle under the GC roots.
+`Activity.mDecor` or `Dialog.mDecor`, `android.app.Activity` owned by the `ActivityThread` that reads it
+as one it's running (see below too), and the three Compose ones in the section on Compose below. After: **every one of
+the 277 child views is under its parent**, the dialog's `DecorView` is dominated by the
+`PartialModalDialog`, and `MainActivity` retains 18 MB under the thread running it, which is the second
+largest rectangle under the GC roots.
 
 **A rule is parked, not dropped, and that's the whole design.** The walk in
 `HeapReachability.walkFromGcRoots` keeps a second queue per strength and only takes from it once the main
@@ -383,6 +384,91 @@ comparison for everything that isn't the activity thread.
 supports, so the `HashMap` it was before that is deliberately not read: a dump that doesn't have the
 `ArrayMap` shape logs a line and reads as a thread running nothing, which leaves its activities held by
 whatever points at them.
+
+## A Compose UI is a hierarchy too, and needs more help to read as one
+
+Everything above is about views, and none of it fires on a Compose screen: the tree is `LayoutNode`s, the
+children are in a vector rather than a `View[]`, and there is no `mChildrenCount`. So the same two
+mechanisms again, plus the ownership rules — measured on a dump of `leakcanary-android-sample` taken off
+an API 36 emulator, since every heap dump in the repo predates Compose.
+
+`LayoutNodeChildReferenceReader` is `ViewChildReferenceReader` for a node, and the array it collapses is
+further down: `LayoutNode._foldedChildren` → `MutableVectorWithMutationTracking.vector` →
+`MutableVector.content` → `LayoutNode[]` → the child. Four objects between two levels of UI, three of them
+bookkeeping, bounded by the vector's `size` rather than by the array's length for the same reason the view
+reader is bounded by `mChildrenCount`.
+
+**Compose flattens harder than the framework does, in three places.** Each of these was found by asking
+`independentPathsBelowDominator` why a `LayoutNode` was a root child:
+
+- `AndroidComposeView.layoutNodes`, a `MutableIntObjectMap` registry of **every** node of the window by
+  semantics id. Not a leak and not an accident — it's how a semantics id is resolved — but it means every
+  node of a screen is one reference from the view, so the tree of a screen is a *list* until the rule says
+  a node belongs to its parent.
+- The modifier graph, which is bidirectional and therefore all one piece: a `Modifier$Node` points at its
+  `NodeChain` and its `NodeCoordinator`, a coordinator at its `GraphicsLayer` and at the coordinators
+  either side of it, a layer at the layers it depends on through `childDependenciesTracker`. One reference
+  into any of it reaches the lot. On that dump there were three from outside, each a GC root away:
+  `InputMethodManager` → `ViewRootImpl` → `ViewTreeObserver.mOnGlobalFocusListeners` →
+  `FocusGroupPropertiesNode`, `SnapshotKt.applyObservers` → `Recomposer` → `CompositionImpl`, and the
+  layer dependency graph. So every modifier of every screen was held from outside the UI, and with it
+  everything the modifiers draw.
+- The composition, which is the next section.
+
+Hence the three rules: a node owned by the parent node's virtual reference, the node at the top of a
+window owned by `AndroidComposeView.root`, and a `Modifier$Node` owned by `NodeChain.head` or by the
+previous node's `child`. `child` rather than `parent` because a chain has to be owned in one direction, and
+outermost first is the order the modifiers were written in.
+
+**What is still flat under the root after all of it**: the `NodeCoordinator`s and `GraphicsLayer`s
+themselves, a few hundred bytes each. Their graph has no one entry to name as the owner, and nothing bigger
+hangs off them, so there's no rule here worth the risk of a wrong claim.
+
+## What a composable remembers: reading a `SlotTable`
+
+A composition keeps its state in one `Object[]` per window — every `remember` of every composable in it,
+every composition local map, every lambda, every `LayoutNode`, side by side — plus an `int[]` describing
+that array. So a bitmap one screen remembers is held by the same array as a bitmap five screens away, and
+the dominator answer for either is the composition rather than a piece of UI. On the sample app's dump
+that array was the single thing holding the images of every screen.
+
+`SlotTableReferenceReader` reads the `int[]` and hands each element out from the node whose composable is
+inside. The layout, read off Compose 1.11.4's bytecode and confirmed against a real dump: **five ints a
+group** — key, group info, parent anchor, how many groups it contains, where its slots start — laid out in
+the order the composables ran, depth first. **Bit 30 of the group info** says the group emitted a node,
+and that node is in the group's first slot. A group's slots run to the *next* group's anchor, the last
+group's to `slotsSize`, and the array past `slotsSize` is the gap the next write is made through.
+
+Three things about it are decisions rather than mechanics:
+
+- **It replaces the array's references instead of adding to them** — the only reader here that does, and
+  the reason is the array's position. A `View[]` sits *under* the parent, so an added reference gives the
+  child two paths that both start at the parent and the level collapses. A composition's array sits under
+  the composition, nowhere near the UI, so an added reference would give a bitmap a second path from a
+  different part of the heap, and its dominator would move *up* to whatever dominates both — the top of
+  the tree. The array is still a node holding its own bytes, still reached through the table's own field,
+  and every element of it is still reached exactly once.
+- **All or nothing per table.** An array only partly handed out from its groups would leave the rest
+  reachable through nothing, which the explorer would draw as uncollected garbage. So a table that doesn't
+  validate keeps every reference of its own and reads the way it did before this existed, and says so
+  through `SharkLog`.
+- **What it validates is a dump caught mid-write**, not a corrupt file. A composition being written to has
+  its two arrays half moved — the gap is wherever the writer left it and the anchors past it are stored
+  negative — so monotonic anchors inside `[0, slotsSize]` and group sizes that stay inside the table are
+  what tell a readable table from one caught in the middle. Compose's newer `linkbuffer.SlotTable` keeps
+  its slots in chunks rather than one array and is refused for the same reason: it isn't decodable from
+  these four fields.
+
+Measured, the two commits together, on that API 36 sample app dump: `AndroidComposeView` retains
+**10,368,941 B where it retained 2,619,473 B**, its root `LayoutNode` **7,744,454 B where it retained
+8,895 B**, and the `BitmapPainter`s and `AndroidImageBitmap`s of a screen are dominated by a `LayoutNode`
+under `AndroidComposeView` → `ComposeView` → … → `DecorView` → `MainActivity` →
+`ActivityThread$ActivityClientRecord`. A second dump of the same app: 12,844,587 B and 5,139,099 B.
+
+**An image often lands on an ancestor composable rather than the exact one**, and that is the honest
+answer rather than a bug: a value the UI both remembers and draws occupies a slot in more than one group —
+a `Box`'s slot 108 and a `Column`'s slot 170 in one case here — so the dominator is the composable
+containing both. Read it as "this subtree is why the bytes are here", the same as any shared object.
 
 ## What holds an object: one chain, with the dominators on it marked
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LayoutNodeChildReferenceReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LayoutNodeChildReferenceReader.kt
@@ -1,0 +1,94 @@
+package shark.explorer
+
+import shark.HeapGraph
+import shark.HeapObject
+import shark.HeapObject.HeapInstance
+import shark.Reference
+import shark.Reference.LazyDetails
+import shark.ReferenceLocationType.ARRAY_ENTRY
+import shark.ValueHolder
+
+/**
+ * A Compose `LayoutNode`'s children, as references from the parent straight to each child — the same
+ * thing [ViewChildReferenceReader] does for a `ViewGroup`, and for the same reasons.
+ *
+ * A node keeps its children in a growable vector with a mutation callback around it, so the parent to
+ * child link of a Compose UI really goes `LayoutNode` → `MutableVectorWithMutationTracking` →
+ * `MutableVector` → `LayoutNode[]` → child: four objects, three of them unnamed bookkeeping, between
+ * every two levels of a UI. Read that way a Compose hierarchy comes out four times as deep as it is, and
+ * it's an array that gets to own each node rather than its parent — see [OwnerReferences].
+ *
+ * So this adds one virtual reference per child, in the shape Shark gives the collections it flattens.
+ * **Additive**: the vector and its array are still reached through `_foldedChildren` and are still nodes
+ * holding their own bytes, and both ways to a child now start at the parent, so the parent dominates it.
+ */
+internal class LayoutNodeChildReferenceReader(private val graph: HeapGraph) {
+
+  /**
+   * `LayoutNode` is final, so this is an id to compare against rather than a hierarchy to walk.
+   * [HeapGraph.findClassByName] scans every string of the heap dump, hence once.
+   */
+  private val layoutNodeClassId: Long by lazy {
+    graph.findClassByName(LAYOUT_NODE_CLASS_NAME)?.objectId ?: ValueHolder.NULL_REFERENCE
+  }
+
+  /** The children of [source] when it's a `LayoutNode`, and nothing at all for anything else. */
+  fun childReferencesOf(source: HeapObject): Sequence<Reference> {
+    if (source !is HeapInstance || source.instanceClassId != layoutNodeClassId) {
+      return emptySequence()
+    }
+    // Fields read by name against the whole instance rather than by their declaring class: which class
+    // holds the children has changed with Compose versions, and the vector was once the field's own value
+    // rather than something wrapped in a tracker, which reads here as a tracker without a vector in it.
+    val children = source.fieldNamed(FOLDED_CHILDREN_FIELD_NAME)?.valueAsInstance
+      ?: return emptySequence()
+    val vector = children.fieldNamed(VECTOR_FIELD_NAME)?.valueAsInstance ?: children
+    val content = vector.fieldNamed(CONTENT_FIELD_NAME)?.valueAsObjectArray ?: return emptySequence()
+    val elementIds = content.readRecord().elementIds
+    // Bounded by the size the vector keeps rather than by the length of the array it grows in powers of
+    // two, for the reason [ViewChildReferenceReader] gives: a slot past the size is not a child, and
+    // calling it one attributes a node its parent let go of to that parent.
+    val childCount = vector.fieldNamed(SIZE_FIELD_NAME)?.value?.asInt
+      ?.coerceIn(0, elementIds.size)
+      ?: elementIds.size
+    val parentClassId = source.instanceClassId
+    return sequence {
+      for (index in 0 until childCount) {
+        val childObjectId = elementIds[index]
+        if (childObjectId != ValueHolder.NULL_REFERENCE && graph.objectExists(childObjectId)) {
+          yield(
+            Reference(
+              valueObjectId = childObjectId,
+              isLowPriority = false,
+              lazyDetailsResolver = {
+                LazyDetails(
+                  name = "$index",
+                  locationClassObjectId = parentClassId,
+                  locationType = ARRAY_ENTRY,
+                  isVirtual = true,
+                  matchedLibraryLeak = null
+                )
+              }
+            )
+          )
+        }
+      }
+    }
+  }
+
+  companion object {
+    /** Also what an [OwnerRule] names to say that a parent owns the children read here. */
+    const val LAYOUT_NODE_CLASS_NAME = "androidx.compose.ui.node.LayoutNode"
+
+    private const val FOLDED_CHILDREN_FIELD_NAME = "_foldedChildren"
+
+    private const val VECTOR_FIELD_NAME = "vector"
+
+    private const val CONTENT_FIELD_NAME = "content"
+
+    private const val SIZE_FIELD_NAME = "size"
+
+    private fun HeapInstance.fieldNamed(fieldName: String) =
+      readFields().firstOrNull { it.name == fieldName }
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
@@ -228,6 +228,8 @@ internal class OwnerReferences private constructor(
 
     private const val ACTIVITY_CLASS_NAME = "android.app.Activity"
 
+    private const val MODIFIER_NODE_CLASS_NAME = "androidx.compose.ui.Modifier\$Node"
+
     /**
      * The scoped providers of the dependency injection frameworks the explorer knows about, read off a
      * heap dump of an app built with each — see `notes/dependency-injection.md`.
@@ -305,6 +307,52 @@ internal class OwnerReferences private constructor(
       OwnerRule(
         ownedObjects = InstancesOf(ACTIVITY_CLASS_NAME),
         ownerVirtualClassNames = setOf(RunningActivityReferenceReader.ACTIVITY_THREAD_CLASS_NAME)
+      ),
+      // A Compose UI is a tree of LayoutNodes and the same rule applies to it, through the virtual
+      // reference [LayoutNodeChildReferenceReader] reads from a parent to each child.
+      //
+      // It needs saying louder here than for a view, because Compose keeps a flat registry of every node
+      // of a window — `AndroidComposeView.layoutNodes`, by semantics id — so *every* node of a UI is one
+      // reference from the view that hosts it, and the tree of a screen is a list until this rule turns
+      // it back into a tree. The rest of the rivals are Compose's own graphs pointing sideways: the nodes
+      // waiting to be measured, the ones waiting to be positioned, a focus listener the input method
+      // manager holds, a modifier node's coordinator.
+      OwnerRule(
+        ownedObjects = InstancesOf(LayoutNodeChildReferenceReader.LAYOUT_NODE_CLASS_NAME),
+        ownerVirtualClassNames = setOf(LayoutNodeChildReferenceReader.LAYOUT_NODE_CLASS_NAME)
+      ),
+      // The node at the top of a window has no parent node, and belongs to the view hosting it — the same
+      // rule as a decor view belonging to its Activity, and what puts a Compose UI's bytes inside the
+      // hierarchy of the screen showing it.
+      //
+      // The composition holds that node too, in a slot of its table, and this is deliberately the owner
+      // instead: a composition is one flat store per window, so owning from there would be the registry
+      // problem again. See [SlotTableReferenceReader] for what a slot reference is.
+      OwnerRule(
+        ownedObjects = InstancesOf(LayoutNodeChildReferenceReader.LAYOUT_NODE_CLASS_NAME),
+        ownerFieldsByClassName = mapOf(
+          "androidx.compose.ui.platform.AndroidComposeView" to setOf("root")
+        )
+      ),
+      // What a node of a Compose UI is made of belongs to that node: its modifiers are a chain hanging
+      // off its `NodeChain`, from the outermost through each one's `child` to the tail.
+      //
+      // Without this the chain is a way *into* the UI rather than a part of it, and that is measurable:
+      // Compose's modifier nodes point back at their coordinators, which point back at their layers and
+      // at each other, so a single reference into any one of them reaches the lot. A heap dump taken on
+      // API 36 has three such references from outside — a focus listener the input method manager reaches
+      // through the window's `ViewTreeObserver`, the snapshot observer's static list of what it observes,
+      // and the `Recomposer` — so every modifier of every screen was held from a GC root of its own, and
+      // the images the UI draws were dominated by the top of the heap rather than by the UI showing them.
+      //
+      // `child` and not `parent`: a chain has to be owned in one direction, and it reads outermost first,
+      // the way the modifiers were written.
+      OwnerRule(
+        ownedObjects = InstancesOf(MODIFIER_NODE_CLASS_NAME),
+        ownerFieldsByClassName = mapOf(
+          "androidx.compose.ui.node.NodeChain" to setOf("head"),
+          MODIFIER_NODE_CLASS_NAME to setOf("child")
+        )
       ),
       // A dependency injection singleton is held by the provider its component caches it in, and every
       // other reference to one is an injection site the component handed it to. Which is nearly always a

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -74,7 +74,8 @@ internal class WeakeningReference(
  *
  * Where a structure is worth presenting the way you think about it anyway, the reference is **added**
  * rather than swapped in: [DataStructureReferenceReader] gives a collection a reference to each entry,
- * [ViewChildReferenceReader] gives a `ViewGroup` one to each of its children and
+ * [ViewChildReferenceReader] gives a `ViewGroup` one to each of its children,
+ * [LayoutNodeChildReferenceReader] does the same for a Compose `LayoutNode` and
  * [RunningActivityReferenceReader] gives an `ActivityThread` one to each activity the app is running — and
  * the table, the `View[]` and the `ArrayMap` they really live in are still reached through their fields and
  * still nodes of their own.
@@ -86,6 +87,8 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
       .createFor(graph)
 
   private val viewChildReader = ViewChildReferenceReader(graph)
+
+  private val layoutNodeChildReader = LayoutNodeChildReferenceReader(graph)
 
   private val dataStructureReader = DataStructureReferenceReader(graph)
 
@@ -111,8 +114,8 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
   /** The references from [source] that keep their target alive. */
   fun retainingReferencesOf(source: HeapObject): Sequence<Reference> {
     val references = retainingReader.read(source) + classMetadataReferencesOf(source) +
-      viewChildReader.childReferencesOf(source) + dataStructureReader.entryReferencesOf(source) +
-      runningActivityReader.activityReferencesOf(source)
+      viewChildReader.childReferencesOf(source) + layoutNodeChildReader.childReferencesOf(source) +
+      dataStructureReader.entryReferencesOf(source) + runningActivityReader.activityReferencesOf(source)
     val cachedValueIds = cachedMapValues.cachedValueIdsOf(source)
     return if (cachedValueIds.isEmpty()) {
       references

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -79,6 +79,11 @@ internal class WeakeningReference(
  * [RunningActivityReferenceReader] gives an `ActivityThread` one to each activity the app is running — and
  * the table, the `View[]` and the `ArrayMap` they really live in are still reached through their fields and
  * still nodes of their own.
+ *
+ * [SlotTableReferenceReader] is the one exception, and only for the references *out of* one array per
+ * Compose composition: adding there would push what a composable remembers further up the tree rather
+ * than down to it, for the reason its KDoc gives. Every object it moves a reference to is still reached
+ * exactly once, and the array is still a node of its own.
  */
 internal class ReferenceStrengthReader(private val graph: HeapGraph) {
 
@@ -95,6 +100,8 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
   private val runningActivityReader = RunningActivityReferenceReader(graph)
 
   private val cachedMapValues = CachedMapValues(graph)
+
+  private val slotTableReader = SlotTableReferenceReader(graph)
 
   /**
    * Which fields of a class hold their value without retaining it, by class object id. Cached because
@@ -113,9 +120,15 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
 
   /** The references from [source] that keep their target alive. */
   fun retainingReferencesOf(source: HeapObject): Sequence<Reference> {
+    if (slotTableReader.slotsReadFromTheirGroups(source)) {
+      // The one reader here that replaces an object's references rather than adding to them, and the
+      // KDoc of [SlotTableReferenceReader] is about why.
+      return emptySequence()
+    }
     val references = retainingReader.read(source) + classMetadataReferencesOf(source) +
       viewChildReader.childReferencesOf(source) + layoutNodeChildReader.childReferencesOf(source) +
-      dataStructureReader.entryReferencesOf(source) + runningActivityReader.activityReferencesOf(source)
+      slotTableReader.groupReferencesOf(source) + dataStructureReader.entryReferencesOf(source) +
+      runningActivityReader.activityReferencesOf(source)
     val cachedValueIds = cachedMapValues.cachedValueIdsOf(source)
     return if (cachedValueIds.isEmpty()) {
       references

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SlotTableReferenceReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SlotTableReferenceReader.kt
@@ -1,0 +1,386 @@
+package shark.explorer
+
+import androidx.collection.LongObjectMap
+import androidx.collection.LongSet
+import androidx.collection.MutableIntList
+import androidx.collection.MutableLongList
+import androidx.collection.MutableLongObjectMap
+import androidx.collection.MutableLongSet
+import shark.HeapGraph
+import shark.HeapObject
+import shark.HeapObject.HeapInstance
+import shark.HeapObject.HeapObjectArray
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.IntArrayDump
+import shark.Reference
+import shark.Reference.LazyDetails
+import shark.ReferenceLocationType.ARRAY_ENTRY
+import shark.SharkLog
+import shark.ValueHolder
+
+/**
+ * What a Compose composition holds, read as references from the node each value belongs to — the
+ * `LayoutNode` whose composable remembered it — rather than from the one flat array the composition
+ * really keeps it all in.
+ *
+ * A `SlotTable` is that array plus an `int[]` describing it: every `remember` of every composable in a
+ * window, every composition local map, every lambda, every `LayoutNode`, side by side in one `Object[]`
+ * that grows to the size of the UI. Read as it is stored, a composition is one flat list of thousands of
+ * unrelated objects, so an image a screen remembers is held by the same array as an image five screens
+ * away, and the answer to "what is holding this bitmap" is a composition rather than a piece of UI.
+ *
+ * The `int[]` is what makes the shape recoverable. It is a fixed number of ints per group, laid out in
+ * the order the composables ran, where a group knows how many groups it contains and where its own slots
+ * start, and where a group that emitted a node keeps that node in its first slot. So the enclosing node
+ * of any slot is a walk of that array away, and the slots between two groups are one group's.
+ *
+ * **Unlike [ViewChildReferenceReader] this replaces the array's references rather than adding to them**,
+ * which is the one thing to understand before changing it. Adding worked for a `ViewGroup` because the
+ * `View[]` sits under the parent, so both ways to a child start there and the parent dominates it. A
+ * composition's array sits under the composition, nowhere near the UI the values belong to, so an added
+ * reference would only give a bitmap a second way of being reached and push it further up — to whatever
+ * dominates both the composition and the screen, which is the top of the tree. The array is still a node
+ * holding its own bytes, still reached through the table's own field, and every one of its elements is
+ * still reached exactly once, which is what [ReferenceStrengthReader] needs of a reader here. Only which
+ * object is named as holding an element changes.
+ *
+ * What that buys, and what it costs, are the same thing: a remembered value is attributed to the node
+ * that remembers it, so a composable's images are its own, unless something outside the UI holds the
+ * value too — then the two paths meet above both and the value belongs to neither, which is the honest
+ * answer for something a screen and a repository share.
+ */
+internal class SlotTableReferenceReader(private val graph: HeapGraph) {
+
+  /**
+   * Built on first use rather than in a constructor, and as a whole object assigned at once, so that a
+   * read given up on half way is retried rather than remembered — the rule for every index here, see the
+   * shark-explorer AGENTS guide. Empty for a heap dump with no composition in it.
+   */
+  private val slots: TableSlots by lazy { readSlotTables() }
+
+  /**
+   * The slots of every group [source] holds: what its composables remembered, the keys they were
+   * remembered under, and the nodes they emitted. Empty for anything else, which is nearly every object
+   * of a heap dump.
+   */
+  fun groupReferencesOf(source: HeapObject): Sequence<Reference> {
+    if (source !is HeapInstance) {
+      return emptySequence()
+    }
+    val slotsHeld = slots.slotsBySourceId[source.objectId] ?: return emptySequence()
+    val locationClassObjectId = source.instanceClassId
+    // Iterated by index rather than as a sequence of pairs, so that reading it twice reads the same
+    // slots and boxes nothing: this runs for every reference of every node of the tree.
+    return sequence {
+      for (pair in 0 until slotsHeld.size / 2) {
+        val slotIndex = slotsHeld[pair * 2]
+        val valueObjectId = slotsHeld[pair * 2 + 1]
+        yield(
+          Reference(
+            valueObjectId = valueObjectId,
+            isLowPriority = false,
+            lazyDetailsResolver = {
+              LazyDetails(
+                // The index in the table the value really is at, so that a path says where to look for
+                // it. There is no field here, and the class of the array the slot is in would name the
+                // composition rather than the node holding the slot.
+                name = "slot $slotIndex",
+                locationClassObjectId = locationClassObjectId,
+                locationType = ARRAY_ENTRY,
+                isVirtual = true,
+                matchedLibraryLeak = null
+              )
+            }
+          )
+        )
+      }
+    }
+  }
+
+  /**
+   * Whether [source] is the array a composition keeps its slots in, whose elements [groupReferencesOf]
+   * hands out from the groups holding them instead — so it holds nothing of its own.
+   */
+  fun slotsReadFromTheirGroups(source: HeapObject): Boolean =
+    source is HeapObjectArray && slots.tableSlotArrayIds.contains(source.objectId)
+
+  /**
+   * Reads every slot table of the heap dump, which costs a class lookup per name below and a handful of
+   * record reads per composition — a table, its two arrays, and nothing per object of the heap dump.
+   */
+  private fun readSlotTables(): TableSlots {
+    val slotsBySourceId = MutableLongObjectMap<MutableLongList>()
+    val tableSlotArrayIds = MutableLongSet()
+    SLOT_TABLE_CLASS_NAMES.forEach { className ->
+      graph.findClassByName(className)?.instances?.forEach { table ->
+        readTable(table, slotsBySourceId, tableSlotArrayIds)
+      }
+    }
+    return TableSlots(slotsBySourceId, tableSlotArrayIds)
+  }
+
+  /**
+   * Reads one composition's slots into [slotsBySourceId], and records its array in [tableSlotArrayIds]
+   * when it read all of them.
+   *
+   * All or nothing per table: an array whose elements are only partly handed out from their groups would
+   * leave the rest reachable through nothing, so a table this can't make sense of keeps its own
+   * references and reads the way it did before this class existed.
+   */
+  private fun readTable(
+    table: HeapInstance,
+    slotsBySourceId: MutableLongObjectMap<MutableLongList>,
+    tableSlotArrayIds: MutableLongSet
+  ) {
+    val arrays = arraysOf(table) ?: return
+    val slotArrayIds = arrays.slots.readRecord().elementIds
+    val describesItsSlots = describesItsSlots(
+      table = table,
+      groups = arrays.groups,
+      groupCount = arrays.groupCount,
+      slotArraySize = slotArrayIds.size,
+      slotCount = arrays.slotCount
+    )
+    if (!describesItsSlots) {
+      return
+    }
+    readGroups(
+      tableObjectId = table.objectId,
+      groups = arrays.groups,
+      groupCount = arrays.groupCount,
+      slotArrayIds = slotArrayIds,
+      slotCount = arrays.slotCount,
+      slotsBySourceId = slotsBySourceId
+    )
+    tableSlotArrayIds += arrays.slots.objectId
+  }
+
+  /**
+   * The two arrays [table] keeps its state in and how much of each is in use, or null when it holds them
+   * in a shape this can't read — which is a Compose version that moved them, and so is worth a line of
+   * the log rather than a failure: a table skipped here reads the way it did before this class existed.
+   */
+  private fun arraysOf(table: HeapInstance): TableArrays? {
+    var groups: IntArray? = null
+    var slots: HeapObjectArray? = null
+    var groupCount = -1
+    var slotCount = -1
+    // Fields matched by name against the whole instance rather than by their declaring class, since
+    // which class of the hierarchy declares them is exactly what moves between Compose versions.
+    table.readFields().forEach { field ->
+      when (field.name) {
+        GROUPS_FIELD_NAME -> groups =
+          (field.valueAsPrimitiveArray?.readRecord() as? IntArrayDump)?.array
+        SLOTS_FIELD_NAME -> slots = field.valueAsObjectArray
+        GROUPS_SIZE_FIELD_NAME -> groupCount = field.value.asInt ?: -1
+        SLOTS_SIZE_FIELD_NAME -> slotCount = field.value.asInt ?: -1
+      }
+    }
+    val groupInts = groups
+    val slotArray = slots
+    val unreadable = when {
+      groupInts == null -> "no $GROUPS_FIELD_NAME of ints describing them"
+      slotArray == null -> "no $SLOTS_FIELD_NAME array to read them out of"
+      groupCount < 0 || slotCount < 0 -> "$groupCount groups over $slotCount slots"
+      else -> return TableArrays(groupInts, slotArray, groupCount, slotCount)
+    }
+    SharkLog.d {
+      "${table.instanceClassSimpleName} keeps its slots in a shape this can't read — $unreadable — so " +
+        "what it holds reads as the composition's rather than as the UI's"
+    }
+    return null
+  }
+
+  /**
+   * Whether the `int[]` of [table] describes the slots of [slotArraySize] as this reads it: a whole
+   * number of groups, each containing groups that are there, and each starting its data where the
+   * previous group's ended.
+   *
+   * A heap dump is a file and a file can say anything, but the reason to check is nearer than that. A
+   * composition being written to while the heap was dumped has its two arrays half moved — the gap they
+   * are written through is wherever the writer left it, and the anchors on the far side of it are stored
+   * negative — so the ordering below is what tells a table that can be read from one caught mid-change.
+   */
+  @Suppress("ReturnCount")
+  private fun describesItsSlots(
+    table: HeapInstance,
+    groups: IntArray,
+    groupCount: Int,
+    slotArraySize: Int,
+    slotCount: Int
+  ): Boolean {
+    fun refuse(reason: String): Boolean {
+      SharkLog.d {
+        "${table.instanceClassSimpleName} describes $groupCount groups over $slotCount slots and " +
+          "$reason, so what it holds reads as the composition's rather than as the UI's"
+      }
+      return false
+    }
+    if (groupCount * GROUP_INT_COUNT > groups.size) {
+      return refuse("says more groups than its ${groups.size} ints describe")
+    }
+    if (slotCount > slotArraySize) {
+      return refuse("says more slots than the $slotArraySize it has")
+    }
+    var previousDataStart = 0
+    for (address in 0 until groupCount) {
+      val dataStart = groups[address * GROUP_INT_COUNT + DATA_ANCHOR_INT]
+      if (dataStart < previousDataStart || dataStart > slotCount) {
+        return refuse("has group $address starting its slots at $dataStart")
+      }
+      previousDataStart = dataStart
+      val size = groups[address * GROUP_INT_COUNT + GROUP_SIZE_INT]
+      if (size < 1 || address + size > groupCount) {
+        return refuse("has group $address containing $size groups")
+      }
+    }
+    return true
+  }
+
+  /**
+   * Walks the groups of one composition in the order they ran, recording each group's slots against the
+   * node it is inside — or against the table itself, for the groups above the first node of it.
+   *
+   * The groups are depth first, and a group says how many groups it contains, so the group in scope at
+   * any point is the innermost one that hasn't run out: a stack of where each ends is the whole of
+   * knowing which node a slot belongs to.
+   */
+  private fun readGroups(
+    tableObjectId: Long,
+    groups: IntArray,
+    groupCount: Int,
+    slotArrayIds: LongArray,
+    slotCount: Int,
+    slotsBySourceId: MutableLongObjectMap<MutableLongList>
+  ) {
+    val enclosingEnds = MutableIntList()
+    val enclosingSourceIds = MutableLongList()
+    for (address in 0 until groupCount) {
+      while (enclosingEnds.isNotEmpty() && address >= enclosingEnds.last()) {
+        enclosingEnds.removeAt(enclosingEnds.lastIndex)
+        enclosingSourceIds.removeAt(enclosingSourceIds.lastIndex)
+      }
+      val enclosingSourceId =
+        if (enclosingSourceIds.isEmpty()) tableObjectId else enclosingSourceIds.last()
+      val groupInfo = groups[address * GROUP_INT_COUNT + GROUP_INFO_INT]
+      val dataStart = groups[address * GROUP_INT_COUNT + DATA_ANCHOR_INT]
+      // Where the next group's data starts is where this one's ends, the data being laid out in the
+      // same order as the groups. The last group's ends at the last slot in use, the array past that
+      // being the gap the next write will be made through.
+      val dataEnd = if (address + 1 < groupCount) {
+        groups[(address + 1) * GROUP_INT_COUNT + DATA_ANCHOR_INT]
+      } else {
+        slotCount
+      }
+      var slotIndex = dataStart
+      var sourceId = enclosingSourceId
+      if (groupInfo and NODE_GROUP_MASK != 0 && slotIndex < dataEnd) {
+        // A node group keeps its node in its first slot, and everything after that belongs to the node:
+        // the node itself is the enclosing group's, which is the reference the node tree already has,
+        // so the two agree and the parent gets to hold its child.
+        val node = graph.findObjectByIdOrNull(slotArrayIds[slotIndex])
+        if (node is HeapInstance) {
+          slotsBySourceId.slotsOf(enclosingSourceId).addSlot(slotIndex, node.objectId)
+          sourceId = node.objectId
+        }
+        slotIndex++
+      }
+      while (slotIndex < dataEnd) {
+        val valueObjectId = slotArrayIds[slotIndex]
+        // Nothing holds itself: a group that remembers the node it emitted would otherwise be the only
+        // thing reaching it, which is no way of reaching it at all.
+        if (valueObjectId != ValueHolder.NULL_REFERENCE && valueObjectId != sourceId &&
+          graph.objectExists(valueObjectId)
+        ) {
+          slotsBySourceId.slotsOf(sourceId).addSlot(slotIndex, valueObjectId)
+        }
+        slotIndex++
+      }
+      enclosingEnds += address + groups[address * GROUP_INT_COUNT + GROUP_SIZE_INT]
+      enclosingSourceIds += sourceId
+    }
+    // The slots the table isn't using: the gap a write is made through, which the writer nulls as it
+    // gives a slot up, and which is the composition's own either way.
+    for (index in slotCount until slotArrayIds.size) {
+      val valueObjectId = slotArrayIds[index]
+      if (valueObjectId != ValueHolder.NULL_REFERENCE && graph.objectExists(valueObjectId)) {
+        slotsBySourceId.slotsOf(tableObjectId).addSlot(index, valueObjectId)
+      }
+    }
+  }
+
+  /**
+   * The slots every object of a heap dump holds through a composition, and the arrays those slots were
+   * read out of.
+   */
+  private class TableSlots(
+    /**
+     * By the object id of what holds them, as the index of a slot followed by what it points at. Two
+     * longs a slot rather than a list of pairs, a composition having as many slots as a UI has state.
+     */
+    val slotsBySourceId: LongObjectMap<MutableLongList>,
+    /** The arrays [slotsBySourceId] accounts for every element of. */
+    val tableSlotArrayIds: LongSet
+  )
+
+  /** The two arrays one composition is, and how much of each of them it is using. */
+  private class TableArrays(
+    /** Five ints per group, in the order the composables ran. */
+    val groups: IntArray,
+    /** Everything every composable of the composition remembered, side by side. */
+    val slots: HeapObjectArray,
+    val groupCount: Int,
+    /** How many slots are in use: the array past this is the gap the next write is made through. */
+    val slotCount: Int
+  )
+
+  companion object {
+    /**
+     * What a composition keeps its state in, oldest name first. All of them are the same two arrays
+     * described by the same ints, so one reader covers every Compose version that has one — and a
+     * version whose table this can't read says so through [SharkLog] rather than reading wrong.
+     */
+    private val SLOT_TABLE_CLASS_NAMES = listOf(
+      "androidx.compose.runtime.SlotTable",
+      "androidx.compose.runtime.composer.gapbuffer.SlotTable",
+      "androidx.compose.runtime.composer.linkbuffer.SlotTable"
+    )
+
+    private const val GROUPS_FIELD_NAME = "groups"
+
+    private const val GROUPS_SIZE_FIELD_NAME = "groupsSize"
+
+    private const val SLOTS_FIELD_NAME = "slots"
+
+    private const val SLOTS_SIZE_FIELD_NAME = "slotsSize"
+
+    /**
+     * How a group is described: five ints, of which this needs three — the flags that say whether the
+     * group emitted a node, how many groups it contains, and where its slots start.
+     *
+     * The other two are the key the group was composed under and where its parent is, and the count and
+     * the anchor are why this reader is possible at all. Compose treats the lot as private, so expect it
+     * to move; what it can't do is stop being a description of the same two arrays.
+     */
+    private const val GROUP_INT_COUNT = 5
+
+    private const val GROUP_INFO_INT = 1
+
+    private const val GROUP_SIZE_INT = 3
+
+    private const val DATA_ANCHOR_INT = 4
+
+    /** Bit 30 of a group's flags: this group emitted a node, and keeps it in its first slot. */
+    private const val NODE_GROUP_MASK = 1 shl 30
+
+    private fun MutableLongObjectMap<MutableLongList>.slotsOf(sourceId: Long): MutableLongList =
+      getOrPut(sourceId) { MutableLongList() }
+
+    private fun MutableLongList.addSlot(
+      slotIndex: Int,
+      valueObjectId: Long
+    ) {
+      add(slotIndex.toLong())
+      add(valueObjectId)
+    }
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ComposeUiReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ComposeUiReferencesTest.kt
@@ -1,0 +1,282 @@
+package shark.explorer
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder
+import shark.ValueHolder.BooleanHolder
+import shark.ValueHolder.IntHolder
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+
+/**
+ * How a Compose UI reads: a tree of nodes under the view hosting it, each node holding the modifiers it
+ * draws with, rather than a flat list of everything Compose points at.
+ *
+ * [LayoutNodeChildReferenceReader] is what gives a node a reference to each of its children, and the
+ * [OwnerRule]s of [OwnerReferences] are what make a node belong to its parent and a modifier to the chain
+ * it is on.
+ */
+class ComposeUiReferencesTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Test fun `a node of a Compose UI is held by its parent rather than by the window's registry`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+
+      // AndroidComposeView keeps every node of a window in one map, by semantics id, so without the
+      // ownership rule a screen's node tree is a list hanging off the view. The step down to a child names
+      // the child's index on the parent's own class, the vector and the array it grows in being no part of
+      // the way down — see [LayoutNodeChildReferenceReader].
+      assertThat(tree.dominatorOf(ui.childNodeId)!!.nodeId).isEqualTo(ui.rootNodeId)
+      assertThat(tree.independentPathsBelowDominator(ui.childNodeId).paths.map { it.stepLabels() })
+        .containsExactly(listOf("0 → LayoutNode"))
+      // And the node at the top of the window belongs to the view hosting it, which is what puts a Compose
+      // UI's bytes inside the hierarchy of the screen showing it.
+      assertThat(tree.dominatorOf(ui.rootNodeId)!!.label).isEqualTo("AndroidComposeView")
+    }
+  }
+
+  @Test fun `a node in a slot its parent doesn't count is not one of its children`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+
+      // What a parent holds is what the vector's size covers, not what its array has room for: a slot past
+      // the size is a node the parent has let go of, and calling it a child would attribute a leaked piece
+      // of UI to the UI that dropped it. So nothing owns this one, and the array pointing at it is how it
+      // is held after all — parked until nothing that owns it turned up, then counted, since dropping the
+      // rival outright would have made a reachable node read as garbage.
+      assertThat(tree.dominatorOf(ui.uncountedNodeId)!!.label).isEqualTo("LayoutNode[]")
+    }
+  }
+
+  @Test fun `a modifier is held by the chain of the node it is on`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+      val painter = tree.findByLabel("PainterNode")
+
+      // Compose's modifier nodes point back at their coordinators and at each other, so one reference into
+      // any of them — here the focus listener a window's ViewTreeObserver holds — would otherwise hold the
+      // lot from a GC root of its own. The chain owns them instead, outermost first through each `child`.
+      assertThat(tree.dominatorOf(painter.objectId)!!.label).isEqualTo("SizeNode")
+      assertThat(tree.independentPathsBelowDominator(painter.objectId).paths.map { it.stepLabels() })
+        .containsExactly(listOf("child → PainterNode"))
+      assertThat(tree.dominatorOf(tree.findByLabel("SizeNode").objectId)!!.label).isEqualTo("NodeChain")
+      // And what the modifier draws is under the modifier, so it is under the node drawing it.
+      val painted = tree.findByLabel(PAINTED_BY_A_MODIFIER)
+      assertThat(tree.dominatorOf(painted.objectId)!!.nodeId).isEqualTo(painter.objectId)
+    }
+  }
+
+  @Test fun `the tree still retains every byte of a Compose UI`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      // Rules that park a reference are a way of taking edges out of the graph the tree is built from.
+      // This is what says they take no object out of it: every one of them still hangs somewhere under the
+      // root, and nothing reads as garbage.
+      assertThat(explorer.tree.weight(explorer.tree.root)).isEqualTo(explorer.sizes.totalByteCount)
+      assertThat(explorer.sizes.reachableByteCount + explorer.sizes.unreachableByteCount)
+        .isEqualTo(explorer.sizes.totalByteCount)
+      assertThat(explorer.sizes.unreachableByteCount).isZero()
+    }
+  }
+
+  /**
+   * A heap dump shaped like a window of a Compose app: a view holding the node at the top of its UI and a
+   * registry of every node in it, a node tree two deep, and a chain of two modifiers on the lower node.
+   *
+   * The rivals a real dump has are here too, each a GC root of its own so that all of them are closer to a
+   * root than the view is: the registry of every node, a focus listener pointing into the modifier chain,
+   * and a node left in its parent's array after the parent stopped counting it.
+   */
+  @Suppress("LongMethod")
+  private fun composeUiHeapDump(): ComposeUi {
+    val file = testFolder.newFile("compose-ui.hprof")
+    var ids: ComposeUi? = null
+    file.dump {
+      val objectArrayClassId = arrayClass("java.lang.Object")
+      val layoutNodeArrayClassId = arrayClass("androidx.compose.ui.node.LayoutNode")
+
+      /** An instance of a class of its own, so that the tests can name it, holding bytes worth moving. */
+      fun payload(simpleClassName: String) = instance(
+        clazz(
+          className = "com.example.$simpleClassName",
+          fields = listOf("payload" to ReferenceHolder::class)
+        ),
+        listOf(ReferenceHolder(objectArray(objectArrayClassId, LongArray(PAYLOAD_ELEMENT_COUNT))))
+      )
+
+      val vectorClassId = clazz(
+        className = "androidx.compose.runtime.collection.MutableVector",
+        fields = listOf(
+          "content" to ReferenceHolder::class,
+          "size" to IntHolder::class
+        )
+      )
+      val trackedVectorClassId = clazz(
+        className = "androidx.compose.ui.node.MutableVectorWithMutationTracking",
+        fields = listOf("vector" to ReferenceHolder::class)
+      )
+
+      /**
+       * Children the way a node keeps them: a vector with a mutation callback around it, over an array it
+       * grows in powers of two, with only the first [childCount] of the slots in use.
+       */
+      fun children(
+        vararg children: ReferenceHolder,
+        childCount: Int = children.size
+      ): ReferenceHolder {
+        val content = LongArray(CHILD_ARRAY_CAPACITY) { index ->
+          children.getOrNull(index)?.value ?: ValueHolder.NULL_REFERENCE
+        }
+        val vector = instance(
+          vectorClassId,
+          listOf(ReferenceHolder(objectArray(layoutNodeArrayClassId, content)), IntHolder(childCount))
+        )
+        return instance(trackedVectorClassId, listOf(vector))
+      }
+
+      val viewClassId = clazz(
+        className = "android.view.View",
+        fields = listOf(
+          "mParent" to ReferenceHolder::class,
+          "mWindowAttachCount" to IntHolder::class,
+          "mAttachInfo" to ReferenceHolder::class,
+          "mContext" to ReferenceHolder::class
+        )
+      )
+      val layoutNodeClassId = clazz(
+        className = "androidx.compose.ui.node.LayoutNode",
+        fields = listOf(
+          "_foldedChildren" to ReferenceHolder::class,
+          "nodes" to ReferenceHolder::class
+        )
+      )
+      val modifierNodeClassId = clazz(
+        className = "androidx.compose.ui.Modifier\$Node",
+        fields = listOf(
+          "parent" to ReferenceHolder::class,
+          "child" to ReferenceHolder::class
+        )
+      )
+      // The chain points back at the node it is on and the nodes at each other, so their ids have to exist
+      // before the objects holding them are written.
+      val rootNode = reserveObjectId()
+      val childNode = reserveObjectId()
+      val painterNode = reserveObjectId()
+
+      // What the lower node draws with, and the value it paints: a chain of two modifiers, the outer one
+      // held by the chain and the inner one by the outer one's `child`.
+      val painted = payload(PAINTED_BY_A_MODIFIER)
+      instance(
+        clazz(
+          className = "androidx.compose.ui.draw.PainterNode",
+          superclassId = modifierNodeClassId,
+          fields = listOf("painter" to ReferenceHolder::class)
+        ),
+        listOf(painted, NO_REFERENCE, NO_REFERENCE),
+        objectId = painterNode
+      )
+      val sizeNode = instance(
+        clazz(
+          className = "androidx.compose.foundation.layout.SizeNode",
+          superclassId = modifierNodeClassId
+        ),
+        listOf(NO_REFERENCE, painterNode)
+      )
+      val nodeChain = "androidx.compose.ui.node.NodeChain" instance {
+        field["head"] = sizeNode
+        field["tail"] = painterNode
+        field["layoutNode"] = childNode
+      }
+
+      // A node tree two deep, plus a node left in the parent's array past the size it counts.
+      instance(layoutNodeClassId, listOf(children(), nodeChain), objectId = childNode)
+      val uncountedNode = instance(layoutNodeClassId, listOf(children(), NO_REFERENCE))
+      instance(
+        layoutNodeClassId,
+        listOf(children(childNode, uncountedNode, childCount = 1), NO_REFERENCE),
+        objectId = rootNode
+      )
+
+      val composeView = instance(
+        clazz(
+          className = "androidx.compose.ui.platform.AndroidComposeView",
+          superclassId = viewClassId,
+          fields = listOf(
+            "root" to ReferenceHolder::class,
+            "layoutNodes" to ReferenceHolder::class
+          )
+        ),
+        listOf(
+          rootNode,
+          // The registry of every node of the window, which is what the ownership rule beats.
+          ReferenceHolder(
+            objectArray(objectArrayClassId, longArrayOf(rootNode.value, childNode.value))
+          ),
+          // Then what android.view.View declares: mParent, mWindowAttachCount, mAttachInfo, mContext.
+          // The context is there because the object inspectors read it with `!!`, and a view without one
+          // fails to summarise with a bare NullPointerException out of shark-android.
+          NO_REFERENCE,
+          IntHolder(1),
+          NO_REFERENCE,
+          instance(
+            clazz(
+              className = "com.example.MainActivity",
+              superclassId = clazz(
+                className = "android.app.Activity",
+                fields = listOf("mDestroyed" to BooleanHolder::class)
+              )
+            ),
+            listOf(BooleanHolder(false))
+          )
+        )
+      )
+      // The reference into a modifier chain a real dump has: a listener registered on the window's
+      // ViewTreeObserver, which an input method manager reaches from a root of its own.
+      val viewTreeObserver = "android.view.ViewTreeObserver" instance {
+        field["mOnGlobalFocusListeners"] = painterNode
+      }
+      gcRoot(JniGlobal(id = composeView.value, jniGlobalRefId = 0))
+      gcRoot(JniGlobal(id = viewTreeObserver.value, jniGlobalRefId = 1))
+      ids = ComposeUi(
+        file = file,
+        rootNodeId = rootNode.value,
+        childNodeId = childNode.value,
+        uncountedNodeId = uncountedNode.value
+      )
+    }
+    return ids!!
+  }
+
+  /**
+   * The objects of [composeUiHeapDump] the tests name by id, every `LayoutNode` of a dump reading the same
+   * as the next.
+   */
+  private class ComposeUi(
+    val file: File,
+    val rootNodeId: Long,
+    val childNodeId: Long,
+    val uncountedNodeId: Long
+  )
+
+  companion object {
+    /** Larger than the number of children in use, the way a vector grows. */
+    private const val CHILD_ARRAY_CAPACITY = 4
+
+    private const val PAYLOAD_ELEMENT_COUNT = 1024
+
+    private const val PAINTED_BY_A_MODIFIER = "PaintedByAModifier"
+
+    /** A field holding nothing, which is what the chain of a node with no modifiers is. */
+    private val NO_REFERENCE = ReferenceHolder(ValueHolder.NULL_REFERENCE)
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ComposeUiReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ComposeUiReferencesTest.kt
@@ -11,19 +11,110 @@ import shark.ValueHolder.BooleanHolder
 import shark.ValueHolder.IntHolder
 import shark.ValueHolder.ReferenceHolder
 import shark.dump
+import shark.explorer.ReachabilityStrength.STRONG
 
 /**
- * How a Compose UI reads: a tree of nodes under the view hosting it, each node holding the modifiers it
- * draws with, rather than a flat list of everything Compose points at.
+ * How a Compose UI reads: the values a composition remembers, attributed to the node whose composable
+ * remembered them, and the node tree they hang off.
  *
- * [LayoutNodeChildReferenceReader] is what gives a node a reference to each of its children, and the
- * [OwnerRule]s of [OwnerReferences] are what make a node belong to its parent and a modifier to the chain
- * it is on.
+ * Two mechanisms are under test. [SlotTableReferenceReader] hands the elements of a composition's one flat
+ * array out from the groups holding them, and the [OwnerRule]s of [OwnerReferences] make a node belong to
+ * its parent and a modifier to the chain it is on.
  */
 class ComposeUiReferencesTest {
 
   @get:Rule
   var testFolder = TemporaryFolder()
+
+  @Test fun `what a composable remembers is held by the node it ran in`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+      val remembered = tree.findByLabel(REMEMBERED_BY_THE_NODE)
+
+      // The array all of it really lives in is under the composition, nowhere near the UI, so this is the
+      // whole point of reading a slot as its group's: the value is drawn under the node that remembers it,
+      // and the step down to it says which slot of the table it is in.
+      assertThat(remembered.strength).isEqualTo(STRONG)
+      assertThat(tree.dominatorOf(remembered.objectId)!!.nodeId).isEqualTo(ui.childNodeId)
+      assertThat(tree.independentPathsBelowDominator(remembered.objectId).paths.map { it.stepLabels() })
+        .containsExactly(listOf("slot 4 → $REMEMBERED_BY_THE_NODE"))
+      // And a group's slots stop where the group it contains begins, so what the node above remembers is
+      // the node above's rather than everything below it.
+      val rememberedHigherUp = tree.findByLabel(REMEMBERED_BY_THE_ROOT_NODE)
+      assertThat(tree.dominatorOf(rememberedHigherUp.objectId)!!.nodeId).isEqualTo(ui.rootNodeId)
+    }
+  }
+
+  @Test fun `a value a composable remembers and its modifier holds is held by the node once`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+      val painted = tree.findByLabel(PAINTED_BY_A_MODIFIER)
+
+      // Two ways to it, a slot of the node's group and the modifier the node draws with, and both of them
+      // start at the node — which is what puts an image a composable both remembers and draws under that
+      // composable rather than above everything that reaches into Compose.
+      assertThat(tree.dominatorOf(painted.objectId)!!.nodeId).isEqualTo(ui.childNodeId)
+      assertThat(tree.independentPathsBelowDominator(painted.objectId).paths.map { it.stepLabels() })
+        .containsExactlyInAnyOrder(
+          listOf("slot 5 → $PAINTED_BY_A_MODIFIER"),
+          listOf(
+            "nodes → NodeChain",
+            "head → SizeNode",
+            "child → PainterNode",
+            "painter → $PAINTED_BY_A_MODIFIER"
+          )
+        )
+    }
+  }
+
+  @Test fun `a composition's array of slots holds nothing of its own`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+
+      // Still a node of the tree, reached through the table's own field and holding its own bytes — the
+      // explorer needs every object of a heap dump to be a node exactly once — and retaining nothing of
+      // what it points at, every element of it having been handed out from the group it belongs to.
+      assertThat(tree.dominatorOf(ui.slotArrayId)!!.nodeId).isEqualTo(ui.slotTableId)
+      assertThat(tree.descendantsOf(ui.slotArrayId)).isEmpty()
+    }
+  }
+
+  @Test fun `a slot no node of the composition is under is the composition's own`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+      val aboveTheFirstNode = tree.findByLabel(REMEMBERED_BY_THE_TABLE)
+      val leftInTheGap = tree.findByLabel(LEFT_IN_THE_GAP)
+
+      // Two of them: a group that emitted no node has no piece of UI to belong to, and the array is longer
+      // than the slots in use, its tail being the gap the next write is made through — a reference left in
+      // there is the composition's too.
+      assertThat(tree.dominatorOf(aboveTheFirstNode.objectId)!!.nodeId).isEqualTo(ui.slotTableId)
+      assertThat(tree.dominatorOf(leftInTheGap.objectId)!!.nodeId).isEqualTo(ui.slotTableId)
+      assertThat(tree.independentPathsBelowDominator(leftInTheGap.objectId).paths.map { it.stepLabels() })
+        .containsExactly(listOf("slot 6 → $LEFT_IN_THE_GAP"))
+    }
+  }
+
+  @Test fun `a slot table this can't read keeps its own references`() {
+    val ui = composeUiHeapDump()
+    HeapExplorer.open(ui.file).use { explorer ->
+      val tree = explorer.tree
+      val chunked = tree.findByLabel(HELD_BY_A_TABLE_OF_ANOTHER_SHAPE)
+
+      // Compose ships a second implementation whose slots are chunks rather than one array, and a table
+      // whose shape this can't read has to keep every reference out of it: the alternative is an object
+      // reachable through nothing, which would read as uncollected garbage. So it reads the way it did
+      // before [SlotTableReferenceReader] existed, through the array itself.
+      assertThat(chunked.strength).isEqualTo(STRONG)
+      val chunk = tree.dominatorOf(chunked.objectId)!!
+      assertThat(chunk.label).isEqualTo("Object[]")
+      assertThat(tree.dominatorOf(chunk.nodeId)!!.nodeId).isEqualTo(ui.chunkedTableId)
+    }
+  }
 
   @Test fun `a node of a Compose UI is held by its parent rather than by the window's registry`() {
     val ui = composeUiHeapDump()
@@ -70,18 +161,15 @@ class ComposeUiReferencesTest {
       assertThat(tree.independentPathsBelowDominator(painter.objectId).paths.map { it.stepLabels() })
         .containsExactly(listOf("child → PainterNode"))
       assertThat(tree.dominatorOf(tree.findByLabel("SizeNode").objectId)!!.label).isEqualTo("NodeChain")
-      // And what the modifier draws is under the modifier, so it is under the node drawing it.
-      val painted = tree.findByLabel(PAINTED_BY_A_MODIFIER)
-      assertThat(tree.dominatorOf(painted.objectId)!!.nodeId).isEqualTo(painter.objectId)
     }
   }
 
   @Test fun `the tree still retains every byte of a Compose UI`() {
     val ui = composeUiHeapDump()
     HeapExplorer.open(ui.file).use { explorer ->
-      // Rules that park a reference are a way of taking edges out of the graph the tree is built from.
-      // This is what says they take no object out of it: every one of them still hangs somewhere under the
-      // root, and nothing reads as garbage.
+      // A reader that moves an array's references and rules that park them are both ways of taking edges
+      // out of the graph the tree is built from. This is what says they take no object out of it: every one
+      // of them still hangs somewhere under the root, and nothing reads as garbage.
       assertThat(explorer.tree.weight(explorer.tree.root)).isEqualTo(explorer.sizes.totalByteCount)
       assertThat(explorer.sizes.reachableByteCount + explorer.sizes.unreachableByteCount)
         .isEqualTo(explorer.sizes.totalByteCount)
@@ -91,7 +179,8 @@ class ComposeUiReferencesTest {
 
   /**
    * A heap dump shaped like a window of a Compose app: a view holding the node at the top of its UI and a
-   * registry of every node in it, a node tree two deep, and a chain of two modifiers on the lower node.
+   * registry of every node in it, a node tree two deep, a chain of two modifiers on the lower node, and a
+   * composition whose slot table remembers a value against each of them.
    *
    * The rivals a real dump has are here too, each a GC root of its own so that all of them are closer to a
    * root than the view is: the registry of every node, a focus listener pointing into the modifier chain,
@@ -207,6 +296,59 @@ class ComposeUiReferencesTest {
         objectId = rootNode
       )
 
+      // What the composition remembers: a value against the group of each node, one above the first node
+      // of it, and one left in the gap past the slots in use.
+      val rememberedByTheTable = payload(REMEMBERED_BY_THE_TABLE)
+      val rememberedByTheRootNode = payload(REMEMBERED_BY_THE_ROOT_NODE)
+      val rememberedByTheNode = payload(REMEMBERED_BY_THE_NODE)
+      val leftInTheGap = payload(LEFT_IN_THE_GAP)
+      val slotArrayId = objectArray(
+        objectArrayClassId,
+        longArrayOf(
+          // Group 0, which emitted no node: its own slot, and so the composition's.
+          rememberedByTheTable.value,
+          // Group 1, a node group: the node in its first slot, then what it remembers.
+          rootNode.value,
+          rememberedByTheRootNode.value,
+          // Group 2, the node group inside it, the same way, and a value its modifier holds too.
+          childNode.value,
+          rememberedByTheNode.value,
+          painted.value,
+          // Past the slots in use: the gap, and a reference the last write left behind in it.
+          leftInTheGap.value,
+          ValueHolder.NULL_REFERENCE
+        )
+      )
+      val slotTable = "androidx.compose.runtime.composer.gapbuffer.SlotTable" instance {
+        // Five ints a group: the key it was composed under, its flags, where its parent is, how many
+        // groups it contains, and where its slots start.
+        field["groups"] = ReferenceHolder(
+          primitiveIntArray(
+            intArrayOf(
+              100, 0, -1, 3, 0,
+              101, NODE_GROUP_FLAG, 0, 2, 1,
+              102, NODE_GROUP_FLAG, 1, 1, 3
+            )
+          )
+        )
+        field["groupsSize"] = IntHolder(3)
+        field["slots"] = ReferenceHolder(slotArrayId)
+        field["slotsSize"] = IntHolder(6)
+        field["writer"] = BooleanHolder(false)
+      }
+      // Compose's other implementation, whose slots are chunks: a table this can't decode, and so one that
+      // has to be left holding its own references.
+      val chunkedTable = "androidx.compose.runtime.composer.linkbuffer.SlotTable" instance {
+        field["chunks"] = ReferenceHolder(
+          objectArray(
+            objectArrayClassId,
+            longArrayOf(payload(HELD_BY_A_TABLE_OF_ANOTHER_SHAPE).value)
+          )
+        )
+      }
+      val composition = "androidx.compose.runtime.CompositionImpl" instance {
+        field["slotStorage"] = slotTable
+      }
       val composeView = instance(
         clazz(
           className = "androidx.compose.ui.platform.AndroidComposeView",
@@ -246,12 +388,17 @@ class ComposeUiReferencesTest {
         field["mOnGlobalFocusListeners"] = painterNode
       }
       gcRoot(JniGlobal(id = composeView.value, jniGlobalRefId = 0))
-      gcRoot(JniGlobal(id = viewTreeObserver.value, jniGlobalRefId = 1))
+      gcRoot(JniGlobal(id = composition.value, jniGlobalRefId = 1))
+      gcRoot(JniGlobal(id = chunkedTable.value, jniGlobalRefId = 2))
+      gcRoot(JniGlobal(id = viewTreeObserver.value, jniGlobalRefId = 3))
       ids = ComposeUi(
         file = file,
         rootNodeId = rootNode.value,
         childNodeId = childNode.value,
-        uncountedNodeId = uncountedNode.value
+        uncountedNodeId = uncountedNode.value,
+        slotTableId = slotTable.value,
+        slotArrayId = slotArrayId,
+        chunkedTableId = chunkedTable.value
       )
     }
     return ids!!
@@ -265,16 +412,32 @@ class ComposeUiReferencesTest {
     val file: File,
     val rootNodeId: Long,
     val childNodeId: Long,
-    val uncountedNodeId: Long
+    val uncountedNodeId: Long,
+    val slotTableId: Long,
+    val slotArrayId: Long,
+    val chunkedTableId: Long
   )
 
   companion object {
+    /** Bit 30 of a group's flags, which is how Compose says the group emitted a node. */
+    private const val NODE_GROUP_FLAG = 1 shl 30
+
     /** Larger than the number of children in use, the way a vector grows. */
     private const val CHILD_ARRAY_CAPACITY = 4
 
     private const val PAYLOAD_ELEMENT_COUNT = 1024
 
+    private const val REMEMBERED_BY_THE_TABLE = "RememberedByTheTable"
+
+    private const val REMEMBERED_BY_THE_ROOT_NODE = "RememberedByTheRootNode"
+
+    private const val REMEMBERED_BY_THE_NODE = "RememberedByTheNode"
+
     private const val PAINTED_BY_A_MODIFIER = "PaintedByAModifier"
+
+    private const val LEFT_IN_THE_GAP = "LeftInTheGap"
+
+    private const val HELD_BY_A_TABLE_OF_ANOTHER_SHAPE = "HeldByATableOfAnotherShape"
 
     /** A field holding nothing, which is what the chain of a node with no modifiers is. */
     private val NO_REFERENCE = ReferenceHolder(ValueHolder.NULL_REFERENCE)

--- a/shark/shark-hprof-test/src/main/kotlin/shark/HprofWriterHelper.kt
+++ b/shark/shark-hprof-test/src/main/kotlin/shark/HprofWriterHelper.kt
@@ -34,6 +34,7 @@ import java.io.File
 import java.util.UUID
 import kotlin.random.Random
 import kotlin.reflect.KClass
+import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.IntArrayDump
 import shark.HprofRecord.HeapDumpRecord.ObjectRecord.PrimitiveArrayDumpRecord.LongArrayDump
 
 class HprofWriterHelper constructor(
@@ -351,6 +352,12 @@ class HprofWriterHelper constructor(
 
   fun primitiveByteArray(array: ByteArray): Long {
     val arrayDump = ByteArrayDump(id, 1, array)
+    writer.write(arrayDump)
+    return arrayDump.id
+  }
+
+  fun primitiveIntArray(array: IntArray): Long {
+    val arrayDump = IntArrayDump(id, 1, array)
     writer.write(arrayDump)
     return arrayDump.id
   }


### PR DESCRIPTION
Stacked on #2939 — the base is `create-ownership-rule-that-bit`, so this diff is just the two commits
here. Third of the three things asked for in that thread: after reading an evicting cache as a cache,
this is the Compose slot table work.

## The problem

On a Compose screen the explorer had nothing to say. Every image was flat under the root, and the answer
to "what is holding this bitmap" was a composition — one `Object[]` per window holding every `remember`
of every composable in it, side by side, so an image one screen remembers is held by the same array as an
image five screens away.

Three things were flattening a Compose UI, each found by asking `independentPathsBelowDominator` why a
`LayoutNode` was a child of the root, on a dump of `leakcanary-app` taken off an API 36
emulator:

The sample app has no Compose in it, and the images these numbers move around came from a screen added
to `leakcanary-app` for the measurement and deleted again, so a dump of it as it stands has the hierarchy
and not the images.

- `AndroidComposeView.layoutNodes`, a registry of **every** node of the window by semantics id, so a
  screen's node tree hangs off the view as a list.
- The modifier graph, which is bidirectional and therefore all one piece — a node points at its
  coordinator, a coordinator at its layer and at its neighbours, a layer at the layers it depends on. Three
  references reached into it from outside, each a GC root away: `InputMethodManager` → `ViewRootImpl` →
  `ViewTreeObserver.mOnGlobalFocusListeners`, `SnapshotKt.applyObservers` → `Recomposer`, and the layer
  dependency graph.
- The composition itself.

## What this does

**`Hold a Compose UI's nodes and modifiers where they belong`** — the two mechanisms a view hierarchy
already has, for a `LayoutNode`: a virtual reference from a parent to each child
(`LayoutNodeChildReferenceReader`, bounded by the vector's `size` the way the view reader is bounded by
`mChildrenCount`), and `OwnerRule`s saying a node belongs to its parent, the top node of a window to the
`AndroidComposeView` hosting it, and a `Modifier$Node` to the chain it is on.

**`Read what a composable remembers as the node's, not the composition's`** — `SlotTableReferenceReader`
reads the `int[]` that describes the slot array (five ints a group, bit 30 of the group info meaning the
group emitted a node into its first slot, a group's slots running to the next group's anchor) and hands
each slot out from the node whose composable is inside it.

That reader is **the one that replaces an object's references rather than adding to them**, which is the
thing to know before changing it. Adding works for a `ViewGroup` because the `View[]` sits under the
parent, so both paths start there. A composition's array sits under the composition, nowhere near the UI,
so an added reference would move a bitmap's dominator *up* to whatever dominates both. The array is still
a node holding its own bytes, still reached through the table's own field, and every element is still
reached exactly once. A table that doesn't validate — a dump caught mid-write, or Compose's newer
chunked `linkbuffer.SlotTable` — keeps every reference of its own and says so in the log, all or nothing
per table, since half a table read would leave objects reachable through nothing.

## Measured

On that API 36 dump of `leakcanary-app`, the two commits together:

| | Before | After |
| --- | --- | --- |
| `AndroidComposeView` retained | 2,619,473 B | **10,368,941 B** |
| its root `LayoutNode` retained | 8,895 B | **7,744,454 B** |

The `BitmapPainter`s and `AndroidImageBitmap`s of a screen are now dominated by a `LayoutNode` under
`AndroidComposeView` → `ComposeView` → … → `DecorView` → `MainActivity` →
`ActivityThread$ActivityClientRecord`. A second dump of the same app: 12,844,587 B and 5,139,099 B.

Two honest limits, both written down in `notes/dominator-tree.md`: an image the UI both remembers and
draws occupies a slot in more than one group, so it lands on the composable containing both rather than on
the exact one; and the `NodeCoordinator`s and `GraphicsLayer`s themselves are still flat under the root, a
few hundred bytes each, their graph having no one entry worth naming as the owner.

## Tests

`ComposeUiReferencesTest`, nine of them over one synthetic dump shaped like a Compose window — a view with
its node registry, a node tree two deep, a node left in the parent's array past the size it counts, a
chain of two modifiers with a focus listener pointing into it, a gapbuffer slot table remembering a value
against each node, and a chunked one this can't read. Including the invariant that matters for a reader
that moves edges: the tree still retains every byte of the dump and nothing reads as garbage.

