### PR TITLE
Name the idea the explorer is built on: semantic dominators

### DIFF
--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -443,7 +443,7 @@ the stretches are.
 The `Leaks` screen finds the objects that shouldn't be in memory the two ways Shark finds them — the
 `KeyedWeakReference`s LeakCanary left behind (`WatchedObjects`), and a pass over every instance with
 `AndroidObjectInspectors.appLeakingObjectFilters` — and then answers everything else about them **with the
-same code the rest of the window uses**: `HeapDominatorTreemap.rootPathTo`, the function that draws the
+same code the rest of the window uses**: `SemanticDominatorTreemap.rootPathTo`, the function that draws the
 chain beside the map. No path here comes from `RealLeakTracerFactory` or the shortest path finder — though
 what a leak is *called* does, since the chain is handed to a `LeakTrace` to be hashed, see below.
 

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -1,5 +1,36 @@
 # Dominator tree
 
+## Semantic dominators
+
+**This is not the garbage collector's dominator tree.** It's a dominator tree over a *curated* edge set,
+and the name for what that computes is **semantic dominators**: it answers "what owns this object?" where a
+GC dominator tree answers "what would the collector free?". The two come apart wherever something is held
+by more than one thing, and a real dump is full of that — a bitmap a cache and a screen both hold has no
+single owner the collector would blame, so a GC dominator tree hands its bytes to the whole heap and says
+nothing. Most of the sections below are about closing that gap.
+
+`shark.HeapDominatorTree` does the computing either way — what makes the dominators semantic is the graph it
+is handed, not the algorithm — and the explorer's tree is `SemanticDominatorTreemap`.
+
+Two patterns curate the edge set, and they're the same rule read off the two ends of a reference:
+
+- **Deny-listing a reference.** "Don't follow this one unless nothing else holds the target." Names the
+  edge, in `ReferenceStrengthReader`: `WEAKENING_FIELDS_BY_CLASS_NAME` covers the four `java.lang.ref`
+  strengths plus the cache and thread local fields, and `CachedMapValues` covers the cache entries no field
+  name can name. Both end up as a `ReachabilityStrength` weaker than `STRONG`.
+- **Allow-listing an owner.** "Only this reference owns the target, so park every rival unless no owner
+  reaches it." Names the target and the one edge into it that owns, which makes rivals of all the rest:
+  `OwnerRule` and `OwnerReferences`.
+
+**Either way the edge is deferred, not dropped**, which is the whole of why neither pattern needs to know
+what state the object it's about is in. A deny-listed edge waits in the queue of the strength it weakens
+the path to, drained after every stronger queue; a rival waits in the parked queue of the strength that
+parked it, drained once that strength has nothing else left. Both queues are in
+`HeapReachability.walkFromGcRoots`, and both patterns are gated in `SemanticReferenceReader`, so the
+dominator tree, the referrer index and the path search all see one edge set. What follows from deferring is
+that a rule moves where bytes are attributed without changing how many are reachable — the sections on each
+pattern below say what that measured out at.
+
 ## Which implementation to use
 
 `shark.HeapDominatorTree` — exact Lengauer–Tarjan with the simple link-eval, on `main` since
@@ -14,7 +45,7 @@ is still `a`.
 
 ## How the explorer uses it
 
-`HeapExplorer.open` calls `HeapDominatorTree.buildFor` with a `WeakeningAwareReferenceReader` wrapping
+`HeapExplorer.open` calls `HeapDominatorTree.buildFor` with a `SemanticReferenceReader` wrapping
 `ActualMatchingReferenceReaderFactory`, then `buildNodes` with `AndroidObjectSizeCalculator`. One tree
 per open heap dump, built once, holding every object of the dump.
 
@@ -52,7 +83,7 @@ and only one of them belongs here:
 **The strength that decides whether a weakening edge is followed is the target's, not the reference's.**
 A `WeakReference` whose referent is also held strongly is the common case, and following that edge adds a
 second path to an object that was already in the tree: its bytes move up to the two paths' common
-ancestor and the treemap reshuffles, revealing nothing. So `WeakeningAwareReferenceReader` asks
+ancestor and the treemap reshuffles, revealing nothing. So `SemanticReferenceReader` asks
 `HeapReachability` how the target came out and follows a weakening edge only when nothing strong reaches
 it. Every weakly reachable object is therefore in the tree, under the reference that is the only thing
 holding it, and nothing else moves.
@@ -154,7 +185,7 @@ stay ungrouped; two of the core tests exist to pin both cases.
 **`HeapGraph.findClassByName` is not a lookup**, it's two linear scans over every string in the dump, and
 grouping is the one place that's tempting to call it per object. Doing it per class object cost 49 s and
 doing it per primitive array — via `HeapPrimitiveArray.arrayClass`, which calls it internally — cost
-another 6.8 s, so `HeapDominatorTreemap` memoizes it in `classIdByName` and reads `instanceClassId` /
+another 6.8 s, so `SemanticDominatorTreemap` memoizes it in `classIdByName` and reads `instanceClassId` /
 `arrayClassId` directly where they exist.
 
 ## What logically owns a bitmap: Coil, measured
@@ -184,6 +215,9 @@ itself under pressure, and an *owner*, which is a piece of UI or a job. The domi
 them apart, so it hands the bytes to the root — which is what `ReachabilityStrength.CACHE` is for.
 
 ## A cache is not an owner: the `CACHE` strength
+
+The first of the two semantic dominator patterns: **deny-listing**, which names an edge and follows it only
+when nothing else holds its target.
 
 The fix for the above is to stop treating a cache's reference as retaining. `CACHE` ranks between
 `STRONG` and `SOFT`, and `ReferenceStrengthReader.CACHE_FIELDS_BY_CLASS_NAME` is the curated list of
@@ -239,6 +273,9 @@ rather than images.
 
 ## An owner beats a bystander: the `OwnerReferences` rule
 
+The second semantic dominator pattern: **allow-listing**, which names the one edge into an object that owns
+it and parks every rival unless no owner turns up.
+
 A view that's part of a hierarchy is held by its parent, and a dominator tree that doesn't know that
 scatters a window across whatever happened to be closest to a GC root. Measured on the 82 MB dump before
 the rule: all 279 attached views had rival referrers, median ~10 and up to 246, and **170 of the 277
@@ -261,7 +298,7 @@ largest rectangle under the GC roots.
 **A rule is parked, not dropped, and that's the whole design.** The walk in
 `HeapReachability.walkFromGcRoots` keeps a second queue per strength and only takes from it once the main
 one is empty, so an owner gets every chance to reach the object first, wherever in the heap dump it is.
-When no owner turns up, `markLastResortHeld` records it and the rivals count after all. Dropping a rival
+When no owner turns up, `markNoOwnerReached` records it and the rivals count after all. Dropping a rival
 outright would be a correctness bug, not a mis-attribution: a detached hierarchy leaked through a
 mid-tree child would become unreachable, the explorer would call live objects garbage, and the same rule
 in `PathFinder` would make LeakCanary report no leak. Measured proof that it costs nothing: after the
@@ -297,8 +334,8 @@ Two things to know before adding a rule:
 
 Ownership is **not** a `ReachabilityStrength` and can't be: strength is a min over the references of a
 path, while owning is a property of the last reference alone. It's a separate binary verdict per object,
-gated in the same place — `WeakeningAwareReferenceReader`, which the dominator tree, the referrer index
-and the path search all read through, so all three see one edge set.
+gated in the same place — `SemanticReferenceReader`, which the dominator tree, the referrer index and
+the path search all read through, so all three see one edge set.
 
 ### The virtual references the explorer adds
 
@@ -478,8 +515,9 @@ containing both. Read it as "this subtree is why the bytes are here", the same a
 like a LeakCanary leak trace. Which of its steps *dominate* the object is marked on it, and that marking
 is what the reader gets two different things out of:
 
-- **A step marked a dominator is one every way of holding the object goes through**, so it is what would
-  free it. The lowest such step is `dominatorOf`, and it is a *group* rather than an object when nothing
+- **A step marked a dominator is one every way the curated edge set counts goes through**, so it is what
+  owns the object — not necessarily what would free it, since a deferred edge is still a reference in the
+  heap. The lowest such step is `dominatorOf`, and it is a *group* rather than an object when nothing
   in particular holds it (`DominatorKind.WHOLE_HEAP_DUMP`, where the tree draws it directly under the root)
   or when nothing holds it at all (`UNCOLLECTED_GARBAGE`, the one pile the top of the tree has).
 - **A stretch of unmarked steps between two marked ones is a stretch the chain didn't have to take**, since

--- a/shark/shark-explorer/notes/treemap-rendering.md
+++ b/shark/shark-explorer/notes/treemap-rendering.md
@@ -3,18 +3,18 @@
 Implemented in `shark-explorer-core`: `Squarify.kt` (row layout), `TreemapLayout.kt` (adaptive depth
 and hit testing), `RadialLayout.kt` (the same, as rings), `StackLayout.kt` (the same, as a row per
 level), `TreemapRect.kt`, `LayoutCell.kt` (what the three layouts have in common),
