### PR TITLE
Name a tab as it opens, let it grow in, and wrap the strip

### DIFF
--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -52,6 +52,7 @@ import shark.explorer.ObjectDominator
 import shark.explorer.ObjectList
 import shark.explorer.ObjectListFilter
 import shark.explorer.Place
+import shark.explorer.PresentedCell
 import shark.explorer.RadialLayout
 import shark.explorer.RadialPresentation
 import shark.explorer.RootPath
@@ -180,6 +181,24 @@ internal fun HeapDumpExplorer(
     )
   }
 
+  // What each tab is called, for the tabs the window couldn't name itself. A label is cheap enough to draw
+  // on every rectangle of the map, so naming a strip of them is one small read — but it is still a read,
+  // and reads queue on the heap dump's one thread.
+  //
+  // Which is why this goes in ahead of the effect that lays the view out: opening a tab asks for both, and
+  // the layout is the larger by orders of magnitude. Named after it, a tab would show its placeholder for
+  // as long as laying the tree out takes, which on a real dump is what someone sees as a flicker.
+  val unnamedPlaces = tabs.tabs.map { it.place }.filter { it.title == null && it !in placeTitles }
+  LaunchedEffect(session, unnamedPlaces) {
+    if (unnamedPlaces.isEmpty()) {
+      return@LaunchedEffect
+    }
+    val named = session.read("what to call ${unnamedPlaces.size} tabs") { explorer ->
+      unnamedPlaces.associateWith { explorer.tree.titleOf(it) }
+    }
+    placeTitles = placeTitles + named
+  }
+
   // Resizing, going to an object and switching shape all lay the tree out again, which reads the heap dump
   // for every visible label. All of it ends up here, on the heap dump's thread. Keyed on the request rather
   // than on the place, so that typing into a list doesn't lay the map out again and the map of the tab
@@ -285,20 +304,6 @@ internal fun HeapDumpExplorer(
     }
     delay(HOVER_SETTLE_MILLIS)
     session.describing(hoveredPlace) { hoveredDetails = it }
-  }
-
-  // What each tab is called. A label is cheap enough to draw on every rectangle of the map, so naming a
-  // strip of them is one small read — but it is still a read, which is why a tab opened in the background
-  // is named a beat after it appears rather than not at all.
-  val unnamedPlaces = tabs.tabs.map { it.place }.filter { it.title == null && it !in placeTitles }
-  LaunchedEffect(session, unnamedPlaces) {
-    if (unnamedPlaces.isEmpty()) {
-      return@LaunchedEffect
-    }
-    val named = session.read("what to call ${unnamedPlaces.size} tabs") { explorer ->
-      unnamedPlaces.associateWith { explorer.tree.titleOf(it) }
-    }
-    placeTitles = placeTitles + named
   }
 
   // The panel shows the bitmap it describes as big as the panel is wide, so its pixels are read again at
