### PR TITLE
Copy a shark:// link to a tab, and follow one back to it

### DIFF
--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -19,3 +19,6 @@ uses, without the one for a newly recognized library leak:
 ## Unreleased
 
 * ✨ Initial release.
+* ✨ Right click a tab to copy a `shark://` link to it. Clicking one brings the app to the front and
+  opens that place in a new tab — an object, a filtered object list, the leaks with the same groups
+  unfolded. See [Link to a tab](shark-explorer.md#link-to-a-tab).

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -19,6 +19,7 @@ uses, without the one for a newly recognized library leak:
 ## Unreleased
 
 * ✨ Initial release.
-* ✨ Right click a tab to copy a `shark://` link to it. Clicking one brings the app to the front and
-  opens that place in a new tab — an object, a filtered object list, the leaks with the same groups
+* ✨ Right click anything the window can take you to — a tab, a rectangle, a row, a field — and copy a
+  `shark://` link to it, beside opening it in a new tab. Clicking one brings the app to the front and
+  opens that place in a new tab: an object, a filtered object list, the leaks with the same groups
   unfolded. See [Link to a tab](shark-explorer.md#link-to-a-tab).

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -55,8 +55,8 @@ a few seconds.
   clickable, which is also the way back out.
 * **Everything naming an object is a way to it**, and the same three clicks work everywhere: click to go
   there in this tab, middle click or ⌘/Ctrl click to open it in a tab behind this one, right click for a
-  menu that says so. The buttons along the top always open a new tab, and every tab can be closed —
-  including the last, which leaves the heap dump open and the buttons ready.
+  menu offering both that and a link to the object. The buttons along the top always open a new tab, and
+  every tab can be closed — including the last, which leaves the heap dump open and the buttons ready.
 * **The three panes are resizable, and each folds away to a button.** A chain thirty steps long or a
   details panel of forty fields is sometimes worth the whole window.
 * **Shape** switches between rectangles and rings. A ring has room for fewer children, so it groups the
@@ -70,9 +70,13 @@ a few seconds.
 
 ## Link to a tab
 
-**Right click a tab and pick "Copy link to this tab"** to get a `shark://` URL of wherever that tab is.
-Paste it anywhere links are clickable — a chat message, an issue, a note to yourself — and clicking it
-brings Shark Explorer to the front and opens that place in a new tab.
+**Right click and pick "Copy link"** to get a `shark://` URL of wherever that is. Paste it anywhere links
+are clickable — a chat message, an issue, a note to yourself — and clicking it brings Shark Explorer to
+the front and opens that place in a new tab.
+
+It sits beside "open in a new tab" everywhere that offers one: a tab, a button along the top, a rectangle
+of the map, a row of the object list or of the leaks, a step of a chain, a field of the details panel, a
+starred object. Wherever the window will take you somewhere, it will also hand you the link to it.
 
 ```
 shark://vugs93jp/object?id=0x7f2a4b18

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -68,6 +68,32 @@ a few seconds.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
 
+## Link to a tab
+
+**Right click a tab and pick "Copy link to this tab"** to get a `shark://` URL of wherever that tab is.
+Paste it anywhere links are clickable — a chat message, an issue, a note to yourself — and clicking it
+brings Shark Explorer to the front and opens that place in a new tab.
+
+```
+shark://vugs93jp/object?id=0x7f2a4b18
+shark://vugs93jp/objects?query=Bitmap&exact=true
+shark://vugs93jp/leaks
+```
+
+Anywhere a tab can be is a link: an object, the object list with its search and filters filled in, the
+leaks with the same groups unfolded, the starred objects. So "look at this" is a URL rather than a
+paragraph of directions, which is also how a tool or an agent that has read your heap dump can point you
+straight at what it found.
+
+The part after `shark://` is **the window, not the heap dump** — the same dump open twice is two windows,
+and a link leads to the one it was copied from. Which means a link works while that window is open and
+stops working once it is closed or the app is restarted; following one then opens an empty window saying
+so. A link never replaces what you were reading: it always opens a tab of its own.
+
+Links reach the app from an installed build — the installer is what tells the OS that `shark://` is this
+app's. A copy run from source can still be linked to from another one, but the OS won't start it for a
+link.
+
 ## Reporting a problem
 
 Bug reports go to the [LeakCanary issue tracker](https://github.com/square/leakcanary/issues). Every run

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -151,6 +151,47 @@ of the run. Nothing downloads or installs. Three things about it that reading th
 `UpdateNotice` is one per run rather than per window, so dismissing the bar in one window clears it in all
 of them.
 
+## A `shark://` link never reaches a run from Gradle, and that is not a bug in the code
+
+`DeepLink` is the URL, `DeepLinkScheme` is the OS end of it and `DeepLinkPeers` is how a link crosses
+from one run of this app to another. What reading them won't tell you is that **none of it can be tried
+from `run` or `runNamed`**, on any platform, and the reason is different on each:
+
+- **macOS delivers to a bundle identity.** A JVM launched from a shell script — which is what `runNamed`'s
+  generated bundle is — registers with LaunchServices as `net.java.openjdk.java` whatever the wrapper's
+  `Info.plist` says. Measured with `lsappinfo find pid=<pid>`. Only a launcher `jpackage` built gets its
+  own `CFBundleIdentifier`, and the Apple Event carrying the URL goes to the identity, so a `runNamed`
+  process is handed nothing however well its plist declares the scheme.
+- **Windows and Linux are registered at runtime**, by `DeepLinkScheme.registerWithTheOs`, and it declines
+  for a run whose executable is `java` — registering that would tell the OS to open links with a JVM and
+  no classpath.
+
+So the loop for anything about links is a package, not a compile:
+
+```bash
+./gradlew :shark:shark-explorer:shark-explorer-app:createDistributable
+cp -R "shark/shark-explorer/shark-explorer-app/build/compose/binaries/main/app/Shark Explorer.app" \
+  ~/Applications/
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+  -f ~/Applications/"Shark Explorer.app"
+open -a ~/Applications/"Shark Explorer.app" --args --title="Links" path/to/dump.hprof
+grep "Windows of this run" ~/.shark-explorer/logs/$(ls -t ~/.shark-explorer/logs | head -1)
+open "shark://<the id that printed>/leaks"
+```
+
+**Read the result in the log rather than off the screen.** Following a link raises the app over whatever
+the person at the machine was doing, so a screenshot to check it worked costs them their window and shows
+you theirs. `The OS handed this run`, `A link asked window <id> for <place>` and `A link asked this window
+for <place>` are the three lines that say a link was delivered, routed and opened as a tab.
+
+A run from source is still *reachable*: every run publishes a loopback port under `~/.shark-explorer/runs`,
+and the installed app hands on any link naming a window it doesn't have. That is what makes a link to a
+`./gradlew run` window work — the installed app is the courier, so there has to be one.
+
+**Deliberately not single instance.** Several explorers open at once is how this app is used, so a run
+holding a link asks each of the others in turn rather than the second run handing its command line to the
+first and exiting.
+
 ## Gradle facts that aren't visible from these build scripts
 
 - **`shark-explorer-app` is excluded by name** from the repo-wide Java 8 target in the root

--- a/shark/shark-explorer/shark-explorer-app/build.gradle.kts
+++ b/shark/shark-explorer/shark-explorer-app/build.gradle.kts
@@ -128,6 +128,28 @@ compose.desktop {
         // and the Managed Software Center entry are both keyed on this, so it has to be a name Square
         // owns, and changing it after the first release is a migration for everyone who installed one.
         bundleID = "com.squareup.leakcanary.shark-explorer"
+        // What makes `shark://` links reach this app on macOS: LaunchServices reads the scheme out of
+        // the installed bundle, and hands a click on one to the running process as an Apple Event,
+        // which java.awt.Desktop turns into the handler DeepLinkScheme installs. See DeepLink.
+        //
+        // Only a bundle jpackage built has this, and that is the trap: a JVM launched by `run` or
+        // `runNamed` registers as net.java.openjdk.java whatever its wrapper says, so no link ever
+        // arrives there. Try links against `createDistributable`, per shark/shark-explorer/AGENTS.md.
+        infoPlist {
+          extraKeysRawXml = """
+            <key>CFBundleURLTypes</key>
+            <array>
+              <dict>
+                <key>CFBundleURLName</key>
+                <string>com.squareup.leakcanary.shark-explorer.link</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                  <string>shark</string>
+                </array>
+              </dict>
+            </array>
+          """.trimIndent()
+        }
       }
       windows {
         iconFile.set(project.file("icons/shark-explorer-icon.ico"))

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DeepLinkPeers.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DeepLinkPeers.kt
@@ -1,0 +1,274 @@
+package shark.explorer.app
+
+import java.io.BufferedReader
+import java.io.Closeable
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import java.security.SecureRandom
+import java.util.Properties
+import shark.SharkLog
+import shark.explorer.DeepLink
+
+/**
+ * How a link reaches the run that has the window it names, when the OS starts a new process to deliver it.
+ *
+ * Which is Windows and Linux always, and macOS whenever the app was not launched from its own bundle —
+ * a `./gradlew run` among others, see the module's AGENTS.md. A packaged macOS app is handed the URL
+ * inside the process that is already running and never gets here.
+ *
+ * **Every run listens, rather than one of them being the instance and the others deferring to it.** Several
+ * explorers open at once is the normal way this app is used — one per piece of work, often on the same heap
+ * dump — and making the second run of it hand its command line to the first and exit would take that away.
+ * So a run publishes where it can be reached, and a run holding a link asks each of the others in turn
+ * whether the window is theirs. Nobody is in charge and nothing is lost when any of them is killed.
+ *
+ * The socket is on the loopback address, so nothing off this machine can reach it, and a caller has to
+ * quote the token out of the file to be listened to at all — which proves it can read the user's home
+ * directory, and therefore that it is the user.
+ */
+internal object DeepLinkPeers {
+
+  /**
+   * Publishes this run and answers links for it until closed.
+   *
+   * Failing to listen is not a reason to refuse to start: the app works, and what stops working is links
+   * arriving from another process — which the log then says, rather than links quietly going nowhere.
+   */
+  fun listen(windows: ExplorerWindows): Closeable {
+    val serverSocket = try {
+      ServerSocket(ANY_FREE_PORT, BACKLOG, InetAddress.getLoopbackAddress())
+    } catch (throwable: Throwable) {
+      SharkLog.d(throwable) { "Could not listen for links: this run will not answer any" }
+      return Closeable {}
+    }
+    val token = newToken()
+    val file = File(peerDirectory(), "${ProcessHandle.current().pid()}$PEER_SUFFIX")
+    return try {
+      write(file, serverSocket.localPort, token)
+      SharkLog.d { "Answering links on port ${serverSocket.localPort}, published as $file" }
+      val thread = Thread({ accept(serverSocket, token, windows) }, THREAD_NAME).apply {
+        isDaemon = true
+        start()
+      }
+      // A run that is killed rather than closed leaves its file behind, which the next run to read the
+      // directory deletes when nothing answers on the port. This is only the tidy case.
+      val close = Closeable {
+        file.delete()
+        serverSocket.close()
+        thread.interrupt()
+      }
+      Runtime.getRuntime().addShutdownHook(Thread { file.delete() })
+      close
+    } catch (throwable: Throwable) {
+      SharkLog.d(throwable) { "Could not publish this run at $file: it will not answer links" }
+      serverSocket.close()
+      Closeable {}
+    }
+  }
+
+  /**
+   * Follows [link] in this run, or in whichever other run has the window it names.
+   *
+   * Which is what a run handed a link by the OS does with it, and the macOS half of the reason this exists
+   * at all: there, one installed app is handed every `shark://` link on the machine, including the ones
+   * naming a window of a run from source that the OS knows nothing about.
+   *
+   * Asking the others is a connection each, so it happens off the caller's thread — a link arrives on the
+   * event thread there, and a run that has been killed is only found out about by waiting for it.
+   */
+  fun follow(
+    link: DeepLink,
+    windows: ExplorerWindows
+  ) {
+    if (windows.holds(link.windowId)) {
+      windows.open(link)
+      return
+    }
+    Thread({
+      // Nobody else's, so this run answers for it, which is an empty window saying the window has gone.
+      if (deliver(listOf(link)).isNotEmpty()) {
+        windows.open(link)
+      }
+    }, THREAD_NAME).apply {
+      isDaemon = true
+      start()
+    }
+  }
+
+  /**
+   * Hands each of [links] to whichever other run has the window it names, and returns the ones nobody
+   * claimed.
+   *
+   * The leftovers are the caller's to answer for, which is what makes a link to a window that has gone an
+   * empty window saying so rather than a process that started and exited without a word.
+   */
+  fun deliver(links: List<DeepLink>): List<DeepLink> {
+    if (links.isEmpty()) {
+      return emptyList()
+    }
+    val peers = peers()
+    return links.filter { link -> peers.none { peer -> peer.deliver(link) } }
+  }
+
+  /** Every other run that has published itself, stale files cleared out on the way past. */
+  private fun peers(): List<Peer> {
+    val ourselves = ProcessHandle.current().pid()
+    val files = peerDirectory().listFiles { file -> file.name.endsWith(PEER_SUFFIX) }.orEmpty()
+    return files.mapNotNull { file ->
+      if (file.name == "$ourselves$PEER_SUFFIX") null else read(file)
+    }
+  }
+
+  private fun read(file: File): Peer? {
+    val properties = Properties()
+    return try {
+      file.inputStream().use { properties.load(it) }
+      val port = properties.getProperty(PORT_PROPERTY)?.toIntOrNull()
+      val token = properties.getProperty(TOKEN_PROPERTY)
+      if (port == null || token == null) {
+        SharkLog.d { "$file says no port and token, so it names no run: deleting it" }
+        file.delete()
+        null
+      } else {
+        Peer(file, port, token)
+      }
+    } catch (throwable: Throwable) {
+      SharkLog.d(throwable) { "Could not read $file, so this run cannot be asked about links" }
+      null
+    }
+  }
+
+  private fun write(
+    file: File,
+    port: Int,
+    token: String
+  ) {
+    file.parentFile.mkdirs()
+    val properties = Properties().apply {
+      setProperty(PORT_PROPERTY, port.toString())
+      setProperty(TOKEN_PROPERTY, token)
+    }
+    file.outputStream().use { properties.store(it, "Where this Shark Explorer run answers links") }
+    // Best effort, and only worth anything on a machine with more than one user on it: the token is what
+    // this is protecting, and a token nobody can read is a run nothing can send a link to.
+    file.setReadable(false, false)
+    file.setReadable(true, true)
+  }
+
+  /**
+   * One line in, one line out, per connection: the token and the link, answered with whether the window
+   * this link names belongs to this run.
+   */
+  private fun accept(
+    serverSocket: ServerSocket,
+    token: String,
+    windows: ExplorerWindows
+  ) {
+    while (!serverSocket.isClosed) {
+      try {
+        serverSocket.accept().use { socket ->
+          socket.soTimeout = READ_TIMEOUT_MILLIS
+          answer(socket, token, windows)
+        }
+      } catch (closed: SocketException) {
+        // Which is what closing the socket out from under accept() looks like, and it is how this ends.
+        SharkLog.d { "Stopped answering links: ${closed.message}" }
+        return
+      } catch (throwable: Throwable) {
+        SharkLog.d(throwable) { "A link could not be read off the socket, carrying on listening" }
+      }
+    }
+  }
+
+  private fun answer(
+    socket: Socket,
+    token: String,
+    windows: ExplorerWindows
+  ) {
+    val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.UTF_8))
+    val writer = PrintWriter(OutputStreamWriter(socket.getOutputStream(), Charsets.UTF_8), true)
+    val request = reader.readLine()
+    if (request == null) {
+      SharkLog.d { "Something connected asking nothing" }
+      return
+    }
+    val sentToken = request.substringBefore(' ')
+    val uri = request.substringAfter(' ', "")
+    if (sentToken != token) {
+      // Loopback only, so this is a stale file being read by a run that started before this one, far more
+      // often than it is anything to worry about.
+      SharkLog.d { "A link arrived quoting the wrong token, so it was not read" }
+      writer.println(DECLINED)
+      return
+    }
+    val link = try {
+      DeepLink.parse(uri)
+    } catch (invalidLink: IllegalArgumentException) {
+      SharkLog.d { "A run handed over \"$uri\", which is no link: ${invalidLink.message}" }
+      writer.println(DECLINED)
+      return
+    }
+    // Answered before the window is asked to go anywhere, because the run on the other end is waiting to
+    // find out whether to keep looking, and going somewhere is a frame away rather than a read away.
+    if (windows.holds(link.windowId)) {
+      writer.println(ACCEPTED)
+      windows.open(link)
+    } else {
+      writer.println(DECLINED)
+    }
+  }
+
+  private fun newToken(): String {
+    val bytes = ByteArray(TOKEN_BYTES)
+    SecureRandom().nextBytes(bytes)
+    return bytes.joinToString("") { "%02x".format(it) }
+  }
+
+  private fun peerDirectory(): File = File(SHARK_EXPLORER_DIRECTORY, "runs")
+
+  /** Another run of this app, and the way to ask it whether a window is one of its. */
+  private class Peer(
+    private val file: File,
+    private val port: Int,
+    private val token: String
+  ) {
+
+    /** Whether this run took [link], which only the run whose window it names does. */
+    fun deliver(link: DeepLink): Boolean = try {
+      Socket().use { socket ->
+        socket.connect(InetSocketAddress(InetAddress.getLoopbackAddress(), port), CONNECT_TIMEOUT_MILLIS)
+        socket.soTimeout = READ_TIMEOUT_MILLIS
+        val writer = PrintWriter(OutputStreamWriter(socket.getOutputStream(), Charsets.UTF_8), true)
+        writer.println("$token ${link.toUri()}")
+        val answer =
+          BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.UTF_8)).readLine()
+        answer == ACCEPTED
+      }
+    } catch (throwable: Throwable) {
+      // A run that was killed leaves its file behind and nothing on the port, which is the common case
+      // here rather than a failure: clear it out so the directory is the runs that are actually up.
+      SharkLog.d { "Nothing answered on port $port, so $file names a run that has gone: deleting it" }
+      file.delete()
+      false
+    }
+  }
+
+  private const val ANY_FREE_PORT = 0
+  private const val BACKLOG = 8
+  private const val CONNECT_TIMEOUT_MILLIS = 500
+  private const val READ_TIMEOUT_MILLIS = 2_000
+  private const val TOKEN_BYTES = 16
+  private const val PEER_SUFFIX = ".run"
+  private const val PORT_PROPERTY = "port"
+  private const val TOKEN_PROPERTY = "token"
+  private const val ACCEPTED = "OK"
+  private const val DECLINED = "NO"
+  private const val THREAD_NAME = "shark-explorer-links"
+}

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DeepLinkScheme.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DeepLinkScheme.kt
@@ -1,0 +1,194 @@
+package shark.explorer.app
+
+import java.awt.Desktop
+import java.awt.Desktop.Action.APP_OPEN_URI
+import java.awt.Desktop.Action.APP_REQUEST_FOREGROUND
+import java.io.File
+import java.util.concurrent.TimeUnit
+import shark.SharkLog
+import shark.explorer.DeepLink
+
+/**
+ * Telling the OS that `shark://` links are this app's, and taking the ones it hands over.
+ *
+ * The three platforms split in two here. **macOS is told at build time** — `CFBundleURLTypes` in the
+ * `Info.plist` the Compose plugin writes, see this module's build script — and hands a URL to the process
+ * that is already running, through an Apple Event that AWT turns into [Desktop.setOpenURIHandler]. Nothing
+ * has to be registered at runtime and no second process is started.
+ *
+ * **Windows and Linux have no such thing in the packaging**, so the app registers itself the first time it
+ * runs, and a link there launches a whole new process with the URL on its command line. Reaching the run
+ * that has the window is then [DeepLinkPeers]' job.
+ *
+ * All of it is best effort, and every failure is one line in the log rather than anything the reader is
+ * asked to deal with: an app that opens heap dumps and doesn't answer links is worth having, and one that
+ * refuses to start because a registry key wouldn't take is not.
+ */
+internal object DeepLinkScheme {
+
+  /**
+   * Takes the URLs macOS hands to this process, which is every `shark://` link followed while it is running
+   * and the one that started it.
+   *
+   * A link that arrives before this is installed is not lost: AWT holds the event until there is a handler
+   * for it, which is what makes a link that launches the app work without a second path for it. Measured,
+   * not assumed — see the module's AGENTS.md.
+   */
+  fun takeUrisFromTheOs(windows: ExplorerWindows) {
+    if (!Desktop.isDesktopSupported() || !Desktop.getDesktop().isSupported(APP_OPEN_URI)) {
+      // Windows and Linux, where the OS starts a process per link instead. Said in the log because this is
+      // also what a macOS build that has lost its Info.plist entry looks like.
+      SharkLog.d { "This OS hands no URLs to a running process, so links arrive on the command line" }
+      return
+    }
+    Desktop.getDesktop().setOpenURIHandler { event ->
+      val uri = event.uri.toString()
+      SharkLog.d { "The OS handed this run \"$uri\"" }
+      val link = try {
+        DeepLink.parse(uri)
+      } catch (invalidLink: IllegalArgumentException) {
+        SharkLog.d { "Which is no link: ${invalidLink.message}" }
+        return@setOpenURIHandler
+      }
+      // Not straight to a window of this run: macOS hands every `shark://` link on the machine to the one
+      // installed app, and the window named may belong to another run — one from source, most of all.
+      DeepLinkPeers.follow(link, windows)
+    }
+    SharkLog.d { "Taking ${DeepLink.SCHEME}:// links the OS hands to this run" }
+  }
+
+  /**
+   * Puts this process in front of the others, which a window raising itself does not do on macOS.
+   *
+   * `toFront()` orders the windows of an application; which application is in front is the process's to ask
+   * for, and this is how it asks. Verified to raise the app even when the OS was told to open the link
+   * without activating it.
+   */
+  fun bringProcessToFront() {
+    try {
+      if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(APP_REQUEST_FOREGROUND)) {
+        Desktop.getDesktop().requestForeground(true)
+      }
+    } catch (throwable: Throwable) {
+      SharkLog.d(throwable) { "Could not bring this run to the front" }
+    }
+  }
+
+  /**
+   * Registers `shark://` with Windows or Linux, off the thread that is opening a window.
+   *
+   * Only from a packaged build: the launcher a link would be started with has to be this app, and a run
+   * from Gradle or an IDE is the JVM with a classpath, which nothing can usefully write into a registry key
+   * or a desktop entry. Such a run still *answers* links — see [DeepLinkPeers] — it just isn't what the OS
+   * starts to deliver one.
+   */
+  fun registerWithTheOs() {
+    val launcher = launcherPath()
+    if (launcher == null) {
+      SharkLog.d {
+        "Not registering ${DeepLink.SCHEME}:// with the OS: this run is a JVM on a classpath rather than " +
+          "a packaged app, so there is no launcher to register"
+      }
+      return
+    }
+    Thread({
+      try {
+        when {
+          isWindows() -> registerOnWindows(launcher)
+          isLinux() -> registerOnLinux(launcher)
+          // macOS is told by the Info.plist of the bundle, at build time.
+          else -> Unit
+        }
+      } catch (throwable: Throwable) {
+        SharkLog.d(throwable) { "Could not register ${DeepLink.SCHEME}:// with the OS" }
+      }
+    }, "shark-explorer-scheme").apply {
+      isDaemon = true
+      start()
+    }
+  }
+
+  /**
+   * The executable a link should be started with, or null when this run is not one.
+   *
+   * A packaged build is a launcher jpackage generated; everything else is `java`, and registering that
+   * would tell the OS to open links with a JVM and no classpath.
+   */
+  private fun launcherPath(): String? {
+    val command = ProcessHandle.current().info().command().orElse(null) ?: return null
+    val name = File(command).name
+    return if (name in JVM_EXECUTABLES) null else command
+  }
+
+  private fun registerOnWindows(launcher: String) {
+    val command = "\"$launcher\" \"%1\""
+    if (run("reg", "query", COMMAND_KEY, "/ve").contains(launcher)) {
+      SharkLog.d { "${DeepLink.SCHEME}:// already opens $launcher" }
+      return
+    }
+    run("reg", "add", SCHEME_KEY, "/ve", "/d", "URL:$APP_NAME", "/f")
+    run("reg", "add", SCHEME_KEY, "/v", "URL Protocol", "/d", "", "/f")
+    run("reg", "add", COMMAND_KEY, "/ve", "/d", command, "/f")
+    SharkLog.d { "Registered ${DeepLink.SCHEME}:// to open $launcher" }
+  }
+
+  private fun registerOnLinux(launcher: String) {
+    val applications = File(System.getProperty("user.home"), ".local/share/applications")
+    val desktopFile = File(applications, DESKTOP_FILE_NAME)
+    val entry = desktopEntry(launcher)
+    if (desktopFile.isFile && desktopFile.readText() == entry) {
+      SharkLog.d { "${DeepLink.SCHEME}:// already opens $launcher" }
+      return
+    }
+    applications.mkdirs()
+    desktopFile.writeText(entry)
+    // Both are best effort and neither exists everywhere: a desktop that reads the directory itself needs
+    // no database, and one with no xdg-utils installed has no xdg-mime to make this the default handler.
+    run("update-desktop-database", applications.path)
+    run("xdg-mime", "default", DESKTOP_FILE_NAME, "x-scheme-handler/${DeepLink.SCHEME}")
+    SharkLog.d { "Registered ${DeepLink.SCHEME}:// in $desktopFile to open $launcher" }
+  }
+
+  /**
+   * Hidden from the menu, because a packaged install already has a visible entry of its own from its `.deb`
+   * and two of them is one too many. A hidden entry is still a handler.
+   */
+  private fun desktopEntry(launcher: String): String =
+    """
+    [Desktop Entry]
+    Type=Application
+    Name=$APP_NAME
+    Exec="$launcher" %u
+    Terminal=false
+    NoDisplay=true
+    MimeType=x-scheme-handler/${DeepLink.SCHEME};
+    """.trimIndent() + "\n"
+
+  /** What the command printed, or empty for one that failed or isn't installed. */
+  private fun run(vararg command: String): String = try {
+    val process = ProcessBuilder(*command).redirectErrorStream(true).start()
+    val output = process.inputStream.bufferedReader().readText()
+    if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      process.destroy()
+    }
+    output
+  } catch (throwable: Throwable) {
+    SharkLog.d { "${command.first()} could not be run: ${throwable.message}" }
+    ""
+  }
+
+  private fun isWindows(): Boolean = osName().startsWith("windows")
+
+  private fun isLinux(): Boolean = osName().startsWith("linux")
+
+  private fun osName(): String = System.getProperty("os.name").orEmpty().lowercase()
+
+  /** A run launched as one of these is a classpath rather than an app, whatever bundle it came out of. */
+  private val JVM_EXECUTABLES = setOf("java", "java.exe", "javaw.exe")
+
+  private val SCHEME_KEY = "HKCU\\Software\\Classes\\${DeepLink.SCHEME}"
+  private val COMMAND_KEY = "$SCHEME_KEY\\shell\\open\\command"
+
+  private const val DESKTOP_FILE_NAME = "shark-explorer.desktop"
+  private const val COMMAND_TIMEOUT_SECONDS = 10L
+}

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -60,6 +60,8 @@ internal fun DetailsPanel(
   bitmap: ImageBitmap?,
   isStarred: Boolean,
   onOpen: (Long, OpenIn) -> Unit,
+  /** Puts a link to a field's object on the clipboard, beside opening it. See [OpenTarget]. */
+  onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
   onToggleStar: () -> Unit,
   modifier: Modifier = Modifier
@@ -90,6 +92,7 @@ internal fun DetailsPanel(
           bitmap = bitmap,
           isStarred = isStarred,
           onOpen = onOpen,
+          onCopyLink = onCopyLink,
           onListInstances = onListInstances,
           onToggleStar = onToggleStar
         )
@@ -155,6 +158,7 @@ private fun ObjectDetails(
   bitmap: ImageBitmap?,
   isStarred: Boolean,
   onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
   onToggleStar: () -> Unit
 ) {
@@ -194,7 +198,7 @@ private fun ObjectDetails(
       Text(LIST_INSTANCES)
     }
   }
-  Fields(summary, onOpen)
+  Fields(summary, onOpen, onCopyLink)
 }
 
 /**
@@ -244,14 +248,15 @@ internal fun Hint(
 @Composable
 private fun Fields(
   summary: HeapObjectSummary,
-  onInspect: (Long, OpenIn) -> Unit
+  onInspect: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
   if (summary.fields.isEmpty()) {
     return
   }
   Text("Fields", style = MaterialTheme.typography.labelSmall)
   summary.fields.forEach { field ->
-    Inspectable("${field.name} = ${field.value}", field.inspectableObjectId, onInspect)
+    Inspectable("${field.name} = ${field.value}", field.inspectableObjectId, onInspect, onCopyLink)
   }
   if (summary.hiddenFieldCount > 0) {
     Text(
@@ -266,17 +271,21 @@ private fun Fields(
 internal fun Inspectable(
   text: String,
   objectId: Long?,
-  onInspect: (Long, OpenIn) -> Unit
+  onInspect: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
   if (objectId == null) {
     Text(text, style = MaterialTheme.typography.bodySmall)
   } else {
-    Text(
-      text,
-      Modifier.openable { openIn -> onInspect(objectId, openIn) },
-      style = MaterialTheme.typography.bodySmall,
-      color = LINK_COLOR
-    )
+    val open: (OpenIn) -> Unit = { openIn -> onInspect(objectId, openIn) }
+    OpenTarget(open, { onCopyLink(objectId) }) {
+      Text(
+        text,
+        Modifier.openable(open),
+        style = MaterialTheme.typography.bodySmall,
+        color = LINK_COLOR
+      )
+    }
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerArguments.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerArguments.kt
@@ -1,9 +1,11 @@
 package shark.explorer.app
 
 import java.io.File
+import shark.explorer.DeepLink
 
 /**
- * What the command line asked this run to do: which heap dumps to open, and what to call its windows.
+ * What the command line asked this run to do: which heap dumps to open, what to call its windows, and
+ * which links to follow.
  *
  * Plain state parsed from the arguments, so what a command line means is unit tested rather than found
  * out by launching the app.
@@ -19,7 +21,12 @@ internal data class ExplorerArguments(
    * for a piece of work can say which work it is: "the window titled *Hover previews* is the one with the
    * change in it".
    */