-`HeapDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and `present()`, which labels and
+`SemanticDominatorTreemap.kt` (the dominator tree as a `TreemapTree`, and `present()`, which labels and
 colours the cells a layout produced), `TreemapPresentation.kt` (a presentation per shape, each with an
 `of()` pairing a layout with that). Drawn by `TreemapView`, `RadialView` and `StackView` in
 `shark-explorer-app`.
 
-**`of()` is a presentation's own, not a method per shape on `HeapDominatorTreemap`.** It used to be the
+**`of()` is a presentation's own, not a method per shape on `SemanticDominatorTreemap`.** It used to be the
 other way round, and adding a third shape is what moved it: that class is a 1,200 line heap dump reader
 which detekt allows 50 functions, and `presentStack` was the fiftieth. Rather than split it somewhere
 arbitrary, the per-shape method came out of it — which is also the better line, since which shapes exist
 is no business of a heap dump reader. `present(cells)` is all that stayed behind: it reads a name and a
 strength off a `CellSubject`, and every shape's cells are those. **So a fourth shape needs nothing in
-`HeapDominatorTreemap` at all.**
+`SemanticDominatorTreemap` at all.**
 
 ## Three shapes, one cut of the tree
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -28,11 +28,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import shark.explorer.CellSubject
-import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectKind
 import shark.explorer.HeapObjectSummary
 import shark.explorer.ObjectGroupKind
 import shark.explorer.ObjectGroupSummary
+import shark.explorer.SemanticDominatorTreemap
 import shark.explorer.formatByteSize
 import shark.explorer.formatByteSizeOfTotal
 import shark.explorer.formatObjectCount
@@ -139,7 +139,7 @@ private fun ObjectGroupDetails(
 
 /** What a pile of objects is called wherever it is described: here, and on the card at the pointer. */
 internal fun ObjectGroupSummary.title(): String = when (kind) {
-  ObjectGroupKind.UNREACHABLE -> HeapDominatorTreemap.UNREACHABLE_LABEL
+  ObjectGroupKind.UNREACHABLE -> SemanticDominatorTreemap.UNREACHABLE_LABEL
   ObjectGroupKind.CLASS -> "${formatObjectCount(objectCount)} of one class"
 }
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.withContext
 import shark.SharkLog
 import shark.explorer.BitmapCounts
 import shark.explorer.DeviceHeapDumps
-import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapLeaks
 import shark.explorer.HeapObjectKind
 import shark.explorer.HeapSizes
@@ -57,6 +56,7 @@ import shark.explorer.RadialLayout
 import shark.explorer.RadialPresentation
 import shark.explorer.RootPath
 import shark.explorer.RootPathWay
+import shark.explorer.SemanticDominatorTreemap
 import shark.explorer.StackLayout
 import shark.explorer.StackPresentation
 import shark.explorer.Tabs
@@ -221,7 +221,7 @@ internal fun HeapDumpExplorer(
         SharkLog.d {
           "${nodeIdText(requested)} is no node of the tree: rooting the view at the whole heap dump"
         }
-        HeapDominatorTreemap.ROOT_OBJECT_ID
+        SemanticDominatorTreemap.ROOT_OBJECT_ID
       }
       ViewState(
         rootObjectId = rooted,
@@ -849,7 +849,7 @@ private fun DescribedObject(selection: Selection?) {
       )
     }
     is Selection.ObjectGroup -> Text(
-      selection.summary.className ?: HeapDominatorTreemap.UNREACHABLE_LABEL,
+      selection.summary.className ?: SemanticDominatorTreemap.UNREACHABLE_LABEL,
       style = MaterialTheme.typography.bodyMedium
     )
     is Selection.Group -> Text(
@@ -883,7 +883,7 @@ private fun ScreenBar(
     verticalAlignment = Alignment.CenterVertically
   ) {
     TextButton(onClick = onShowWholeHeapDump) {
-      Text(HeapDominatorTreemap.ROOT_LABEL)
+      Text(SemanticDominatorTreemap.ROOT_LABEL)
     }
     TextButton(onClick = onListObjects) {
       Text(Place.OBJECTS_LABEL)
@@ -1099,7 +1099,7 @@ internal class ViewState(
   companion object {
     /** Nothing laid out yet. An empty treemap and an empty radial view draw the same nothing. */
     val EMPTY = ViewState(
-      rootObjectId = HeapDominatorTreemap.ROOT_OBJECT_ID,
+      rootObjectId = SemanticDominatorTreemap.ROOT_OBJECT_ID,
       presentation = ViewPresentation.Treemap(TreemapPresentation.EMPTY)
     )
   }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -38,12 +38,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import shark.ReferenceLocationType
-import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectKind
 import shark.explorer.LeakStatus
 import shark.explorer.PathReference
 import shark.explorer.PathStep
 import shark.explorer.ReachabilityStrength
+import shark.explorer.SemanticDominatorTreemap
 import shark.explorer.formatByteSizeOfTotal
 import shark.explorer.formatObjectCount
 import shark.explorer.hexObjectId
@@ -77,8 +77,8 @@ internal fun PathRootRow(
     NodeGutter(kind = null, incoming = null, outgoing = nextStrength, endsInArrow = nextStrength != null)
     Column(Modifier.padding(bottom = PathDetail.FULL.rowSpacing)) {
       Text(
-        HeapDominatorTreemap.ROOT_LABEL,
-        Modifier.openable { openIn -> onOpen(HeapDominatorTreemap.ROOT_OBJECT_ID, openIn) },
+        SemanticDominatorTreemap.ROOT_LABEL,
+        Modifier.openable { openIn -> onOpen(SemanticDominatorTreemap.ROOT_OBJECT_ID, openIn) },
         style = MaterialTheme.typography.bodyMedium,
         fontWeight = FontWeight.Bold
       )
@@ -332,8 +332,8 @@ internal enum class PathRole {
   STEP,
 
   /**
-   * An object that dominates the one the chain leads to: every path from a GC root goes through it, so
-   * releasing it is what would free the object.
+   * An object that dominates the one the chain leads to: every path the explorer counts as a way it is held
+   * goes through it, so it is what owns the object.
    */
   DOMINATOR,
 
@@ -375,7 +375,7 @@ internal fun ObjectIdentity(
     if ('.' in className) {
       Text(className, style = MaterialTheme.typography.bodySmall, color = MUTED_TEXT)
     }
-    if (objectId != null && objectId != HeapDominatorTreemap.ROOT_OBJECT_ID) {
+    if (objectId != null && objectId != SemanticDominatorTreemap.ROOT_OBJECT_ID) {
       Text(hexObjectId(objectId), style = MaterialTheme.typography.bodySmall, color = MUTED_TEXT)
     }
   }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import shark.explorer.DrawnRootPath
 import shark.explorer.HEAD_INDEX
-import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectSummary
 import shark.explorer.RootPath
 import shark.explorer.RootPathStep
 import shark.explorer.RootPathWay
+import shark.explorer.SemanticDominatorTreemap
 import shark.explorer.detours
 import shark.explorer.drawnWith
 import shark.explorer.stepsAfter
@@ -49,8 +49,9 @@ import shark.explorer.stepsBelow
  * chain and a few more steps. Which makes moving the pointer around the map read as the chain growing and
  * shrinking, and leaves the reader the part of it they were already reading.
  *
- * Everything here is read on the heap dump's thread — see [shark.explorer.HeapDominatorTreemap.rootPathTo] —
- * so [rootPath] arrives a little after whatever was pointed at changed.
+ * Everything here is read on the heap dump's thread — see
+ * [shark.explorer.SemanticDominatorTreemap.rootPathTo] — so [rootPath] arrives a little after whatever was
+ * pointed at changed.
  */
 @Composable
 internal fun RootPathPanel(
@@ -74,7 +75,7 @@ internal fun RootPathPanel(
   modifier: Modifier = Modifier
 ) {
   val summary = (selection as? Selection.Object)?.summary
-  val isWholeHeapDump = summary?.objectId == HeapDominatorTreemap.ROOT_OBJECT_ID
+  val isWholeHeapDump = summary?.objectId == SemanticDominatorTreemap.ROOT_OBJECT_ID
   val chain = rootPath?.takeIf { summary != null && !isWholeHeapDump && it.steps.isNotEmpty() }
   val drawn = chain?.let { path ->
     path.drawnWith(path.detours()) { detour ->

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -44,7 +44,6 @@ import shark.dump
 import shark.explorer.Adb
 import shark.explorer.AdbOutput
 import shark.explorer.DeviceHeapDumps
-import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectKind
 import shark.explorer.Place
 import shark.explorer.ReachabilityStrength
@@ -52,6 +51,7 @@ import shark.explorer.ReachabilityStrength.PHANTOM
 import shark.explorer.ReachabilityStrength.STRONG
 import shark.explorer.ReachabilityStrength.UNREACHABLE
 import shark.explorer.ReachabilityStrength.WEAK
+import shark.explorer.SemanticDominatorTreemap
 import shark.explorer.formatByteSize
 import shark.explorer.hexObjectId
 
@@ -597,7 +597,7 @@ class ExplorerAppTest {
       clickContainerEdge(yFraction = 0.5f)
 
       waitUntilAtLeastOneExists(
-        hasText(HeapDominatorTreemap.UNREACHABLE_LABEL),
+        hasText(SemanticDominatorTreemap.UNREACHABLE_LABEL),
         OPEN_TIMEOUT_MILLIS
       )
       onNodeWithText(UNREACHABLE_EXPLANATION).assertIsDisplayed()
@@ -808,7 +808,7 @@ class ExplorerAppTest {
 
   /** And the tab open on it, which is what the strip says a window opens on. */
   private fun ComposeUiTest.wholeHeapDumpTab(): SemanticsNodeInteraction =
-    onNode(hasText(HeapDominatorTreemap.ROOT_LABEL) and isTab())
+    onNode(hasText(SemanticDominatorTreemap.ROOT_LABEL) and isTab())
 
   /** A button on the row of screens an open heap dump can be read through. */
   private fun ComposeUiTest.screenButton(label: String): SemanticsNodeInteraction =
@@ -822,7 +822,7 @@ class ExplorerAppTest {
    * the role: the bar has buttons, the strip has tabs, and a row that navigates is a link with neither.
    */
   private fun isWholeHeapDumpRow(): SemanticsMatcher =
-    hasText(HeapDominatorTreemap.ROOT_LABEL) and hasClickAction() and !isButton() and !isTab()
+    hasText(SemanticDominatorTreemap.ROOT_LABEL) and hasClickAction() and !isButton() and !isTab()
 
   private fun isButton(): SemanticsMatcher =
     SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/HeapDumpSessionTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/HeapDumpSessionTest.kt
@@ -11,7 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import shark.explorer.HeapDominatorTreemap
+import shark.explorer.SemanticDominatorTreemap
 
 /**
  * What happens to a read of the heap dump when whoever asked for it stops waiting for the answer.
@@ -92,7 +92,7 @@ class HeapDumpSessionTest {
    * stop on every record it reads — and positive ids because the tree gathers small children into piles,
    * which stand for objects and are none.
    */
-  private fun HeapDominatorTreemap.objectsNearTheRoot(): List<Long> =
+  private fun SemanticDominatorTreemap.objectsNearTheRoot(): List<Long> =
     children(root).flatMap { child -> children(child) + child }.filter { it > 0L }
 
   companion object {

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/MapMovesTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/MapMovesTest.kt
@@ -23,7 +23,7 @@ import java.io.File
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import shark.explorer.HeapDominatorTreemap
+import shark.explorer.SemanticDominatorTreemap
 
 /**
  * Where a click on the map takes the map.
@@ -67,7 +67,7 @@ class MapMovesTest {
 
       // A tab of its own rather than this one moved: the bar is the way in to a heap dump, so clicking it
       // while reading an object is asking for both. Either way the map is drawn at the top again.
-      onNode(hasText(HeapDominatorTreemap.ROOT_LABEL) and isButton()).performClick()
+      onNode(hasText(SemanticDominatorTreemap.ROOT_LABEL) and isButton()).performClick()
 
       waitUntilZoomedOut()
     }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
@@ -31,8 +31,8 @@ import shark.dump
 import shark.explorer.Adb
 import shark.explorer.AdbOutput
 import shark.explorer.DeviceHeapDumps
-import shark.explorer.HeapDominatorTreemap
 import shark.explorer.Place
+import shark.explorer.SemanticDominatorTreemap
 import shark.explorer.hexObjectId
 
 /**
@@ -60,7 +60,7 @@ class TabStripTest {
       openHeapDump()
 
       assertThat(tabs().fetchSemanticsNodes()).hasSize(1)
-      tab(HeapDominatorTreemap.ROOT_LABEL).assertIsDisplayed()
+      tab(SemanticDominatorTreemap.ROOT_LABEL).assertIsDisplayed()
     }
   }
 
@@ -148,7 +148,7 @@ class TabStripTest {
       // Behind rather than in front: opening a tab this way is parking somewhere to come back to, so the
       // tab being read stays the one on screen and the whole heap dump is still what the panes describe.
       waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { tabs().fetchSemanticsNodes().size == 2 }
-      tab(HeapDominatorTreemap.ROOT_LABEL).assertIsSelected()
+      tab(SemanticDominatorTreemap.ROOT_LABEL).assertIsSelected()
       tab(tabTitleOfTheArray()).assertIsNotSelected()
     }
   }
@@ -207,7 +207,7 @@ class TabStripTest {
     waitForTheTree(OPEN_TIMEOUT_MILLIS)
     // A tab is named by a read of the heap dump, so a window whose strip has not caught up yet is one
     // where every assertion about a title would be about the placeholder.
-    waitUntilAtLeastOneExists(hasText(HeapDominatorTreemap.ROOT_LABEL) and isTab(), OPEN_TIMEOUT_MILLIS)
+    waitUntilAtLeastOneExists(hasText(SemanticDominatorTreemap.ROOT_LABEL) and isTab(), OPEN_TIMEOUT_MILLIS)
   }
 
   /**

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DataStructureReferenceReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DataStructureReferenceReader.kt
@@ -33,7 +33,7 @@ import shark.Reference
  * LeakCanary makes on purpose — the animation handler tends to keep that target alive — and it is the one
  * thing this explorer can't say. Here a weak reference holds nothing, the strength of what reaches an
  * object is a property the whole tree is built on, and an edge like that would make a weakly held object
- * read as strongly held. See [WeakeningAwareReferenceReader].
+ * read as strongly held. See [SemanticReferenceReader].
  */
 internal class DataStructureReferenceReader(graph: HeapGraph) {
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DominatorPaths.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DominatorPaths.kt
@@ -3,11 +3,15 @@ package shark.explorer
 import shark.ReferenceLocationType
 
 /**
- * The one node a dominator tree attributes an object's bytes to. See
- * [HeapDominatorTreemap.dominatorOf].
+ * The one node an object's bytes are attributed to: its semantic dominator. See
+ * [SemanticDominatorTreemap.dominatorOf].
  *
- * There is always exactly one: releasing this is what would free the object, and there is no second
- * answer. When no single object holds it — several holders on paths that meet nowhere — the dominator is
+ * There is always exactly one and there is no second answer, because every way the explorer counts the
+ * object as held goes through this node. Not necessarily what the collector would have to see go, though —
+ * a reference the edge set deferred is still there in the heap, so a cache or a rival referrer can go on
+ * holding an object attributed to its owner. That gap is what the word semantic is carrying.
+ *
+ * When no single object holds it — several holders on paths that meet nowhere — the dominator is
  * where the tree draws it rather than an object: the whole heap dump, or the pile of garbage. [kind] is
  * which.
  */
@@ -72,7 +76,7 @@ data class IndependentPaths(
 data class IndependentPath(
   /**
    * Which kind of GC root the chain starts at, for a path found by
-   * [HeapDominatorTreemap.independentPathsFromRoots]. Null for one found below an object, which is where
+   * [SemanticDominatorTreemap.independentPathsFromRoots]. Null for one found below an object, which is where
    * that chain starts instead.
    */
   val gcRootLabel: String?,

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapExplorer.kt
@@ -27,7 +27,7 @@ class HeapExplorer private constructor(
   private val graph: CloseableHeapGraph,
   private val reachability: HeapReachability,
   /** Every object of the heap dump, reachable or not, weighted by what it retains. */
-  val tree: HeapDominatorTreemap,
+  val tree: SemanticDominatorTreemap,
   /** The device and process that wrote the heap dump, which is where its bitmaps still are. */
   val origin: HeapDumpOrigin
 ) : Closeable {
@@ -86,10 +86,10 @@ class HeapExplorer private constructor(
         val tree = steps.run("Working out what retains what") {
           val dominatorTree = HeapDominatorTree.buildFor(
             graph = graph,
-            referenceReader = WeakeningAwareReferenceReader(strengthReader, reachability, ownerReferences),
+            referenceReader = SemanticReferenceReader(strengthReader, reachability, ownerReferences),
             gcRootProvider = gcRootProvider
           )
-          HeapDominatorTreemap(
+          SemanticDominatorTreemap(
             graph = graph,
             reachability = reachability,
             strengthReader = strengthReader,

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
@@ -4,7 +4,7 @@ import java.security.MessageDigest
 
 /**
  * Every object of a heap dump that shouldn't be there, gathered into the leaks they are instances of. See
- * [HeapDominatorTreemap.findLeaks].
+ * [SemanticDominatorTreemap.findLeaks].
  *
  * The same answer LeakCanary's analysis gives, computed here instead so that every row keeps the object id
  * it came from: a leak trace names classes, and a screen you can click through has to name objects. Which

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapReachability.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapReachability.kt
@@ -125,6 +125,9 @@ internal class HeapReachability private constructor(
    * And nothing is lost by it. Every object was reached by a walk at exactly the strength this compares
    * against — the strongest path to it — so it keeps at least the edges of that path, and the graph the
    * dominator tree is built from still has every object of the heap dump in it.
+   *
+   * Shares its name with [OwnerReferences.isHeldThrough] on purpose: same question of the other pattern,
+   * and an edge has to pass both to be in the set [SemanticReferenceReader] reads.
    */
   fun isHeldThrough(
     objectId: Long,
@@ -234,14 +237,14 @@ internal class HeapReachability private constructor(
         // can't cost an object the strength it's really held at.
         val parked = ArrayDeque<Long>()
         while (queue.isNotEmpty() || parked.isNotEmpty()) {
-          val isLastResort = queue.isEmpty()
-          val objectId = if (isLastResort) parked.removeFirst() else queue.removeFirst()
+          val takingFromParked = queue.isEmpty()
+          val objectId = if (takingFromParked) parked.removeFirst() else queue.removeFirst()
           val heapObject = graph.findObjectByIdOrNull(objectId) ?: continue
           if (!reach(heapObject, strength)) {
             continue
           }
-          if (isLastResort) {
-            ownerReferences.markLastResortHeld(heapObject)
+          if (takingFromParked) {
+            ownerReferences.markNoOwnerReached(heapObject)
           }
           val ownership = ownerReferences.ownershipOf(heapObject)
           // A reference that retains its target doesn't weaken the path it's on.
@@ -382,7 +385,7 @@ internal class HeapReachability private constructor(
 
     /**
      * Runs [block] for every unreachable object the unreachable [objectId] points at, which is the same
-     * set of edges [WeakeningAwareReferenceReader] gives the dominator tree: a reference that doesn't
+     * set of edges [SemanticReferenceReader] gives the dominator tree: a reference that doesn't
      * retain is followed when nothing stronger holds its target, and nothing at all holds these.
      *
      * It has to be the same set, because it decides which pieces of garbage the tree is walked from. A

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakFingerprint.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakFingerprint.kt
@@ -22,7 +22,7 @@ import shark.ReferenceLocationType
  * That trace is built to be hashed and for nothing else: what the explorer draws is the chain, which says
  * more than a leak trace does. Which is why the GC root it names is [LeakTrace.GcRootType.UNKNOWN] — the
  * leak fingerprint doesn't include the root, and the explorer names roots its own way, see
- * `HeapDominatorTreemap.rootPathTo`.
+ * `SemanticDominatorTreemap.rootPathTo`.
  */
 internal fun List<PathStep>.leakFingerprint(): String = toLeakTrace().leakFingerprint
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NodeIds.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NodeIds.kt
@@ -1,7 +1,7 @@
 package shark.explorer
 
-import shark.explorer.HeapDominatorTreemap.Companion.ROOT_OBJECT_ID
-import shark.explorer.HeapDominatorTreemap.Companion.UNREACHABLE_NODE_ID
+import shark.explorer.SemanticDominatorTreemap.Companion.ROOT_OBJECT_ID
+import shark.explorer.SemanticDominatorTreemap.Companion.UNREACHABLE_NODE_ID
 
 /**
  * The address a heap dump recorded an object at, which is what an object id is.
@@ -17,16 +17,16 @@ fun hexObjectId(objectId: Long): String {
 }
 
 /**
- * How a node of a [HeapDominatorTreemap] reads in a message: the address of an object, or which pile of
+ * How a node of a [SemanticDominatorTreemap] reads in a message: the address of an object, or which pile of
  * objects it is.
  *
  * A pile is no object of the heap dump, so it has no address to name it by. See
- * [HeapDominatorTreemap.isPileId].
+ * [SemanticDominatorTreemap.isPileId].
  */
 fun nodeIdText(nodeId: Long): String = when {
   nodeId == ROOT_OBJECT_ID -> "the whole heap dump"
   nodeId == UNREACHABLE_NODE_ID -> "the uncollected garbage"
-  HeapDominatorTreemap.isPileId(nodeId) -> "the class pile ${nodeId - UNREACHABLE_NODE_ID}"
+  SemanticDominatorTreemap.isPileId(nodeId) -> "the class pile ${nodeId - UNREACHABLE_NODE_ID}"
   else -> hexObjectId(nodeId)
 }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ObjectList.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ObjectList.kt
@@ -17,7 +17,7 @@ enum class HeapObjectKind(
 }
 
 /**
- * Which objects of a heap dump a list shows. See [HeapDominatorTreemap.listObjects].
+ * Which objects of a heap dump a list shows. See [SemanticDominatorTreemap.listObjects].
  *
  * The default matches everything: a heap dump is worth scrolling through before it's worth searching.
  */
@@ -50,7 +50,7 @@ data class ObjectListFilter(
   }
 }
 
-/** One row of a list of objects. See [HeapDominatorTreemap.listObjects]. */
+/** One row of a list of objects. See [SemanticDominatorTreemap.listObjects]. */
 data class ObjectListEntry(
   val objectId: Long,
   /** Fully qualified class name, or array type. */
@@ -69,7 +69,7 @@ data class ObjectListEntry(
 )
 
 /**
- * Every object a filter matches, largest first, capped. See [HeapDominatorTreemap.listObjects].
+ * Every object a filter matches, largest first, capped. See [SemanticDominatorTreemap.listObjects].
  */
 data class ObjectList(
   val filter: ObjectListFilter,

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/OwnerReferences.kt
@@ -101,15 +101,21 @@ internal class ScopedProvider(
  * Which objects of a heap dump something owns, and which references are the owning ones — the
  * [OwnerRule] list applied to one heap dump.
  *
+ * **Allow-listing an owner**, one of the two patterns behind the explorer's **semantic dominators**: a
+ * dominator tree built over a curated edge set, so that it answers "what owns this object?" rather than
+ * "what would the collector free?". Allow-listing names the target and the one edge into it that owns,
+ * which makes rivals of all the rest. Deny-listing a reference is the other pattern, and the same rule read
+ * off the other end of a reference: see [ReferenceStrengthReader].
+ *
  * The rule this exists to apply: **a reference into an object something else owns is not one of the ways
  * that object is held, unless nothing that owns it reached it.** A walk therefore parks a rival
  * reference instead of dropping it, and only takes a parked one once it has nothing else left to
  * follow — see [HeapReachability.walkFromGcRoots]. That's what makes the rule safe to apply without
  * knowing anything about the state of the objects: when the owner turns out not to be there, the walk
- * calls [markLastResortHeld] and the rivals count after all.
+ * calls [markNoOwnerReached] and the rivals count after all.
  *
  * Filled in by the walk, then read by everything that needs the same edges the walk followed:
- * [WeakeningAwareReferenceReader], and so the dominator tree, the referrer index and the path search.
+ * [SemanticReferenceReader], and so the dominator tree, the referrer index and the path search.
  * So [isHeldThrough] is only meaningful once [HeapReachability.computeFor] has returned.
  */
 internal class OwnerReferences private constructor(
@@ -132,7 +138,7 @@ internal class OwnerReferences private constructor(
    * after all: a view of a hierarchy whose parent is gone, a dialog's decor view once the dialog is
    * collected.
    */
-  private val lastResortHeldObjectIndexes = BitSet(graph.objectCount)
+  private val noOwnerReachedObjectIndexes = BitSet(graph.objectCount)
 
   /** What [source] owns, worked out once per object rather than once per reference out of it. */
   fun ownershipOf(source: HeapObject): Ownership =
@@ -151,8 +157,8 @@ internal class OwnerReferences private constructor(
    * Records that nothing that owns [heapObject] reached it, so [isHeldThrough] answers true for every
    * reference into it from here on.
    */
-  fun markLastResortHeld(heapObject: HeapObject) {
-    lastResortHeldObjectIndexes.set(heapObject.objectIndex)
+  fun markNoOwnerReached(heapObject: HeapObject) {
+    noOwnerReachedObjectIndexes.set(heapObject.objectIndex)
   }
 
   /**
@@ -160,8 +166,11 @@ internal class OwnerReferences private constructor(
    *
    * True for everything but a rival reference into an object an owner reached. Nothing is lost by it:
    * every object was reached either through a reference this keeps, or from the parked references, and
-   * then [markLastResortHeld] keeps all of them. So the graph the dominator tree is built from still has
+   * then [markNoOwnerReached] keeps all of them. So the graph the dominator tree is built from still has
    * every object of the heap dump in it, reachable and garbage alike.
+   *
+   * Shares its name with [HeapReachability.isHeldThrough] on purpose: same question of the other pattern,
+   * and an edge has to pass both to be in the set [SemanticReferenceReader] reads.
    */
   fun isHeldThrough(
     sourceOwnership: Ownership,
@@ -171,7 +180,7 @@ internal class OwnerReferences private constructor(
       return true
     }
     val target = graph.findObjectByIdOrNull(reference.valueObjectId) ?: return true
-    return lastResortHeldObjectIndexes.get(target.objectIndex)
+    return noOwnerReachedObjectIndexes.get(target.objectIndex)
   }
 
   /** Every instance of a class owns the same fields and the same virtual references. */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
@@ -20,7 +20,7 @@ sealed interface Place {
   /**
    * What a tab showing this is called, or null for a place only the heap dump can name.
    *
-   * See [HeapDominatorTreemap.titleOf], which is the one that always answers.
+   * See [SemanticDominatorTreemap.titleOf], which is the one that always answers.
    */
   val title: String?
 
@@ -57,7 +57,7 @@ sealed interface Place {
     override val viewRootObjectId: Long get() = parentObjectId
   }
 
-  /** Every object of the heap dump as a list, filtered. See [HeapDominatorTreemap.listObjects]. */
+  /** Every object of the heap dump as a list, filtered. See [SemanticDominatorTreemap.listObjects]. */
   data class Objects(val filter: ObjectListFilter = ObjectListFilter()) : Place {
 
     // Named after what it is filtered to, so that two of these open at once are two different lists on
@@ -68,7 +68,7 @@ sealed interface Place {
     override val viewRootObjectId: Long? get() = null
   }
 
-  /** Every leaking object of the heap dump, gathered into leaks. See [HeapDominatorTreemap.findLeaks]. */
+  /** Every leaking object of the heap dump, gathered into leaks. See [SemanticDominatorTreemap.findLeaks]. */
   data class Leaks(
     /**
      * Which leaks have been unfolded to show the objects in them, by [LeakGroup.leakFingerprint] and which
@@ -110,7 +110,7 @@ sealed interface Place {
     }
 
     /** The place a window opens on, which is the heap dump as a whole. */
-    fun wholeHeapDump(): Object = Object(HeapDominatorTreemap.ROOT_OBJECT_ID)
+    fun wholeHeapDump(): Object = Object(SemanticDominatorTreemap.ROOT_OBJECT_ID)
 
     /** What the button leading to the list of every object says, on the bar and on a tab. */
     const val OBJECTS_LABEL = "Object list"
@@ -130,12 +130,12 @@ sealed interface Place {
  * class is still a tab strip you can pick out of. A class pile keeps the name the map draws on it —
  * `42 × Bitmap` — because how many instances it stands for is the whole of what it is.
  */
-fun HeapDominatorTreemap.titleOf(place: Place): String = when (place) {
+fun SemanticDominatorTreemap.titleOf(place: Place): String = when (place) {
   is Place.Object -> {
     val objectId = place.objectId
     val label = label(objectId)
     // The whole heap dump and the piles have no address to add: one is no object, the others are many.
-    if (objectId == HeapDominatorTreemap.ROOT_OBJECT_ID || groupOrNull(objectId) != null) {
+    if (objectId == SemanticDominatorTreemap.ROOT_OBJECT_ID || groupOrNull(objectId) != null) {
       label
     } else {
       "$label ${hexObjectId(objectId)}"
@@ -172,7 +172,7 @@ private fun PresentedCell<*>.title(): String {
   return if (
     place is Place.Object &&
     content is CellContent.Object &&
-    place.objectId != HeapDominatorTreemap.ROOT_OBJECT_ID
+    place.objectId != SemanticDominatorTreemap.ROOT_OBJECT_ID
   ) {
     "$label ${hexObjectId(place.objectId)}"
   } else {

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferenceStrengthReader.kt
@@ -24,7 +24,6 @@ import shark.explorer.ReachabilityStrength.CACHE
 import shark.explorer.ReachabilityStrength.FINALIZER
 import shark.explorer.ReachabilityStrength.PHANTOM
 import shark.explorer.ReachabilityStrength.SOFT
-import shark.explorer.ReachabilityStrength.STRONG
 import shark.explorer.ReachabilityStrength.THREAD_LOCAL
 import shark.explorer.ReachabilityStrength.WEAK
 
@@ -58,6 +57,13 @@ internal class WeakeningReference(
  * Splits an object's outgoing references in two: the ones that keep their target alive, and the ones
  * that don't — what a `java.lang.ref.Reference` holds its referent with, and what a cache holds its
  * entries with.
+ *
+ * **Deny-listing a reference**, one of the two patterns behind the explorer's **semantic dominators**: a
+ * dominator tree built over a curated edge set, so that it answers "what owns this object?" rather than
+ * "what would the collector free?". Deny-listing names the edge — this field of this class holds its value
+ * without keeping it, or this entry belongs to that cache — and the edge then counts as a way its target is
+ * held only when nothing else holds it. Allow-listing an owner is the other pattern, and the same rule read
+ * off the other end of a reference: see [OwnerReferences].
  *
  * Reference strength lives entirely in Shark's ignored reference matchers, and those only say what
  * not to follow, never why. So this reads both halves: a matched [ReferenceReader] for everything
@@ -429,56 +435,5 @@ internal class ReferenceStrengthReader(private val graph: HeapGraph) {
           instanceField(className, it).ignored(patternApplies = ALWAYS)
         }
       }
-  }
-}
-
-/**
- * Reads the references that retain their target, plus the ones that hold an object without retaining it
- * — a `java.lang.ref.Reference`'s referent, a cache's entries, a thread local — when such a reference is
- * the strongest thing reaching the object.
- *
- * That's what puts a weakly reachable object in the tree, dominated by the weak reference itself, and a
- * cached one under its cache entry: every object of the heap dump is a node, and every one of them is
- * held by whatever the garbage collector would have to let go of first.
- *
- * **The target's strength decides, not the reference's.** Following a weak reference to an object that
- * something else holds strongly wouldn't reveal anything — the object is already in the tree — but it
- * would add an edge, which moves the object's retained size up to whatever dominates both paths and
- * attributes it to neither. Which is exactly what a weak reference isn't: it holds nothing.
- *
- * **And a path stays as weak as its weakest reference.** An object held only by a finalizer queue, a
- * thread local or a stack frame doesn't hold what something firmer holds either, so every reference out of
- * it is weighed the same way. Without that, a `FinalizerReference` two steps up a chain would be one more
- * way of holding an object that a field holds squarely, which is a way of holding nothing.
- *
- * Drops the references that lose to an owner for the same reason, and it's the same rule read off a
- * different property of the reference: see [OwnerReferences].
- */
-internal class WeakeningAwareReferenceReader(
-  private val strengthReader: ReferenceStrengthReader,
-  private val reachability: HeapReachability,
-  private val ownerReferences: OwnerReferences
-) : ReferenceReader<HeapObject> {
-
-  override fun read(source: HeapObject): Sequence<Reference> {
-    val pathStrength = reachability.strengthOf(source)
-    val ownership = ownerReferences.ownershipOf(source)
-    val retaining = strengthReader.retainingReferencesOf(source)
-      .filter { ownerReferences.isHeldThrough(ownership, it) }
-      .let { references ->
-        // Nothing to weigh when the path here is strong, which it is for nearly every object of a dump.
-        if (pathStrength == STRONG) {
-          references
-        } else {
-          references.filter { reachability.isHeldThrough(it.valueObjectId, pathStrength) }
-        }
-      }
-    val followed = strengthReader.weakeningReferencesOf(source)
-      .filter { reachability.isHeldThrough(it.valueObjectId, maxOf(pathStrength, it.strength)) }
-    return if (followed.isEmpty()) {
-      retaining
-    } else {
-      retaining + followed.asSequence().map { it.toReference() }
-    }
   }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPath.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPath.kt
@@ -2,7 +2,7 @@ package shark.explorer
 
 /**
  * The shortest way a GC root reaches one object, with the objects that dominate it marked. See
- * [HeapDominatorTreemap.rootPathTo].
+ * [SemanticDominatorTreemap.rootPathTo].
  *
  * What a treemap can't say on its own: a rectangle says which object the tree attributes these bytes to,
  * and this says which of the heap dump's own references had to be followed to get to them. Shortest
@@ -47,7 +47,7 @@ fun RootPath.stepsBelow(rootNodeId: Long): List<RootPathStep> {
     return steps
   }
   val rootIndex = steps.indexOfFirst { it.step.objectId == rootNodeId }
-  if (rootIndex == -1 && rootNodeId != HeapDominatorTreemap.ROOT_OBJECT_ID) {
+  if (rootIndex == -1 && rootNodeId != SemanticDominatorTreemap.ROOT_OBJECT_ID) {
     return steps
   }
   val fromIndex = (rootIndex + 1 until steps.size).firstOrNull { steps[it].isDominator }
@@ -70,9 +70,9 @@ fun RootPath.stepsAfter(objectId: Long): List<RootPathStep>? {
 /**
  * One object along a [RootPath].
  *
- * [isDominator] is what makes the chain more than a list of holders: every path from a GC root to the
- * object goes through each of its dominators, so a marked step is one that releasing would free the
- * object, and the rest are only on the way to it.
+ * [isDominator] is what makes the chain more than a list of holders: every path the explorer counts as a
+ * way the object is held goes through each of its dominators, so a marked step is one that owns it — see
+ * [ObjectDominator] — and the rest are only on the way to it.
  */
 data class RootPathStep(
   val step: PathStep,

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathDetour.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathDetour.kt
@@ -7,8 +7,8 @@ package shark.explorer
  * Every path from a GC root goes through every dominator of the object, so a step that dominates it is one
  * the chain has no choice about. A run of steps between two of those is the opposite: if the chain had to
  * run through them, they would dominate the object as well and be marked. So a detour is exactly where the
- * question "held how else?" has an answer, and [HeapDominatorTreemap.independentPathsBetween] is the answer
- * — asked of the two ends rather than of the whole chain, which is what keeps it to the part in doubt.
+ * question "held how else?" has an answer, and [SemanticDominatorTreemap.independentPathsBetween] is the
+ * answer — asked of the two ends rather than of the whole chain, which is what keeps it to the part in doubt.
  */
 data class RootPathDetour(
   /** Index into [RootPath.steps] of the first step that could have been another object. */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathSearch.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathSearch.kt
@@ -27,7 +27,7 @@ import androidx.collection.IntSet
  * does — an object a leak dominates is held by that leak, and saying so is the whole answer.
  *
  * Object indexes rather than ids throughout, because that is what a [ReferrerIndex] walks in and what the
- * arrays here are indexed by. See [HeapDominatorTreemap.rootPathTo], which reads the objects out.
+ * arrays here are indexed by. See [SemanticDominatorTreemap.rootPathTo], which reads the objects out.
  *
  * One instance per tree rather than per question, because a treemap answers this for every rectangle the
  * pointer crosses and the arrays are the size of the heap dump. Which objects one walk has seen is

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SemanticDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SemanticDominatorTreemap.kt
@@ -58,6 +58,12 @@ import shark.ValueHolder.ShortHolder
 /**
  * A heap dump's dominator tree, seen as a [TreemapTree] weighted by retained size.
  *
+ * **Semantic dominators, not the garbage collector's**, which is what the name is for.
+ * [shark.HeapDominatorTree] computes exact dominators over whatever graph it is given, and what it's given
+ * here is a curated edge set rather than every reference the heap dump records — see
+ * [SemanticReferenceReader]. So a node's parent is what *owns* it, which is the question someone looking at
+ * a rectangle is asking, and not what the collector would have to see go to free it.
+ *
  * Nodes are object ids, and the root is [NULL_REFERENCE]: the virtual root [shark.HeapDominatorTree]
  * puts above every GC root, so that the whole heap dump is one rectangle. Its children are the objects no
  * one object owns, and [UNREACHABLE_NODE_ID] beside them: every object of the dump is in here whether a GC
@@ -76,7 +82,7 @@ import shark.ValueHolder.ShortHolder
 // back into this one. Worth doing, and worth doing on its own rather than inside a change that adds one
 // more answer.
 @Suppress("LargeClass", "TooManyFunctions")
-class HeapDominatorTreemap internal constructor(
+class SemanticDominatorTreemap internal constructor(
   private val graph: HeapGraph,
   private val reachability: HeapReachability,
   private val strengthReader: ReferenceStrengthReader,
@@ -101,7 +107,7 @@ class HeapDominatorTreemap internal constructor(
    * too: a path through a reference the tree ignored would explain a retention the tree doesn't show.
    */
   private val pathReferenceReader by lazy {
-    WeakeningAwareReferenceReader(strengthReader, reachability, ownerReferences)
+    SemanticReferenceReader(strengthReader, reachability, ownerReferences)
   }
 
   /**
@@ -510,9 +516,11 @@ class HeapDominatorTreemap internal constructor(
    * The one node this tree attributes [objectId]'s bytes to, or null for the root itself and for an
    * object that is no node of the tree.
    *
-   * The dominator is the answer to "what would free this": every path from a GC root to the object goes
-   * through it. There is exactly one, which is what makes it worth showing on its own, and it is a group
-   * rather than an object when nothing in particular holds the object — see [DominatorKind].
+   * The dominator is the answer to "what owns this": every path the curated edge set counts goes through
+   * it, though a deferred reference is still there in the heap, so it isn't necessarily what would free the
+   * object — see [ObjectDominator]. There is exactly one, which is what makes it worth showing on its own,
+   * and it is a group rather than an object when nothing in particular holds the object — see
+   * [DominatorKind].
    */
   fun dominatorOf(objectId: Long): ObjectDominator? {
     if (objectId == root || objectId !in nodes) {
@@ -1664,7 +1672,7 @@ class HeapDominatorTreemap internal constructor(
   }
 }
 
-/** What the UI knows about one heap object. See [HeapDominatorTreemap.summarize]. */
+/** What the UI knows about one heap object. See [SemanticDominatorTreemap.summarize]. */
 data class HeapObjectSummary(
   val objectId: Long,
   /** Short name, as drawn on a rectangle. */
@@ -1695,7 +1703,7 @@ data class HeapObjectSummary(
 
 /**
  * What the UI knows about a cell that stands for a pile of objects rather than for one. See
- * [HeapDominatorTreemap.groupOrNull].
+ * [SemanticDominatorTreemap.groupOrNull].
  */
 data class ObjectGroupSummary(
   /** What the tree knows this group by, e.g. to zoom into it. Not an object id. */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SemanticReferenceReader.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/SemanticReferenceReader.kt
@@ -1,0 +1,65 @@
+package shark.explorer
+
+import shark.HeapObject
+import shark.Reference
+import shark.ReferenceReader
+import shark.explorer.ReachabilityStrength.STRONG
+
+/**
+ * The edge set the explorer's **semantic dominators** are computed over: which of a heap dump's references
+ * count as ways their target is held, rather than all of them.
+ *
+ * Two patterns curate it, and this is the one place both are gated, so the dominator tree, the referrer
+ * index and the path search all see the same edges. Deny-listing a reference is one of them — see
+ * [ReferenceStrengthReader] — and allow-listing an owner is the other, which is the same rule read off the
+ * other end of a reference: see [OwnerReferences].
+ *
+ * Reads the references that retain their target, plus the ones that hold an object without retaining it
+ * — a `java.lang.ref.Reference`'s referent, a cache's entries, a thread local — when such a reference is
+ * the strongest thing reaching the object.
+ *
+ * That's what puts a weakly reachable object in the tree, dominated by the weak reference itself, and a
+ * cached one under its cache entry: every object of the heap dump is a node, and every one of them is
+ * held by whatever would have to let go of it first.
+ *
+ * **The target's strength decides, not the reference's.** Following a weak reference to an object that
+ * something else holds strongly wouldn't reveal anything — the object is already in the tree — but it
+ * would add an edge, which moves the object's retained size up to whatever dominates both paths and
+ * attributes it to neither. Which is exactly what a weak reference isn't: it holds nothing.
+ *
+ * **And a path stays as weak as its weakest reference.** An object held only by a finalizer queue, a
+ * thread local or a stack frame doesn't hold what something firmer holds either, so every reference out of
+ * it is weighed the same way. Without that, a `FinalizerReference` two steps up a chain would be one more
+ * way of holding an object that a field holds squarely, which is a way of holding nothing.
+ *
+ * Leaves out the references that lost to an owner for the same reason: they lost during the walk, which is
+ * where the deferring happens, so by the time this reads them the verdict is already in.
+ */
+internal class SemanticReferenceReader(
+  private val strengthReader: ReferenceStrengthReader,
+  private val reachability: HeapReachability,
+  private val ownerReferences: OwnerReferences
+) : ReferenceReader<HeapObject> {
+
+  override fun read(source: HeapObject): Sequence<Reference> {
+    val pathStrength = reachability.strengthOf(source)
+    val ownership = ownerReferences.ownershipOf(source)
+    val retaining = strengthReader.retainingReferencesOf(source)
+      .filter { ownerReferences.isHeldThrough(ownership, it) }
+      .let { references ->
+        // Nothing to weigh when the path here is strong, which it is for nearly every object of a dump.
+        if (pathStrength == STRONG) {
+          references
+        } else {
+          references.filter { reachability.isHeldThrough(it.valueObjectId, pathStrength) }
+        }
+      }
+    val followed = strengthReader.weakeningReferencesOf(source)
+      .filter { reachability.isHeldThrough(it.valueObjectId, maxOf(pathStrength, it.strength)) }
+    return if (followed.isEmpty()) {
+      retaining
+    } else {
+      retaining + followed.asSequence().map { it.toReference() }
+    }
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/TreemapPresentation.kt
@@ -23,12 +23,12 @@ class TreemapPresentation(
     /**
      * Lays [tree] out into [viewport] rooted at [root] and reads what it takes to draw the result.
      *
-     * Here rather than in [HeapDominatorTreemap] — as is every shape's — because which shapes there are
+     * Here rather than in [SemanticDominatorTreemap] — as is every shape's — because which shapes there are
      * is not something a heap dump reader should have to know: it labels cells, and pairing that with a
-     * layout is this side of the line. See [HeapDominatorTreemap.present].
+     * layout is this side of the line. See [SemanticDominatorTreemap.present].
      */
     fun of(
-      tree: HeapDominatorTreemap,
+      tree: SemanticDominatorTreemap,
       layout: TreemapLayout<Long>,
       viewport: TreemapRect,
       root: Long = tree.root
@@ -53,7 +53,7 @@ class RadialPresentation(
   companion object {
     /** See [TreemapPresentation.of]. */
     fun of(
-      tree: HeapDominatorTreemap,
+      tree: SemanticDominatorTreemap,
       layout: RadialLayout<Long>,
       viewport: TreemapRect,
       root: Long = tree.root
@@ -78,7 +78,7 @@ class StackPresentation(
   companion object {
     /** See [TreemapPresentation.of]. */
     fun of(
-      tree: HeapDominatorTreemap,
+      tree: SemanticDominatorTreemap,
       layout: StackLayout<Long>,
       viewport: TreemapRect,
       root: Long = tree.root
@@ -120,14 +120,14 @@ sealed interface CellContent {
     /**
      * Whether the object is an `android.graphics.Bitmap`, which is what makes a cell one an image can
      * be drawn on. Says nothing about whether the heap dump has that image: see
-     * [HeapDominatorTreemap.bitmapImages], which is the read that finds out.
+     * [SemanticDominatorTreemap.bitmapImages], which is the read that finds out.
      */
     val isBitmap: Boolean = false
   ) : CellContent
 
   /**
    * A pile of objects as one cell: half of the heap dump, or every instance of one class the root
-   * dominates. See [HeapDominatorTreemap.groupOrNull].
+   * dominates. See [SemanticDominatorTreemap.groupOrNull].
    */
   data class ObjectGroup(
     val kind: ObjectGroupKind,

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerDumps.kt
@@ -53,11 +53,11 @@ internal fun TemporaryFolder.weaklyReachablePayloadHeapDump(): File {
 }
 
 /**
- * A heap dump where an owner holds three objects a last resort holder also holds — a stack frame, a
+ * A heap dump where an owner holds three objects a weakening holder also holds — a stack frame, a
  * thread local and a finalizer queue — plus one object only the stack frame holds.
  */
-internal fun TemporaryFolder.lastResortHoldersHeapDump(): File {
-  val file = newFile("last-resort-holders.hprof")
+internal fun TemporaryFolder.weakeningHoldersHeapDump(): File {
+  val file = newFile("weakening-holders.hprof")
   file.dump {
     val classes = referenceClasses()
     val onStack = "com.example.OnStack" instance { }
@@ -447,7 +447,7 @@ internal const val CACHE_ENTRY_CLASS_NAME = "coil3.memory.RealStrongMemoryCache\
 /** The one class group of a [crowdedRootHeapDump], which is the tiles. */
 internal const val TILE_CLASS_NAME = "com.example.Tile"
 
-/** Past `MIN_CHILDREN_TO_GROUP_BY_CLASS` in [HeapDominatorTreemap], which is 200. */
+/** Past `MIN_CHILDREN_TO_GROUP_BY_CLASS` in [SemanticDominatorTreemap], which is 200. */
 internal const val TILE_COUNT = 205
 
 /** Enough objects between a GC root and a payload that the chain to it has to be cut. */

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
@@ -23,7 +23,7 @@ class HeapExplorerTest {
       // The objects the GC roots hold, drawn straight under the whole heap dump rather than under a level
       // of their own: a dump whose garbage was all collected has no pile of it to sit beside them either.
       assertThat(rootChildren.map { tree.label(it) }).contains("Holder")
-      assertThat(rootChildren).noneMatch { HeapDominatorTreemap.isPileId(it) }
+      assertThat(rootChildren).noneMatch { SemanticDominatorTreemap.isPileId(it) }
       // The virtual root has no shallow size of its own, so it weighs exactly what it dominates.
       assertThat(tree.weight(tree.root)).isEqualTo(rootChildren.sumOf { tree.weight(it) })
       assertThat(tree.weight(tree.root)).isEqualTo(explorer.sizes.totalByteCount)
@@ -43,7 +43,7 @@ class HeapExplorerTest {
     testFolder.openTestHeapDump().use { explorer ->
       val tree = explorer.tree
 
-      assertThat(tree.label(tree.root)).isEqualTo(HeapDominatorTreemap.ROOT_LABEL)
+      assertThat(tree.label(tree.root)).isEqualTo(SemanticDominatorTreemap.ROOT_LABEL)
       assertThat(tree.summarize(tree.root).inspectorLabels).isEmpty()
     }
   }
@@ -198,7 +198,7 @@ class HeapExplorerTest {
       assertThat(tree.titleOf(Place.Object(view.objectId)))
         .isEqualTo("View ${hexObjectId(view.objectId)}")
       // The whole heap dump is no object, so it has no address to be named by.
-      assertThat(tree.titleOf(Place.wholeHeapDump())).isEqualTo(HeapDominatorTreemap.ROOT_LABEL)
+      assertThat(tree.titleOf(Place.wholeHeapDump())).isEqualTo(SemanticDominatorTreemap.ROOT_LABEL)
     }
   }
 
@@ -347,7 +347,7 @@ class HeapExplorerTest {
   }
 
   @Test fun `what only holds an object until the runtime is done with it is on no path`() {
-    HeapExplorer.open(testFolder.lastResortHoldersHeapDump()).use { explorer ->
+    HeapExplorer.open(testFolder.weakeningHoldersHeapDump()).use { explorer ->
       val tree = explorer.tree
 
       // A thread inside a method, a value left in a thread local, an object queued for finalization: each
@@ -368,7 +368,7 @@ class HeapExplorerTest {
   }
 
   @Test fun `an object nothing but a stack frame holds is drawn under the frame's root`() {