@@ -409,6 +414,12 @@ internal fun HeapDumpExplorer(
    * does the same thing" has to mean to be true.
    */
   val open: (Place, OpenIn) -> Unit = { destination, openIn ->
+    // Named before the tab exists, from the view the click came from: the read that names tabs is a beat
+    // behind however small it is, and a tab that opens under a placeholder is one whose title, and width,
+    // change as you watch. Everything a view draws is named already, which is most of what is ever clicked.
+    view.presentation.cells.titleOf(destination)?.let { title ->
+      placeTitles = placeTitles + (destination to title)
+    }
     tabs = when (openIn) {
       OpenIn.CURRENT_TAB -> tabs.goTo(destination)
       OpenIn.NEW_TAB -> tabs.open(destination, inBackground = true)
@@ -1102,6 +1113,16 @@ internal sealed interface ViewPresentation {
   data class Radial(val presentation: RadialPresentation) : ViewPresentation
 
   data class Stack(val presentation: StackPresentation) : ViewPresentation
+
+  /**
+   * What was drawn and what it was named, whatever shape it came out as: every place a click on the view
+   * leads to, already named. See [titleOf].
+   */
+  val cells: List<PresentedCell<*>> get() = when (this) {
+    is Treemap -> presentation.cells
+    is Radial -> presentation.cells
+    is Stack -> presentation.cells
+  }
 }
 
 /** What a laid out view amounts to, for the log: one that drew nothing at all says so here. */

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
@@ -1,5 +1,10 @@
 package shark.explorer.app
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
@@ -16,6 +21,8 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerButton
@@ -36,7 +43,6 @@ import shark.explorer.Tabs
  * and which instance of it — is the whole of how a strip of a dozen instances of one class is one you can
  * pick out of.
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun TabStrip(
   tabs: Tabs,
@@ -55,43 +61,88 @@ internal fun TabStrip(
     verticalAlignment = Alignment.Bottom
   ) {
     tabs.tabs.forEach { tab ->
-      val isSelected = tab.id == tabs.selectedId
-      Row(
-        Modifier
-          .background(
-            if (isSelected) {
-              MaterialTheme.colorScheme.surface
-            } else {
-              MaterialTheme.colorScheme.surfaceVariant
-            }
-          )
-          // Middle clicking a tab closes it, which is the other half of middle clicking opening one.
-          .onClick(matcher = PointerMatcher.mouse(PointerButton.Tertiary)) { onClose(tab.id) }
-          // Selectable rather than clickable, because a strip of these is a set with one of them on: it
-          // is also what tells a tab apart from the button and the chain row that lead to the same place.
-          .selectable(selected = isSelected, role = Role.Tab) { onSelect(tab.id) }
-          .padding(start = 8.dp, end = 4.dp, top = 4.dp, bottom = 4.dp)
-          .widthIn(max = MAX_TAB_WIDTH),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
-      ) {
-        Text(
-          titleOf(tab.place),
-          style = MaterialTheme.typography.bodySmall,
-          fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
-          modifier = Modifier.weight(1f, fill = false)
-        )
-        // Its own click target rather than a modifier on the tab, so that closing a tab is never
-        // selecting it first: a strip where closing the fourth tab shows you the fourth tab is a strip
-        // that fights back.
-        Text(
-          CLOSE_TAB,
-          Modifier.clickable { onClose(tab.id) }.padding(horizontal = 2.dp),
-          style = MaterialTheme.typography.bodySmall
+      // Keyed on the tab rather than on where it is in the strip, because a tab opens *beside* the one it
+      // was opened from: without this, inserting one in the middle would hand its state to the tab that
+      // used to be there, and the one that grew in would be whichever ended up last.
+      key(tab.id) {
+        TabView(
+          title = titleOf(tab.place),
+          isSelected = tab.id == tabs.selectedId,
+          onSelect = { onSelect(tab.id) },
+          onClose = { onClose(tab.id) }
         )
       }
+    }
+  }
+}
+
+/**
+ * One tab, growing into the strip as it opens.
+ *
+ * Widening from nothing rather than appearing at full width, the way a browser does it, because a tab
+ * opened in the background is one nothing else on screen announces: what says a middle click did anything
+ * at all is the strip moving over to make room. It also puts the tab where it went — beside the one it was
+ * opened from, which is not where a strip that pops a tab in reads as having put it.
+ *
+ * Closing is not animated, deliberately: a strip that holds a tab open for a moment after it was closed is
+ * one where the tab under the pointer isn't the tab a second click closes.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun TabView(
+  title: String,
+  isSelected: Boolean,
+  onSelect: () -> Unit,
+  onClose: () -> Unit
+) {
+  // Starting closed and opening on the first composition, which is what makes this animate on the way in:
+  // a tab that was already open when the strip drew it has nothing to animate.
+  val opening = remember { MutableTransitionState(false) }
+  opening.targetState = true
+  AnimatedVisibility(
+    visibleState = opening,
+    // From the start edge, so the tab holds the spot it was inserted at and pushes the ones after it along,
+    // rather than sliding in from under its neighbour.
+    enter = expandHorizontally(
+      animationSpec = tween(TAB_OPEN_MILLIS),
+      expandFrom = Alignment.Start
+    ) + fadeIn(tween(TAB_OPEN_MILLIS))
+  ) {
+    Row(
+      Modifier
+        .background(
+          if (isSelected) {
+            MaterialTheme.colorScheme.surface
+          } else {
+            MaterialTheme.colorScheme.surfaceVariant
+          }
+        )
+        // Middle clicking a tab closes it, which is the other half of middle clicking opening one.
+        .onClick(matcher = PointerMatcher.mouse(PointerButton.Tertiary)) { onClose() }
+        // Selectable rather than clickable, because a strip of these is a set with one of them on: it
+        // is also what tells a tab apart from the button and the chain row that lead to the same place.
+        .selectable(selected = isSelected, role = Role.Tab) { onSelect() }
+        .padding(start = 8.dp, end = 4.dp, top = 4.dp, bottom = 4.dp)
+        .widthIn(max = MAX_TAB_WIDTH),
+      horizontalArrangement = Arrangement.spacedBy(4.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Text(
+        title,
+        style = MaterialTheme.typography.bodySmall,
+        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.weight(1f, fill = false)
+      )
+      // Its own click target rather than a modifier on the tab, so that closing a tab is never
+      // selecting it first: a strip where closing the fourth tab shows you the fourth tab is a strip
+      // that fights back.
+      Text(
+        CLOSE_TAB,
+        Modifier.clickable { onClose() }.padding(horizontal = 2.dp),
+        style = MaterialTheme.typography.bodySmall
+      )
     }
   }
 }
@@ -110,3 +161,11 @@ internal const val CLOSE_TAB = "✕"
 
 /** Wide enough for a class name and an address, short enough that ten tabs are all still on the strip. */
 private val MAX_TAB_WIDTH = 220.dp
+
+/**
+ * How long a tab takes to grow into the strip.
+ *
+ * Long enough to be read as the strip making room, short enough that a middle click and the tab being
+ * there are one thing: a tab you have to wait for is one you would rather had just appeared.
+ */
+private const val TAB_OPEN_MILLIS = 150

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
@@ -9,14 +9,13 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.onClick
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -34,14 +33,17 @@ import shark.explorer.Place
 import shark.explorer.Tabs
 
 /**
- * The tabs open in this window, left to right, as a strip under the bar that opens them.
+ * The tabs open in this window, left to right and wrapping onto a line of its own once a line is full, as
+ * a strip under the bar that opens them.
  *
  * Every tab is closeable, the last one included: a window with no tab still holds the heap dump it spent
  * seconds reading, and the bar above is one click from a tab again. See [Tabs].
  *
- * The strip scrolls rather than shrinking its tabs to nothing, because what a tab is called — which class,
+ * Neither shrinking its tabs nor scrolling them off the edge, because what a tab is called — which class,
  * and which instance of it — is the whole of how a strip of a dozen instances of one class is one you can
- * pick out of.
+ * pick out of, and a tab you have to go looking for is one you may as well not have opened. So the strip
+ * grows down into the window instead: what it costs is the view's height, and only for someone who has
+ * opened enough tabs to be reading across them anyway.
  */
 @Composable
 internal fun TabStrip(
@@ -55,10 +57,11 @@ internal fun TabStrip(
   if (tabs.tabs.isEmpty()) {
     return
   }
-  Row(
-    modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 4.dp),
+  FlowRow(
+    modifier.fillMaxWidth().padding(horizontal = 4.dp),
     horizontalArrangement = Arrangement.spacedBy(2.dp),
-    verticalAlignment = Alignment.Bottom
+    verticalArrangement = Arrangement.spacedBy(2.dp),
+    itemVerticalAlignment = Alignment.Bottom
   ) {
     tabs.tabs.forEach { tab ->
       // Keyed on the tab rather than on where it is in the strip, because a tab opens *beside* the one it

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
@@ -103,6 +103,23 @@ class TabStripTest {
     }
   }
 
+  @Test fun `a tab opened from the view is named without reading the heap dump for it`() {
+    explorerUiTest {
+      openHeapDump()
+      // The window's first tab is named by a read of its own, there being no view yet to have drawn it.
+      val readsBefore = logged.count { it.startsWith(NAMING_READ) }
+
+      middleClickTheArray()
+
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { tabs().fetchSemanticsNodes().size == 2 }
+      tab(tabTitleOfTheArray()).assertIsDisplayed()
+      // Named from the rectangle that was clicked, which the view labelled when it laid the tree out. A
+      // read to name it would land a beat after the tab is on the strip, however small a read it is, and
+      // the placeholder it replaces is what someone watching sees as the tab flickering.
+      assertThat(logged.filter { it.startsWith(NAMING_READ) }).hasSize(readsBefore)
+    }
+  }
+
   @Test fun `middle clicking an object opens it in a tab behind the one being read`() {
     explorerUiTest {
       openHeapDump()
@@ -201,6 +218,9 @@ class TabStripTest {
 
     /** Opening a heap dump and laying the tree out both happen on another thread. */
     private const val OPEN_TIMEOUT_MILLIS = 10_000L
+
+    /** What the window logs when it has to read the heap dump to find out what to call a tab. */
+    private const val NAMING_READ = "Reading what to call"
 
     /** An `adb` that answers as if nothing were plugged in, so no test here reaches a real device. */
     private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
@@ -77,6 +77,25 @@ class TabStripTest {
     }
   }
 
+  @Test fun `tabs that no longer fit across the window go on a line of their own`() {
+    explorerUiTest {
+      openHeapDump()
+
+      repeat(TABS_PAST_ONE_LINE) { screenButton(Place.OBJECTS_LABEL).performClick() }
+
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
+        tabs().fetchSemanticsNodes().size == TABS_PAST_ONE_LINE + 1
+      }
+      // Every tab still readable and still on screen, rather than squeezed to nothing or scrolled off the
+      // edge: which class and which instance of it is the whole of what a tab is for, and a tab you have
+      // to go looking for is one you may as well not have opened.
+      waitForIdle()
+      val bounds = tabs().fetchSemanticsNodes().map { it.boundsInRoot }
+      assertThat(bounds.map { it.top }.distinct()).hasSizeGreaterThan(1)
+      assertThat(bounds).allMatch { it.right <= WINDOW_WIDTH.value }
+    }
+  }
+
   @Test fun `clicking an object inside a tab moves that tab rather than opening one`() {
     explorerUiTest {
       openHeapDump()
@@ -221,6 +240,13 @@ class TabStripTest {
 
     /** What the window logs when it has to read the heap dump to find out what to call a tab. */
     private const val NAMING_READ = "Reading what to call"
+
+    /**
+     * Enough tabs off the bar that they can't all fit across a window, whose width a UI test fixes at
+     * [WINDOW_WIDTH]. A tab named after the object list is one of the narrower ones there is, so this is
+     * comfortably past what a line holds rather than exactly it.
+     */
+    private const val TABS_PAST_ONE_LINE = 20
 
     /** An `adb` that answers as if nothing were plugged in, so no test here reaches a real device. */
     private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
@@ -146,3 +146,36 @@ fun HeapDominatorTreemap.titleOf(place: Place): String = when (place) {
   is Place.Leaks -> place.title
   is Place.Starred -> place.title
 }
+
+/**
+ * What a tab opened at [place] is called, from the name a view already drew there, or null for a place
+ * none of these cells stands for.
+ *
+ * The same answer [titleOf] gives, and not a heap dump read: a cell was named when the view was laid out,
+ * so a tab opened by clicking one can be named as it opens instead of a beat later. A beat later is a tab
+ * whose title, and with it its width, change in front of whoever opened it — which is a flicker, and every
+ * cell of every view is one a click opens a tab at.
+ */
+fun List<PresentedCell<*>>.titleOf(place: Place): String? =
+  firstOrNull { Place.of(it.cell) == place }?.title()
+
+/**
+ * What a tab open where this cell leads is called.
+ *
+ * A cell is labelled with a class name and nothing else, because that is all a rectangle has room for. A
+ * tab has room for which instance of it this is, and needs it — see [titleOf].
+ */
+private fun PresentedCell<*>.title(): String {
+  val place = Place.of(cell)
+  // Only one object of the heap dump has an address to be named by: a pile of them is named by how many
+  // it holds, and the whole heap dump is no object at all.
+  return if (
+    place is Place.Object &&
+    content is CellContent.Object &&
+    place.objectId != HeapDominatorTreemap.ROOT_OBJECT_ID
+  ) {
+    "$label ${hexObjectId(place.objectId)}"
+  } else {
+    label
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
@@ -202,6 +202,29 @@ class HeapExplorerTest {
     }
   }
 
+  @Test fun `a laid out view names every place a click on it opens a tab at`() {
+    // The crowded root is the dump that draws all three kinds of cell at once: objects, a pile of the
+    // instances of one class, and the children a rectangle had no room to subdivide into.
+    HeapExplorer.open(testFolder.crowdedRootHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val cells = TreemapPresentation.of(tree, TreemapLayout(), VIEWPORT).cells
+
+      // Which is what lets a tab be named as it opens rather than by a read that lands a beat later. The
+      // two have to agree, or a tab would be renamed the moment anything else asked what to call it.
+      val places = cells.map { Place.of(it.cell) }.distinct()
+      assertThat(places.map { cells.titleOf(it) })
+        .isEqualTo(places.map { tree.titleOf(it) })
+      // Not the label alone: a strip of a dozen instances of one class is only one you can pick out of if
+      // each tab says which instance it is.
+      val tile = tree.instancesOf("Tile").first()
+      assertThat(cells.titleOf(Place.Object(tile.objectId)))
+        .isEqualTo("Tile ${hexObjectId(tile.objectId)}")
+      // And nothing at all for a place no cell of this view stands for, which is what has the window fall
+      // back to reading the heap dump for a tab opened from a list or from the chain.
+      assertThat(cells.titleOf(Place.Object(NO_SUCH_OBJECT_ID))).isNull()
+    }
+  }
+
   @Test fun `a cache that evicts is not what keeps an image in memory`() {
     HeapExplorer.open(testFolder.coilCachedImageHeapDump(alsoShownByATile = true)).use { explorer ->
       val tree = explorer.tree
@@ -641,6 +664,9 @@ class HeapExplorerTest {
     private const val CACHE_ENTRY_LABEL = "RealStrongMemoryCache\$InternalValue"
 
     private val VIEWPORT = TreemapRect(left = 0.0, top = 0.0, right = 800.0, bottom = 600.0)
+
+    /** An address no heap dump the tests write has an object at. */
+    private const val NO_SUCH_OBJECT_ID = -1L
 
     /** Matches `MAX_FIELDS` in [HeapDominatorTreemap], which isn't public. */
     private const val MAX_FIELDS_SHOWN = 500


### PR DESCRIPTION
Three things about the tab strip: it flickered when a tab opened, tabs appeared rather than animating in, and the strip scrolled sideways once they stopped fitting.

## The flicker

Opening a tab showed a `…` placeholder that took its real title, and with it its real width, a beat later.

Naming a tab open on an object is a read of the heap dump, and reads queue on the one thread that owns it. The click that opens a tab also asks for a layout of the tree rooted at that object, which is the larger of the two by orders of magnitude — and that one went in first. So the placeholder stayed up for as long as laying the tree out took, then the tab jumped from a sliver to 220dp wide and shoved the rest of the strip along.

Every cell of a view was labelled when the view was laid out, and every cell is one a click opens a tab at. So the window now names the place from the view the click came from, before the tab exists — no read, and the tab is born with its title.

`List<PresentedCell<*>>.titleOf(place)` is that answer, sitting next to the `HeapDominatorTreemap.titleOf(place)` that reads the heap dump. Two ways of naming a place that drift apart would be a tab that renames itself the moment anything else asks what to call it, so `HeapExplorerTest` pins that they agree for every cell of a laid out view — objects, class piles, and the children a rectangle had no room to subdivide into.

For the places no view drew — a row of the object list, a step of the chain — the read stays. It now goes in **ahead** of the effect that lays the view out rather than behind it, so it lands in about a millisecond instead of behind seconds of layout.

`TabStripTest` asserts a tab opened from the map costs no naming read at all, which the session log records either way. Removing the fix fails it.

## Growing in

Tabs now widen into the strip over 150 ms from the edge they were inserted at, the way a browser's do on a ⌘ click. A tab opened in the background is one nothing else on screen announces — what says the middle click did anything is the strip moving over to make room, and where it moved over is where the tab went.

Closing stays instant, deliberately: a strip that holds a closed tab open for a moment is one where the tab under the pointer isn't the tab a second click closes.

Each tab is also keyed on its id now rather than on its position, which it had to be for this: a tab opens *beside* the one it was opened from, so without a key, inserting one in the middle would hand its state to the tab that used to be there and the one that grew in would be whichever ended up last.

## Wrapping instead of scrolling

The strip scrolled sideways once the tabs stopped fitting, which put a tab somewhere you had to go looking for it. It's a `FlowRow` now: a tab that no longer fits across the window starts a line of its own. What that costs is the view's height, and only for someone who has opened enough tabs to be reading across them anyway.

`TabStripTest` opens 20 tabs off the bar and asserts they land on more than one line with none of them past the window's edge — which is what tells wrapping from scrolling, since a scrolled strip lays its tabs out past the edge and leaves them there.

## Testing

`:shark:shark-explorer:shark-explorer-core:check` and `:shark:shark-explorer:shark-explorer-app:check` pass, `detekt` is clean, and the app was relaunched on a 197 MB dump to try each change.

No changelog entry: the Shark Explorer change log has nothing but *Initial release* under Unreleased, so this is all a fix to behaviour that has never shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)