-  val titlePrefix: String?
+  val titlePrefix: String?,
+  /**
+   * Places to go to, in the order they were named. How Windows and Linux deliver a link — the OS starts a
+   * process per one — and how a link is followed by hand on any of the three. See [DeepLink].
+   */
+  val deepLinks: List<DeepLink> = emptyList()
 ) {
 
   companion object {
@@ -34,6 +41,7 @@ internal data class ExplorerArguments(
     fun parse(args: List<String>): ExplorerArguments {
       var titlePrefix: String? = null
       val heapDumpFiles = mutableListOf<File>()
+      val deepLinks = mutableListOf<DeepLink>()
       val remaining = ArrayDeque(args)
       while (remaining.isNotEmpty()) {
         val argument = remaining.removeFirst()
@@ -45,6 +53,12 @@ internal data class ExplorerArguments(
           }
           argument.startsWith("$TITLE_OPTION=") -> argument.substringAfter('=')
           argument.startsWith("-") -> throw IllegalArgumentException("Unknown option $argument. $USAGE")
+          // Ahead of taking it for a path, and by its scheme rather than by anything about this app's
+          // state: a link is what Windows and Linux put on the command line to deliver one.
+          DeepLink.looksLikeOne(argument) -> {
+            deepLinks += DeepLink.parse(argument)
+            titlePrefix
+          }
           else -> {
             heapDumpFiles += File(argument)
             titlePrefix
@@ -52,13 +66,18 @@ internal data class ExplorerArguments(
         }
       }
       require(titlePrefix != "") { "$TITLE_OPTION was given nothing to call the windows. $USAGE" }
-      return ExplorerArguments(heapDumpFiles = heapDumpFiles, titlePrefix = titlePrefix)
+      return ExplorerArguments(
+        heapDumpFiles = heapDumpFiles,
+        titlePrefix = titlePrefix,
+        deepLinks = deepLinks
+      )
     }
 
     private const val TITLE_OPTION = "--title"
 
     /** Shown with whatever was wrong, so that the message says what to type instead. */
-    private const val USAGE =
-      "Usage: shark-explorer [$TITLE_OPTION=\"<window title prefix>\"] [<heap dump>…]"
+    private val USAGE =
+      "Usage: shark-explorer [$TITLE_OPTION=\"<window title prefix>\"] [<heap dump>…] " +
+        "[${DeepLink.SCHEME}://<window>/<place>…]"
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerLogging.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerLogging.kt
@@ -102,7 +102,10 @@ private class Loggers(private val loggers: List<SharkLog.Logger>) : SharkLog.Log
 }
 
 /**
- * Where the log files go: under the user's home directory rather than beside the heap dump or in the
- * working directory, so that every run writes to the same place however it was started.
+ * Where this app keeps what it writes: under the user's home directory rather than beside the heap dump or
+ * in the working directory, so that every run reads and writes the same place however it was started.
  */
-private val LOG_DIRECTORY = File(System.getProperty("user.home"), ".shark-explorer/logs")
+internal val SHARK_EXPLORER_DIRECTORY = File(System.getProperty("user.home"), ".shark-explorer")
+
+/** One file per run. See [SessionLog]. */
+private val LOG_DIRECTORY = File(SHARK_EXPLORER_DIRECTORY, "logs")

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerWindow.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerWindow.kt
@@ -5,9 +5,13 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import java.awt.EventQueue
+import java.awt.Frame
 import java.io.File
 import shark.SharkLog
+import shark.explorer.DeepLink
 import shark.explorer.NativeBitmapPixels
+import shark.explorer.Place
 
 /**
  * One window of the app, which is one heap dump.
@@ -16,7 +20,7 @@ import shark.explorer.NativeBitmapPixels
  * one shows can be tested without a display: `explorerApplication` only draws a window per entry.
  */
 internal class ExplorerWindow(
-  heapDumpFile: File?,
+  heapDumpFile: File? = null,
   bitmapPixels: NativeBitmapPixels? = null,
   /**
    * How many steps down and to the right of centre this window opens: no two windows on screen are at
@@ -25,7 +29,15 @@ internal class ExplorerWindow(
    */
   val cascade: Int = 0,
   /** What this run calls its windows, in front of the heap dump. See [ExplorerArguments.titlePrefix]. */
-  val titlePrefix: String? = null
+  val titlePrefix: String? = null,
+  /**
+   * What a link to a place in this window names it by, and the whole of what makes deep linking work: a
+   * link is answered by the window it was copied from and by no other, however many windows have the same
+   * heap dump open. See [DeepLink].
+   */
+  val deepLinkId: String = DeepLink.newWindowId(),
+  /** Why this window is empty, for one opened by a link naming a window that had already gone. */
+  deepLinkProblem: String? = null
 ) {
 
   /** Null in the window the app starts with when it was given no heap dump to open. */
@@ -39,29 +51,144 @@ internal class ExplorerWindow(
   var bitmapPixels: NativeBitmapPixels? by mutableStateOf(bitmapPixels)
 
   /**
-   * Which heap dump this window is, and which run it belongs to, for the window list of the OS: several
-   * windows all called after the app tell you nothing about which one to switch to.
+   * Said in the middle of a window with nothing in it. See [ExplorerWindows.open].
    */
+  var deepLinkProblem: String? by mutableStateOf(deepLinkProblem)
+
+  /**
+   * Places a link has asked this window for and whose tabs are not open yet, oldest first.
+   *
+   * A list handed over rather than a call into the tabs, because a link arrives on whichever thread the OS
+   * or another run of this app delivered it on, and the tabs of a window are a composable's state. So this
+   * is the one point where the two meet: a link puts a place here, and the window takes it on the next
+   * frame. Which also settles what a link that arrives while the heap dump is still opening does — it
+   * waits, rather than being dropped.
+   */
+  var linkedPlaces: List<Place> by mutableStateOf(emptyList())
+    private set
+
+  /** Which heap dump this window is, and which run it belongs to, for the window list of the OS. */
   val title: String
     get() = listOfNotNull(titlePrefix, heapDumpFile?.name ?: APP_NAME).joinToString(TITLE_SEPARATOR)
+
+  /**
+   * The OS window this one is drawn as, for the one thing a link needs that Compose keeps no state for:
+   * putting the window in front of whatever is covering it.
+   */
+  private var frame: Frame? = null
+
+  /** Asks this window for [place], which its tabs open on the next frame. See [linkedPlaces]. */
+  fun goToLinked(place: Place) {
+    linkedPlaces = linkedPlaces + place
+  }
+
+  /** Taken by the tabs, which is what makes the window stop asking for it. */
+  fun linkedPlaceOpened(place: Place) {
+    linkedPlaces = linkedPlaces - place
+  }
+
+  fun attachTo(frame: Frame) {
+    this.frame = frame
+  }
+
+  /**
+   * Puts this window in front, which is half of what following a link means.
+   *
+   * On the event thread because it touches AWT and a link arrives on whatever thread delivered it. Nothing
+   * here asks to be permanently above other windows: a link is a request to look at something once, and a
+   * window that stays on top afterwards is one the reader has to put back.
+   */
+  fun bringToFront() {
+    val frame = frame
+    if (frame == null) {
+      // Which is what a link that raised nothing at all looks like from here.
+      SharkLog.d { "Window $deepLinkId has no frame yet, so nothing was brought to the front" }
+      return
+    }
+    EventQueue.invokeLater {
+      // A minimised window is raised by restoring it; toFront alone leaves it in the dock or the taskbar.
+      if (frame.extendedState and Frame.ICONIFIED != 0) {
+        frame.extendedState = frame.extendedState and Frame.ICONIFIED.inv()
+      }
+      // Which application is in front is the process's to ask for, and toFront only orders this one's
+      // windows: without this the right window is raised behind whatever the reader was looking at.
+      DeepLinkScheme.bringProcessToFront()
+      frame.toFront()
+      frame.requestFocus()
+    }
+  }
+}
+
+/**
+ * Every window of this run, and the way in for anything that isn't drawing one.
+ *
+ * Hoisted out of the composable that draws the windows because a link arrives from outside the app — the
+ * OS, another run of it, this run's own command line — and has to find a window from a thread that is
+ * composing nothing. See [ExplorerWindow.linkedPlaces].
+ */
+internal class ExplorerWindows(
+  /** Put in front of every window title of this run. See [ExplorerArguments.titlePrefix]. */
+  private val titlePrefix: String? = null,
+  /** One Compose window is drawn per entry, so a window opening or closing is an edit of this. */
+  private val windows: SnapshotStateList<ExplorerWindow> = mutableStateListOf()
+) : MutableList<ExplorerWindow> by windows {
+
+  /** Whether a window of this run answers to [windowId], which is what a link asks before it is handed over. */
+  fun holds(windowId: String): Boolean = any { it.deepLinkId == windowId }
+
+  /**
+   * Follows [link]: the window it names opens the place in a new tab and comes to the front.
+   *
+   * A link whose window has gone gets an empty window saying so rather than silence. Silence is the one
+   * answer that can't be told from the app having failed to start, and a link is usually followed from
+   * somewhere that cannot see whether this app did anything at all.
+   */
+  fun open(link: DeepLink) {
+    val window = firstOrNull { it.deepLinkId == link.windowId }
+    if (window == null) {
+      SharkLog.d { "No window of this run is ${link.windowId}: opening one to say so" }
+      add(
+        ExplorerWindow(
+          cascade = freeCascade(),
+          titlePrefix = titlePrefix,
+          deepLinkProblem = noSuchWindow(link.windowId)
+        )
+      )
+      return
+    }
+    SharkLog.d { "A link asked window ${link.windowId} for ${link.place}" }
+    window.goToLinked(link.place)
+    window.bringToFront()
+  }
+
+  /** The first step of the cascade no window is at, which is where the next window goes. */
+  fun freeCascade(): Int = generateSequence(0, Int::inc).first { step -> none { it.cascade == step } }
+
+  companion object {
+    /** What an empty window opened by a link naming a window that has gone says in the middle of it. */
+    fun noSuchWindow(windowId: String): String =
+      "No window called $windowId is open. A link leads to one window of one run of this app, so it " +
+        "stops working when that window is closed or the app is restarted."
+  }
 }
 
 /**
  * A window per heap dump named on the command line, or one window with none — something has to carry
  * the button that opens the first one.
  */
-internal fun explorerWindows(arguments: ExplorerArguments): SnapshotStateList<ExplorerWindow> =
-  mutableStateListOf<ExplorerWindow>().apply {
+internal fun explorerWindows(arguments: ExplorerArguments): ExplorerWindows =
+  ExplorerWindows(arguments.titlePrefix).apply {
     val titlePrefix = arguments.titlePrefix
     if (arguments.heapDumpFiles.isEmpty()) {
       add(ExplorerWindow(null, titlePrefix = titlePrefix))
     } else {
-      addAll(
-        arguments.heapDumpFiles.mapIndexed { index, file ->
-          ExplorerWindow(file, cascade = index, titlePrefix = titlePrefix)
-        }
-      )
+      arguments.heapDumpFiles.forEachIndexed { index, file ->
+        add(ExplorerWindow(file, cascade = index, titlePrefix = titlePrefix))
+      }
     }
+    // Which window is which, for reading a link out of a log afterwards: a link names one of these and
+    // nothing else in the file says what the name stands for.
+    SharkLog.d { "Windows of this run: ${joinToString { "${it.deepLinkId} ${it.title}" }}" }
   }
 
 /**
@@ -71,7 +198,7 @@ internal fun explorerWindows(arguments: ExplorerArguments): SnapshotStateList<Ex
  * two dumps is looking at both, and closing a window closes one of them rather than the trail through
  * several. The window that shows nothing has nothing to keep, so the first heap dump opens in it.
  */
-internal fun MutableList<ExplorerWindow>.openHeapDump(
+internal fun ExplorerWindows.openHeapDump(
   window: ExplorerWindow,
   heapDumpFile: File,
   /** Fetched with the dump, for a device whose dump can't carry the pixels of its bitmaps. */
@@ -92,6 +219,8 @@ internal fun MutableList<ExplorerWindow>.openHeapDump(
   } else {
     window.heapDumpFile = heapDumpFile
     window.bitmapPixels = bitmapPixels
+    // Whatever a link said about this window being empty is answered now that it isn't.
+    window.deepLinkProblem = null
   }
   // One run's log covers every window of that run, and what tells the lines apart afterwards is the
   // thread each was written from, so which window a heap dump went to is worth a line of its own.
@@ -103,7 +232,3 @@ internal fun MutableList<ExplorerWindow>.openHeapDump(
 
 /** Between what a run is called and which heap dump a window shows, as elsewhere in this window. */
 private const val TITLE_SEPARATOR = " · "
-
-/** The first step of the cascade no window is at, which is where the next window goes. */
-private fun List<ExplorerWindow>.freeCascade(): Int =
-  generateSequence(0, Int::inc).first { step -> none { it.cascade == step } }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -463,6 +463,21 @@ internal fun HeapDumpExplorer(
    * been reading all along — there is no second hit test to run for it.
    */
   val openHovered: (OpenIn) -> Unit = { openIn -> hovered?.place?.let { open(it, openIn) } }
+  /**
+   * Where every "copy link" in this window ends up, for the same reason [open] is one function: a link to a
+   * rectangle, a row, a field, a button and a tab is one thing, and five of them would drift.
+   */
+  val copyLink: (Place) -> Unit = { destination ->
+    val link = DeepLink(deepLinkId, destination).toUri()
+    // In the log as well as on the clipboard, so that a link someone reports as not working can be compared
+    // against the one this window actually handed out.
+    SharkLog.d { "Copied $link" }
+    copyToClipboard(link)
+  }
+  /** The same, for everything that names an object by its id. */
+  val copyObjectLink: (Long) -> Unit = { objectId -> copyLink(Place.Object(objectId)) }
+  /** And for the view's right click menu, which is on whatever the pointer is on. */
+  val copyHoveredLink: () -> Unit = { hovered?.place?.let { copyLink(it) } }
 
   if (showsBitmapsFromDevice) {
     BitmapsFromDeviceDialog(
@@ -486,10 +501,8 @@ internal fun HeapDumpExplorer(
     ScreenBar(
       starredCount = favourites.size,
       bitmapCounts = bitmapCounts,
-      onShowWholeHeapDump = { openInNewTab(Place.wholeHeapDump()) },
-      onListObjects = { openInNewTab(Place.Objects()) },
-      onShowLeaks = { openInNewTab(Place.Leaks()) },
-      onShowStarred = { openInNewTab(Place.Starred) },
+      onOpen = openInNewTab,
+      onCopyLink = copyLink,
       onFetchBitmaps = { showsBitmapsFromDevice = true }
     )
     TabStrip(
@@ -497,13 +510,7 @@ internal fun HeapDumpExplorer(
       titleOf = { it.title ?: placeTitles[it] ?: NAMING_TAB },
       onSelect = { id -> tabs = tabs.select(id) },
       onClose = { id -> tabs = tabs.close(id) },
-      onCopyLink = { place ->
-        val link = DeepLink(deepLinkId, place).toUri()
-        // In the log as well as on the clipboard, so that a link someone reports as not working can be
-        // compared against the one this window actually handed out.
-        SharkLog.d { "Copied $link" }
-        copyToClipboard(link)
-      }
+      onCopyLink = copyLink
     )
     Row(verticalAlignment = Alignment.CenterVertically) {
       HistoryArrows(
@@ -529,6 +536,7 @@ internal fun HeapDumpExplorer(
           favourites = favourites,
           sizes = sizes,
           onOpen = openObject,
+          onCopyLink = copyObjectLink,
           onReplacePlace = { tabs = tabs.replacingCurrent(it) },
           onRemoveStar = { objectId -> favourites = favourites.filterNot { it.objectId == objectId } },
           modifier = Modifier.fillMaxSize()
@@ -545,7 +553,8 @@ internal fun HeapDumpExplorer(
             ways = detourWays,
             chosenWays = chosenWays,
             onChooseWay = { detour, way -> chosenWays = chosenWays + (detour to way) },
-            onOpen = openObject
+            onOpen = openObject,
+            onCopyLink = copyObjectLink
           )
           ViewPane(
             panes = panes,
@@ -568,6 +577,7 @@ internal fun HeapDumpExplorer(
             onHover = onHover,
             onClick = onClickCell,
             onOpenHovered = openHovered,
+            onCopyHoveredLink = copyHoveredLink,
             onMeasured = { viewportSize = it }
           )
           DetailsPane(
@@ -577,6 +587,7 @@ internal fun HeapDumpExplorer(
             bitmap = describedBitmap,
             isStarred = favourites.any { it.objectId == describedSummary?.objectId },
             onOpen = openObject,
+            onCopyLink = copyObjectLink,
             onListInstances = { className ->
               open(
                 Place.Objects(
@@ -658,7 +669,8 @@ private fun RowScope.ChainPane(
   ways: Map<Int, List<RootPathWay>>,
   chosenWays: Map<Int, Int>,
   onChooseWay: (Int, Int) -> Unit,
-  onOpen: (Long, OpenIn) -> Unit
+  onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
   if (panes.isFolded(Pane.CHAIN)) {
     FoldedPane(Pane.CHAIN) { panes.toggleFold(Pane.CHAIN) }
@@ -678,6 +690,7 @@ private fun RowScope.ChainPane(
       chosenWays = chosenWays,
       onChooseWay = onChooseWay,
       onOpen = onOpen,
+      onCopyLink = onCopyLink,
       modifier = Modifier.weight(1f).fillMaxWidth()
     )
   }
@@ -710,6 +723,8 @@ private fun RowScope.ViewPane(
   onClick: (LayoutCell<Long>, OpenIn) -> Unit,
   /** Where the right click menu over the view leads, which is whatever the pointer is on. */
   onOpenHovered: (OpenIn) -> Unit,
+  /** And what that menu copies a link to, which is the same rectangle. */
+  onCopyHoveredLink: () -> Unit,
   onMeasured: (IntSize) -> Unit
 ) {
   if (panes.isFolded(Pane.VIEW)) {
@@ -735,7 +750,7 @@ private fun RowScope.ViewPane(
     Box(Modifier.weight(1f).fillMaxWidth()) {
       // The one gesture the views can't read themselves: a right click is the menu's, and the menu is what
       // makes middle clicking a rectangle findable by someone who has never tried it.
-      OpenTarget(onOpenHovered) {
+      OpenTarget(onOpenHovered, onCopyHoveredLink) {
         TreeScreen(
           view = view,
           stronglyReachableByteCount = sizes.stronglyReachableByteCount,
@@ -770,6 +785,7 @@ private fun RowScope.DetailsPane(
   bitmap: ImageBitmap?,
   isStarred: Boolean,
   onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
   onToggleStar: () -> Unit
 ) {
@@ -788,6 +804,7 @@ private fun RowScope.DetailsPane(
       bitmap = bitmap,
       isStarred = isStarred,
       onOpen = onOpen,
+      onCopyLink = onCopyLink,
       onListInstances = onListInstances,
       onToggleStar = onToggleStar,
       modifier = Modifier.weight(1f).fillMaxWidth()
@@ -828,6 +845,7 @@ private fun ListPlace(
   favourites: List<Favourite>,
   sizes: HeapSizes,
   onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit,
   onReplacePlace: (Place) -> Unit,
   onRemoveStar: (Long) -> Unit,
   modifier: Modifier = Modifier
@@ -842,6 +860,7 @@ private fun ListPlace(
       // rather than walking back through what was typed into it.
       onFilterChange = { filter -> onReplacePlace(place.copy(filter = filter)) },
       onOpen = onOpen,
+      onCopyLink = onCopyLink,
       modifier = modifier
     )
     is Place.Leaks -> LeaksScreen(
@@ -858,12 +877,14 @@ private fun ListPlace(
         )
       },
       onOpen = onOpen,
+      onCopyLink = onCopyLink,
       modifier = modifier
     )
     is Place.Starred -> StarredScreen(
       favourites = favourites,
       stronglyReachableByteCount = sizes.stronglyReachableByteCount,
       onOpen = onOpen,
+      onCopyLink = onCopyLink,
       onRemove = onRemoveStar,
       modifier = modifier
     )
@@ -915,10 +936,9 @@ private fun DescribedObject(selection: Selection?) {
 private fun ScreenBar(
   starredCount: Int,
   bitmapCounts: BitmapCounts,
-  onShowWholeHeapDump: () -> Unit,
-  onListObjects: () -> Unit,
-  onShowLeaks: () -> Unit,
-  onShowStarred: () -> Unit,
+  onOpen: (Place) -> Unit,
+  /** A link to the screen a button leads to, from the right click menu on it. See [CopyLinkTarget]. */
+  onCopyLink: (Place) -> Unit,
   onFetchBitmaps: () -> Unit
 ) {
   Row(
@@ -926,26 +946,45 @@ private fun ScreenBar(
     horizontalArrangement = Arrangement.spacedBy(4.dp),
     verticalAlignment = Alignment.CenterVertically
   ) {
-    TextButton(onClick = onShowWholeHeapDump) {
-      Text(HeapDominatorTreemap.ROOT_LABEL)
-    }
-    TextButton(onClick = onListObjects) {
-      Text(Place.OBJECTS_LABEL)
-    }
+    ScreenButton(Place.wholeHeapDump(), HeapDominatorTreemap.ROOT_LABEL, onOpen, onCopyLink)
+    ScreenButton(Place.Objects(), Place.OBJECTS_LABEL, onOpen, onCopyLink)
     // Beside the list of every object, because it is the same list with the answer already found in it:
     // the objects that shouldn't be there, gathered into the leaks they are instances of.
-    TextButton(onClick = onShowLeaks) {
-      Text(Place.LEAKS_LABEL)
-    }
-    TextButton(onClick = onShowStarred, enabled = starredCount > 0) {
-      Text("$STARRED_GLYPH $starredCount starred")
-    }
+    ScreenButton(Place.Leaks(), Place.LEAKS_LABEL, onOpen, onCopyLink)
+    ScreenButton(
+      place = Place.Starred,
+      label = "$STARRED_GLYPH $starredCount starred",
+      onOpen = onOpen,
+      onCopyLink = onCopyLink,
+      isEnabled = starredCount > 0
+    )
     // Only when there are bitmaps the dump has no pixels for, because that's the only thing a device can
     // add: pixels the dump carries are already on the map by the time this bar is read.
     if (bitmapCounts.withoutImageCount > 0) {
       TextButton(onClick = onFetchBitmaps) {
         Text("$FETCH_BITMAPS ${bitmapCountText(bitmapCounts.withoutImageCount)}")
       }
+    }
+  }
+}
+
+/**
+ * One button of the bar: a screen it always opens a tab of its own on, and a link to that screen.
+ *
+ * No "open in a new tab" in its menu, unlike everything else that leads somewhere: this is the one kind of
+ * way to a place that has no other tab to open in.
+ */
+@Composable
+private fun ScreenButton(
+  place: Place,
+  label: String,
+  onOpen: (Place) -> Unit,
+  onCopyLink: (Place) -> Unit,
+  isEnabled: Boolean = true
+) {
+  CopyLinkTarget({ onCopyLink(place) }) {
+    TextButton(onClick = { onOpen(place) }, enabled = isEnabled) {
+      Text(label)
     }
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -35,12 +35,15 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import shark.SharkLog
 import shark.explorer.BitmapCounts
+import shark.explorer.DeepLink
 import shark.explorer.DeviceHeapDumps
 import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapLeaks
@@ -100,6 +103,13 @@ internal fun HeapDumpExplorer(
   deviceHeapDumps: DeviceHeapDumps,
   /** Already fetched off the device, when the dump was taken with the pixels asked for in the same go. */
   fetchedBitmapPixels: NativeBitmapPixels? = null,
+  /** What a link to one of these tabs names this window by. See [DeepLink]. */
+  deepLinkId: String = remember { DeepLink.newWindowId() },
+  /** Places a link has asked for, opened as tabs. See [ExplorerWindow.linkedPlaces]. */
+  linkedPlaces: List<Place> = emptyList(),
+  onLinkedPlaceOpened: (Place) -> Unit = {},
+  /** Overridden by tests, which have no system clipboard and want to read what would have been copied. */
+  copyToClipboard: (String) -> Unit = ::copyTextToClipboard,
   modifier: Modifier = Modifier
 ) {
   var tabs by remember { mutableStateOf(Tabs.opening(Place.wholeHeapDump())) }
@@ -179,6 +189,17 @@ internal fun HeapDumpExplorer(
       radialLayout = radialLayout,
       stackLayout = stackLayout
     )
+  }
+
+  // A link that arrived is a tab, always a new one and always in front: following a link is asking to be
+  // somewhere else, and it must not throw away the tab it was followed from. One per run of this effect
+  // rather than a loop over the list, so that a link arriving while another is being opened is queued
+  // behind it rather than racing it.
+  LaunchedEffect(linkedPlaces) {
+    val linked = linkedPlaces.firstOrNull() ?: return@LaunchedEffect
+    SharkLog.d { "A link asked this window for $linked" }
+    tabs = tabs.open(linked)
+    onLinkedPlaceOpened(linked)
   }
 
   // What each tab is called, for the tabs the window couldn't name itself. A label is cheap enough to draw
@@ -475,7 +496,14 @@ internal fun HeapDumpExplorer(
       tabs = tabs,
       titleOf = { it.title ?: placeTitles[it] ?: NAMING_TAB },
       onSelect = { id -> tabs = tabs.select(id) },
-      onClose = { id -> tabs = tabs.close(id) }
+      onClose = { id -> tabs = tabs.close(id) },
+      onCopyLink = { place ->
+        val link = DeepLink(deepLinkId, place).toUri()
+        // In the log as well as on the clipboard, so that a link someone reports as not working can be
+        // compared against the one this window actually handed out.
+        SharkLog.d { "Copied $link" }
+        copyToClipboard(link)
+      }
     )
     Row(verticalAlignment = Alignment.CenterVertically) {
       HistoryArrows(
@@ -589,6 +617,22 @@ internal fun HeapDumpExplorer(
         }
       }
     }
+  }
+}
+
+/**
+ * Puts [text] on the system clipboard, through AWT.
+ *
+ * AWT's clipboard rather than Compose's, because this is one call from an event handler rather than
+ * something a composable has to hold: Compose's is a composition local and a suspending write, both of
+ * which would have to be threaded down to the tab that is being copied.
+ */
+internal fun copyTextToClipboard(text: String) {
+  try {
+    Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
+  } catch (throwable: Throwable) {
+    // A headless JVM and a desktop with no clipboard both land here, and neither is worth a dialog.
+    SharkLog.d(throwable) { "Could not put \"$text\" on the clipboard" }
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
@@ -56,6 +56,8 @@ internal fun LeaksScreen(
   expandedGroups: Set<String>,
   onToggleGroup: (String) -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
+  /** Puts a link to a row's object on the clipboard, beside opening it. See [OpenTarget]. */
+  onCopyLink: (Long) -> Unit,
   modifier: Modifier = Modifier
 ) {
   Surface(modifier, color = MaterialTheme.colorScheme.surface) {
@@ -92,7 +94,8 @@ internal fun LeaksScreen(
               LeakingObjectRow(
                 leakingObject = group.objects.first(),
                 isLast = !hasMore,
-                onOpen = onOpen
+                onOpen = onOpen,
+                onCopyLink = onCopyLink
               )
             }
             if (hasMore) {
@@ -111,7 +114,8 @@ internal fun LeaksScreen(
                     LeakingObjectRow(
                       leakingObject = leakingObject,
                       isLast = index == group.objects.size - 2,
-                      onOpen = onOpen
+                      onOpen = onOpen,
+                      onCopyLink = onCopyLink
                     )
                   }
                 }
@@ -292,57 +296,65 @@ private fun LeakingObjectRow(
   leakingObject: LeakingObject,
   /** Whether it closes the leak it is in, which is where the rule down the objects stops. */
   isLast: Boolean,
-  onOpen: (Long, OpenIn) -> Unit
+  onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
   Row(Modifier.fillMaxWidth().height(IntrinsicSize.Min).background(INSTANCE_BACKGROUND)) {
     SectionBar()
     Spacer(Modifier.width(INSTANCE_INSET - SECTION_BAR_WIDTH))
     InstanceRule(isLast)
     Column(Modifier.weight(1f).padding(start = 8.dp, end = 12.dp, bottom = 4.dp)) {
-      Row(
-        Modifier.fillMaxWidth().openable { openIn -> onOpen(leakingObject.objectId, openIn) }
-          .padding(vertical = 2.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically
-      ) {
-        Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(leakingObject.strength)))
-        Column(Modifier.weight(1f)) {
-          Text(
-            leakingObject.identityText(),
-            style = MaterialTheme.typography.bodySmall,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-          )
-          leakingObject.headline?.let { headline ->
+      val open: (OpenIn) -> Unit = { openIn -> onOpen(leakingObject.objectId, openIn) }
+      OpenTarget(open, { onCopyLink(leakingObject.objectId) }) {
+        Row(
+          Modifier.fillMaxWidth().openable(open).padding(vertical = 2.dp),
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(leakingObject.strength)))
+          Column(Modifier.weight(1f)) {
             Text(
-              headline,
+              leakingObject.identityText(),
               style = MaterialTheme.typography.bodySmall,
-              color = MUTED_TEXT,
               maxLines = 1,
               overflow = TextOverflow.Ellipsis
             )
+            leakingObject.headline?.let { headline ->
+              Text(
+                headline,
+                style = MaterialTheme.typography.bodySmall,
+                color = MUTED_TEXT,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+              )
+            }
+            // Why *this* object shouldn't be here, which the inspector that recognized it read off the object
+            // itself: two objects of one leak can be leaking for reasons that don't read the same.
+            leakingObject.leakingReason?.let { reason ->
+              Text(
+                reason,
+                style = MaterialTheme.typography.bodySmall,
+                color = MUTED_TEXT,
+                maxLines = MAX_SUBTITLE_LINES,
+                overflow = TextOverflow.Ellipsis
+              )
+            }
           }
-          // Why *this* object shouldn't be here, which the inspector that recognized it read off the object
-          // itself: two objects of one leak can be leaking for reasons that don't read the same.
-          leakingObject.leakingReason?.let { reason ->
-            Text(
-              reason,
-              style = MaterialTheme.typography.bodySmall,
-              color = MUTED_TEXT,
-              maxLines = MAX_SUBTITLE_LINES,
-              overflow = TextOverflow.Ellipsis
-            )
-          }
+          Text(
+            formatByteSize(leakingObject.retainedSize),
+            Modifier.width(SIZE_COLUMN_WIDTH),
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.End
+          )
         }
-        Text(
-          formatByteSize(leakingObject.retainedSize),
-          Modifier.width(SIZE_COLUMN_WIDTH),
-          style = MaterialTheme.typography.bodySmall,
-          textAlign = TextAlign.End
-        )
       }
       leakingObject.watcher?.let { watcher ->
-        WatcherRow(watcher, alreadySaid = leakingObject.leakingReason.orEmpty(), onOpen = onOpen)
+        WatcherRow(
+          watcher = watcher,
+          alreadySaid = leakingObject.leakingReason.orEmpty(),
+          onOpen = onOpen,
+          onCopyLink = onCopyLink
+        )
       }
     }
   }
@@ -379,21 +391,23 @@ private fun WatcherRow(
    * inspector built out of the watcher's own description — so printing it again is printing it twice.
    */
   alreadySaid: String,
-  onOpen: (Long, OpenIn) -> Unit
+  onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
-  Column(
-    Modifier.fillMaxWidth().openable { openIn -> onOpen(watcher.weakReferenceObjectId, openIn) }
-      .padding(bottom = 2.dp)
-  ) {
-    Text(watcher.watchText(), style = MaterialTheme.typography.bodySmall, color = LINK_COLOR)
-    if (watcher.description.isNotEmpty() && watcher.description !in alreadySaid) {
-      Text(
-        watcher.description,
-        style = MaterialTheme.typography.bodySmall,
-        color = MUTED_TEXT,
-        maxLines = MAX_SUBTITLE_LINES,
-        overflow = TextOverflow.Ellipsis
-      )
+  val objectId = watcher.weakReferenceObjectId
+  val open: (OpenIn) -> Unit = { openIn -> onOpen(objectId, openIn) }
+  OpenTarget(open, { onCopyLink(objectId) }) {
+    Column(Modifier.fillMaxWidth().openable(open).padding(bottom = 2.dp)) {
+      Text(watcher.watchText(), style = MaterialTheme.typography.bodySmall, color = LINK_COLOR)
+      if (watcher.description.isNotEmpty() && watcher.description !in alreadySaid) {
+        Text(
+          watcher.description,
+          style = MaterialTheme.typography.bodySmall,
+          color = MUTED_TEXT,
+          maxLines = MAX_SUBTITLE_LINES,
+          overflow = TextOverflow.Ellipsis
+        )
+      }
     }
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -38,9 +38,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import shark.SharkLog
 import shark.explorer.CommandLineAdb
+import shark.explorer.DeepLink
 import shark.explorer.DeviceHeapDumps
 import shark.explorer.HeapSizes
 import shark.explorer.NativeBitmapPixels
+import shark.explorer.Place
 import shark.explorer.ReachabilityStrength
 import shark.explorer.formatByteSize
 import shark.explorer.formatObjectCount
@@ -48,6 +50,13 @@ import shark.explorer.jdwp.JdwpBitmaps
 import shark.explorer.jdwp.JdwpGc
 
 fun main(args: Array<String>) {
+  // A command line that is nothing but links is a courier: Windows and Linux deliver a link by starting a
+  // process with it, so this is most of the runs of this app on those two. Answered before anything else
+  // and without opening a log file — one file per link would push out every run worth reading, and the
+  // last 20 is what a bug report attaches. See [SessionLog].
+  if (deliveredToAnotherRun(args)) {
+    return
+  }
   // Launched from a terminal, so Shark's own diagnostics and any failure to open a heap dump belong on
   // stdout as well as in the window — and in a file, so that a session someone reports on can be read
   // back after it. See [installLogging].
@@ -66,9 +75,43 @@ fun main(args: Array<String>) {
     // reads as one on the line above.
     SharkLog.d { "Read that as $arguments" }
     nameThisRun(arguments.titlePrefix ?: APP_NAME)
-    // Heap dump paths on the command line open straight away, which is how this is usually run.
-    explorerApplication(arguments)
+    val windows = explorerWindows(arguments)
+    // Both before the first window, so that a link arriving while the heap dumps are still opening is one
+    // the window queues rather than one that lands on an app not listening yet.
+    DeepLinkScheme.takeUrisFromTheOs(windows)
+    DeepLinkScheme.registerWithTheOs()
+    DeepLinkPeers.listen(windows).use {
+      // Whatever no other run claimed, which for a link naming a window that has gone is an empty window
+      // saying so. Ours to answer for now: nobody else is going to.
+      DeepLinkPeers.deliver(arguments.deepLinks).forEach { windows.open(it) }
+      // Heap dump paths on the command line open straight away, which is how this is usually run.
+      explorerApplication(windows)
+    }
   }
+}
+
+/**
+ * Hands a command line of nothing but links to the runs that have those windows, and says whether every
+ * one of them was taken.
+ *
+ * False for anything else on the command line, for a link nobody claimed and for a link that doesn't
+ * parse — all three are a run that has something to show, and the full path below shows it, with a log
+ * file and a window rather than from here.
+ */
+private fun deliveredToAnotherRun(args: Array<String>): Boolean {
+  if (args.isEmpty() || !args.all { DeepLink.looksLikeOne(it) }) {
+    return false
+  }
+  val links = args.map {
+    try {
+      DeepLink.parse(it)
+    } catch (invalidLink: IllegalArgumentException) {
+      // Left to the full path, which has somewhere to say this: a courier has no window and, on Windows,
+      // no console either.
+      return false
+    }
+  }
+  return DeepLinkPeers.deliver(links).isEmpty()
 }
 
 /**
@@ -94,8 +137,7 @@ private fun nameThisRun(name: String) {
 }
 
 /** One window per heap dump open, which is what [openHeapDump] keeps true as more are opened. */
-private fun explorerApplication(arguments: ExplorerArguments) = application {
-  val windows = remember { explorerWindows(arguments) }
+private fun explorerApplication(windows: ExplorerWindows) = application {
   val updateNotice = remember { UpdateNotice() }
   // Once per run, not once per window, and off the UI thread: this is a network request, and a window that
   // waits for GitHub to answer before it draws is a window that hangs when GitHub is unreachable.
@@ -123,6 +165,12 @@ private fun explorerApplication(arguments: ExplorerArguments) = application {
           position = cascadedPosition(window.cascade)
         )
       ) {
+        // The OS window this one came out as, which is the one thing following a link needs and Compose
+        // keeps no state for: raising a window is AWT's, not the composition's. See [ExplorerWindow].
+        DisposableEffect(this.window) {
+          window.attachTo(this@Window.window)
+          onDispose {}
+        }
         MaterialTheme {
           ExplorerApp(
             heapDumpFile = window.heapDumpFile,
@@ -130,7 +178,11 @@ private fun explorerApplication(arguments: ExplorerArguments) = application {
             onHeapDumpChosen = { file, fetchedPixels ->
               windows.openHeapDump(window, file, fetchedPixels)
             },
-            updateNotice = updateNotice
+            updateNotice = updateNotice,
+            deepLinkId = window.deepLinkId,
+            linkedPlaces = window.linkedPlaces,
+            onLinkedPlaceOpened = { place -> window.linkedPlaceOpened(place) },
+            deepLinkProblem = window.deepLinkProblem
           )
         }
       }
@@ -156,6 +208,20 @@ internal fun ExplorerApp(
    * that a test only gets the bar when it is what the test is about.
    */
   updateNotice: UpdateNotice = remember { UpdateNotice() },
+  /** What a link to a place in this window names it by. See [shark.explorer.DeepLink]. */
+  deepLinkId: String = remember { DeepLink.newWindowId() },
+  /** Places a link has asked this window for, which its tabs open. See [ExplorerWindow.linkedPlaces]. */
+  linkedPlaces: List<Place> = emptyList(),
+  onLinkedPlaceOpened: (Place) -> Unit = {},
+  /**
+   * Why this window has no heap dump, for one a link opened because the window it named had gone.
+   *
+   * Shown where "open an Android heap dump" would be, rather than as a dialog: the window is empty either
+   * way, and the two buttons above are what to do about it in both cases.
+   */
+  deepLinkProblem: String? = null,
+  /** Overridden by tests, which have no system clipboard and want to read what would have been copied. */
+  copyToClipboard: (String) -> Unit = ::copyTextToClipboard,
   /** Overridden by tests, which have no display to put a file dialog on. */
   chooseHeapDumpFile: () -> File? = ::showHeapDumpFileDialog,
   /** Overridden by tests, which have no device to go back to and no `adb` to ask. */
@@ -242,6 +308,10 @@ internal fun ExplorerApp(
         sizes = currentState.sizes,
         deviceHeapDumps = deviceHeapDumps,
         fetchedBitmapPixels = currentState.bitmapPixels,
+        deepLinkId = deepLinkId,
+        linkedPlaces = linkedPlaces,
+        onLinkedPlaceOpened = onLinkedPlaceOpened,
+        copyToClipboard = copyToClipboard,
         modifier = Modifier.weight(1f)
       )
     } else {
@@ -253,7 +323,13 @@ internal fun ExplorerApp(
           if (currentState is HeapDumpState.Opening) {
             CircularProgressIndicator()
           }
-          Text(currentState.centerMessage(), style = MaterialTheme.typography.bodyLarge)
+          // A window a link opened to say the window it named has gone says that instead of the invitation
+          // to open a heap dump: it was opened to carry a message, and the invitation is under it anyway.
+          Text(
+            deepLinkProblem?.takeIf { currentState is HeapDumpState.None }
+              ?: currentState.centerMessage(),
+            style = MaterialTheme.typography.bodyLarge
+          )
         }
       }
     }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ObjectsScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ObjectsScreen.kt
@@ -58,6 +58,8 @@ internal fun ObjectsScreen(
   isListing: Boolean,
   onFilterChange: (ObjectListFilter) -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
+  /** Puts a link to a row's object on the clipboard, beside opening it. See [OpenTarget]. */
+  onCopyLink: (Long) -> Unit,
   modifier: Modifier = Modifier
 ) {
   Surface(modifier, color = MaterialTheme.colorScheme.surface) {
@@ -77,7 +79,7 @@ internal fun ObjectsScreen(
       HorizontalDivider()
       LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
         items(list.entries, key = { it.objectId }) { entry ->
-          ObjectRow(entry, stronglyReachableByteCount, onOpen)
+          ObjectRow(entry, stronglyReachableByteCount, onOpen, onCopyLink)
         }
       }
     }
@@ -191,55 +193,59 @@ private fun HeaderCell(
 private fun ObjectRow(
   entry: ObjectListEntry,
   stronglyReachableByteCount: Long,
-  onOpen: (Long, OpenIn) -> Unit
+  onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
-  Row(
-    Modifier.fillMaxWidth()
-      .openable { openIn -> onOpen(entry.objectId, openIn) }
-      .padding(horizontal = 12.dp, vertical = 4.dp),
-    horizontalArrangement = Arrangement.spacedBy(8.dp),
-    verticalAlignment = Alignment.CenterVertically
-  ) {
-    Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(entry.strength)))
-    Column(Modifier.weight(1f)) {
-      Text(
-        entry.classNameText(),
-        style = MaterialTheme.typography.bodyMedium,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis
-      )
-      entry.headline?.let { headline ->
+  val open: (OpenIn) -> Unit = { openIn -> onOpen(entry.objectId, openIn) }
+  OpenTarget(open, { onCopyLink(entry.objectId) }) {
+    Row(
+      Modifier.fillMaxWidth()
+        .openable(open)
+        .padding(horizontal = 12.dp, vertical = 4.dp),
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(entry.strength)))
+      Column(Modifier.weight(1f)) {
         Text(
-          headline,
-          style = MaterialTheme.typography.bodySmall,
-          color = MUTED_TEXT,
+          entry.classNameText(),
+          style = MaterialTheme.typography.bodyMedium,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis
         )
+        entry.headline?.let { headline ->
+          Text(
+            headline,
+            style = MaterialTheme.typography.bodySmall,
+            color = MUTED_TEXT,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+          )
+        }
       }
-    }
-    Text(
-      formatByteSize(entry.shallowSize),
-      Modifier.width(SIZE_COLUMN_WIDTH),
-      style = MaterialTheme.typography.bodySmall,
-      textAlign = TextAlign.End
-    )
-    // The share under the size rather than beside it: the column is as wide as a size and no wider,
-    // and a table's numbers only line up while every cell in the column is the same shape.
-    Column(Modifier.width(SIZE_COLUMN_WIDTH)) {
       Text(
-        formatByteSize(entry.retainedSize),
-        Modifier.fillMaxWidth(),
-        style = MaterialTheme.typography.bodyMedium,
+        formatByteSize(entry.shallowSize),
+        Modifier.width(SIZE_COLUMN_WIDTH),
+        style = MaterialTheme.typography.bodySmall,
         textAlign = TextAlign.End
       )
-      Text(
-        formatPercentOfTotal(entry.retainedSize, stronglyReachableByteCount),
-        Modifier.fillMaxWidth(),
-        style = MaterialTheme.typography.labelSmall,
-        color = MUTED_TEXT,
-        textAlign = TextAlign.End
-      )
+      // The share under the size rather than beside it: the column is as wide as a size and no wider,
+      // and a table's numbers only line up while every cell in the column is the same shape.
+      Column(Modifier.width(SIZE_COLUMN_WIDTH)) {
+        Text(
+          formatByteSize(entry.retainedSize),
+          Modifier.fillMaxWidth(),
+          style = MaterialTheme.typography.bodyMedium,
+          textAlign = TextAlign.End
+        )
+        Text(
+          formatPercentOfTotal(entry.retainedSize, stronglyReachableByteCount),
+          Modifier.fillMaxWidth(),
+          style = MaterialTheme.typography.labelSmall,
+          color = MUTED_TEXT,
+          textAlign = TextAlign.End
+        )
+      }
     }
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/OpenIn.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/OpenIn.kt
@@ -43,21 +43,44 @@ internal enum class OpenIn {
 }
 
 /**
- * Whatever it wraps is a way to an object, with the gestures a browser has taught everyone.
+ * Whatever it wraps is a way to a place, with the gestures a browser has taught everyone.
  *
  * The right click menu is here rather than beside the click handling because it takes a composable to
  * draw, and it is what makes the gesture discoverable: a reader who has never tried ⌘ clicking a
  * rectangle finds the same thing spelled out in words.
+ *
+ * **Copying a link sits beside opening a tab wherever there is one of these**, because they are the same
+ * thought a step apart: a place worth a tab of its own is a place worth sending to someone. See
+ * [shark.explorer.DeepLink].
  */
 @Composable
 internal fun OpenTarget(
   onOpen: (OpenIn) -> Unit,
+  onCopyLink: () -> Unit,
   content: @Composable () -> Unit
 ) {
   ContextMenuArea(
-    items = { listOf(ContextMenuItem(OPEN_IN_NEW_TAB) { onOpen(OpenIn.NEW_TAB) }) },
+    items = {
+      listOf(
+        ContextMenuItem(OPEN_IN_NEW_TAB) { onOpen(OpenIn.NEW_TAB) },
+        ContextMenuItem(COPY_LINK, onCopyLink)
+      )
+    },
     content = content
   )
+}
+
+/**
+ * Whatever it wraps names a place that is already open, or that a click opens with no choice about where.
+ *
+ * A tab and a button on the bar: nothing to offer about which tab, and still a place to link to.
+ */
+@Composable
+internal fun CopyLinkTarget(
+  onCopyLink: () -> Unit,
+  content: @Composable () -> Unit
+) {
+  ContextMenuArea(items = { listOf(ContextMenuItem(COPY_LINK, onCopyLink)) }, content = content)
 }
 
 /**
@@ -118,3 +141,12 @@ private fun PointerEvent.openIn(): OpenIn = when {
 
 /** What the right click menu on anything naming an object offers. */
 internal const val OPEN_IN_NEW_TAB = "Open in a new tab"
+
+/**
+ * And what it offers beside it, everywhere: a `shark://` link to that same place, on the clipboard.
+ *
+ * "Copy link" rather than "Copy link to this object" or "…to this tab", because it is the same item on a
+ * rectangle, a row, a field, a button and a tab, and a menu that renames it per surface reads as five
+ * different things rather than as the one thing it is.
+ */
+internal const val COPY_LINK = "Copy link"

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -71,17 +71,21 @@ import shark.explorer.hexObjectId
 @Composable
 internal fun PathRootRow(
   nextStrength: ReachabilityStrength?,
-  onOpen: (Long, OpenIn) -> Unit
+  onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
   Row(Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
     NodeGutter(kind = null, incoming = null, outgoing = nextStrength, endsInArrow = nextStrength != null)
     Column(Modifier.padding(bottom = PathDetail.FULL.rowSpacing)) {
-      Text(
-        HeapDominatorTreemap.ROOT_LABEL,
-        Modifier.openable { openIn -> onOpen(HeapDominatorTreemap.ROOT_OBJECT_ID, openIn) },
-        style = MaterialTheme.typography.bodyMedium,
-        fontWeight = FontWeight.Bold
-      )
+      val open: (OpenIn) -> Unit = { openIn -> onOpen(HeapDominatorTreemap.ROOT_OBJECT_ID, openIn) }
+      OpenTarget(open, { onCopyLink(HeapDominatorTreemap.ROOT_OBJECT_ID) }) {
+        Text(
+          HeapDominatorTreemap.ROOT_LABEL,
+          Modifier.openable(open),
+          style = MaterialTheme.typography.bodyMedium,
+          fontWeight = FontWeight.Bold
+        )
+      }
     }
   }
 }
@@ -125,6 +129,7 @@ internal fun PathStepRow(
   /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
   stronglyReachableByteCount: Long,
   onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit,
   role: PathRole = PathRole.STEP,
   detail: PathDetail = PathDetail.FULL,
   /** What hangs under the object, which is where a stretch of the chain below it is switched. */
@@ -156,7 +161,8 @@ internal fun PathStepRow(
         typeName = step.kind.typeName,
         objectId = step.objectId,
         // Folded objects are drawn nowhere on the map: a string's characters are counted inside the string.
-        onOpen = if (step.isInspectable) ({ openIn -> onOpen(step.objectId, openIn) }) else null
+        onOpen = if (step.isInspectable) ({ openIn -> onOpen(step.objectId, openIn) }) else null,
+        onCopyLink = { onCopyLink(step.objectId) }
       )
     } else {
       BriefStepLine(step, stronglyReachableByteCount)
@@ -357,9 +363,28 @@ internal fun ObjectIdentity(
   objectId: Long?,
   modifier: Modifier = Modifier,
   /** Where clicking it goes, or null for a name that is already what the window is showing. */
-  onOpen: ((OpenIn) -> Unit)? = null
+  onOpen: ((OpenIn) -> Unit)? = null,
+  /** Put on the clipboard by the menu beside "open in a new tab", so only where there is one. */
+  onCopyLink: () -> Unit = {}
 ) {
-  Column(if (onOpen == null) modifier else modifier.openable(onOpen)) {
+  if (onOpen == null) {
+    ObjectIdentityLines(className, typeName, objectId, modifier)
+    return
+  }
+  OpenTarget(onOpen, onCopyLink) {
+    ObjectIdentityLines(className, typeName, objectId, modifier.openable(onOpen))
+  }
+}
+
+/** The lines themselves, which are the same whether or not this name leads anywhere. */
+@Composable
+private fun ObjectIdentityLines(
+  className: String,
+  typeName: String?,
+  objectId: Long?,
+  modifier: Modifier
+) {
+  Column(modifier) {
     Text(
       // One line of text rather than two words side by side: what the object is reads as one phrase, and
       // anything that has to find this line by what it says — a test, a screen reader — finds one of it.

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
@@ -71,6 +71,8 @@ internal fun RootPathPanel(
   chosenWays: Map<Int, Int>,
   onChooseWay: (Int, Int) -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
+  /** Puts a link to a step's object on the clipboard, beside opening it. See [OpenTarget]. */
+  onCopyLink: (Long) -> Unit,
   modifier: Modifier = Modifier
 ) {
   val summary = (selection as? Selection.Object)?.summary
@@ -115,7 +117,8 @@ internal fun RootPathPanel(
       PathRootRow(
         nextStrength = drawn?.path?.steps?.firstOrNull()?.step?.strength
           ?: cutTail?.firstOrNull()?.step?.strength,
-        onOpen = onOpen
+        onOpen = onOpen,
+        onCopyLink = onCopyLink
       )
       if (drawn != null) {
         RootPathTrace(
@@ -124,7 +127,8 @@ internal fun RootPathPanel(
           ways = ways,
           chosenWays = chosenWays,
           onChooseWay = onChooseWay,
-          onOpen = onOpen
+          onOpen = onOpen,
+          onCopyLink = onCopyLink
         )
       } else {
         noChainText(selection, summary, isWholeHeapDump, rootPath, hasTail = cutTail != null)?.let {
@@ -176,7 +180,8 @@ private fun RootPathTrace(
   ways: Map<Int, List<RootPathWay>>,
   chosenWays: Map<Int, Int>,
   onChooseWay: (Int, Int) -> Unit,
-  onOpen: (Long, OpenIn) -> Unit
+  onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
 ) {
   val steps = drawn.path.steps
   Column(Modifier.fillMaxWidth()) {
@@ -195,6 +200,7 @@ private fun RootPathTrace(
         nextStrength = next?.step?.strength,
         stronglyReachableByteCount = stronglyReachableByteCount,
         onOpen = onOpen,
+        onCopyLink = onCopyLink,
         role = when {
           // The object the details panel is about, whatever the pointer has added below it.
           next == null -> PathRole.TARGET
@@ -236,6 +242,7 @@ private fun HoveredTail(
         stronglyReachableByteCount = stronglyReachableByteCount,
         // Nothing to click: the pointer is on the map, and it leaving the map is what takes this away.
         onOpen = { _, _ -> },
+        onCopyLink = {},
         role = when {
           // The end of a cut tail is the only object being described here, since the chain above it isn't
           // the way to it; the end of one that runs on is described by the card at the pointer instead.

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StarredScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/StarredScreen.kt
@@ -33,6 +33,8 @@ internal fun StarredScreen(
   /** What a retained size here is a share of. See [shark.explorer.HeapSizes.stronglyReachableByteCount]. */
   stronglyReachableByteCount: Long,
   onOpen: (Long, OpenIn) -> Unit,
+  /** Puts a link to a starred object on the clipboard, beside opening it. See [OpenTarget]. */
+  onCopyLink: (Long) -> Unit,
   onRemove: (Long) -> Unit,
   modifier: Modifier = Modifier
 ) {
@@ -48,7 +50,7 @@ internal fun StarredScreen(
       favourites.forEach { favourite ->
         Row(verticalAlignment = Alignment.CenterVertically) {
           Column(Modifier.weight(1f)) {
-            Inspectable(favourite.label, favourite.objectId, onOpen)
+            Inspectable(favourite.label, favourite.objectId, onOpen, onCopyLink)
             Text(favourite.className, style = MaterialTheme.typography.bodySmall)
             SelectionContainer {
               Text(hexObjectId(favourite.objectId), style = MaterialTheme.typography.bodySmall)

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
@@ -5,6 +5,8 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
@@ -52,6 +54,8 @@ internal fun TabStrip(
   titleOf: (Place) -> String,
   onSelect: (Int) -> Unit,
   onClose: (Int) -> Unit,
+  /** Puts a link to where the tab is on the clipboard. See [shark.explorer.DeepLink]. */
+  onCopyLink: (Place) -> Unit,
   modifier: Modifier = Modifier
 ) {
   if (tabs.tabs.isEmpty()) {
@@ -72,7 +76,8 @@ internal fun TabStrip(
           title = titleOf(tab.place),
           isSelected = tab.id == tabs.selectedId,
           onSelect = { onSelect(tab.id) },
-          onClose = { onClose(tab.id) }
+          onClose = { onClose(tab.id) },
+          onCopyLink = { onCopyLink(tab.place) }
         )
       }
     }
@@ -96,7 +101,8 @@ private fun TabView(
   title: String,
   isSelected: Boolean,
   onSelect: () -> Unit,
-  onClose: () -> Unit
+  onClose: () -> Unit,
+  onCopyLink: () -> Unit
 ) {
   // Starting closed and opening on the first composition, which is what makes this animate on the way in:
   // a tab that was already open when the strip drew it has nothing to animate.
@@ -111,41 +117,45 @@ private fun TabView(
       expandFrom = Alignment.Start
     ) + fadeIn(tween(TAB_OPEN_MILLIS))
   ) {
-    Row(
-      Modifier
-        .background(
-          if (isSelected) {
-            MaterialTheme.colorScheme.surface
-          } else {
-            MaterialTheme.colorScheme.surfaceVariant
-          }
+    // Where a tab is, is a place, and a place is a link — so the way to hand this tab to someone else is
+    // on the tab itself, next to the only other thing a tab does.
+    ContextMenuArea(items = { listOf(ContextMenuItem(COPY_LINK_TO_TAB, onCopyLink)) }) {
+      Row(
+        Modifier
+          .background(
+            if (isSelected) {
+              MaterialTheme.colorScheme.surface
+            } else {
+              MaterialTheme.colorScheme.surfaceVariant
+            }
+          )
+          // Middle clicking a tab closes it, which is the other half of middle clicking opening one.
+          .onClick(matcher = PointerMatcher.mouse(PointerButton.Tertiary)) { onClose() }
+          // Selectable rather than clickable, because a strip of these is a set with one of them on: it
+          // is also what tells a tab apart from the button and the chain row that lead to the same place.
+          .selectable(selected = isSelected, role = Role.Tab) { onSelect() }
+          .padding(start = 8.dp, end = 4.dp, top = 4.dp, bottom = 4.dp)
+          .widthIn(max = MAX_TAB_WIDTH),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        Text(
+          title,
+          style = MaterialTheme.typography.bodySmall,
+          fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier.weight(1f, fill = false)
         )
-        // Middle clicking a tab closes it, which is the other half of middle clicking opening one.
-        .onClick(matcher = PointerMatcher.mouse(PointerButton.Tertiary)) { onClose() }
-        // Selectable rather than clickable, because a strip of these is a set with one of them on: it
-        // is also what tells a tab apart from the button and the chain row that lead to the same place.
-        .selectable(selected = isSelected, role = Role.Tab) { onSelect() }
-        .padding(start = 8.dp, end = 4.dp, top = 4.dp, bottom = 4.dp)
-        .widthIn(max = MAX_TAB_WIDTH),
-      horizontalArrangement = Arrangement.spacedBy(4.dp),
-      verticalAlignment = Alignment.CenterVertically
-    ) {
-      Text(
-        title,
-        style = MaterialTheme.typography.bodySmall,
-        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        modifier = Modifier.weight(1f, fill = false)
-      )
-      // Its own click target rather than a modifier on the tab, so that closing a tab is never
-      // selecting it first: a strip where closing the fourth tab shows you the fourth tab is a strip
-      // that fights back.
-      Text(
-        CLOSE_TAB,
-        Modifier.clickable { onClose() }.padding(horizontal = 2.dp),
-        style = MaterialTheme.typography.bodySmall
-      )
+        // Its own click target rather than a modifier on the tab, so that closing a tab is never
+        // selecting it first: a strip where closing the fourth tab shows you the fourth tab is a strip
+        // that fights back.
+        Text(
+          CLOSE_TAB,
+          Modifier.clickable { onClose() }.padding(horizontal = 2.dp),
+          style = MaterialTheme.typography.bodySmall
+        )
+      }
     }
   }
 }
@@ -161,6 +171,14 @@ internal const val NO_TAB_OPEN =
 
 /** What closes a tab, on the tab: its own click target, so a test presses it rather than the tab. */
 internal const val CLOSE_TAB = "✕"
+
+/**
+ * What the right click menu on a tab offers.
+ *
+ * "Link" rather than "URL" because what it copies is one: it goes to this tab of this window, and following
+ * it puts the reader where this tab is rather than in front of the heap dump it belongs to.
+ */
+internal const val COPY_LINK_TO_TAB = "Copy link to this tab"
 
 /** Wide enough for a class name and an address, short enough that ten tabs are all still on the strip. */
 private val MAX_TAB_WIDTH = 220.dp

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
-import androidx.compose.foundation.ContextMenuArea
-import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
 import androidx.compose.foundation.background
@@ -118,8 +116,8 @@ private fun TabView(
     ) + fadeIn(tween(TAB_OPEN_MILLIS))
   ) {
     // Where a tab is, is a place, and a place is a link — so the way to hand this tab to someone else is
-    // on the tab itself, next to the only other thing a tab does.
-    ContextMenuArea(items = { listOf(ContextMenuItem(COPY_LINK_TO_TAB, onCopyLink)) }) {
+    // on the tab itself. The same item as on everything else that names a place: see [CopyLinkTarget].
+    CopyLinkTarget(onCopyLink) {
       Row(
         Modifier
           .background(
@@ -171,14 +169,6 @@ internal const val NO_TAB_OPEN =
 
 /** What closes a tab, on the tab: its own click target, so a test presses it rather than the tab. */
 internal const val CLOSE_TAB = "✕"
-
-/**
- * What the right click menu on a tab offers.
- *
- * "Link" rather than "URL" because what it copies is one: it goes to this tab of this window, and following
- * it puts the reader where this tab is rather than in front of the heap dump it belongs to.
- */
-internal const val COPY_LINK_TO_TAB = "Copy link to this tab"
 
 /** Wide enough for a class name and an address, short enough that ten tabs are all still on the strip. */
 private val MAX_TAB_WIDTH = 220.dp

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
@@ -43,6 +44,7 @@ import shark.ValueHolder.ReferenceHolder
 import shark.dump
 import shark.explorer.Adb
 import shark.explorer.AdbOutput
+import shark.explorer.DeepLink
 import shark.explorer.DeviceHeapDumps
 import shark.explorer.HeapDominatorTreemap
 import shark.explorer.HeapObjectKind
@@ -204,6 +206,24 @@ class ExplorerAppTest {
       assertThat(after.left).isGreaterThan(before.left)
       assertThat(after.top).isEqualTo(before.top)
       assertThat(after.contains(pointerAt(TREEMAP_X + POINTER_STEP, TREEMAP_Y))).isFalse()
+    }
+  }
+
+  @Test fun `the map's menu copies a link to the rectangle under the pointer`() {
+    val copied = mutableListOf<String>()
+    explorerUiTest {
+      openHeapDump(copyToClipboard = { copied += it })
+      hoverView(TREEMAP_X, TREEMAP_Y)
+      // The card naming the rectangle, which is how a test knows the pointer has settled on one: the menu
+      // acts on what is hovered, and nothing is until then.
+      waitUntilAtLeastOneExists(hasText(hexObjectId(payloadObjectId)), OPEN_TIMEOUT_MILLIS)
+
+      onRoot().performMouseInput { rightClick(pointerAt(TREEMAP_X, TREEMAP_Y)) }
+      onNodeWithText(COPY_LINK).performClick()
+
+      // Beside opening the rectangle in a tab of its own, which is the menu's other item: a link is the
+      // same move made somewhere else, so wherever one is offered so is the other.
+      assertThat(copied).containsExactly(DeepLink(WINDOW_ID, Place.Object(payloadObjectId)).toUri())
     }
   }
 
@@ -768,6 +788,7 @@ class ExplorerAppTest {
   private fun ComposeUiTest.setExplorerContent(
     heapDumpFile: File? = null,
     chooseHeapDumpFile: () -> File? = { null },
+    copyToClipboard: (String) -> Unit = {},
     // An `adb` that is connected to nothing, rather than the one on this machine: a test that shells out
     // has whatever devices happen to be plugged in to answer for.
     deviceHeapDumps: DeviceHeapDumps = DeviceHeapDumps(NO_DEVICE_ADB)
@@ -776,17 +797,22 @@ class ExplorerAppTest {
       var shown: File? by remember { mutableStateOf(heapDumpFile) }
       ExplorerApp(
         heapDumpFile = shown,
+        deepLinkId = WINDOW_ID,
         // No pixels to keep track of: nothing here takes a dump off a device, which is the only way
         // any come with one.
         onHeapDumpChosen = { file, _ -> shown = file },
+        copyToClipboard = copyToClipboard,
         chooseHeapDumpFile = chooseHeapDumpFile,
         deviceHeapDumps = deviceHeapDumps
       )
     }
   }
 
-  private fun ComposeUiTest.openHeapDump(heapDumpFile: File = testHeapDump()) {
-    setExplorerContent(heapDumpFile)
+  private fun ComposeUiTest.openHeapDump(
+    heapDumpFile: File = testHeapDump(),
+    copyToClipboard: (String) -> Unit = {}
+  ) {
+    setExplorerContent(heapDumpFile, copyToClipboard = copyToClipboard)
     waitForTheTree(OPEN_TIMEOUT_MILLIS)
   }
 
@@ -986,6 +1012,9 @@ class ExplorerAppTest {
 
     /** Opening a heap dump and rebuilding a tree both happen on another thread. */
     private const val OPEN_TIMEOUT_MILLIS = 10_000L
+
+    /** What a link copied here names this window by, fixed so that the copied link can be spelled out. */
+    private const val WINDOW_ID = "abcd2345"
 
     /** How the log says a treemap was laid out, and what it calls the node at the top of the tree. */
     private const val TREEMAP_LAID_OUT = "Read the treemap rooted at"

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerArgumentsTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerArgumentsTest.kt
@@ -4,6 +4,8 @@ import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import shark.explorer.DeepLink
+import shark.explorer.Place
 
 /** What a command line means, without launching anything: see [ExplorerArguments]. */
 class ExplorerArgumentsTest {
@@ -57,9 +59,35 @@ class ExplorerArgumentsTest {
       .hasMessageContaining("--titel=$TITLE")
   }
 
+  @Test fun `a link on the command line is a place to go and not a heap dump to open`() {
+    val arguments = ExplorerArguments.parse(listOf(LINK))
+
+    // Which is how Windows and Linux deliver one: the OS starts a process with the link on its command
+    // line, and a link taken for a path would be a window saying that file could not be read.
+    assertThat(arguments.deepLinks).containsExactly(DeepLink("abcd2345", Place.Starred))
+    assertThat(arguments.heapDumpFiles).isEmpty()
+  }
+
+  @Test fun `heap dumps and links can be asked for together`() {
+    val arguments = ExplorerArguments.parse(listOf("--title=$TITLE", FIRST_PATH, LINK))
+
+    assertThat(arguments.heapDumpFiles).containsExactly(File(FIRST_PATH))
+    assertThat(arguments.deepLinks).containsExactly(DeepLink("abcd2345", Place.Starred))
+    assertThat(arguments.titlePrefix).isEqualTo(TITLE)
+  }
+
+  @Test fun `a link nobody can read says what is wrong with it`() {
+    // Rather than being taken for a path, which would report a heap dump that could not be found and send
+    // whoever typed it looking for a file.
+    assertThatThrownBy { ExplorerArguments.parse(listOf("shark://abcd2345/dominators")) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("is no place")
+  }
+
   companion object {
     private const val FIRST_PATH = "first.hprof"
     private const val SECOND_PATH = "dumps/second.hprof"
     private const val TITLE = "Hover previews"
+    private const val LINK = "shark://abcd2345/starred"
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerWindowTest.kt
@@ -4,6 +4,8 @@ import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
+import shark.explorer.DeepLink
+import shark.explorer.Place
 
 /**
  * How many windows the app has and which heap dump each one shows. No heap dump is read here: a window
@@ -116,6 +118,87 @@ class ExplorerWindowTest {
       .containsExactly("$TITLE · ${FIRST_DUMP.name}", "$TITLE · ${SECOND_DUMP.name}")
   }
 
+  @Test fun `every window answers to an id of its own`() {
+    val windows = explorerWindows(opening(FIRST_DUMP, FIRST_DUMP))
+
+    // The whole reason a link names a window rather than a heap dump: the same dump open twice is two
+    // places to be, and a link has to lead to the one it was copied from.
+    assertThat(windows.map { it.deepLinkId }).doesNotHaveDuplicates()
+  }
+
+  @Test fun `a link goes to the window it names and to no other`() {
+    val windows = explorerWindows(opening(FIRST_DUMP, SECOND_DUMP))
+    val (first, second) = windows
+
+    windows.open(DeepLink(second.deepLinkId, Place.Starred))
+
+    assertThat(second.linkedPlaces).containsExactly(Place.Starred)
+    assertThat(first.linkedPlaces).isEmpty()
+    assertThat(windows).hasSize(2)
+  }
+
+  @Test fun `a place a link asked for is dropped once a tab has opened it`() {
+    val windows = explorerWindows(opening(FIRST_DUMP))
+    val window = windows.single()
+    windows.open(DeepLink(window.deepLinkId, Place.Leaks()))
+
+    window.linkedPlaceOpened(Place.Leaks())
+
+    // Otherwise every recomposition would open the tab again, which is what a link asked for once looking
+    // like a link followed forever would be.
+    assertThat(window.linkedPlaces).isEmpty()
+  }
+
+  @Test fun `two links are two tabs, in the order they arrived`() {
+    val windows = explorerWindows(opening(FIRST_DUMP))
+    val window = windows.single()
+
+    windows.open(DeepLink(window.deepLinkId, Place.Starred))
+    windows.open(DeepLink(window.deepLinkId, Place.Leaks()))
+
+    assertThat(window.linkedPlaces).containsExactly(Place.Starred, Place.Leaks())
+  }
+
+  @Test fun `a link to a window that has gone opens one saying so`() {
+    val windows = explorerWindows(opening(FIRST_DUMP))
+
+    windows.open(DeepLink(CLOSED_WINDOW_ID, Place.Starred))
+
+    // Rather than nothing at all, which is the one answer that can't be told from the app having failed
+    // to start — and a link is usually followed from somewhere that can't see either way.
+    assertThat(windows).hasSize(2)
+    assertThat(windows.last().deepLinkProblem).contains(CLOSED_WINDOW_ID)
+    assertThat(windows.last().heapDumpFile).isNull()
+    assertThat(logged).anyMatch { CLOSED_WINDOW_ID in it }
+  }
+
+  @Test fun `a window opened by a link that found nothing lands beside the others`() {
+    val windows = explorerWindows(opening(FIRST_DUMP, SECOND_DUMP))
+
+    windows.open(DeepLink(CLOSED_WINDOW_ID, Place.Starred))
+
+    assertThat(windows.map { it.cascade }).doesNotHaveDuplicates()
+  }
+
+  @Test fun `a window that gets a heap dump stops saying a link found nothing`() {
+    val windows = explorerWindows(noHeapDumps())
+    windows.open(DeepLink(CLOSED_WINDOW_ID, Place.Starred))
+    val empty = windows.last()
+
+    windows.openHeapDump(empty, FIRST_DUMP)
+
+    // The message was about this window having nothing in it, and now it has something in it.
+    assertThat(empty.deepLinkProblem).isNull()
+  }
+
+  @Test fun `a run knows which windows are its own`() {
+    val windows = explorerWindows(opening(FIRST_DUMP))
+
+    // What another run of this app asks before handing a link over. See [DeepLinkPeers].
+    assertThat(windows.holds(windows.single().deepLinkId)).isTrue()
+    assertThat(windows.holds(CLOSED_WINDOW_ID)).isFalse()
+  }
+
   private fun noHeapDumps(titlePrefix: String? = null) =
     ExplorerArguments(heapDumpFiles = emptyList(), titlePrefix = titlePrefix)
 
@@ -129,5 +212,8 @@ class ExplorerWindowTest {
     private val FIRST_DUMP = File("first.hprof")
     private val SECOND_DUMP = File("second.hprof")
     private const val TITLE = "Hover previews"
+
+    /** Shaped like one this run could have handed out, and belonging to no window of it. */
+    private const val CLOSED_WINDOW_ID = "qrst6789"
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeaksScreenTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeaksScreenTest.kt
@@ -158,7 +158,7 @@ class LeaksScreenTest {
     explorerUiTest {
       // Rendered from leaks rather than read off a heap dump: what is being pinned is how the two ends of a
       // leak are named, and a dump whose leaks have the shape to show it is a dump built for it.
-      setContent { MaterialTheme { LeaksScreen(TWO_ENDED_LEAKS, false, emptySet(), {}, { _, _ -> }) } }
+      setContent { MaterialTheme { LeaksScreen(TWO_ENDED_LEAKS, false, emptySet(), {}, { _, _ -> }, {}) } }
 
       // Both ends and a gap for what is between them, then the leak whose two ends are one reference. Each
       // ends on an arrow, because what it points at is the object on the row below.

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ObjectsScreenTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ObjectsScreenTest.kt
@@ -17,10 +17,13 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import java.io.File
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -29,6 +32,7 @@ import shark.ValueHolder.ReferenceHolder
 import shark.dump
 import shark.explorer.Adb
 import shark.explorer.AdbOutput
+import shark.explorer.DeepLink
 import shark.explorer.DeviceHeapDumps
 import shark.explorer.HeapObjectKind
 import shark.explorer.Place
@@ -124,11 +128,47 @@ class ObjectsScreenTest {
     }
   }
 
-  private fun ComposeUiTest.openHeapDump() {
+  @Test fun `a listed object can be opened in a tab of its own from its menu`() {
+    explorerUiTest {
+      openHeapDump()
+      listObjects()
+
+      onNodeWithText("java.lang.Object[] array").performMouseInput { rightClick() }
+      onNodeWithText(OPEN_IN_NEW_TAB).performClick()
+
+      // The gesture ⌘ clicking a row already had, spelled out in words: a row of a list is a way to an
+      // object like a rectangle of the map, so it answers the same menu.
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
+        onAllNodes(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Tab))
+          .fetchSemanticsNodes().size == 3
+      }
+    }
+  }
+
+  @Test fun `a listed object's menu copies a link to it`() {
+    val copied = mutableListOf<String>()
+    explorerUiTest {
+      openHeapDump(copyToClipboard = { copied += it })
+      listObjects()
+
+      onNodeWithText("java.lang.Object[] array").performMouseInput { rightClick() }
+      onNodeWithText(COPY_LINK).performClick()
+
+      // Beside "open in a new tab" wherever that is, this row included: the two are the same thought a
+      // step apart, and a link is how the object leaves this window at all.
+      assertThat(copied)
+        .containsExactly(DeepLink(WINDOW_ID, Place.Object(payloadObjectId)).toUri())
+    }
+  }
+
+  private fun ComposeUiTest.openHeapDump(copyToClipboard: (String) -> Unit = {}) {
+    val heapDumpFile = testHeapDump()
     setContent {
       MaterialTheme {
         ExplorerApp(
-          heapDumpFile = testHeapDump(),
+          heapDumpFile = heapDumpFile,
+          deepLinkId = WINDOW_ID,
+          copyToClipboard = copyToClipboard,
           // Nothing here opens a second heap dump, and which window one would land in is
           // `ExplorerWindowTest`'s.
           onHeapDumpChosen = { _, _ -> },
@@ -184,6 +224,9 @@ class ObjectsScreenTest {
     private const val OPEN_TIMEOUT_MILLIS = 10_000L
 
     private const val TREEMAP_LAID_OUT = "Read the treemap rooted at"
+
+    /** What a link copied here names this window by, fixed so that the copied link can be spelled out. */
+    private const val WINDOW_ID = "abcd2345"
 
     /** An `adb` that answers as if nothing were plugged in, so no test here reaches a real device. */
     private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
@@ -1,6 +1,9 @@
 package shark.explorer.app
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -19,6 +22,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
@@ -30,6 +34,7 @@ import shark.ValueHolder.ReferenceHolder
 import shark.dump
 import shark.explorer.Adb
 import shark.explorer.AdbOutput
+import shark.explorer.DeepLink
 import shark.explorer.DeviceHeapDumps
 import shark.explorer.HeapDominatorTreemap
 import shark.explorer.Place
@@ -166,6 +171,52 @@ class TabStripTest {
     }
   }
 
+  @Test fun `right clicking a tab copies a link to where that tab is`() {
+    val copied = mutableListOf<String>()
+    explorerUiTest {
+      openHeapDump(copyToClipboard = { copied += it })
+
+      tab(HeapDominatorTreemap.ROOT_LABEL).performMouseInput { rightClick() }
+      onNodeWithText(COPY_LINK_TO_TAB).performClick()
+
+      // The window rather than the heap dump, because the same dump open twice is two places to be —
+      // and the tab's own place, so that following it lands where it was copied from. See [DeepLink].
+      assertThat(copied).containsExactly(DeepLink(WINDOW_ID, Place.wholeHeapDump()).toUri())
+    }
+  }
+
+  @Test fun `a tab copied and followed leads back to the object it was on`() {
+    val copied = mutableListOf<String>()
+    explorerUiTest {
+      openHeapDump(copyToClipboard = { copied += it })
+      clickTheArray()
+      waitUntilAtLeastOneExists(hasText(tabTitleOfTheArray()), OPEN_TIMEOUT_MILLIS)
+
+      tab(tabTitleOfTheArray()).performMouseInput { rightClick() }
+      onNodeWithText(COPY_LINK_TO_TAB).performClick()
+
+      // Where a link is copied from is wherever the tab has been moved to, not where it opened: a tab is
+      // read in, and the object worth sending someone is the one being looked at when they are sent it.
+      assertThat(DeepLink.parse(copied.single()).place).isEqualTo(Place.Object(payloadObjectId))
+    }
+  }
+
+  @Test fun `a link opens the place it names in a tab of its own, in front`() {
+    explorerUiTest {
+      var asked by mutableStateOf(emptyList<Place>())
+      openHeapDump(linkedPlaces = { asked }, onLinkedPlaceOpened = { asked = asked - it })
+
+      asked = listOf(Place.Starred)
+
+      // Always another tab, never the one open: a link is somewhere else to look, and closing what
+      // someone was reading to show them it is the one thing a link should not do.
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { tabs().fetchSemanticsNodes().size == 2 }
+      tab(Place.STARRED_LABEL).assertIsSelected()
+      // And taken as it opens, so that the next frame doesn't open it again.
+      assertThat(asked).isEmpty()
+    }
+  }
+
   /** Clicks the array, which covers almost the whole treemap, with the given mouse button. */
   private fun ComposeUiTest.clickTheArray(button: MouseButton = MouseButton.Primary) {
     val view = onNodeWithContentDescription(VIEW_DESCRIPTION).fetchSemanticsNode().boundsInRoot
@@ -194,13 +245,25 @@ class TabStripTest {
   private fun isButton(): SemanticsMatcher =
     SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
 
-  private fun ComposeUiTest.openHeapDump() {
+  private fun ComposeUiTest.openHeapDump(
+    /** Read inside the composition, so that a test can ask for a place once the window is up. */
+    linkedPlaces: () -> List<Place> = { emptyList() },
+    onLinkedPlaceOpened: (Place) -> Unit = {},
+    copyToClipboard: (String) -> Unit = {}
+  ) {
+    // Written before the composition rather than in it: every recomposition would write it again, and
+    // the second one fails rather than returning the file the window is already reading.
+    val heapDumpFile = testHeapDump()
     setContent {
       MaterialTheme {
         ExplorerApp(
-          heapDumpFile = testHeapDump(),
+          heapDumpFile = heapDumpFile,
           onHeapDumpChosen = { _, _ -> },
-          deviceHeapDumps = DeviceHeapDumps(NO_DEVICE_ADB)
+          deviceHeapDumps = DeviceHeapDumps(NO_DEVICE_ADB),
+          deepLinkId = WINDOW_ID,
+          linkedPlaces = linkedPlaces(),
+          onLinkedPlaceOpened = onLinkedPlaceOpened,
+          copyToClipboard = copyToClipboard
         )
       }
     }
@@ -247,6 +310,9 @@ class TabStripTest {
      * comfortably past what a line holds rather than exactly it.
      */
     private const val TABS_PAST_ONE_LINE = 20
+
+    /** What a link copied here names this window by, fixed so that the copied link can be spelled out. */
+    private const val WINDOW_ID = "abcd2345"
 
     /** An `adb` that answers as if nothing were plugged in, so no test here reaches a real device. */
     private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/TabStripTest.kt
@@ -177,7 +177,7 @@ class TabStripTest {
       openHeapDump(copyToClipboard = { copied += it })
 
       tab(HeapDominatorTreemap.ROOT_LABEL).performMouseInput { rightClick() }
-      onNodeWithText(COPY_LINK_TO_TAB).performClick()
+      onNodeWithText(COPY_LINK).performClick()
 
       // The window rather than the heap dump, because the same dump open twice is two places to be —
       // and the tab's own place, so that following it lands where it was copied from. See [DeepLink].
@@ -193,11 +193,27 @@ class TabStripTest {
       waitUntilAtLeastOneExists(hasText(tabTitleOfTheArray()), OPEN_TIMEOUT_MILLIS)
 
       tab(tabTitleOfTheArray()).performMouseInput { rightClick() }
-      onNodeWithText(COPY_LINK_TO_TAB).performClick()
+      onNodeWithText(COPY_LINK).performClick()
 
       // Where a link is copied from is wherever the tab has been moved to, not where it opened: a tab is
       // read in, and the object worth sending someone is the one being looked at when they are sent it.
       assertThat(DeepLink.parse(copied.single()).place).isEqualTo(Place.Object(payloadObjectId))
+    }
+  }
+
+  @Test fun `right clicking a button on the bar copies a link to the screen it opens`() {
+    val copied = mutableListOf<String>()
+    explorerUiTest {
+      openHeapDump(copyToClipboard = { copied += it })
+
+      screenButton(Place.LEAKS_LABEL).performMouseInput { rightClick() }
+      onNodeWithText(COPY_LINK).performClick()
+
+      // A button opens a screen nobody has been to yet, and a link to it is that screen as it opens: no
+      // tab has to be opened first to have something to copy.
+      assertThat(copied).containsExactly(DeepLink(WINDOW_ID, Place.Leaks()).toUri())
+      // And nothing was opened by asking for the link, which a menu that clicked the button would have.
+      assertThat(tabs().fetchSemanticsNodes()).hasSize(1)
     }
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DeepLink.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DeepLink.kt
@@ -1,0 +1,262 @@
+package shark.explorer
+
+import java.net.URLDecoder
+import java.net.URLEncoder
+import kotlin.random.Random
+
+/**
+ * A link to one place in one open window: `shark://<window>/<place>?<what that place needs>`.
+ *
+ * The point of it is that anything on screen can be handed to someone else — or printed by a script or an
+ * agent — as one line of text that puts them in front of it. So every [Place] has a spelling here, and the
+ * spellings carry the whole of the place rather than a shorthand for it: a filtered list of objects arrives
+ * filtered, and a page of leaks arrives with the same ones unfolded.
+ *
+ * **It names a window and not a heap dump.** The same dump is often open twice — that is what comparing two
+ * of them is — so a path would be ambiguous exactly when it matters. A [windowId] is not ambiguous, and it
+ * also settles what a link means once the window is gone: nothing, which is the honest answer, rather than
+ * the same object in whichever other window happened to have that file open.
+ *
+ * Immutable and in this module rather than in the UI, so that what a link means is unit tested rather than
+ * found out by clicking one. See [Place].
+ */
+data class DeepLink(
+  /** Which open window answers to this link. See [newWindowId]. */
+  val windowId: String,
+  val place: Place
+) {
+
+  /** The link as text, which is what gets copied, printed and pasted. */
+  fun toUri(): String {
+    val parameters = place.linkParameters()
+    val query = if (parameters.isEmpty()) {
+      ""
+    } else {
+      "?" + parameters.joinToString("&") { (name, value) -> "${encode(name)}=${encode(value)}" }
+    }
+    return "$SCHEME://$windowId/${place.linkPath()}$query"
+  }
+
+  companion object {
+
+    /**
+     * Ours, and short because it is typed and pasted by hand: no application on this machine claimed it and
+     * it is not one of the schemes IANA has registered.
+     */
+    const val SCHEME = "shark"
+
+    /** Whether [argument] is a link rather than a heap dump path, which is all a command line has to ask. */
+    fun looksLikeOne(argument: String): Boolean = argument.startsWith(PREFIX)
+
+    /**
+     * A window id: eight lowercase characters, from an alphabet with no `l`, `1`, `o` or `0` in it so that a
+     * link read off a screen and typed back in is the link that was read.
+     *
+     * Random rather than counted up, which is not a detail. Ids handed out in order would repeat across
+     * runs, so a link copied yesterday would open *something* today — the second window of this run rather
+     * than the window it was made from — and be wrong without saying so. A random id is either the window it
+     * names or no window at all, and the second of those is an error message.
+     */
+    fun newWindowId(random: Random = Random.Default): String =
+      (1..WINDOW_ID_LENGTH).map { ID_ALPHABET[random.nextInt(ID_ALPHABET.length)] }.joinToString("")
+
+    /**
+     * Reads a link, or throws [IllegalArgumentException] saying what is wrong with it.
+     *
+     * Thrown rather than returned as a null, and worded for whoever typed it, because every one of these
+     * arrives from outside the app: a command line, another run of it, or the OS handing over a URL somebody
+     * pasted into a browser. Same shape as `ExplorerArguments.parse`, for the same reason.
+     */
+    fun parse(uri: String): DeepLink {
+      require(looksLikeOne(uri)) {
+        "A link starts with \"$PREFIX\", and this one is \"$uri\". ${usage()}"
+      }
+      val afterScheme = uri.substring(PREFIX.length)
+      val query = afterScheme.substringAfter('?', "")
+      val segments = afterScheme.substringBefore('?').split('/').filter { it.isNotEmpty() }
+      require(segments.size == 2) {
+        "A link is a window and a place, \"$PREFIX<window>/<place>\", and \"$uri\" names " +
+          "${segments.size} of the two. ${usage()}"
+      }
+      return DeepLink(windowId = segments[0], place = placeOf(segments[1], parseQuery(query), uri))
+    }
+
+    private fun placeOf(
+      path: String,
+      parameters: List<Pair<String, String>>,
+      uri: String
+    ): Place = when (path) {
+      OBJECT_PATH -> Place.Object(parameters.nodeId(ID_PARAMETER, uri))
+      SMALLER_OBJECTS_PATH -> Place.SmallerObjects(
+        parentObjectId = parameters.nodeId(PARENT_PARAMETER, uri),
+        nodeCount = parameters.required(COUNT_PARAMETER, uri).toIntOrThrow(COUNT_PARAMETER, uri),
+        byteCount = parameters.required(BYTES_PARAMETER, uri).toLongOrThrow(BYTES_PARAMETER, uri)
+      )
+      OBJECTS_PATH -> Place.Objects(
+        ObjectListFilter(
+          query = parameters.firstOrNull(QUERY_PARAMETER).orEmpty(),
+          isExactMatch = parameters.firstOrNull(EXACT_PARAMETER).toBoolean(),
+          // Absent means every kind, which is the filter a list opens with. Present and empty is a filter
+          // matching nothing, which the checkboxes can also be put into, so the two can't be merged.
+          kinds = parameters.firstOrNull(KINDS_PARAMETER)?.parseKinds(uri)
+            ?: HeapObjectKind.values().toSet()
+        )
+      )
+      LEAKS_PATH -> Place.Leaks(parameters.all(EXPANDED_PARAMETER).toSet())
+      STARRED_PATH -> Place.Starred
+      else -> throw IllegalArgumentException("\"$path\" is no place of \"$uri\". ${usage()}")
+    }
+
+    /**
+     * What every message about a bad link ends with, so that it says what to type instead.
+     *
+     * A function rather than a constant because it reads a constant declared below it, and a companion
+     * object's properties are initialised in the order they are written.
+     */
+    private fun usage(): String = "A place is one of ${PLACE_PATHS.joinToString(", ")}."
+
+    private fun String.parseKinds(uri: String): Set<HeapObjectKind> =
+      split(',').filter { it.isNotEmpty() }.map { name ->
+        HeapObjectKind.values().firstOrNull { it.name == name }
+          ?: throw IllegalArgumentException(
+            "\"$name\" is no object kind of \"$uri\". Kinds are " +
+              HeapObjectKind.values().joinToString(", ") { it.name } + "."
+          )
+      }.toSet()
+
+    private fun parseQuery(query: String): List<Pair<String, String>> =
+      if (query.isEmpty()) {
+        emptyList()
+      } else {
+        query.split('&').filter { it.isNotEmpty() }.map { parameter ->
+          decode(parameter.substringBefore('=')) to decode(parameter.substringAfter('=', ""))
+        }
+      }
+
+    private fun List<Pair<String, String>>.firstOrNull(name: String): String? =
+      firstOrNull { it.first == name }?.second
+
+    private fun List<Pair<String, String>>.all(name: String): List<String> =
+      filter { it.first == name }.map { it.second }
+
+    private fun List<Pair<String, String>>.required(
+      name: String,
+      uri: String
+    ): String = firstOrNull(name)
+      ?: throw IllegalArgumentException("\"$uri\" needs a \"$name\" to say which place it is.")
+
+    /**
+     * A node id as a link writes one: `0x` and the whole 64 bits, unsigned.
+     *
+     * Not [hexObjectId], which masks an id down to its low 32 bits so that an object of a 32 bit dump reads
+     * the way every other tool writes it. That is right for a label and wrong here — a link has to come back
+     * as the id it was made from, and a tree's nodes run the full range of [Long]: the uncollected garbage
+     * and the class piles sit at the bottom of it, and an object above the 2 GB mark of a 32 bit dump is
+     * negative. See [HeapDominatorTreemap.isPileId].
+     */
+    private fun List<Pair<String, String>>.nodeId(
+      name: String,
+      uri: String
+    ): Long {
+      val text = required(name, uri)
+      return try {
+        java.lang.Long.parseUnsignedLong(text.removePrefix(HEX_PREFIX), HEX_RADIX)
+      } catch (notANumber: NumberFormatException) {
+        throw IllegalArgumentException(
+          "\"$name\" of \"$uri\" is \"$text\", which is no object id. An object id is \"$HEX_PREFIX\" " +
+            "and up to 16 hexadecimal digits."
+        )
+      }
+    }
+
+    private fun String.toIntOrThrow(
+      name: String,
+      uri: String
+    ): Int = toIntOrNull()
+      ?: throw IllegalArgumentException("\"$name\" of \"$uri\" is \"$this\", which is no whole number.")
+
+    private fun String.toLongOrThrow(
+      name: String,
+      uri: String
+    ): Long = toLongOrNull()
+      ?: throw IllegalArgumentException("\"$name\" of \"$uri\" is \"$this\", which is no whole number.")
+
+    private fun encode(value: String): String = URLEncoder.encode(value, CHARSET)
+
+    private fun decode(value: String): String = URLDecoder.decode(value, CHARSET)
+
+    /** Spelled as a name because the [java.nio.charset.Charset] overloads are Java 10, and this is Java 8. */
+    private const val CHARSET = "UTF-8"
+
+    private const val PREFIX = "$SCHEME://"
+
+    private const val WINDOW_ID_LENGTH = 8
+
+    /** No `l`, `1`, `o` or `0`: a window id is read off a screen and typed back in often enough to care. */
+    private const val ID_ALPHABET = "abcdefghijkmnpqrstuvwxyz23456789"
+
+    internal const val OBJECT_PATH = "object"
+    internal const val SMALLER_OBJECTS_PATH = "smaller-objects"
+    internal const val OBJECTS_PATH = "objects"
+    internal const val LEAKS_PATH = "leaks"
+    internal const val STARRED_PATH = "starred"
+
+    private val PLACE_PATHS =
+      listOf(OBJECT_PATH, SMALLER_OBJECTS_PATH, OBJECTS_PATH, LEAKS_PATH, STARRED_PATH)
+
+    internal const val ID_PARAMETER = "id"
+    internal const val PARENT_PARAMETER = "parent"
+    internal const val COUNT_PARAMETER = "count"
+    internal const val BYTES_PARAMETER = "bytes"
+    internal const val QUERY_PARAMETER = "query"
+    internal const val EXACT_PARAMETER = "exact"
+    internal const val KINDS_PARAMETER = "kinds"
+    internal const val EXPANDED_PARAMETER = "expanded"
+
+    internal const val HEX_PREFIX = "0x"
+    private const val HEX_RADIX = 16
+  }
+}
+
+/** Which of the five a place is written as. The other half of `DeepLink.placeOf`, and it has to stay so. */
+private fun Place.linkPath(): String = when (this) {
+  is Place.Object -> DeepLink.OBJECT_PATH
+  is Place.SmallerObjects -> DeepLink.SMALLER_OBJECTS_PATH
+  is Place.Objects -> DeepLink.OBJECTS_PATH
+  is Place.Leaks -> DeepLink.LEAKS_PATH
+  is Place.Starred -> DeepLink.STARRED_PATH
+}
+
+/**
+ * Everything the place needs beyond which of the five it is.
+ *
+ * What is at its default is left out, so that the link to a list nobody has filtered is `…/objects` and not
+ * that plus three empty answers. The sets are written in a fixed order rather than in theirs, so that one
+ * tab always gives the same link — a link that changed between two copies of it would be one nobody could
+ * compare, or test.
+ */
+private fun Place.linkParameters(): List<Pair<String, String>> = when (this) {
+  is Place.Object -> listOf(DeepLink.ID_PARAMETER to linkNodeId(objectId))
+  is Place.SmallerObjects -> listOf(
+    DeepLink.PARENT_PARAMETER to linkNodeId(parentObjectId),
+    DeepLink.COUNT_PARAMETER to nodeCount.toString(),
+    DeepLink.BYTES_PARAMETER to byteCount.toString()
+  )
+  is Place.Objects -> buildList {
+    if (filter.query.isNotEmpty()) {
+      add(DeepLink.QUERY_PARAMETER to filter.query)
+    }
+    if (filter.isExactMatch) {
+      add(DeepLink.EXACT_PARAMETER to true.toString())
+    }
+    if (filter.kinds != HeapObjectKind.values().toSet()) {
+      add(DeepLink.KINDS_PARAMETER to filter.kinds.sortedBy { it.ordinal }.joinToString(",") { it.name })
+    }
+  }
+  is Place.Leaks -> expandedGroups.sorted().map { DeepLink.EXPANDED_PARAMETER to it }
+  is Place.Starred -> emptyList()
+}
+
+/** The exact 64 bits, unsigned, which is what `DeepLink.nodeId` reads back. */
+private fun linkNodeId(nodeId: Long): String =
+  DeepLink.HEX_PREFIX + java.lang.Long.toUnsignedString(nodeId, 16)

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
@@ -83,7 +83,7 @@ sealed interface Place {
   }
 
   /** The objects starred so far, kept so that two of them can be compared. */
-  object Starred : Place {
+  data object Starred : Place {
 
     override val title: String get() = STARRED_LABEL
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/DeepLinkTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/DeepLinkTest.kt
@@ -1,0 +1,233 @@
+package shark.explorer
+
+import kotlin.random.Random
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+
+class DeepLinkTest {
+
+  @Test
+  fun `link to an object names the window and the object`() {
+    val link = DeepLink("abcd2345", Place.Object(0x12ab34cd))
+
+    assertThat(link.toUri()).isEqualTo("shark://abcd2345/object?id=0x12ab34cd")
+  }
+
+  @Test
+  fun `link to an object is read back as the object`() {
+    assertThat(DeepLink.parse("shark://abcd2345/object?id=0x12ab34cd"))
+      .isEqualTo(DeepLink("abcd2345", Place.Object(0x12ab34cd)))
+  }
+
+  /**
+   * The whole heap dump is [HeapDominatorTreemap.ROOT_OBJECT_ID], which is no address, and the uncollected
+   * garbage and the class piles are at the very bottom of [Long]. A link to any of them is a link to a tab
+   * somebody has open, so all of them have to survive the trip.
+   */
+  @Test
+  fun `every node id survives being written and read back`() {
+    val nodeIds = listOf(
+      HeapDominatorTreemap.ROOT_OBJECT_ID,
+      HeapDominatorTreemap.UNREACHABLE_NODE_ID,
+      HeapDominatorTreemap.UNREACHABLE_NODE_ID + 1,
+      Long.MAX_VALUE,
+      -1L,
+      // An object above the 2 GB mark of a 32 bit heap dump, which shark widens by sign.
+      Int.MIN_VALUE.toLong(),
+      -2112345088L
+    )
+
+    nodeIds.forEach { nodeId ->
+      val link = DeepLink("abcd2345", Place.Object(nodeId))
+      assertThat(DeepLink.parse(link.toUri()).place)
+        .describedAs(link.toUri())
+        .isEqualTo(Place.Object(nodeId))
+    }
+  }
+
+  /**
+   * [hexObjectId] masks an id down to its low 32 bits so a label reads the way other tools write an address.
+   * A link cannot do that: two different nodes would come back as one.
+   */
+  @Test
+  fun `a negative object id is not written the way a label writes it`() {
+    val link = DeepLink("abcd2345", Place.Object(-2112345088L)).toUri()
+
+    assertThat(link).isEqualTo("shark://abcd2345/object?id=0xffffffff82182c00")
+    // Which is 0x82182c00 on a label, and that is a different node of the tree.
+    assertThat(link).doesNotContain(hexObjectId(-2112345088L))
+  }
+
+  @Test
+  fun `link to a pile of smaller objects carries what the pile is`() {
+    val place = Place.SmallerObjects(parentObjectId = 0x40, nodeCount = 42, byteCount = 9876)
+
+    assertThat(DeepLink("abcd2345", place).toUri())
+      .isEqualTo("shark://abcd2345/smaller-objects?parent=0x40&count=42&bytes=9876")
+    assertThat(DeepLink.parse(DeepLink("abcd2345", place).toUri()).place).isEqualTo(place)
+  }
+
+  @Test
+  fun `link to an unfiltered object list is the list and nothing else`() {
+    assertThat(DeepLink("abcd2345", Place.Objects()).toUri()).isEqualTo("shark://abcd2345/objects")
+  }
+
+  @Test
+  fun `an object list arrives filtered the way it was left`() {
+    val place = Place.Objects(
+      ObjectListFilter(
+        query = "android.graphics.Bitmap",
+        isExactMatch = true,
+        kinds = setOf(HeapObjectKind.INSTANCE, HeapObjectKind.CLASS)
+      )
+    )
+
+    val uri = DeepLink("abcd2345", place).toUri()
+
+    assertThat(uri).isEqualTo(
+      "shark://abcd2345/objects?query=android.graphics.Bitmap&exact=true&kinds=CLASS%2CINSTANCE"
+    )
+    assertThat(DeepLink.parse(uri).place).isEqualTo(place)
+  }
+
+  /** Unchecking every kind is a list showing nothing, which is a state the checkboxes can be left in. */
+  @Test
+  fun `an object list filtered to no kind at all is not an unfiltered one`() {
+    val place = Place.Objects(ObjectListFilter(kinds = emptySet()))
+
+    val uri = DeepLink("abcd2345", place).toUri()
+
+    assertThat(uri).isEqualTo("shark://abcd2345/objects?kinds=")
+    assertThat(DeepLink.parse(uri).place).isEqualTo(place)
+  }
+
+  /** A query is typed by hand, so it holds spaces, `&` and every other character a URL is built from. */
+  @Test
+  fun `a query full of the characters a URL is made of survives`() {
+    val query = "com.example a&b=c?d/e#f+g%h"
+    val place = Place.Objects(ObjectListFilter(query = query))
+
+    assertThat(DeepLink.parse(DeepLink("abcd2345", place).toUri()).place).isEqualTo(place)
+  }
+
+  @Test
+  fun `leaks arrive with the same ones unfolded`() {
+    val place = Place.Leaks(expandedGroups = setOf("APPLICATION 12ab", "LIBRARY 34cd"))
+
+    val uri = DeepLink("abcd2345", place).toUri()
+
+    assertThat(uri)
+      .isEqualTo("shark://abcd2345/leaks?expanded=APPLICATION+12ab&expanded=LIBRARY+34cd")
+    assertThat(DeepLink.parse(uri).place).isEqualTo(place)
+  }
+
+  @Test
+  fun `leaks with nothing unfolded is the page and nothing else`() {
+    assertThat(DeepLink("abcd2345", Place.Leaks()).toUri()).isEqualTo("shark://abcd2345/leaks")
+    assertThat(DeepLink.parse("shark://abcd2345/leaks").place).isEqualTo(Place.Leaks())
+  }
+
+  @Test
+  fun `starred is a place with nothing to say about it`() {
+    assertThat(DeepLink("abcd2345", Place.Starred).toUri()).isEqualTo("shark://abcd2345/starred")
+    assertThat(DeepLink.parse("shark://abcd2345/starred").place).isEqualTo(Place.Starred)
+  }
+
+  /**
+   * The one that has to keep being true as places are added: every [Place] is reachable by link, which is
+   * the whole promise. A place with no spelling here fails this rather than being found out by clicking one.
+   */
+  @Test
+  fun `every place survives being written and read back`() {
+    val places = listOf(
+      Place.wholeHeapDump(),
+      Place.Object(0x12ab34cd),
+      Place.SmallerObjects(parentObjectId = 0x40, nodeCount = 42, byteCount = 9876),
+      Place.Objects(),
+      Place.Objects(ObjectListFilter(query = "Bitmap", isExactMatch = true)),
+      Place.Leaks(),
+      Place.Leaks(expandedGroups = setOf("APPLICATION 12ab")),
+      Place.Starred
+    )
+
+    places.forEach { place ->
+      val uri = DeepLink("abcd2345", place).toUri()
+      assertThat(DeepLink.parse(uri).place).describedAs(uri).isEqualTo(place)
+    }
+  }
+
+  /** Two copies of one tab's link are compared and pasted next to each other, so they have to be one string. */
+  @Test
+  fun `a place is always written the same way`() {
+    val place = Place.Leaks(expandedGroups = setOf("LIBRARY 34cd", "APPLICATION 12ab"))
+    val sameOtherWayRound = Place.Leaks(expandedGroups = setOf("APPLICATION 12ab", "LIBRARY 34cd"))
+
+    assertThat(DeepLink("abcd2345", place).toUri())
+      .isEqualTo(DeepLink("abcd2345", sameOtherWayRound).toUri())
+  }
+
+  @Test
+  fun `something that is not a link says so`() {
+    assertThatThrownBy { DeepLink.parse("https://example.com/object?id=0x1") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("starts with \"shark://\"")
+  }
+
+  @Test
+  fun `a link naming no place says which places there are`() {
+    assertThatThrownBy { DeepLink.parse("shark://abcd2345") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("object, smaller-objects, objects, leaks, starred")
+  }
+
+  @Test
+  fun `a link to a place this app has no screen for says so`() {
+    assertThatThrownBy { DeepLink.parse("shark://abcd2345/dominators") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("\"dominators\" is no place")
+  }
+
+  @Test
+  fun `an object link with no object says what is missing`() {
+    assertThatThrownBy { DeepLink.parse("shark://abcd2345/object") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("needs a \"id\"")
+  }
+
+  @Test
+  fun `an object id that is not one says so`() {
+    assertThatThrownBy { DeepLink.parse("shark://abcd2345/object?id=the+big+one") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("which is no object id")
+  }
+
+  @Test
+  fun `an object kind this app has never heard of says which kinds there are`() {
+    assertThatThrownBy { DeepLink.parse("shark://abcd2345/objects?kinds=WIDGETS") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Kinds are CLASS, INSTANCE, OBJECT_ARRAY, PRIMITIVE_ARRAY")
+  }
+
+  @Test
+  fun `a window id is eight characters of an alphabet nothing can be misread in`() {
+    val ids = (1..200).map { DeepLink.newWindowId(Random(it)) }
+
+    assertThat(ids).allMatch { it.length == 8 }
+    assertThat(ids.joinToString("")).matches("[abcdefghijkmnpqrstuvwxyz23456789]+")
+  }
+
+  @Test
+  fun `two windows do not get one id`() {
+    val ids = (1..1000).map { DeepLink.newWindowId() }
+
+    assertThat(ids.toSet()).hasSize(ids.size)
+  }
+
+  @Test
+  fun `a link tells itself apart from a heap dump path`() {
+    assertThat(DeepLink.looksLikeOne("shark://abcd2345/starred")).isTrue()
+    assertThat(DeepLink.looksLikeOne("/Users/me/dumps/shark.hprof")).isFalse()
+    assertThat(DeepLink.looksLikeOne("--title=Reading a leak")).isFalse()
+  }
+}


### PR DESCRIPTION
Right click a tab → **Copy link to this tab** → a `shark://` URL. Click it anywhere — a chat message, an issue, a terminal — and Shark Explorer comes to the front with that place open in a new tab.

```
shark://vugs93jp/object?id=0x7f2a4b18
shark://vugs93jp/objects?query=Bitmap&exact=true
shark://vugs93jp/leaks?expanded=<group>
shark://vugs93jp/starred
```

Every `Place` has a spelling, and it carries the whole place rather than a shorthand: a filtered object list arrives filtered, a page of leaks arrives with the same groups unfolded. So any state the app can be in is reachable through a link — which is the point, since the next user of this is a tool or an agent printing "here is what I found" as a URL rather than as directions.

## A link names a window, not a heap dump

The same dump open twice is what comparing two of them is, so a path would be ambiguous exactly when it matters. A window id is not, and it also settles what a link means once the window has gone: nothing. Following one then opens an empty window saying so, rather than the same object in whichever other window happened to have that file open.

A link always opens a tab of its own and never replaces what was being read.

## How each OS delivers one

| | Told that `shark://` is ours | How the URL arrives |
| --- | --- | --- |
| macOS | `CFBundleURLTypes` in the packaged `Info.plist` | Apple Event into the running process, via `Desktop.setOpenURIHandler` |
| Windows | `HKCU\Software\Classes\shark`, written on first run | A new process with the URL on its command line |
| Linux | `~/.local/share/applications/shark-explorer.desktop`, written on first run | Same |

For the two that start a process per link, `DeepLinkPeers` is how that process reaches the run that has the window: every run publishes a loopback port and a token under `~/.shark-explorer/runs`, and a run holding a link asks each of the others in turn. **Deliberately not single-instance** — several explorers open at once, one per piece of work, is how this app is used, and making the second run hand its command line to the first and exit would take that away. Nobody is in charge and nothing breaks when any of them is killed.

The macOS handler goes through the same peers, because one installed app is handed every `shark://` link on the machine, including ones naming a window of a run from source.

All of the OS end is best effort: every failure is one line in the log, never a refusal to start.

## Tested

- `DeepLinkTest` — 23 tests over the URL itself: every place round-trips, every synthetic node id (`ROOT_OBJECT_ID`, `UNREACHABLE_NODE_ID`, pile ids, `Long.MAX_VALUE`, negatives), URL-hostile query text, deterministic output, and each error message. Node ids are the exact unsigned 64 bits rather than `hexObjectId`, which masks to the low 32.
- `ExplorerWindowTest` — 8 more: a link reaches only the window it names, a place is dropped once its tab opens, two links are two tabs in order, a link to a window that has gone opens one saying so and it lands beside the others.
- `ExplorerArgumentsTest`, `TabStripTest` — a link on the command line is not a heap dump path; right clicking a tab copies the link to where that tab *is*; a link opens a tab of its own, in front.
- **End to end on macOS, from a `createDistributable` build**: `open "shark://<id>/leaks"`, the filtered object list, starred, and a link to a closed window, all read back out of the run's log file.

Windows and Linux could not be tried from here, so those two are best effort.

## Only macOS could be verified, and here is why the other loop matters

`shark/shark-explorer/AGENTS.md` gains a section on it: **a JVM launched from a shell script registers with LaunchServices as `net.java.openjdk.java` whatever its wrapper's plist says**, so no link ever reaches a `./gradlew run` or `runNamed`. Only a `jpackage` launcher gets its own bundle identity. Anything about links is a package, not a compile — the section has the loop, and says to read the result out of the log rather than off the screen, since following a link raises the app over whatever the person at the machine was doing.