-    HeapExplorer.open(testFolder.lastResortHoldersHeapDump()).use { explorer ->
+    HeapExplorer.open(testFolder.weakeningHoldersHeapDump()).use { explorer ->
       val tree = explorer.tree
       val onlyOnStack = tree.findByLabel("OnlyOnStack")
 
@@ -504,7 +504,7 @@ class HeapExplorerTest {
       val tree = explorer.tree
 
       assertThat(tree.rootPathTo(tree.root)).isEqualTo(RootPath.NONE)
-      assertThat(tree.rootPathTo(HeapDominatorTreemap.UNREACHABLE_NODE_ID)).isEqualTo(RootPath.NONE)
+      assertThat(tree.rootPathTo(SemanticDominatorTreemap.UNREACHABLE_NODE_ID)).isEqualTo(RootPath.NONE)
     }
   }
 
@@ -518,7 +518,7 @@ class HeapExplorerTest {
       // pixels — are each read as a pile of objects that this tree has never heard of, and every panel
       // asking about one is told there is nothing there.
       assertThat(dump.payloadObjectId).isNegative()
-      assertThat(HeapDominatorTreemap.isPileId(dump.payloadObjectId)).isFalse()
+      assertThat(SemanticDominatorTreemap.isPileId(dump.payloadObjectId)).isFalse()
       assertThat(dump.payloadObjectId in tree).isTrue()
       assertThat(tree.groupOrNull(dump.payloadObjectId)).isNull()
       assertThat(tree.summarize(dump.payloadObjectId).className).isEqualTo("java.lang.Object[]")
@@ -645,7 +645,7 @@ class HeapExplorerTest {
         .single { (it.cell.subject as? CellSubject.Node)?.node == group }
 
       assertThat(tree.label(group))
-        .isEqualTo("$TILE_COUNT ${HeapDominatorTreemap.CLASS_GROUP_LABEL_SEPARATOR} Tile")
+        .isEqualTo("$TILE_COUNT ${SemanticDominatorTreemap.CLASS_GROUP_LABEL_SEPARATOR} Tile")
       assertThat(presented.content)
         .isEqualTo(CellContent.ObjectGroup(ObjectGroupKind.CLASS, STRONG, TILE_COUNT))
       // Held as firmly as the instances in it, which are all held the same way — being up here is what
@@ -656,7 +656,7 @@ class HeapExplorerTest {
     }
   }
 
-  private fun HeapDominatorTreemap.classGroup(): ObjectGroupSummary =
+  private fun SemanticDominatorTreemap.classGroup(): ObjectGroupSummary =
     children(root).mapNotNull { groupOrNull(it) }.single()
 
   companion object {
@@ -668,10 +668,10 @@ class HeapExplorerTest {
     /** An address no heap dump the tests write has an object at. */
     private const val NO_SUCH_OBJECT_ID = -1L
 
-    /** Matches `MAX_FIELDS` in [HeapDominatorTreemap], which isn't public. */
+    /** Matches `MAX_FIELDS` in [SemanticDominatorTreemap], which isn't public. */
     private const val MAX_FIELDS_SHOWN = 500
 
-    /** Matches `MAX_ROOT_PATH_STEPS` in [HeapDominatorTreemap], which isn't public. */
+    /** Matches `MAX_ROOT_PATH_STEPS` in [SemanticDominatorTreemap], which isn't public. */
     private const val MAX_ROOT_PATH_STEPS_SHOWN = 20
 
     /** Object ids are 4 bytes in a dump built by the test DSL. */

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapReachabilityTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapReachabilityTest.kt
@@ -11,13 +11,13 @@ import shark.GcRoot.StickyClass
 import shark.HprofWriterHelper
 import shark.ValueHolder.ReferenceHolder
 import shark.dump
-import shark.explorer.HeapDominatorTreemap.Companion.UNREACHABLE_LABEL
-import shark.explorer.HeapDominatorTreemap.Companion.UNREACHABLE_NODE_ID
 import shark.explorer.ReachabilityStrength.FINALIZER
 import shark.explorer.ReachabilityStrength.PHANTOM
 import shark.explorer.ReachabilityStrength.SOFT
 import shark.explorer.ReachabilityStrength.STRONG
 import shark.explorer.ReachabilityStrength.WEAK
+import shark.explorer.SemanticDominatorTreemap.Companion.UNREACHABLE_LABEL
+import shark.explorer.SemanticDominatorTreemap.Companion.UNREACHABLE_NODE_ID
 
 class HeapReachabilityTest {
 
@@ -367,7 +367,7 @@ class HeapReachabilityTest {
   }
 
   /** The one `Object[]` of a payload heap dump, found by walking the tree. */
-  private fun HeapDominatorTreemap.payloadObjectId(): Long {
+  private fun SemanticDominatorTreemap.payloadObjectId(): Long {
     val toVisit = ArrayDeque(listOf(root))
     while (toVisit.isNotEmpty()) {
       val objectId = toVisit.removeFirst()

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NodeIdsTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NodeIdsTest.kt
@@ -2,8 +2,8 @@ package shark.explorer
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import shark.explorer.HeapDominatorTreemap.Companion.ROOT_OBJECT_ID
-import shark.explorer.HeapDominatorTreemap.Companion.UNREACHABLE_NODE_ID
+import shark.explorer.SemanticDominatorTreemap.Companion.ROOT_OBJECT_ID
+import shark.explorer.SemanticDominatorTreemap.Companion.UNREACHABLE_NODE_ID
 
 class NodeIdsTest {
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/OwnerReferencesTest.kt
@@ -57,7 +57,7 @@ class OwnerReferencesTest {
       // What a parent holds is what mChildrenCount covers, not what its array has room for. A slot past
       // the count is a view the parent has let go of or hasn't taken yet, and calling it a child would
       // attribute a removed view to the parent that removed it — which is the leak you'd be looking for.
-      // So nothing owns this one, and the array that points at it holds it as a last resort.
+      // So no owner reaches this one, and the array that points at it counts after all.
       assertThat(tree.dominatorOf(uncounted.objectId)!!.label).isEqualTo("View[]")
     }
   }
@@ -111,8 +111,8 @@ class OwnerReferencesTest {
       val uncounted = tree.findByLabel("UncountedActivity")
 
       // What the thread runs is what mSize covers, not what its array has room for. A pair past the count
-      // is an entry the map has let go of or hasn't taken yet, so nothing owns the activity in it and the
-      // record that points at it holds it as a last resort.
+      // is an entry the map has let go of or hasn't taken yet, so no owner reaches the activity in it and
+      // the record that points at it counts after all.
       assertThat(tree.dominatorOf(uncounted.objectId)!!.label)
         .isEqualTo("ActivityThread\$ActivityClientRecord")
     }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/RootPathTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/RootPathTest.kt
@@ -2,8 +2,8 @@ package shark.explorer
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import shark.explorer.HeapDominatorTreemap.Companion.ROOT_OBJECT_ID
-import shark.explorer.HeapDominatorTreemap.Companion.UNREACHABLE_NODE_ID
+import shark.explorer.SemanticDominatorTreemap.Companion.ROOT_OBJECT_ID
+import shark.explorer.SemanticDominatorTreemap.Companion.UNREACHABLE_NODE_ID
 
 class RootPathTest {
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapReading.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TreemapReading.kt
@@ -1,8 +1,8 @@
 package shark.explorer
 
-/** How the tests of a [HeapDominatorTreemap] read one, shared by the classes that assert on trees. */
+/** How the tests of a [SemanticDominatorTreemap] read one, shared by the classes that assert on trees. */
 
-internal fun HeapDominatorTreemap.findByLabel(label: String): HeapObjectSummary =
+internal fun SemanticDominatorTreemap.findByLabel(label: String): HeapObjectSummary =
   allSummaries().single { it.label == label }
 
 /**
@@ -10,7 +10,7 @@ internal fun HeapDominatorTreemap.findByLabel(label: String): HeapObjectSummary 
  * the index. Which is what the tests of a dump of a real JVM have to use, [allSummaries] reading every
  * object of the dump out of the heap dump file.
  */
-internal fun HeapDominatorTreemap.instancesOf(simpleClassName: String): List<ObjectListEntry> =
+internal fun SemanticDominatorTreemap.instancesOf(simpleClassName: String): List<ObjectListEntry> =
   listObjects(
     ObjectListFilter(
       query = simpleClassName,
@@ -19,11 +19,11 @@ internal fun HeapDominatorTreemap.instancesOf(simpleClassName: String): List<Obj
     )
   ).entries
 
-internal fun HeapDominatorTreemap.onlyInstanceOf(simpleClassName: String): ObjectListEntry =
+internal fun SemanticDominatorTreemap.onlyInstanceOf(simpleClassName: String): ObjectListEntry =
   instancesOf(simpleClassName).single()
 
 /** Every object the tree has between [objectId] and its root, nearest first. */
-internal fun HeapDominatorTreemap.dominatorLabelsOf(objectId: Long): List<String> {
+internal fun SemanticDominatorTreemap.dominatorLabelsOf(objectId: Long): List<String> {
   val labels = mutableListOf<String>()
   var dominator = dominatorOf(objectId)
   while (dominator != null) {
@@ -34,16 +34,16 @@ internal fun HeapDominatorTreemap.dominatorLabelsOf(objectId: Long): List<String
 }
 
 /** Every object of the tree, walked past the groups, which stand for objects rather than being one. */
-internal fun HeapDominatorTreemap.allSummaries(): List<HeapObjectSummary> = summariesBelow(root)
+internal fun SemanticDominatorTreemap.allSummaries(): List<HeapObjectSummary> = summariesBelow(root)
 
 /**
  * Every object the tree draws below [node], however deep and not counting [node] itself: what the tree
  * says it retains, spelled out.
  */
-internal fun HeapDominatorTreemap.descendantsOf(node: Long): List<HeapObjectSummary> =
+internal fun SemanticDominatorTreemap.descendantsOf(node: Long): List<HeapObjectSummary> =
   children(node).flatMap { child -> summariesBelow(child) }
 
-private fun HeapDominatorTreemap.summariesBelow(from: Long): List<HeapObjectSummary> {
+private fun SemanticDominatorTreemap.summariesBelow(from: Long): List<HeapObjectSummary> {
   val summaries = mutableListOf<HeapObjectSummary>()
   val toVisit = ArrayDeque(listOf(from))
   while (toVisit.isNotEmpty()) {
@@ -64,7 +64,7 @@ private fun HeapDominatorTreemap.summariesBelow(from: Long): List<HeapObjectSumm
  * A group holds an object from the roots the tree was walked from rather than from an object of the heap
  * dump, so which of the two searches answers depends on which kind of thing dominates it.
  */
-internal fun HeapDominatorTreemap.independentPathsBelowDominator(objectId: Long): IndependentPaths {
+internal fun SemanticDominatorTreemap.independentPathsBelowDominator(objectId: Long): IndependentPaths {
   val dominator = dominatorOf(objectId) ?: return IndependentPaths.NONE
   return if (dominator.kind == DominatorKind.OBJECT) {
     independentPathsBetween(dominator.nodeId, objectId)


### PR DESCRIPTION
The shark-explorer's tree is a dominator tree over a *curated* edge set rather than over every reference a heap dump records, so it answers "what owns this?" where a GC dominator tree answers "what would the collector free?". The notes and the KDoc had been circling that idea without a name for it, which left the two patterns that curate the edge set reading as unrelated mechanisms:

- **Deny-listing a reference** — name the edge, follow it only when nothing else holds the target. `ReferenceStrengthReader`.
- **Allow-listing an owner** — name the target and the one edge into it that owns, which makes rivals of the rest. `OwnerRule` / `OwnerReferences`.

They're the same rule read off the two ends of a reference, and either way the edge is **deferred, not dropped** — which is why neither pattern needs to know what state the object it's about is in.

## What's here

**Prose.** A `## Semantic dominators` section at the top of `notes/dominator-tree.md` defining the term and naming both patterns under it, a lead-in on each of the two pattern sections tying it back, and the term used in the KDoc of `SemanticReferenceReader`, `ReferenceStrengthReader`, `OwnerReferences` and `SemanticDominatorTreemap`. The two same-named `isHeldThrough` methods now say the parallel is deliberate.

**A claim that was false, in five places.** Naming the concept exposed it: `ObjectDominator`, `SemanticDominatorTreemap.dominatorOf`, `RootPathStep`, `PathRole.DOMINATOR` and `dominator-tree.md` all said the dominator is what *would free* the object. A deferred edge is still a reference in the heap, so a cache or a losing rival can go on holding an object attributed to its owner. Fixed in all five.

**Renames.**

| Before | After |
| --- | --- |
| `WeakeningAwareReferenceReader` | `SemanticReferenceReader`, moved into its own file |
| `HeapDominatorTreemap` | `SemanticDominatorTreemap` |
| `markLastResortHeld` | `markNoOwnerReached` |
| `lastResortHeldObjectIndexes` | `noOwnerReachedObjectIndexes` |
| `isLastResort` | `takingFromParked` |
| `lastResortHoldersHeapDump` (test fixture) | `weakeningHoldersHeapDump` |

`SemanticReferenceReader` moved out of `ReferenceStrengthReader.kt` because it is the one place both patterns are gated — the thing the new name is about — rather than a tail of the deny-list reader.

No behaviour change: every edit is a comment, a KDoc, a notes file, or a name.

## Verification

```
./gradlew :shark:shark-explorer:shark-explorer-core:check :shark:shark-explorer:shark-explorer-app:check
BUILD SUCCESSFUL
```

Both test tasks also forced green with `--rerun-tasks`. `detekt` runs as part of `check` and passes. No `api/*.api` file to update and no Dokka run: both explorer modules are in `modulesWithoutPublicApi` and no other module depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)