### PR TITLE
Take a note on any tab, in markdown that knows the heap dump

### DIFF
--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -27,3 +27,5 @@ uses, without the one for a newly recognized library leak:
   that have one. Class names, addresses and `shark://` links written in a note become links back into
   the window, shortened to read as prose, and GitHub URLs are shortened the way GitHub shortens them.
   See [Take notes](shark-explorer.md#take-notes).
+* ✨ Right click ← or → for the list of everywhere that arrow leads, so going back four moves is one
+  click rather than four.

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -23,3 +23,7 @@ uses, without the one for a newly recognized library leak:
   `shark://` link to it, beside opening it in a new tab. Clicking one brings the app to the front and
   opens that place in a new tab: an object, a filtered object list, the leaks with the same groups
   unfolded. See [Link to a tab](shark-explorer.md#link-to-a-tab).
+* ✨ **Notes**: every tab takes a markdown note, kept between runs, and the tab strip marks the tabs
+  that have one. Class names, addresses and `shark://` links written in a note become links back into
+  the window, shortened to read as prose, and GitHub URLs are shortened the way GitHub shortens them.
+  See [Take notes](shark-explorer.md#take-notes).

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -23,10 +23,10 @@ uses, without the one for a newly recognized library leak:
   `shark://` link to it, beside opening it in a new tab. Clicking one brings the app to the front and
   opens that place in a new tab: an object, a filtered object list, the leaks with the same groups
   unfolded. See [Link to a tab](shark-explorer.md#link-to-a-tab).
-* ✨ **Notes**: every object takes a markdown note, kept between runs, and the tab strip marks the tabs
-  whose object has one. A note is the object's rather than the tab's, so two tabs on one object are one
-  note. Class names, addresses and `shark://` links written in a note become links back into the window,
-  shortened to read as prose, and GitHub URLs are shortened the way GitHub shortens them.
+* ✨ **Notes**: every location takes a markdown note, kept between runs, and the tab strip marks the tabs
+  whose location has one. A note belongs to the location rather than to the tab, so two tabs on one
+  location are one note. Class names, addresses and `shark://` links written in a note become links back
+  into the window, shortened to read as prose, and GitHub URLs are shortened the way GitHub shortens them.
   See [Take notes](shark-explorer.md#take-notes).
 * ✨ Right click ← or → for the list of everywhere that arrow leads, so going back four moves is one
   click rather than four.

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -23,9 +23,10 @@ uses, without the one for a newly recognized library leak:
   `shark://` link to it, beside opening it in a new tab. Clicking one brings the app to the front and
   opens that place in a new tab: an object, a filtered object list, the leaks with the same groups
   unfolded. See [Link to a tab](shark-explorer.md#link-to-a-tab).
-* ✨ **Notes**: every tab takes a markdown note, kept between runs, and the tab strip marks the tabs
-  that have one. Class names, addresses and `shark://` links written in a note become links back into
-  the window, shortened to read as prose, and GitHub URLs are shortened the way GitHub shortens them.
+* ✨ **Notes**: every object takes a markdown note, kept between runs, and the tab strip marks the tabs
+  whose object has one. A note is the object's rather than the tab's, so two tabs on one object are one
+  note. Class names, addresses and `shark://` links written in a note become links back into the window,
+  shortened to read as prose, and GitHub URLs are shortened the way GitHub shortens them.
   See [Take notes](shark-explorer.md#take-notes).
 * ✨ Right click ← or → for the list of everywhere that arrow leads, so going back four moves is one
   click rather than four.

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -57,6 +57,9 @@ a few seconds.
   there in this tab, middle click or ⌘/Ctrl click to open it in a tab behind this one, right click for a
   menu offering both that and a link to the object. The buttons along the top always open a new tab, and
   every tab can be closed — including the last, which leaves the heap dump open and the buttons ready.
+* **← and → walk the tab's own history**, so a tab you wandered off in is one click from where it was.
+  **Right click either arrow** for the list of everywhere it leads: picking the fourth entry is one click
+  rather than four.
 * **The three panes are resizable, and each folds away to a button.** A chain thirty steps long or a
   details panel of forty fields is sometimes worth the whole window.
 * **Shape** switches between rectangles and rings. A ring has room for fewer children, so it groups the

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -70,7 +70,7 @@ a few seconds.
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
-* Every object takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
+* Every location takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
 
 ## Link to a tab
 
@@ -104,19 +104,20 @@ link.
 
 ## Take notes
 
-**✎ Add Note**, under the title saying what the tab is on, starts a markdown note about **that object** —
-or about the list of leaks, the object list, the starred objects, or the heap dump as a whole on the tab a
-window opens with. Type into the box, press **Save**, and the note is drawn where the box was; **Cancel**
-throws what you typed away. It is there again the next time you open that object, and the tab strip puts a ✎
-on the tabs whose object has one.
+**✎ Add Note**, under the title saying where the tab is, starts a markdown note about **that location** —
+an object, the object list, the leaks, the starred objects, or the heap dump as a whole on the tab a window
+opens with. Type into the box, press **Save**, and the note is drawn where the box was; **Cancel** throws what
+you typed away. It is there again the next time you are at that location, and the tab strip puts a ✎ on the
+tabs whose location has one.
 
-A note is the **object's**, not the tab's: two tabs on one object are one note, and so are two windows on one
-heap dump. Which is why writing about an object you got to twice is adding to what you already wrote rather
-than starting again beside it, and why the same is true of the note you left there last week.
+A note belongs to the **location**, not to the tab: two tabs on one location are one note, and so are two
+windows on one heap dump. Which is why writing about an object you got to twice adds to what you already wrote
+rather than starting again beside it, and why the same is true of the note you left there last week. To throw a
+note away, open it, delete the text and **Save**: an empty note is no note, and the ✎ comes off the tab.
 
 The note appears under that row and above the panes, because it is about the whole of what the tab is showing.
-On an object nobody has written about there is nothing there at all — only the button, which goes away once
-there is a note, since the note carries its own **✎ Edit**.
+Where nobody has written anything there is nothing there at all — only the button, which goes away once there
+is a note, since the note carries its own **✎ Edit**.
 
 The notes live in `~/.shark-explorer/notes`, one directory per heap dump and one `.md` file per tab, so a
 note can be opened in an editor, pasted into an issue, or read by an agent without going through this app.
@@ -139,8 +140,8 @@ Headings, lists, quotes, `code`, **bold**, *italic*, fenced code blocks and `[li
 all work, and **one line is one line**: no blank line needed between two of them, the way a comment box on
 GitHub reads markdown. Nothing inside a fenced code block is linked or shortened.
 
-A note is filed under what its tab is *about* rather than how it is arranged, so searching in the object list
-or unfolding a leak stays on the same note rather than starting a new one.
+A location is *where* you are rather than how it is arranged, so searching in the object list, unfolding a leak
+or resizing the window stays on the same note rather than starting a new one.
 
 Since a `shark://` link names a window, a link written into a note stops working once that window is closed
 — see above. Copy one for the tab you want to come back to *while you are writing about it*, and it will

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -67,6 +67,7 @@ a few seconds.
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
+* Every tab takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
 
 ## Link to a tab
 
@@ -97,6 +98,47 @@ so. A link never replaces what you were reading: it always opens a tab of its ow
 Links reach the app from an installed build — the installer is what tells the OS that `shark://` is this
 app's. A copy run from source can still be linked to from another one, but the OS won't start it for a
 link.
+
+## Take notes
+
+**✎ Add Note**, at the end of the row that says where the tab is, starts a markdown note about the tab you
+are on — this object, this list of leaks, or the heap dump itself on the tab a window opens with. Type into
+the box, press **Save**, and the note is drawn where the box was; **Cancel** throws what you typed away. It
+is there again the next time you open that tab, and the tab strip puts a ✎ on the tabs you have written
+about.
+
+A note appears under that row and above the panes, because it is about the whole of what the tab is showing.
+On a tab nobody has written about there is nothing there at all — only the button, which goes away once
+there is a note, since the note carries its own **✎ Edit**.
+
+The notes live in `~/.shark-explorer/notes`, one directory per heap dump and one `.md` file per tab, so a
+note can be opened in an editor, pasted into an issue, or read by an agent without going through this app.
+
+You type plain markdown — nothing is reformatted as you go — and once it is saved, **anything in it that
+this heap dump recognises becomes a way back into the window**:
+
+| What you write | What it reads as | What clicking it does |
+| --- | --- | --- |
+| `com.example.MyApp$Cache` | `MyApp$Cache` | Opens that class in a new tab |
+| `0x7f2a4b18` | `Cache instance (0x7f2a4b18)` | Opens that object in a new tab |
+| `shark://vugs93jp/leaks` | `Leaks` | Follows the link, like clicking it anywhere else |
+| `https://github.com/square/leakcanary/issues/2841` | `square/leakcanary#2841` | Opens it in your browser |
+
+A name or an address this dump has nothing for is left exactly as you typed it: a class this heap dump has
+never heard of is a class you wrote about, not a broken link. Which is also how the notes stay readable
+outside the app — nothing is rewritten on disk, only on screen.
+
+Headings, lists, quotes, `code`, **bold**, *italic*, fenced code blocks and `[links](https://example.com)`
+all work, and **one line is one line**: no blank line needed between two of them, the way a comment box on
+GitHub reads markdown. Nothing inside a fenced code block is linked or shortened.
+
+A note is filed under what its tab is *about* rather than how it is arranged: searching in the object list
+or unfolding a leak stays on the same note, and the same object opened in two tabs, or in two windows, is
+one note rather than two saving over each other.
+
+Since a `shark://` link names a window, a link written into a note stops working once that window is closed
+— see above. Copy one for the tab you want to come back to *while you are writing about it*, and it will
+take you there for as long as that window is open.
 
 ## Reporting a problem
 

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -70,7 +70,7 @@ a few seconds.
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
-* Every tab takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
+* Every object takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
 
 ## Link to a tab
 
@@ -104,14 +104,18 @@ link.
 
 ## Take notes
 
-**✎ Add Note**, at the end of the row that says where the tab is, starts a markdown note about the tab you
-are on — this object, this list of leaks, or the heap dump itself on the tab a window opens with. Type into
-the box, press **Save**, and the note is drawn where the box was; **Cancel** throws what you typed away. It
-is there again the next time you open that tab, and the tab strip puts a ✎ on the tabs you have written
-about.
+**✎ Add Note**, under the title saying what the tab is on, starts a markdown note about **that object** —
+or about the list of leaks, the object list, the starred objects, or the heap dump as a whole on the tab a
+window opens with. Type into the box, press **Save**, and the note is drawn where the box was; **Cancel**
+throws what you typed away. It is there again the next time you open that object, and the tab strip puts a ✎
+on the tabs whose object has one.
 
-A note appears under that row and above the panes, because it is about the whole of what the tab is showing.
-On a tab nobody has written about there is nothing there at all — only the button, which goes away once
+A note is the **object's**, not the tab's: two tabs on one object are one note, and so are two windows on one
+heap dump. Which is why writing about an object you got to twice is adding to what you already wrote rather
+than starting again beside it, and why the same is true of the note you left there last week.
+
+The note appears under that row and above the panes, because it is about the whole of what the tab is showing.
+On an object nobody has written about there is nothing there at all — only the button, which goes away once
 there is a note, since the note carries its own **✎ Edit**.
 
 The notes live in `~/.shark-explorer/notes`, one directory per heap dump and one `.md` file per tab, so a
@@ -135,9 +139,8 @@ Headings, lists, quotes, `code`, **bold**, *italic*, fenced code blocks and `[li
 all work, and **one line is one line**: no blank line needed between two of them, the way a comment box on
 GitHub reads markdown. Nothing inside a fenced code block is linked or shortened.
 
-A note is filed under what its tab is *about* rather than how it is arranged: searching in the object list
-or unfolding a leak stays on the same note, and the same object opened in two tabs, or in two windows, is
-one note rather than two saving over each other.
+A note is filed under what its tab is *about* rather than how it is arranged, so searching in the object list
+or unfolding a leak stays on the same note rather than starting a new one.
 
 Since a `shark://` link names a window, a link written into a note stops working once that window is closed
 — see above. Copy one for the tab you want to come back to *while you are writing about it*, and it will

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -477,6 +477,10 @@ numbers belong in `notes/bitmaps.md`.
   checking in binary fixtures or hand-writing hprof bytes. A dump with bitmaps in it is `BitmapDumps.kt`
   in `shark-explorer-core`'s tests — the `"a.b.C" instance { }` shorthand declares a class per instance,
   so two bitmaps built that way are two `android.graphics.Bitmap` classes, which no real dump has.
+- **A UI test that opens a note must pass an `ExplorerNotes` over a temporary directory.** `ExplorerApp`'s
+  default keeps notes in `~/.shark-explorer/notes`, so a test taking it writes into the notes of whoever is
+  running it. A window that never opens one only lists that directory to see which tabs to mark, which is
+  why the tests that don't touch notes need no directory of their own.
 - **A UI test must pass a `DeviceHeapDumps` built on a fake `Adb`.** `ExplorerApp`'s default shells out to
   the machine's `adb`, so a test that takes it has whatever device is plugged in to answer for — and the
   window can dump the heap of a real process. `FakeAdb` matches command prefixes, because the remote dump

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -676,6 +676,93 @@ Zooming, resizing and switching shape move the rectangles rather than the pointe
 follows at all, so each view remembers where the pointer is and works out what it is on again whenever it
 is laid out anew.
 
+## A note belongs to the tab, and the names in it are links
+
+Every tab takes a note, rather than the notes being a screen of their own. A note is written while reading an
+object and it is about that object, so it belongs where the object is: a note you have to leave the object to
+write is one written about however much of it you can still remember, and a note that isn't in front of you
+when you come back to the object is one you forgot you had.
+
+**Between the row that says where the tab is and the panes that read it**, because a note is about the whole
+of what the tab is showing: under the title it is about, above everything that describes it. At the foot of
+the window it read as a note on whichever pane happened to be above it, which is a note about the details
+panel or about the chain rather than about the object.
+
+**Filed under what the tab is about, not under the tab.** `Place.noteKey()` is the whole of that distinction.
+A place carries the state of its screen as well as its subject — what the object list is filtered to, which
+leaks are unfolded, how many objects a pile of small ones stands for at this window width — and all of that
+changes while reading. Keyed on the place itself, a note would follow the search box: typing a letter into it
+would be moving to a different notepad, and the note just written would be filed under a half typed query
+nobody will run again. So one note per object, one for the object list however it is filtered, one for the
+leaks however they are unfolded. It also means a tab is not an identity a note can hang off: two tabs on one
+object are one note, which is the same reason two windows on one dump are.
+
+The note about the heap dump as a whole goes on the tab a window opens with, which is the whole dump as an
+object like any other — so there is somewhere to write the story that isn't about one object without adding a
+screen for it.
+
+**Two states and no fold**: writing is a plain box with save and cancel, written is the note as it means, and
+there is no third state, because a tab nobody has written about has no section at all. What starts one is a
+button in the row above (`AddNoteButton`), which goes away as soon as there is a note — one way in on screen
+at a time, and nothing spent on the tabs that will never have one, which is most of them. A note that exists
+is simply on screen, so there is nothing to fold and nothing to remember folding: a note behind a button is a
+note nobody remembers is there. The strip marks a tab that has one with a `✎` for the same reason — what makes
+notes worth writing is the window saying which objects you have already worked something out about. Which tabs
+those are is one directory listing (`NoteDirectory.keysWithNotes`) rather than a file opened per tab, since it
+is a question about the whole strip.
+
+Which is also why **the window reads the file rather than the section**: whether there is a section at all is
+the answer to that read, so a section that started it could only ever appear after itself.
+
+**What makes a note worth keeping is that the names in it lead back into the window.** A note is mostly made
+of things out of the heap dump — a class, an address, a link to the tab you were on — and typing those out
+again as prose is what makes notes not worth writing. So `Note.of(text)` leaves every dotted name and every
+`0x…` as a `NoteMention`, `HeapDominatorTreemap.referencesOf` asks the dump what they are, and
+`Note.resolvedWith` turns the ones it recognises into links shortened to read as prose. What it doesn't
+recognise stays exactly as typed: a class this dump has never heard of is a class somebody wrote about.
+
+- **Parsed and resolved on save.** The box takes plain text while it is being typed — markdown is what gets
+  typed there, and a box that reformats it as you go is a box arguing with you — so there is nothing to draw
+  until there is something saved, and the resolve, which is a heap dump read, is one per save rather than one
+  per pause in the typing. It only runs at all for a note that mentions something.
+- **Resolving is idempotent**, because a note is resolved again every time the dump answers: what is drawn is
+  built from the mention rather than from what the span is showing now.
+- **An address is two `Long`s.** A 32 bit dump's ids are four bytes widened by sign, so `0x82182c00` is
+  either that or the negative id `hexObjectId` prints as `0x82182c00`, and only the dump says which.
+- **A `shark://` link keeps its link and gains a name.** Resolving a mention never replaces a link that is
+  already there, so a link to an object reads as that object and still leads to the window it names —
+  followed exactly the way one arriving from the OS is, which is what makes the same link work in a note, a
+  chat message and an issue. A note outlives the window, so most of them are dead links a run later: that is
+  the honest answer, and it is the same empty window a stale link opens anywhere else.
+- **Inline code is still read for mentions, a fenced block is not.** `` `com.example.Thing` `` is how anyone
+  who writes markdown writes a class name; a fenced block is quoted rather than written.
+- **One line is one block.** No two-space line endings, no blank line above a list. A note is written in
+  lines, and this is how GitHub's comment box reads them.
+
+**One notepad per place per run, not per window.** The same dump open in two windows is how two views of it
+are compared, and two notepads over one file would have each window saving over the other's note with neither
+ever showing the loss. `ExplorerNotes` is one per run, hands out one `HeapDumpNotes` per dump and one
+`PlaceNotes` per place, so typing in one window shows up in the other.
+
+**Saving is a button, and the draft is the run's.** Nothing is written until save, and cancel throws the draft
+away: a box with those two buttons under it is a promise about which of the two happens, and an autosave with
+a cancel button beside it is neither. What an autosave was covering is the typing somebody clicked away from,
+which is why the draft lives in `PlaceNotes` — the run's notepad for that place — rather than in the section:
+leaving the tab half way through a sentence and coming back finds the sentence. A draft is not filed when the
+window closes either, which is the answer cancel gives and the same one. Nothing is saved until the file has
+been read — an empty notepad because the disk was slow, written out, is a note deleted — and the button that
+starts a note is disabled until then for the same reason. The save itself is `NonCancellable`, since the
+section that asked for it is gone the moment the draft is.
+
+**Markdown files in `~/.shark-explorer/notes`, a directory per dump.** Not beside the heap dump: dumps are
+opened from device pulls, temporary files, read only mounts and checkouts of this repository, so writing there
+means littering some and failing on the rest. Markdown, because a note about a leak ends up in an issue or
+read by an agent more often than it is read here again. The directory is the dump's name plus a hash of the
+directory it was in, since two runs of one app produce two `heap.hprof`s and they are two investigations;
+inside it, a file per `noteKey` rather than one document with a section per place, so that a save touches only
+the note that was typed into, nothing has to be parsed back out of a document that also holds somebody's own
+headings, and the listing is the index.
+
 ## Testing split
 
 Headless `runComposeUiTest` on the JVM covers the UI, so there's no emulator in the loop — a real

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -661,6 +661,13 @@ itself: on that row the name is what the whole window is about, while everywhere
 mention of an object among others. At body size it read as one more label in a bar of them, and a window
 whose subject is the smallest question on screen is one you have to hunt for the answer in.
 
+**That row is two things with a rule between them**: how the tab got here — the arrows — and what it is on,
+which is the title and, at the end of it, what the notes offer. Without the rule it is one undifferentiated
+strip of controls, and a button at the far end of that reads as belonging to the window rather than to the
+object named beside it; with it, the grouping is what says which, and nothing has to be labelled to say so.
+`IntrinsicSize.Min` on the row is what makes the rule as tall as the row itself, the title being one line on
+the whole heap dump and three on an object.
+
 **An address is printed as hex, everywhere.** A decimal object id matches nothing: `hexObjectId` is what
 `shark-cli`, a leak trace and every other tool print, so it is what can be pasted between them.
 
@@ -722,6 +729,15 @@ is a question about the whole strip.
 
 Which is also why **the window reads the file rather than the section**: whether there is a section at all is
 the answer to that read, so a section that started it could only ever appear after itself.
+
+**Why the button is at the end of that row**, of the four places it could be: before the title puts the action
+ahead of its subject, and makes the title's own position depend on whether a note exists. Hugging the end of
+the title moves it on every click, the title being the object the tab is on — a control that moves is one you
+have to look for, and a control at an edge is one you learn once. Under the title reads best, since it is
+where the note itself will appear, but it is a row of window spent on every tab, which is the whole thing
+being avoided. The end of the row keeps the reading order, keeps one position whatever the title says, and
+costs nothing: leading subject, trailing action. It is drawn at the size of the buttons above it rather than
+smaller, too — the one thing on screen that says notes exist should not be the smallest text in the row.
 
 **What makes a note worth keeping is that the names in it lead back into the window.** A note is mostly made
 of things out of the heap dump — a class, an address, a link to the tab you were on — and typing those out

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -692,17 +692,22 @@ Zooming, resizing and switching shape move the rectangles rather than the pointe
 follows at all, so each view remembers where the pointer is and works out what it is on again whenever it
 is laid out anew.
 
-## A note belongs to the object, and the names in it are links
+## A note belongs to the place, and the names in it are links
 
-Every object takes a note, rather than the notes being a screen of their own. A note is written while reading
-an object and it is about that object, so it belongs where the object is: a note you have to leave the object
-to write is one written about however much of it you can still remember, and a note that isn't in front of you
-when you come back to the object is one you forgot you had.
+Every place takes a note, rather than the notes being a screen of their own. A note is written while reading an
+object and it is about that object, so it belongs where the object is: a note you have to leave the object to
+write is one written about however much of it you can still remember, and a note that isn't in front of you when
+you come back to the object is one you forgot you had.
 
-**The object's, not the tab's**, and the distinction is worth stating because every surface of this is drawn on
-a tab: two tabs on one object are one note, and both show what the other is typing, since `ExplorerNotes` hands
-out one `PlaceNotes` per place per run. A tab is a way of looking at an object and there can be several at once;
-what a note is about is the object.
+**The place's, not the tab's**, and the distinction is worth stating because every surface of this is drawn on a
+tab: two tabs on one place are one note, and both show what the other is typing, since `ExplorerNotes` hands out
+one `PlaceNotes` per place per run. A tab is a way of looking at a place and there can be several at once; what
+a note is about is the place.
+
+**And a place, not an object** — the word matters in the other direction too. Three of the keys are lists rather
+than objects, one is a group of objects, and the tab a window opens with is the whole dump; "a note per object"
+reads as if the object list and the leaks had none. The user facing word for it is *location*, since `Place` is
+this codebase's rather than anybody else's.
 
 **Between the row that says where the tab is and the panes that read it**, because a note is about the whole
 of what the tab is showing: under the title it is about, above everything that describes it. At the foot of
@@ -723,12 +728,12 @@ object like any other — so there is somewhere to write the story that isn't ab
 screen for it.
 
 **Two states and no fold**: writing is a plain box with save and cancel, written is the note as it means, and
-there is no third state, because an object nobody has written about has no section at all. What starts one is a
+there is no third state, because a place nobody has written about has no section at all. What starts one is a
 button under the title (`AddNoteButton`), which goes away as soon as there is a note — one way in on screen
-at a time, and nothing spent on the objects that will never have one, which is most of them. A note that exists
+at a time, and nothing spent on the places that will never have one, which is most of them. A note that exists
 is simply on screen, so there is nothing to fold and nothing to remember folding: a note behind a button is a
 note nobody remembers is there. The strip marks a tab that has one with a `✎` for the same reason — what makes
-notes worth writing is the window saying which objects you have already worked something out about. Which tabs
+notes worth writing is the window saying where you have already worked something out. Which tabs
 those are is one directory listing (`NoteDirectory.keysWithNotes`) rather than a file opened per tab, since it
 is a question about the whole strip.
 

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -662,11 +662,11 @@ mention of an object among others. At body size it read as one more label in a b
 whose subject is the smallest question on screen is one you have to hunt for the answer in.
 
 **That row is two things with a rule between them**: how the tab got here — the arrows — and what it is on,
-which is the title and, at the end of it, what the notes offer. Without the rule it is one undifferentiated
-strip of controls, and a button at the far end of that reads as belonging to the window rather than to the
-object named beside it; with it, the grouping is what says which, and nothing has to be labelled to say so.
+which is the title with what the notes offer under it. Without the rule it is one undifferentiated strip of
+controls, and anything at the end of that reads as belonging to the window rather than to the object named
+beside it; with it, the grouping is what says which, and nothing has to be labelled to say so.
 `IntrinsicSize.Min` on the row is what makes the rule as tall as the row itself, the title being one line on
-the whole heap dump and three on an object.
+the whole heap dump and three on an object, with or without a button under it.
 
 **An address is printed as hex, everywhere.** A decimal object id matches nothing: `hexObjectId` is what
 `shark-cli`, a leak trace and every other tool print, so it is what can be pasted between them.
@@ -692,12 +692,17 @@ Zooming, resizing and switching shape move the rectangles rather than the pointe
 follows at all, so each view remembers where the pointer is and works out what it is on again whenever it
 is laid out anew.
 
-## A note belongs to the tab, and the names in it are links
+## A note belongs to the object, and the names in it are links
 
-Every tab takes a note, rather than the notes being a screen of their own. A note is written while reading an
-object and it is about that object, so it belongs where the object is: a note you have to leave the object to
-write is one written about however much of it you can still remember, and a note that isn't in front of you
+Every object takes a note, rather than the notes being a screen of their own. A note is written while reading
+an object and it is about that object, so it belongs where the object is: a note you have to leave the object
+to write is one written about however much of it you can still remember, and a note that isn't in front of you
 when you come back to the object is one you forgot you had.
+
+**The object's, not the tab's**, and the distinction is worth stating because every surface of this is drawn on
+a tab: two tabs on one object are one note, and both show what the other is typing, since `ExplorerNotes` hands
+out one `PlaceNotes` per place per run. A tab is a way of looking at an object and there can be several at once;
+what a note is about is the object.
 
 **Between the row that says where the tab is and the panes that read it**, because a note is about the whole
 of what the tab is showing: under the title it is about, above everything that describes it. At the foot of
@@ -718,9 +723,9 @@ object like any other — so there is somewhere to write the story that isn't ab
 screen for it.
 
 **Two states and no fold**: writing is a plain box with save and cancel, written is the note as it means, and
-there is no third state, because a tab nobody has written about has no section at all. What starts one is a
-button in the row above (`AddNoteButton`), which goes away as soon as there is a note — one way in on screen
-at a time, and nothing spent on the tabs that will never have one, which is most of them. A note that exists
+there is no third state, because an object nobody has written about has no section at all. What starts one is a
+button under the title (`AddNoteButton`), which goes away as soon as there is a note — one way in on screen
+at a time, and nothing spent on the objects that will never have one, which is most of them. A note that exists
 is simply on screen, so there is nothing to fold and nothing to remember folding: a note behind a button is a
 note nobody remembers is there. The strip marks a tab that has one with a `✎` for the same reason — what makes
 notes worth writing is the window saying which objects you have already worked something out about. Which tabs
@@ -730,14 +735,22 @@ is a question about the whole strip.
 Which is also why **the window reads the file rather than the section**: whether there is a section at all is
 the answer to that read, so a section that started it could only ever appear after itself.
 
-**Why the button is at the end of that row**, of the four places it could be: before the title puts the action
-ahead of its subject, and makes the title's own position depend on whether a note exists. Hugging the end of
-the title moves it on every click, the title being the object the tab is on — a control that moves is one you
-have to look for, and a control at an edge is one you learn once. Under the title reads best, since it is
-where the note itself will appear, but it is a row of window spent on every tab, which is the whole thing
-being avoided. The end of the row keeps the reading order, keeps one position whatever the title says, and
-costs nothing: leading subject, trailing action. It is drawn at the size of the buttons above it rather than
-smaller, too — the one thing on screen that says notes exist should not be the smallest text in the row.
+**What a note can do is said in the box, not in the tooltip on the button.** A tooltip is read while deciding
+whether to click, and a paragraph about markdown, class names, addresses and `shark://` links is in the way of
+that decision; the same paragraph is exactly what is wanted once the box is open and empty, which is where the
+placeholder is. So the button's hint says what clicking it does and stops.
+
+**Why the button is under the title**, of the four places it could be: before the title puts the action ahead
+of its subject, and makes the title's own position depend on whether a note exists. Hugging the end of the
+title moves it on every click, the title being the object the tab is on. At the far end of the row it keeps one
+position, but it is then as far from the title as the window is wide, and it read as the window's button rather
+than as this object's. Under the title it is where its own result goes — the note opens exactly there — and it
+reads in the order it happens: this object, then write about it.
+
+What that costs is a line of every tab nobody has written about, which is why it is drawn small: `bodySmall` at
+`ADD_NOTE_HEIGHT`, with no padding of its own, so that it starts where the title starts and adds a line rather
+than a row. A `TextButton` still, rather than a clickable line of text, because it is an action and the role is
+what a screen reader and a test tell it by.
 
 **What makes a note worth keeping is that the names in it lead back into the window.** A note is mostly made
 of things out of the heap dump — a class, an address, a link to the tab you were on — and typing those out

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -656,6 +656,11 @@ rest of that panel — which object, as against what that object holds — and i
 chain are both about, so it belongs between them. So the panel names no object of its own: it starts with
 the star and the numbers.
 
+**And it is set in a title there**, `nameStyle` being how `ObjectIdentity` takes a style it doesn't pick
+itself: on that row the name is what the whole window is about, while everywhere else the same lines are a
+mention of an object among others. At body size it read as one more label in a bar of them, and a window
+whose subject is the smallest question on screen is one you have to hunt for the answer in.
+
 **An address is printed as hex, everywhere.** A decimal object id matches nothing: `hexObjectId` is what
 `shark-cli`, a leak trace and every other tool print, so it is what can be pasted between them.
 

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -189,7 +189,11 @@ the only part that is words, and it is what makes the other two findable.
 seconds reading, and the bar above is one click from a tab again — closing tabs is never closing the dump,
 which is the window's, see above. A tab's history is its own rather than the window's, or the back arrow
 would walk out of the tab being read. And a tab id is counted up rather than reused, so a tab closed and
-another opened are two tabs rather than one that changed its mind.
+another opened are two tabs rather than one that changed its mind. **Right clicking an arrow lists that
+history**, nearest first, because reading a heap dump is a dozen moves down into something and one move back
+out: `NavigationHistory.backEntries` and `goBack(steps)` are that list and the click on the fourth entry of
+it, and a click on an entry the history has since moved past is clamped rather than refused, the list and the
+history being the same value one recomposition apart.
 
 **A tab's name is a read of the heap dump**, class name plus address, because a strip of a dozen instances
 of one class is only one you can pick out of if each tab says which instance it is. So the strip scrolls

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerNotes.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerNotes.kt
@@ -1,0 +1,247 @@
+package shark.explorer.app
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import shark.SharkLog
+import shark.explorer.Note
+import shark.explorer.NoteDirectory
+import shark.explorer.NoteFile
+import shark.explorer.Place
+import shark.explorer.noteKey
+
+/**
+ * The notes of every heap dump this run has open.
+ *
+ * Per run rather than per window, like [UpdateNotice], and for a sharper reason than that one: **the same
+ * heap dump is often open in two windows**, that being how two views of it are compared, and two notepads
+ * over one file would mean each window saving over the other's notes without either of them ever showing
+ * the loss. One notepad shared by both windows can't do that, and typing in one shows up in the other.
+ *
+ * Plain state rather than a composable's, so that it can be handed to a window and to a test. See
+ * `notes/decisions.md`.
+ */
+internal class ExplorerNotes(private val root: File = NOTES_DIRECTORY) {
+
+  private val byDirectory = mutableMapOf<String, HeapDumpNotes>()
+
+  /** The notes about [heapDumpFile], the same ones every time they are asked for. */
+  fun of(heapDumpFile: File): HeapDumpNotes = synchronized(byDirectory) {
+    val directory = NoteDirectory(root, heapDumpFile)
+    byDirectory.getOrPut(directory.directory.path) { HeapDumpNotes(directory) }
+  }
+
+  companion object {
+    /** Beside the logs and the published runs, which is everything else this app keeps between runs. */
+    private val NOTES_DIRECTORY = File(SHARK_EXPLORER_DIRECTORY, "notes")
+  }
+}
+
+/**
+ * What has been written about one heap dump: a note per place, and which places have one.
+ *
+ * Which places have one is here rather than in each note because it is a question about every tab at once —
+ * whether the strip marks it — and answering it by opening a file per tab would be a read per tab per
+ * recomposition. One directory listing answers it for all of them. See [NoteDirectory.keysWithNotes].
+ */
+@Stable
+internal class HeapDumpNotes(private val directory: NoteDirectory) {
+
+  private val byPlace = mutableMapOf<String, PlaceNotes>()
+
+  /**
+   * The places with something written about them, as [noteKey] keys.
+   *
+   * From the directory to start with, and from each save after that: what the mark on a tab means is that
+   * there is a note to come back to, so a draft nobody has saved yet is not one.
+   */
+  var writtenAbout: Set<String> by mutableStateOf(emptySet())
+    private set
+
+  private var isListed = false
+
+  /** Whether [place] has a note, which is what puts a mark on its tab. */
+  fun hasNote(place: Place): Boolean = place.noteKey() in writtenAbout
+
+  /** What has been written about [place], the same notepad every time it is asked for. */
+  fun of(place: Place): PlaceNotes = synchronized(byPlace) {
+    val key = place.noteKey()
+    byPlace.getOrPut(key) {
+      PlaceNotes(
+        noteFile = directory.noteFile(place),
+        onSavedChanged = { hasNote -> written(key, hasNote) }
+      )
+    }
+  }
+
+  /**
+   * Reads which places have a note, once per run of the app.
+   *
+   * Off the UI thread, because it is a directory listing: on a machine where the disk has gone away, not a
+   * fast one. A listing that fails leaves no tab marked, which is the same as the notes not being there —
+   * a window that can't reach them says so where it matters, which is when one is opened. See [PlaceNotes].
+   */
+  suspend fun list() {
+    if (isListed) {
+      return
+    }
+    val keys = try {
+      withContext(Dispatchers.IO) { directory.keysWithNotes() }
+    } catch (throwable: Throwable) {
+      SharkLog.d(throwable) { "Could not list the notes in ${directory.directory}" }
+      return
+    }
+    isListed = true
+    // Whatever has been typed since the listing started is written about too, and its file may not have
+    // landed yet: the union rather than the listing, so that a mark never comes off a tab.
+    writtenAbout = writtenAbout + keys
+    SharkLog.d { "${keys.size} places of ${directory.directory.name} have notes" }
+  }
+
+  private fun written(
+    key: String,
+    hasNote: Boolean
+  ) {
+    writtenAbout = if (hasNote) writtenAbout + key else writtenAbout - key
+  }
+}
+
+/**
+ * What has been written about one place: the note as saved, the [Note] it was read as, and the draft being
+ * typed if there is one.
+ *
+ * All three here rather than in the composable, so that a draft outlives the section that was drawing it:
+ * clicking another tab half way through a sentence and coming back finds the sentence, since this is the
+ * run's notepad for that place rather than the screen's.
+ *
+ * **Nothing touches the disk until a note is saved**, beyond the one read of the file. Which is also what
+ * keeps the tests off the developer's own notes.
+ */
+@Stable
+internal class PlaceNotes(
+  private val noteFile: NoteFile,
+  /** How [HeapDumpNotes] hears that this place has, or no longer has, a note. */
+  private val onSavedChanged: (Boolean) -> Unit
+) {
+
+  /** Where this is kept, shown while writing so the note can be found without this app. */
+  val file: File get() = noteFile.file
+
+  /** The markdown as it was last saved, which is what the section draws and what a draft starts from. */
+  var text by mutableStateOf("")
+    private set
+
+  /**
+   * What that markdown means, which is what the section draws once there is something to draw.
+   *
+   * Worked out by the window rather than here, since resolving the names in it is a read of the heap dump.
+   * For a beat after a save this is the note with its mentions unanswered. See [HeapDumpExplorer].
+   */
+  var note by mutableStateOf(Note.EMPTY)
+    private set
+
+  /** What is being typed, and null when nothing is: the section is either writing or reading, never both. */
+  var draft: String? by mutableStateOf(null)
+    private set
+
+  /**
+   * Whether the file has been read, which is what makes writing safe.
+   *
+   * Until it is true, [text] is empty because nothing has been read rather than because nothing was
+   * written — and saving over that would be deleting a note to say the disk was slow. Which is why the
+   * button that starts one is disabled until then.
+   */
+  var isRead by mutableStateOf(false)
+    private set
+
+  /** What went wrong reading or writing the file, shown in the section. Null while nothing has. */
+  var problem: String? by mutableStateOf(null)
+    private set
+
+  /** Starts writing, from whatever was last saved. */
+  fun edit() {
+    if (draft == null) {
+      draft = text
+    }
+  }
+
+  fun edited(draft: String) {
+    this.draft = draft
+  }
+
+  /** Throws the draft away, which is what the section's cancel promises and nothing else does. */
+  fun cancel() {
+    draft = null
+  }
+
+  /** What [text] was read as, which the window works out and hands back. */
+  fun parsed(note: Note) {
+    this.note = note
+  }
+
+  /**
+   * Reads the file, once per run of the app.
+   *
+   * Off the UI thread, because it is a file: small, and on a machine where the disk has gone away, not
+   * small at all.
+   */
+  suspend fun read() {
+    if (isRead) {
+      return
+    }
+    val read = try {
+      withContext(Dispatchers.IO) { noteFile.read() }
+    } catch (throwable: Throwable) {
+      // In the section as well as in the log, because a note is the one thing in this window that nobody
+      // else has a copy of: a reader who is told nothing would type over it.
+      SharkLog.d(throwable) { "Could not read the note at $file" }
+      problem = "Could not read $file: $throwable"
+      return
+    }
+    SharkLog.d { "Read ${read.length} characters of notes from $file" }
+    text = read
+    isRead = true
+    problem = null
+    if (read.isNotEmpty()) {
+      onSavedChanged(true)
+    }
+  }
+
+  /**
+   * Puts the draft on disk and stops writing, or says why it couldn't and keeps it.
+   *
+   * [NonCancellable] because the section that started this goes away the moment the draft does, and a save
+   * cancelled halfway is the one thing this class exists to prevent.
+   */
+  suspend fun save() {
+    val draft = draft ?: return
+    if (!isRead) {
+      // Which the disabled button already prevents; here too, because this is where it would cost a note.
+      SharkLog.d { "Not saving $file: it has not been read yet" }
+      return
+    }
+    val written = withContext(Dispatchers.IO + NonCancellable) {
+      try {
+        noteFile.write(draft)
+        true
+      } catch (throwable: Throwable) {
+        SharkLog.d(throwable) { "Could not save the note to $file" }
+        problem = "Could not save $file: $throwable"
+        false
+      }
+    }
+    if (!written) {
+      return
+    }
+    SharkLog.d { "Saved ${draft.length} characters of notes to $file" }
+    text = draft
+    this.draft = null
+    problem = null
+    onSavedChanged(draft.isNotEmpty())
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -1,5 +1,7 @@
 package shark.explorer.app
 
+import androidx.compose.foundation.ContextMenuArea
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -232,7 +234,11 @@ internal fun HeapDumpExplorer(
   // Which is why this goes in ahead of the effect that lays the view out: opening a tab asks for both, and
   // the layout is the larger by orders of magnitude. Named after it, a tab would show its placeholder for
   // as long as laying the tree out takes, which on a real dump is what someone sees as a flicker.
-  val unnamedPlaces = tabs.tabs.map { it.place }.filter { it.title == null && it !in placeTitles }
+  // Every place of every history rather than just the one each tab is on, because the right click menus on
+  // the history arrows list them by name: a menu entry called "Naming this tab…" is a move nobody will make.
+  val unnamedPlaces = tabs.tabs.flatMap { it.history.entries }
+    .filter { it.title == null && it !in placeTitles }
+    .distinct()
   LaunchedEffect(session, unnamedPlaces) {
     if (unnamedPlaces.isEmpty()) {
       return@LaunchedEffect
@@ -582,11 +588,12 @@ internal fun HeapDumpExplorer(
     )
     Row(verticalAlignment = Alignment.CenterVertically) {
       HistoryArrows(
-        canGoBack = tabs.canGoBack,
-        canGoForward = tabs.canGoForward,
+        // Named the way the tabs are, since these are the same places under another name.
+        back = tabs.backPlaces.map { it.title ?: placeTitles[it] ?: NAMING_TAB },
+        forward = tabs.forwardPlaces.map { it.title ?: placeTitles[it] ?: NAMING_TAB },
         // A move undone is a place again, and the panes follow it: there is nothing else to put back.
-        onBack = { tabs = tabs.goBack() },
-        onForward = { tabs = tabs.goForward() }
+        onBack = { steps -> tabs = tabs.goBack(steps) },
+        onForward = { steps -> tabs = tabs.goForward(steps) }
       )
       // Which object the tab is on, beside the arrows that moved to it: above the panes rather than in
       // one, because it is the one thing that is as true of a list of objects as of the map.
@@ -1175,16 +1182,53 @@ private fun TreeScreen(
 /** Back and forward through the moves made in this tab. See [shark.explorer.NavigationHistory]. */
 @Composable
 private fun HistoryArrows(
-  canGoBack: Boolean,
-  canGoForward: Boolean,
-  onBack: () -> Unit,
-  onForward: () -> Unit
+  /** Where back leads, one click first. See [Tabs.backPlaces]. */
+  back: List<String>,
+  forward: List<String>,
+  /** How many moves at once, which is 1 for a click on the arrow itself. */
+  onBack: (Int) -> Unit,
+  onForward: (Int) -> Unit
 ) {
-  TextButton(onClick = onBack, enabled = canGoBack) {
-    Text(BACK_ARROW)
+  HistoryArrow(BACK_ARROW, back, onBack)
+  HistoryArrow(FORWARD_ARROW, forward, onForward)
+}
+
+/**
+ * One arrow: a click is one move, and a right click is the list of them.
+ *
+ * Which is the browser gesture, and it is worth having here for the browser's reason: a tab that has walked
+ * twenty objects down a chain is one where getting back to where the walk started is twenty clicks and a
+ * guess about which of them it was. The list says where each one lands, by the name the tab strip uses.
+ */
+@Composable
+private fun HistoryArrow(
+  arrow: String,
+  places: List<String>,
+  onGo: (Int) -> Unit
+) {
+  if (places.isEmpty()) {
+    // Nowhere to go, so nothing to right click either: an empty menu under the pointer reads as the window
+    // having lost the history rather than as there being none.
+    TextButton(onClick = {}, enabled = false) {
+      Text(arrow)
+    }
+    return
   }
-  TextButton(onClick = onForward, enabled = canGoForward) {
-    Text(FORWARD_ARROW)
+  ContextMenuArea(
+    items = {
+      // The nearest few rather than all of them, because the menu is drawn where the pointer is and one
+      // taller than the window has entries that cannot be reached. Everything past them is still one click
+      // of the arrow at a time away.
+      places.take(HISTORY_MENU_LIMIT).mapIndexed { index, title ->
+        ContextMenuItem(title) { onGo(index + 1) }
+      }
+    }
+  ) {
+    Hint("$HISTORY_MENU_HINT ${places.first()}") {
+      TextButton(onClick = { onGo(1) }) {
+        Text(arrow)
+      }
+    }
   }
 }
 
@@ -1431,6 +1475,16 @@ private const val HOVER_SETTLE_MILLIS = 100L
 
 /** What a tab is called for the beat between it being opened and the heap dump having named it. */
 private const val NAMING_TAB = "…"
+
+/**
+ * How many of the places behind an arrow its menu lists.
+ *
+ * Enough for the walk anyone takes in one go, few enough that the menu fits under the pointer on a window
+ * that isn't full height.
+ */
+private const val HISTORY_MENU_LIMIT = 15
+
+private const val HISTORY_MENU_HINT = "Right click for everywhere this leads. One click:"
 
 internal const val BACK_ARROW = "←"
 internal const val FORWARD_ARROW = "→"

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -39,6 +39,7 @@ import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import shark.SharkLog
@@ -51,6 +52,8 @@ import shark.explorer.HeapObjectKind
 import shark.explorer.HeapSizes
 import shark.explorer.LayoutCell
 import shark.explorer.NativeBitmapPixels
+import shark.explorer.Note
+import shark.explorer.NoteLink
 import shark.explorer.ObjectDominator
 import shark.explorer.ObjectList
 import shark.explorer.ObjectListFilter
@@ -70,6 +73,7 @@ import shark.explorer.detours
 import shark.explorer.formatObjectCount
 import shark.explorer.hexObjectId
 import shark.explorer.nodeIdText
+import shark.explorer.referencesOf
 import shark.explorer.titleOf
 import shark.explorer.waysOf
 
@@ -103,11 +107,20 @@ internal fun HeapDumpExplorer(
   deviceHeapDumps: DeviceHeapDumps,
   /** Already fetched off the device, when the dump was taken with the pixels asked for in the same go. */
   fetchedBitmapPixels: NativeBitmapPixels? = null,
+  /** What has been written about the places of this heap dump, shared with every other window on it. */
+  notes: HeapDumpNotes,
   /** What a link to one of these tabs names this window by. See [DeepLink]. */
   deepLinkId: String = remember { DeepLink.newWindowId() },
   /** Places a link has asked for, opened as tabs. See [ExplorerWindow.linkedPlaces]. */
   linkedPlaces: List<Place> = emptyList(),
   onLinkedPlaceOpened: (Place) -> Unit = {},
+  /**
+   * Where a `shark://` link written in the notes goes, which is wherever it names: this window, another
+   * window of this run, another run of the app, or nowhere. See [DeepLinkPeers.follow].
+   */
+  followDeepLink: (DeepLink) -> Unit = { link -> SharkLog.d { "Nothing here to follow $link with" } },
+  /** Overridden by tests, which have no browser. */
+  openUrl: (String) -> Unit = ::openInBrowser,
   /** Overridden by tests, which have no system clipboard and want to read what would have been copied. */
   copyToClipboard: (String) -> Unit = ::copyTextToClipboard,
   modifier: Modifier = Modifier
@@ -157,6 +170,16 @@ internal fun HeapDumpExplorer(
   var favourites by remember { mutableStateOf(emptyList<Favourite>()) }
   /** What each tab is called, by the place it is on. Only grows: a place is named once and stays named. */
   var placeTitles by remember { mutableStateOf(emptyMap<Place, String>()) }
+  /**
+   * The note about the tab on screen, and null once the last tab has been closed — which is the one state
+   * with no tab to write about.
+   */
+  val tabNote = place?.let { current ->
+    TabNote(
+      notes = notes.of(current),
+      subject = current.title ?: placeTitles[current] ?: NAMING_TAB
+    )
+  }
 
   // Nothing is under the pointer while a list is showing: the view isn't there, so the rectangle it was on
   // last is neither where the pointer is now nor what the tab is about.
@@ -410,6 +433,34 @@ internal fun HeapDumpExplorer(
     isListing = false
   }
 
+  // Which tabs have been written about, once per run of the app: a directory listing rather than a note
+  // opened per tab, since what it answers is a question about the whole strip. See [HeapDumpNotes.list].
+  LaunchedEffect(notes) { notes.list() }
+
+  // And what this tab's note says, once per run of the app. Here rather than in the section that draws it,
+  // because a tab nobody has written about has no section at all until the read says whether it has one.
+  LaunchedEffect(tabNote?.notes) { tabNote?.notes?.read() }
+
+  // What a note means, whenever there is a new one to mean anything: reading the markdown is in memory and
+  // cheap, and asking the heap dump what the names in it stand for is a read, so it only happens for a note
+  // that mentions something. Once per save rather than per keystroke, since a draft being typed is drawn as
+  // the text it is. See [Note].
+  LaunchedEffect(session, tabNote?.notes) {
+    val notepad = tabNote?.notes ?: return@LaunchedEffect
+    snapshotFlow { notepad.text }.collectLatest { text ->
+      val parsed = Note.of(text)
+      notepad.parsed(parsed)
+      val mentions = parsed.mentions
+      if (mentions.isEmpty) {
+        return@collectLatest
+      }
+      val references = session.read("what the note on ${tabNote.subject} mentions") { explorer ->
+        explorer.tree.referencesOf(mentions)
+      }
+      notepad.parsed(parsed.resolvedWith(references))
+    }
+  }
+
   // Whether the map is rooted inside a leak, which the cells themselves can't say: a rectangle is drawn
   // inside the one that dominates it, so a view rooted below a leaking object has every rectangle of it
   // leaking and not one of them in the list. A walk up the dominators, so it follows where the map is.
@@ -478,6 +529,22 @@ internal fun HeapDumpExplorer(
   val copyObjectLink: (Long) -> Unit = { objectId -> copyLink(Place.Object(objectId)) }
   /** And for the view's right click menu, which is on whatever the pointer is on. */
   val copyHoveredLink: () -> Unit = { hovered?.place?.let { copyLink(it) } }
+  /**
+   * Where a link written in the notes goes: out to a browser, into whichever window a `shark://` link
+   * names, or to an object of this heap dump.
+   *
+   * An object opens a tab in front, like a button on the bar rather than like a row of a list: the notes
+   * are what the reader is working from, and replacing them with the object they just linked to would take
+   * away the thing they are reading. A `shark://` link is followed the way one arriving from outside the
+   * app is, which is the whole point of it being the same link.
+   */
+  val followNoteLink: (NoteLink) -> Unit = { link ->
+    when (link) {
+      is NoteLink.Web -> openUrl(link.url)
+      is NoteLink.Deep -> followDeepLink(link.deepLink)
+      is NoteLink.Object -> openInNewTab(Place.Object(link.objectId))
+    }
+  }
 
   if (showsBitmapsFromDevice) {
     BitmapsFromDeviceDialog(
@@ -508,6 +575,7 @@ internal fun HeapDumpExplorer(
     TabStrip(
       tabs = tabs,
       titleOf = { it.title ?: placeTitles[it] ?: NAMING_TAB },
+      hasNote = { notes.hasNote(it) },
       onSelect = { id -> tabs = tabs.select(id) },
       onClose = { id -> tabs = tabs.close(id) },
       onCopyLink = copyLink
@@ -522,7 +590,23 @@ internal fun HeapDumpExplorer(
       )
       // Which object the tab is on, beside the arrows that moved to it: above the panes rather than in
       // one, because it is the one thing that is as true of a list of objects as of the map.
-      DescribedObject(details?.selection)
+      Box(Modifier.weight(1f)) {
+        DescribedObject(details?.selection)
+      }
+      // At the far end of the row, and only until there is a note: a tab nobody has written about is a tab
+      // that spends nothing on notes. Once there is one, the note itself is under this row and carries the
+      // way back into it. See [AddNoteButton].
+      if (tabNote != null) {
+        AddNoteButton(tabNote.notes)
+      }
+    }
+    // Under the title it is about and above everything that describes it, so that what it is a note about is
+    // the whole of what this tab is showing rather than whichever pane it happens to sit against.
+    if (tabNote != null) {
+      NoteSection(
+        notes = tabNote.notes,
+        onLink = followNoteLink
+      )
     }
     Box(Modifier.weight(1f)) {
       when {
@@ -630,6 +714,18 @@ internal fun HeapDumpExplorer(
     }
   }
 }
+
+/**
+ * The note about the tab on screen: what has been written in it, and what to call the tab it is about.
+ *
+ * One value rather than two, because both are the same question — which tab is on screen — asked by the
+ * section and by the read that works out what the names in it mean. See [NoteSection].
+ */
+private data class TabNote(
+  val notes: PlaceNotes,
+  /** What the log calls the tab, since a read of the heap dump is logged with what it was for. */
+  val subject: String
+)
 
 /**
  * Puts [text] on the system clipboard, through AWT.

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import java.awt.Toolkit
@@ -835,21 +836,20 @@ private fun RowScope.ViewPane(
     return
   }
   Column(paneWidth(panes, Pane.VIEW).fillMaxHeight()) {
-    // The fold control sits in the row of controls rather than in a header of its own: the view already
-    // has a strip above it, and two thin rows would be one more than the picture can spare.
-    Row(verticalAlignment = Alignment.CenterVertically) {
-      FoldButton(Pane.VIEW) { panes.toggleFold(Pane.VIEW) }
-      ViewControls(
-        sizes = sizes,
-        shape = shape,
-        coloring = coloring,
-        leakCount = leaks?.objectCount,
-        isFindingLeaks = isFindingLeaks,
-        onColoringChange = onColoringChange,
-        onShapeChange = onShapeChange,
-        modifier = Modifier.weight(1f)
-      )
-    }
+    // Named like the two panes either side of it, and for the same reason: left to right the three of them
+    // are three questions about the object, and a middle one that didn't say which question it answers left
+    // the other two reading as a pair.
+    PaneHeader(Pane.VIEW) { panes.toggleFold(Pane.VIEW) }
+    ViewControls(
+      sizes = sizes,
+      shape = shape,
+      coloring = coloring,
+      leakCount = leaks?.objectCount,
+      isFindingLeaks = isFindingLeaks,
+      onColoringChange = onColoringChange,
+      onShapeChange = onShapeChange,
+      modifier = Modifier.fillMaxWidth()
+    )
     Box(Modifier.weight(1f).fillMaxWidth()) {
       // The one gesture the views can't read themselves: a right click is the menu's, and the menu is what
       // makes middle clicking a rectangle findable by someone who has never tried it.
@@ -1005,6 +1005,9 @@ private fun ListPlace(
  */
 @Composable
 private fun DescribedObject(selection: Selection?) {
+  // Larger than the same name is anywhere else in the window, because here it is a title rather than a
+  // mention: everything under it — three panes or a list, and the note — is about this object.
+  val titleStyle = MaterialTheme.typography.titleMedium
   when (selection) {
     null -> Unit
     // Selectable so it can be copied out: an object id is how you point something else — a script, a
@@ -1013,16 +1016,19 @@ private fun DescribedObject(selection: Selection?) {
       ObjectIdentity(
         className = selection.summary.className,
         typeName = selection.summary.kind?.typeName,
-        objectId = selection.summary.objectId
+        objectId = selection.summary.objectId,
+        nameStyle = titleStyle
       )
     }
     is Selection.ObjectGroup -> Text(
       selection.summary.className ?: HeapDominatorTreemap.UNREACHABLE_LABEL,
-      style = MaterialTheme.typography.bodyMedium
+      style = titleStyle,
+      fontWeight = FontWeight.Bold
     )
     is Selection.Group -> Text(
       "${selection.nodeCount} smaller objects",
-      style = MaterialTheme.typography.bodyMedium
+      style = titleStyle,
+      fontWeight = FontWeight.Bold
     )
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -443,12 +443,12 @@ internal fun HeapDumpExplorer(
     isListing = false
   }
 
-  // Which objects have been written about, once per run of the app: a directory listing rather than a note
+  // Which places have been written about, once per run of the app: a directory listing rather than a note
   // opened per tab, since what it answers is a question about the whole strip. See [HeapDumpNotes.list].
   LaunchedEffect(notes) { notes.list() }
 
   // And what the note about this one says, once per run of the app. Here rather than in the section that draws
-  // it, because an object nobody has written about has no section at all until the read says it has none.
+  // it, because a place nobody has written about has no section at all until the read says it has none.
   LaunchedEffect(tabNote?.notes) { tabNote?.notes?.read() }
 
   // What a note means, whenever there is a new one to mean anything: reading the markdown is in memory and

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -5,12 +5,14 @@ import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -19,6 +21,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -587,7 +590,9 @@ internal fun HeapDumpExplorer(
       onClose = { id -> tabs = tabs.close(id) },
       onCopyLink = copyLink
     )
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    // Two things in one row, and a rule between them: how the tab got here, then what it is on. The height is
+    // the taller of the two so that the rule is as tall as the row whether the title is one line or three.
+    Row(Modifier.height(IntrinsicSize.Min), verticalAlignment = Alignment.CenterVertically) {
       HistoryArrows(
         // Named the way the tabs are, since these are the same places under another name.
         back = tabs.backPlaces.map { it.title ?: placeTitles[it] ?: NAMING_TAB },
@@ -596,14 +601,17 @@ internal fun HeapDumpExplorer(
         onBack = { steps -> tabs = tabs.goBack(steps) },
         onForward = { steps -> tabs = tabs.goForward(steps) }
       )
+      VerticalDivider(Modifier.padding(horizontal = 4.dp, vertical = 4.dp))
       // Which object the tab is on, beside the arrows that moved to it: above the panes rather than in
       // one, because it is the one thing that is as true of a list of objects as of the map.
       Box(Modifier.weight(1f)) {
         DescribedObject(details?.selection)
       }
-      // At the far end of the row, and only until there is a note: a tab nobody has written about is a tab
-      // that spends nothing on notes. Once there is one, the note itself is under this row and carries the
-      // way back into it. See [AddNoteButton].
+      // At the end of the title's side of that rule, and only until there is a note: the two of them are one
+      // region, so what the button will be a note about is what it is grouped with, while the arrows keep
+      // theirs. Read left to right it is still the subject before what to do about it, and it stays at the
+      // window's edge rather than moving with a title that changes on every click. Once there is a note it is
+      // under this row and carries the way back into it, so there is never one of each. See [AddNoteButton].
       if (tabNote != null) {
         AddNoteButton(tabNote.notes)
       }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -443,12 +443,12 @@ internal fun HeapDumpExplorer(
     isListing = false
   }
 
-  // Which tabs have been written about, once per run of the app: a directory listing rather than a note
+  // Which objects have been written about, once per run of the app: a directory listing rather than a note
   // opened per tab, since what it answers is a question about the whole strip. See [HeapDumpNotes.list].
   LaunchedEffect(notes) { notes.list() }
 
-  // And what this tab's note says, once per run of the app. Here rather than in the section that draws it,
-  // because a tab nobody has written about has no section at all until the read says whether it has one.
+  // And what the note about this one says, once per run of the app. Here rather than in the section that draws
+  // it, because an object nobody has written about has no section at all until the read says it has none.
   LaunchedEffect(tabNote?.notes) { tabNote?.notes?.read() }
 
   // What a note means, whenever there is a new one to mean anything: reading the markdown is in memory and
@@ -604,16 +604,15 @@ internal fun HeapDumpExplorer(
       VerticalDivider(Modifier.padding(horizontal = 4.dp, vertical = 4.dp))
       // Which object the tab is on, beside the arrows that moved to it: above the panes rather than in
       // one, because it is the one thing that is as true of a list of objects as of the map.
-      Box(Modifier.weight(1f)) {
+      Column(Modifier.weight(1f)) {
         DescribedObject(details?.selection)
-      }
-      // At the end of the title's side of that rule, and only until there is a note: the two of them are one
-      // region, so what the button will be a note about is what it is grouped with, while the arrows keep
-      // theirs. Read left to right it is still the subject before what to do about it, and it stays at the
-      // window's edge rather than moving with a title that changes on every click. Once there is a note it is
-      // under this row and carries the way back into it, so there is never one of each. See [AddNoteButton].
-      if (tabNote != null) {
-        AddNoteButton(tabNote.notes)
+        // Under the title, and only until there is a note: the note will be about what the title names, and
+        // this is where it will appear, so the button is where its own result goes. Small, since that costs a
+        // line of every tab nobody has written about. Once there is a note it is here instead and carries the
+        // way back into the box, so there is never one of each. See [AddNoteButton].
+        if (tabNote != null) {
+          AddNoteButton(tabNote.notes)
+        }
       }
     }
     // Under the title it is about and above everything that describes it, so that what it is a note about is

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -139,6 +139,9 @@ private fun nameThisRun(name: String) {
 /** One window per heap dump open, which is what [openHeapDump] keeps true as more are opened. */
 private fun explorerApplication(windows: ExplorerWindows) = application {
   val updateNotice = remember { UpdateNotice() }
+  // One notepad per place for the whole run, so that a heap dump open in two windows is one set of notes
+  // rather than two that overwrite each other. See [ExplorerNotes].
+  val notes = remember { ExplorerNotes() }
   // Once per run, not once per window, and off the UI thread: this is a network request, and a window that
   // waits for GitHub to answer before it draws is a window that hangs when GitHub is unreachable.
   LaunchedEffect(updateNotice) {
@@ -179,7 +182,11 @@ private fun explorerApplication(windows: ExplorerWindows) = application {
               windows.openHeapDump(window, file, fetchedPixels)
             },
             updateNotice = updateNotice,
+            notes = notes,
             deepLinkId = window.deepLinkId,
+            // The same way a link arriving from the OS is followed, which is what makes a `shark://` link
+            // written in a note work wherever it is read from.
+            followDeepLink = { link -> DeepLinkPeers.follow(link, windows) },
             linkedPlaces = window.linkedPlaces,
             onLinkedPlaceOpened = { place -> window.linkedPlaceOpened(place) },
             deepLinkProblem = window.deepLinkProblem
@@ -208,11 +215,21 @@ internal fun ExplorerApp(
    * that a test only gets the bar when it is what the test is about.
    */
   updateNotice: UpdateNotice = remember { UpdateNotice() },
+  /**
+   * The notes of every heap dump this run has open, shared with every other window. Its own by default, so
+   * that a test writes into a directory it was given rather than into the notes of whoever is running it.
+   */
+  notes: ExplorerNotes = remember { ExplorerNotes() },
   /** What a link to a place in this window names it by. See [shark.explorer.DeepLink]. */
   deepLinkId: String = remember { DeepLink.newWindowId() },
   /** Places a link has asked this window for, which its tabs open. See [ExplorerWindow.linkedPlaces]. */
   linkedPlaces: List<Place> = emptyList(),
   onLinkedPlaceOpened: (Place) -> Unit = {},
+  /**
+   * Where a `shark://` link written in the notes goes. Only the application knows, since routing one is a
+   * question about every window of the run, so a window composed without it says so in the log.
+   */
+  followDeepLink: (DeepLink) -> Unit = { link -> SharkLog.d { "Nothing here to follow $link with" } },
   /**
    * Why this window has no heap dump, for one a link opened because the window it named had gone.
    *
@@ -222,6 +239,8 @@ internal fun ExplorerApp(
   deepLinkProblem: String? = null,
   /** Overridden by tests, which have no system clipboard and want to read what would have been copied. */
   copyToClipboard: (String) -> Unit = ::copyTextToClipboard,
+  /** Overridden by tests, which have no browser to open a link written in the notes in. */
+  openUrl: (String) -> Unit = ::openInBrowser,
   /** Overridden by tests, which have no display to put a file dialog on. */
   chooseHeapDumpFile: () -> File? = ::showHeapDumpFileDialog,
   /** Overridden by tests, which have no device to go back to and no `adb` to ask. */
@@ -308,9 +327,12 @@ internal fun ExplorerApp(
         sizes = currentState.sizes,
         deviceHeapDumps = deviceHeapDumps,
         fetchedBitmapPixels = currentState.bitmapPixels,
+        notes = notes.of(currentState.session.heapDumpFile),
         deepLinkId = deepLinkId,
         linkedPlaces = linkedPlaces,
         onLinkedPlaceOpened = onLinkedPlaceOpened,
+        followDeepLink = followDeepLink,
+        openUrl = openUrl,
         copyToClipboard = copyToClipboard,
         modifier = Modifier.weight(1f)
       )

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
@@ -1,0 +1,347 @@
+package shark.explorer.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import shark.explorer.NoteBlock
+import shark.explorer.NoteLink
+import shark.explorer.NoteSpan
+import shark.explorer.NoteStyle
+import shark.explorer.hexObjectId
+
+/**
+ * What has been written about the tab on screen, between the row that says where the tab is and the panes
+ * that read it.
+ *
+ * There rather than at the foot of the window, because a note is about the whole of what the tab is showing:
+ * under the title it is about, above everything it describes. At the bottom it would read as a note on
+ * whichever pane happened to be above it.
+ *
+ * **Not there at all until there is something to show**, which is what keeps a section that is on every tab
+ * from taking room it has not earned: most tabs are never written about, and the way to start one is
+ * [AddNoteButton] in the row above. So there are two states here rather than three:
+ *
+ * - **Writing**: a plain text box with save and cancel. Plain, because markdown is what gets typed here and
+ *   a box that reformats it as you go is a box arguing with you.
+ * - **Written**: the note as it means, which is where the names in it lead somewhere — a class shortened to
+ *   a link, an address replaced by what is at it, a `shark://` link back to the tab it was copied from.
+ *
+ * One markdown file per place, kept between runs, read by the window rather than here. See [PlaceNotes].
+ */
+@Composable
+internal fun NoteSection(
+  notes: PlaceNotes,
+  /** Where clicking a link in the written note goes. See [HeapDumpExplorer]. */
+  onLink: (NoteLink) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val draft = notes.draft
+  val problem = notes.problem
+  if (draft == null && notes.text.isEmpty() && problem == null) {
+    return
+  }
+  val saving = rememberCoroutineScope()
+
+  Surface(modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.surface) {
+    Column(Modifier.fillMaxWidth()) {
+      when {
+        draft != null -> NoteEditor(
+          notes = notes,
+          draft = draft,
+          onSave = { saving.launch { notes.save() } },
+          onCancel = { notes.cancel() }
+        )
+        notes.text.isNotEmpty() -> WrittenNote(
+          notes = notes,
+          onLink = onLink,
+          onEdit = { notes.edit() }
+        )
+        // Only a problem to report, which is a note that could not be read: the section is the one place
+        // that can say so, since the button that would have started one is disabled until the read lands.
+      }
+      if (problem != null) {
+        Text(
+          problem,
+          Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.error
+        )
+      }
+      HorizontalDivider()
+    }
+  }
+}
+
+/**
+ * The button that starts a note, for the row that says where the tab is.
+ *
+ * In that row rather than in the section, and gone as soon as there is a note, so that a tab nobody has
+ * written about spends no window on saying so. A note carries its own way back into the box — see
+ * [WrittenNote] — which is why there is never one of each on screen.
+ *
+ * Disabled until the file has been read, which is the one moment writing would be dangerous: an empty box
+ * over a note still on its way off the disk is that note deleted a save later.
+ */
+@Composable
+internal fun AddNoteButton(
+  notes: PlaceNotes,
+  modifier: Modifier = Modifier
+) {
+  if (notes.text.isNotEmpty() || notes.draft != null) {
+    return
+  }
+  Hint(WRITE_NOTE_HINT) {
+    TextButton(onClick = { notes.edit() }, modifier = modifier, enabled = notes.isRead) {
+      Text(NOTE_BUTTON, style = MaterialTheme.typography.bodySmall)
+    }
+  }
+}
+
+/** The note as it means, with the way back into the box that wrote it. */
+@Composable
+private fun WrittenNote(
+  notes: PlaceNotes,
+  onLink: (NoteLink) -> Unit,
+  onEdit: () -> Unit
+) {
+  Row(
+    Modifier.fillMaxWidth().padding(start = 8.dp, end = 4.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalAlignment = Alignment.Top
+  ) {
+    Column(
+      Modifier.weight(1f).heightIn(max = MAX_NOTE_HEIGHT)
+        .verticalScroll(rememberScrollState())
+        .padding(vertical = 6.dp),
+      verticalArrangement = Arrangement.spacedBy(BLOCK_SPACING)
+    ) {
+      notes.note.blocks.forEach { block ->
+        NoteBlockView(block, onLink)
+      }
+    }
+    Hint(EDIT_NOTE_HINT) {
+      TextButton(onClick = onEdit) {
+        Text(EDIT_NOTE_BUTTON, style = MaterialTheme.typography.bodySmall)
+      }
+    }
+  }
+}
+
+/**
+ * The markdown as it is typed, with what saving and cancelling mean.
+ *
+ * Nothing is written until save, and cancel throws the typing away rather than filing it: a box with two
+ * buttons under it is a promise about which of those two happens. The draft outlives leaving the tab, so
+ * clicking somewhere else while half way through a sentence is not losing it — see [PlaceNotes.draft].
+ */
+@Composable
+private fun NoteEditor(
+  notes: PlaceNotes,
+  draft: String,
+  onSave: () -> Unit,
+  onCancel: () -> Unit
+) {
+  Column(Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp)) {
+    OutlinedTextField(
+      value = draft,
+      onValueChange = { notes.edited(it) },
+      placeholder = { Text(NOTE_PLACEHOLDER, style = MaterialTheme.typography.bodySmall) },
+      textStyle = MaterialTheme.typography.bodyMedium,
+      modifier = Modifier.fillMaxWidth().height(EDITOR_HEIGHT)
+        .semantics { contentDescription = NOTE_EDITOR_DESCRIPTION }
+    )
+    Row(
+      Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(4.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      TextButton(onClick = onSave) {
+        Text(SAVE_NOTE, style = MaterialTheme.typography.bodySmall)
+      }
+      TextButton(onClick = onCancel) {
+        Text(CANCEL_NOTE, style = MaterialTheme.typography.bodySmall)
+      }
+      // Where it is going to land, which is what someone wanting to open this note in an editor needs and
+      // is worth the room only while they are looking at the box that writes it.
+      Text(
+        "$SAVED_IN ${notes.file}",
+        Modifier.weight(1f),
+        style = MaterialTheme.typography.bodySmall,
+        color = MUTED_TEXT,
+        maxLines = 1
+      )
+    }
+  }
+}
+
+@Composable
+private fun NoteBlockView(
+  block: NoteBlock,
+  onLink: (NoteLink) -> Unit
+) {
+  when (block) {
+    is NoteBlock.Paragraph -> NoteText(block.spans, MaterialTheme.typography.bodyMedium, onLink)
+    is NoteBlock.Heading -> NoteText(block.spans, headingStyle(block.level), onLink)
+    is NoteBlock.Item -> Row(Modifier.padding(start = INDENT_WIDTH * block.depth)) {
+      Text(
+        block.marker,
+        Modifier.width(MARKER_WIDTH),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MUTED_TEXT
+      )
+      NoteText(block.spans, MaterialTheme.typography.bodyMedium, onLink)
+    }
+    is NoteBlock.Quote -> Row {
+      Text(QUOTE_BAR, style = MaterialTheme.typography.bodyMedium, color = MUTED_TEXT)
+      NoteText(block.spans, MaterialTheme.typography.bodyMedium, onLink, color = MUTED_TEXT)
+    }
+    is NoteBlock.Code -> Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
+      Text(
+        block.text,
+        Modifier.padding(8.dp),
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace
+      )
+    }
+    NoteBlock.Rule -> HorizontalDivider()
+  }
+}
+
+/**
+ * One block's worth of styled text, with a click handler on every span that leads somewhere.
+ *
+ * Through [LinkAnnotation], which is what makes part of a line clickable at all: a `Text` is one node, so a
+ * link inside a sentence cannot be a composable of its own.
+ */
+@Composable
+private fun NoteText(
+  spans: List<NoteSpan>,
+  style: TextStyle,
+  onLink: (NoteLink) -> Unit,
+  color: Color = Color.Unspecified
+) {
+  Text(annotatedNote(spans, onLink), style = style, color = color)
+}
+
+private fun annotatedNote(
+  spans: List<NoteSpan>,
+  onLink: (NoteLink) -> Unit
+): AnnotatedString = buildAnnotatedString {
+  spans.forEach { span ->
+    val link = span.link
+    if (link == null) {
+      withStyle(span.spanStyle()) { append(span.text) }
+    } else {
+      withLink(
+        LinkAnnotation.Clickable(
+          tag = link.tag(),
+          styles = TextLinkStyles(SpanStyle(color = LINK_COLOR)),
+          linkInteractionListener = { onLink(link) }
+        )
+      ) {
+        withStyle(span.spanStyle()) { append(span.text) }
+      }
+    }
+  }
+}
+
+private fun NoteSpan.spanStyle(): SpanStyle = SpanStyle(
+  fontWeight = if (NoteStyle.BOLD in styles) FontWeight.Bold else null,
+  fontStyle = if (NoteStyle.ITALIC in styles) FontStyle.Italic else null,
+  fontFamily = if (NoteStyle.CODE in styles) FontFamily.Monospace else null
+)
+
+/** What a link is called where something other than a person reads it: a screen reader, or a test. */
+private fun NoteLink.tag(): String = when (this) {
+  is NoteLink.Web -> url
+  is NoteLink.Deep -> deepLink.toUri()
+  is NoteLink.Object -> hexObjectId(objectId)
+}
+
+/**
+ * A heading has to be bigger than the line under it or it isn't one: `titleSmall` beside `bodyMedium` is the
+ * same size in a slightly heavier weight, which reads as a bold line rather than as a heading.
+ */
+@Composable
+private fun headingStyle(level: Int): TextStyle = when (level) {
+  1 -> MaterialTheme.typography.headlineSmall
+  2 -> MaterialTheme.typography.titleLarge
+  else -> MaterialTheme.typography.titleMedium
+}
+
+/** What starts a note about this tab, in the row that says where the tab is. See [AddNoteButton]. */
+internal const val NOTE_BUTTON = "✎ Add Note"
+
+/** And what opens the one that is already there. */
+internal const val EDIT_NOTE_BUTTON = "✎ Edit"
+
+internal const val SAVE_NOTE = "Save"
+
+internal const val CANCEL_NOTE = "Cancel"
+
+/** What marks a tab that has a note, in front of its title on the strip. */
+internal const val NOTE_MARK = "✎"
+
+internal const val NOTE_MARK_HINT = "This tab has a note."
+
+/** What the editor is called, which is also how a test finds it: there is no other text field here. */
+internal const val NOTE_EDITOR_DESCRIPTION = "The note about this tab, as markdown."
+
+private const val WRITE_NOTE_HINT =
+  "Write a note about this tab, in markdown, kept between runs. A class name, an address like 0x1234 and a " +
+    "shark:// link to a tab all turn into a way back into this window, and http links open in a browser."
+
+private const val EDIT_NOTE_HINT = "Change what this note says."
+
+private const val NOTE_PLACEHOLDER =
+  "Markdown. Class names, 0x addresses and shark:// links become links into this heap dump."
+
+private const val SAVED_IN = "Saved in"
+
+/** In front of a quoted line, since a quote here is one line rather than a paragraph to draw a bar beside. */
+private const val QUOTE_BAR = "▎"
+
+private val BLOCK_SPACING = 4.dp
+
+/** How far a list under a list is drawn in, and how much room the bullet or the number gets. */
+private val INDENT_WIDTH = 16.dp
+private val MARKER_WIDTH = 24.dp
+
+/** Enough for a few lines while writing, so that the panes under it keep the window. */
+private val EDITOR_HEIGHT = 120.dp
+
+/** And how much of it a long note gets before it scrolls instead of pushing the panes down. */
+private val MAX_NOTE_HEIGHT = 160.dp

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
@@ -44,18 +44,19 @@ import shark.explorer.NoteStyle
 import shark.explorer.hexObjectId
 
 /**
- * What has been written about the object the tab is on, between the row that names it and the panes that read
- * it.
+ * What has been written about where the tab is, between the row that says so and the panes that read it.
  *
  * There rather than at the foot of the window, because a note is about the whole of what the tab is showing:
  * under the title it is about, above everything it describes. At the bottom it would read as a note on
  * whichever pane happened to be above it.
  *
- * **A note is the object's, not the tab's**, so two tabs on one object are one note and show each other's
- * writing as it is typed — `Place.noteKey` and [PlaceNotes] are the two halves of that.
+ * **A note belongs to the place, not to the tab**, so two tabs on one place are one note and show each other's
+ * writing as it is typed — `Place.noteKey` and [PlaceNotes] are the two halves of that. A place here is a
+ * location in the heap dump rather than an object: an object, a group of smaller ones, the object list, the
+ * leaks, the starred objects.
  *
  * **Not there at all until there is something to show**, which is what keeps a section that is on every tab
- * from taking room it has not earned: most objects are never written about, and the way to start one is
+ * from taking room it has not earned: most places are never written about, and the way to start one is
  * [AddNoteButton] under the title. So there are two states here rather than three:
  *
  * - **Writing**: a plain text box with save and cancel. Plain, because markdown is what gets typed here and
@@ -112,7 +113,7 @@ internal fun NoteSection(
 /**
  * The button that starts a note, drawn under the title that says what the tab is on.
  *
- * Under it rather than in the section, and gone as soon as there is a note, so that an object nobody has
+ * Under it rather than in the section, and gone as soon as there is a note, so that a place nobody has
  * written about spends no window on saying so. A note carries its own way back into the box — see
  * [WrittenNote] — which is why there is never one of each on screen.
  *

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
@@ -124,8 +124,10 @@ internal fun AddNoteButton(
     return
   }
   Hint(WRITE_NOTE_HINT) {
+    // At the size every other button in the bars above is, rather than the small one [WrittenNote] uses: this
+    // is the only thing in the window that says notes exist, and it was the smallest text in a row of them.
     TextButton(onClick = { notes.edit() }, modifier = modifier, enabled = notes.isRead) {
-      Text(NOTE_BUTTON, style = MaterialTheme.typography.bodySmall)
+      Text(NOTE_BUTTON)
     }
   }
 }

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/NoteSection.kt
@@ -2,6 +2,7 @@ package shark.explorer.app
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -43,16 +44,19 @@ import shark.explorer.NoteStyle
 import shark.explorer.hexObjectId
 
 /**
- * What has been written about the tab on screen, between the row that says where the tab is and the panes
- * that read it.
+ * What has been written about the object the tab is on, between the row that names it and the panes that read
+ * it.
  *
  * There rather than at the foot of the window, because a note is about the whole of what the tab is showing:
  * under the title it is about, above everything it describes. At the bottom it would read as a note on
  * whichever pane happened to be above it.
  *
+ * **A note is the object's, not the tab's**, so two tabs on one object are one note and show each other's
+ * writing as it is typed — `Place.noteKey` and [PlaceNotes] are the two halves of that.
+ *
  * **Not there at all until there is something to show**, which is what keeps a section that is on every tab
- * from taking room it has not earned: most tabs are never written about, and the way to start one is
- * [AddNoteButton] in the row above. So there are two states here rather than three:
+ * from taking room it has not earned: most objects are never written about, and the way to start one is
+ * [AddNoteButton] under the title. So there are two states here rather than three:
  *
  * - **Writing**: a plain text box with save and cancel. Plain, because markdown is what gets typed here and
  *   a box that reformats it as you go is a box arguing with you.
@@ -106,9 +110,9 @@ internal fun NoteSection(
 }
 
 /**
- * The button that starts a note, for the row that says where the tab is.
+ * The button that starts a note, drawn under the title that says what the tab is on.
  *
- * In that row rather than in the section, and gone as soon as there is a note, so that a tab nobody has
+ * Under it rather than in the section, and gone as soon as there is a note, so that an object nobody has
  * written about spends no window on saying so. A note carries its own way back into the box — see
  * [WrittenNote] — which is why there is never one of each on screen.
  *
@@ -124,10 +128,16 @@ internal fun AddNoteButton(
     return
   }
   Hint(WRITE_NOTE_HINT) {
-    // At the size every other button in the bars above is, rather than the small one [WrittenNote] uses: this
-    // is the only thing in the window that says notes exist, and it was the smallest text in a row of them.
-    TextButton(onClick = { notes.edit() }, modifier = modifier, enabled = notes.isRead) {
-      Text(NOTE_BUTTON)
+    // Small, and with no padding of its own around the label, because it hangs under the title on every tab
+    // that has no note: what it costs there should be a line of window rather than a row of one, and it
+    // should start where the title above it starts.
+    TextButton(
+      onClick = { notes.edit() },
+      modifier = modifier.height(ADD_NOTE_HEIGHT),
+      enabled = notes.isRead,
+      contentPadding = PaddingValues(horizontal = 0.dp)
+    ) {
+      Text(NOTE_BUTTON, style = MaterialTheme.typography.bodySmall)
     }
   }
 }
@@ -304,7 +314,7 @@ private fun headingStyle(level: Int): TextStyle = when (level) {
   else -> MaterialTheme.typography.titleMedium
 }
 
-/** What starts a note about this tab, in the row that says where the tab is. See [AddNoteButton]. */
+/** What starts a note about what the tab is on, under the title saying what that is. See [AddNoteButton]. */
 internal const val NOTE_BUTTON = "✎ Add Note"
 
 /** And what opens the one that is already there. */
@@ -317,19 +327,23 @@ internal const val CANCEL_NOTE = "Cancel"
 /** What marks a tab that has a note, in front of its title on the strip. */
 internal const val NOTE_MARK = "✎"
 
-internal const val NOTE_MARK_HINT = "This tab has a note."
+internal const val NOTE_MARK_HINT = "There is a note about what this tab is on."
 
 /** What the editor is called, which is also how a test finds it: there is no other text field here. */
-internal const val NOTE_EDITOR_DESCRIPTION = "The note about this tab, as markdown."
+internal const val NOTE_EDITOR_DESCRIPTION = "The note about what this tab is on, as markdown."
 
-private const val WRITE_NOTE_HINT =
-  "Write a note about this tab, in markdown, kept between runs. A class name, an address like 0x1234 and a " +
-    "shark:// link to a tab all turn into a way back into this window, and http links open in a browser."
+/**
+ * Short, because what a note can do is the box's business rather than this button's: a tooltip is read while
+ * deciding whether to click, and by then everything about markdown and links is a paragraph in the way. It is
+ * in [NOTE_PLACEHOLDER] instead, which is on screen exactly while it is worth reading.
+ */
+private const val WRITE_NOTE_HINT = "Write a note about what this tab is on, kept between runs."
 
 private const val EDIT_NOTE_HINT = "Change what this note says."
 
 private const val NOTE_PLACEHOLDER =
-  "Markdown. Class names, 0x addresses and shark:// links become links into this heap dump."
+  "Markdown. Class names, 0x addresses and shark:// links become links into this heap dump, and http links " +
+    "open in a browser."
 
 private const val SAVED_IN = "Saved in"
 
@@ -344,6 +358,9 @@ private val MARKER_WIDTH = 24.dp
 
 /** Enough for a few lines while writing, so that the panes under it keep the window. */
 private val EDITOR_HEIGHT = 120.dp
+
+/** A line under the title rather than a button beside it. See [AddNoteButton]. */
+private val ADD_NOTE_HEIGHT = 20.dp
 
 /** And how much of it a long note gets before it scrolls instead of pushing the panes down. */
 private val MAX_NOTE_HEIGHT = 160.dp

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -362,17 +362,24 @@ internal fun ObjectIdentity(
   /** Null for the whole heap dump, which is no object and has no address. */
   objectId: Long?,
   modifier: Modifier = Modifier,
+  /**
+   * What the first line is drawn at, which is the body of the text everywhere but one.
+   *
+   * The row above the panes says which object the whole window is about, so there it is a title — see
+   * `DescribedObject`. The grey lines under it stay as they are: what they are for is being skipped.
+   */
+  nameStyle: TextStyle? = null,
   /** Where clicking it goes, or null for a name that is already what the window is showing. */
   onOpen: ((OpenIn) -> Unit)? = null,
   /** Put on the clipboard by the menu beside "open in a new tab", so only where there is one. */
   onCopyLink: () -> Unit = {}
 ) {
   if (onOpen == null) {
-    ObjectIdentityLines(className, typeName, objectId, modifier)
+    ObjectIdentityLines(className, typeName, objectId, nameStyle, modifier)
     return
   }
   OpenTarget(onOpen, onCopyLink) {
-    ObjectIdentityLines(className, typeName, objectId, modifier.openable(onOpen))
+    ObjectIdentityLines(className, typeName, objectId, nameStyle, modifier.openable(onOpen))
   }
 }
 
@@ -382,6 +389,7 @@ private fun ObjectIdentityLines(
   className: String,
   typeName: String?,
   objectId: Long?,
+  nameStyle: TextStyle?,
   modifier: Modifier
 ) {
   Column(modifier) {
@@ -392,7 +400,7 @@ private fun ObjectIdentityLines(
         append(className.substringAfterLast('.'))
         typeName?.let { withStyle(MUTED_SPAN) { append(" $it") } }
       },
-      style = MaterialTheme.typography.bodyMedium,
+      style = nameStyle ?: MaterialTheme.typography.bodyMedium,
       fontWeight = FontWeight.Bold
     )
     // Only where there is a package to read past: for a name that has none the two lines would be the same

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/TabStrip.kt
@@ -50,6 +50,8 @@ internal fun TabStrip(
   tabs: Tabs,
   /** What each tab is called, which for an object is a read of the heap dump. See [Tabs]. */
   titleOf: (Place) -> String,
+  /** Whether each tab has a note, which puts a mark on it. See [NoteSection]. */
+  hasNote: (Place) -> Boolean,
   onSelect: (Int) -> Unit,
   onClose: (Int) -> Unit,
   /** Puts a link to where the tab is on the clipboard. See [shark.explorer.DeepLink]. */
@@ -72,6 +74,7 @@ internal fun TabStrip(
       key(tab.id) {
         TabView(
           title = titleOf(tab.place),
+          hasNote = hasNote(tab.place),
           isSelected = tab.id == tabs.selectedId,
           onSelect = { onSelect(tab.id) },
           onClose = { onClose(tab.id) },
@@ -97,6 +100,7 @@ internal fun TabStrip(
 @Composable
 private fun TabView(
   title: String,
+  hasNote: Boolean,
   isSelected: Boolean,
   onSelect: () -> Unit,
   onClose: () -> Unit,
@@ -137,6 +141,13 @@ private fun TabView(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
       ) {
+        // In front of the title, and only on the tabs that have one: what makes a note worth writing is
+        // that the strip says which objects you have already worked something out about.
+        if (hasNote) {
+          Hint(NOTE_MARK_HINT) {
+            Text(NOTE_MARK, style = MaterialTheme.typography.bodySmall)
+          }
+        }
         Text(
           title,
           style = MaterialTheme.typography.bodySmall,

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/NoteSectionTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/NoteSectionTest.kt
@@ -1,0 +1,392 @@
+package shark.explorer.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import androidx.compose.ui.test.waitUntilDoesNotExist
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+import shark.explorer.Adb
+import shark.explorer.AdbOutput
+import shark.explorer.DeepLink
+import shark.explorer.DeviceHeapDumps
+import shark.explorer.NoteDirectory
+import shark.explorer.Place
+import shark.explorer.hexObjectId
+
+/**
+ * The note kept about a tab, and what makes it worth keeping: the names in it lead back into the window it
+ * was written in, and it is there again the next time that tab is.
+ *
+ * The markdown itself is `NoteTest` in `shark-explorer-core`, and where a note is kept is `NoteFileTest`,
+ * which is where anything about what a note means or is filed under belongs. What is only true here is what
+ * saving and cancelling do, that a saved note is drawn with its links going where they say, that the note
+ * belongs to the tab it was written on, and that what was saved is on disk.
+ */
+@OptIn(ExperimentalTestApi::class)
+class NoteSectionTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  /** Every UI test here records what Shark logged. See [RecordedLog]. */
+  @get:Rule val logged = RecordedLog()
+
+  /** The object id of the holder in [testHeapDump], recorded as the dump is written. */
+  private var holderObjectId = 0L
+
+  /** Which is what keeps notes from costing a strip of window on every tab nobody has written about. */
+  @Test fun `a tab nobody has written about is a button in the row and nothing more`() {
+    explorerUiTest {
+      openHeapDump()
+
+      // The button that starts one, and no section under the row it is in: no editor, and nothing that
+      // offers to change a note that isn't there.
+      onNode(hasText(NOTE_BUTTON) and isButton()).assertIsDisplayed()
+      onNodeWithContentDescription(NOTE_EDITOR_DESCRIPTION).assertDoesNotExist()
+      onNodeWithText(EDIT_NOTE_BUTTON).assertDoesNotExist()
+      onNodeWithText(NOTE_MARK).assertDoesNotExist()
+    }
+  }
+
+  /** The other half of that: one way in on screen at a time, never two. */
+  @Test fun `the button that starts a note goes away once there is one`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+
+      write("Written about the heap dump")
+      save()
+
+      waitUntilDoesNotExist(hasText(NOTE_BUTTON), RENDER_TIMEOUT_MILLIS)
+      onNode(hasText(EDIT_NOTE_BUTTON) and isButton()).assertIsDisplayed()
+    }
+  }
+
+  @Test fun `what is saved is drawn as the markdown it is`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+
+      write("## What holds it")
+      save()
+
+      // The heading without its hashes, and the box that had both of them gone.
+      waitUntilAtLeastOneExists(hasText("What holds it"), RENDER_TIMEOUT_MILLIS)
+      onNodeWithContentDescription(NOTE_EDITOR_DESCRIPTION).assertDoesNotExist()
+    }
+  }
+
+  @Test fun `a class name of the heap dump is shortened to its simple name`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+
+      write("com.example.Holder")
+      save()
+
+      waitUntilAtLeastOneExists(hasText("Holder"), RENDER_TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `a class name leads to that class in a tab of its own`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+      write("com.example.Holder")
+      save()
+      waitUntilAtLeastOneExists(hasText("Holder"), RENDER_TIMEOUT_MILLIS)
+
+      onNodeWithText("Holder").performClick()
+
+      // A tab of its own rather than where the note was being read: the note is what is being worked from,
+      // so the strip gains one — the heap dump, and the class.
+      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+        onAllNodes(isTab()).fetchSemanticsNodes().size == 2
+      }
+    }
+  }
+
+  @Test fun `an address is replaced by what the heap dump has at it`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+
+      write("Kept by ${hexObjectId(holderObjectId)}")
+      save()
+
+      waitUntilAtLeastOneExists(
+        hasText("Holder instance (${hexObjectId(holderObjectId)})", substring = true),
+        RENDER_TIMEOUT_MILLIS
+      )
+    }
+  }
+
+  @Test fun `a name this heap dump has never heard of is left as it was typed`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+
+      write("com.example.Absent")
+      save()
+
+      // Once, in the note as saved, and not shortened to `Absent`.
+      waitUntilExactlyOneExists(hasText("com.example.Absent"), RENDER_TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `a web link is shortened the way github shortens it and opens in a browser`() {
+    val opened = mutableListOf<String>()
+    val url = "https://github.com/square/leakcanary/issues/2841"
+    explorerUiTest {
+      openHeapDump(openUrl = { opened += it })
+      startNote()
+      write(url)
+      save()
+      waitUntilAtLeastOneExists(hasText("square/leakcanary#2841"), RENDER_TIMEOUT_MILLIS)
+
+      onNodeWithText("square/leakcanary#2841").performClick()
+
+      assertThat(opened).containsExactly(url)
+    }
+  }
+
+  @Test fun `a shark link is followed the way one arriving from outside the app is`() {
+    val followed = mutableListOf<DeepLink>()
+    explorerUiTest {
+      openHeapDump(followDeepLink = { followed += it })
+      startNote()
+      // Starred rather than the leaks or the object list, because the bar's button for those says the same
+      // word as the link would: "★ 0 starred" doesn't, so this text is the note's and nothing else.
+      write("shark://$WINDOW_ID/starred")
+      save()
+      waitUntilAtLeastOneExists(hasText(Place.STARRED_LABEL), RENDER_TIMEOUT_MILLIS)
+
+      onNodeWithText(Place.STARRED_LABEL).performClick()
+
+      // Handed to whatever routes links rather than opened here: a link names one window of one run, and
+      // which window that is, is not a question this one can answer. See [DeepLinkPeers.follow].
+      assertThat(followed).containsExactly(DeepLink(WINDOW_ID, Place.Starred))
+    }
+  }
+
+  /** Which is the whole of what the two buttons under the box promise. */
+  @Test fun `cancelling throws the writing away`() {
+    val notesRoot = testFolder.newFolder("notes")
+    val heapDumpFile = testHeapDump()
+    explorerUiTest {
+      openHeapDump(heapDumpFile = heapDumpFile, notesRoot = notesRoot)
+      startNote()
+      write("Thought better of")
+
+      cancel()
+
+      onNodeWithContentDescription(NOTE_EDITOR_DESCRIPTION).assertDoesNotExist()
+      onNode(hasText(NOTE_BUTTON) and isButton()).assertIsDisplayed()
+      onNodeWithText("Thought better of").assertDoesNotExist()
+      assertThat(noteFile(notesRoot, heapDumpFile).read()).isEmpty()
+    }
+  }
+
+  @Test fun `changing a note starts from what was saved`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+      write("Held by com.example.Holder")
+      save()
+      waitUntilAtLeastOneExists(hasText("Holder", substring = true), RENDER_TIMEOUT_MILLIS)
+
+      onNode(hasText(EDIT_NOTE_BUTTON) and isButton()).performClick()
+
+      noteEditor().assertTextContains("Held by com.example.Holder")
+    }
+  }
+
+  /** The whole of what a note being on a tab means: it is the tab's, and it is there when the tab is. */
+  @Test fun `a note belongs to the tab it was written on`() {
+    explorerUiTest {
+      openHeapDump()
+      startNote()
+      write("Written about the heap dump")
+      save()
+      // Marked on the tab, which is how a reader who moves away knows the note went with the tab rather
+      // than with the window.
+      waitUntilAtLeastOneExists(hasText(NOTE_MARK), RENDER_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(
+        hasText("Written about the heap dump", substring = true),
+        RENDER_TIMEOUT_MILLIS
+      )
+
+      // The object list, which nobody has written about: its own note, which is the button and nothing else.
+      onNode(hasText(Place.OBJECTS_LABEL) and isButton()).performClick()
+      waitUntilDoesNotExist(
+        hasText("Written about the heap dump", substring = true),
+        RENDER_TIMEOUT_MILLIS
+      )
+      onNode(hasText(NOTE_BUTTON) and isButton()).assertIsDisplayed()
+
+      // And back onto the heap dump's tab, which is where the note was written.
+      onAllNodes(isTab())[0].performClick()
+
+      waitUntilAtLeastOneExists(
+        hasText("Written about the heap dump", substring = true),
+        RENDER_TIMEOUT_MILLIS
+      )
+    }
+  }
+
+  @Test fun `what was saved is on disk`() {
+    val notesRoot = testFolder.newFolder("notes")
+    val heapDumpFile = testHeapDump()
+    explorerUiTest {
+      openHeapDump(heapDumpFile = heapDumpFile, notesRoot = notesRoot)
+      startNote()
+      write("Held by com.example.Holder")
+
+      save()
+
+      val noteFile = noteFile(notesRoot, heapDumpFile)
+      waitUntil(timeoutMillis = SAVE_TIMEOUT_MILLIS) {
+        noteFile.read() == "Held by com.example.Holder"
+      }
+    }
+  }
+
+  /**
+   * Which is what keeps the same place open in two windows from being two notepads overwriting each other.
+   * No window needed: it is the notepad rather than the section.
+   */
+  @Test fun `one place is one notepad however the heap dump path is spelled`() {
+    val notes = ExplorerNotes(testFolder.newFolder("notes"))
+    val heapDumpFile = testFolder.newFile("heap.hprof")
+    val sameOtherWayRound = File(heapDumpFile.parentFile, "./${heapDumpFile.name}")
+
+    val notepad = notes.of(heapDumpFile).of(Place.Object(HOLDER_ID))
+
+    assertThat(notepad).isSameAs(notes.of(sameOtherWayRound).of(Place.Object(HOLDER_ID)))
+  }
+
+  /** Opens a heap dump, which is where every test above starts. */
+  private fun ComposeUiTest.openHeapDump(
+    heapDumpFile: File = testHeapDump(),
+    notesRoot: File = testFolder.newFolder("notes"),
+    openUrl: (String) -> Unit = {},
+    followDeepLink: (DeepLink) -> Unit = {}
+  ) {
+    setContent {
+      MaterialTheme {
+        ExplorerApp(
+          heapDumpFile = heapDumpFile,
+          deepLinkId = WINDOW_ID,
+          // A directory of this test's, never `~/.shark-explorer`: a test that saved into the real one
+          // would write into the notes of whoever is running it.
+          notes = ExplorerNotes(notesRoot),
+          openUrl = openUrl,
+          followDeepLink = followDeepLink,
+          // Nothing here opens a second heap dump, and which window one would land in is
+          // `ExplorerWindowTest`'s.
+          onHeapDumpChosen = { _, _ -> },
+          // An `adb` connected to nothing, rather than the one on this machine.
+          deviceHeapDumps = DeviceHeapDumps(NO_DEVICE_ADB)
+        )
+      }
+    }
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+  }
+
+  /**
+   * Starts writing about the tab on screen.
+   *
+   * Waits for the button to be enabled rather than clicking it as it is: it stays disabled until the note
+   * file has been read, which is what keeps an empty box from being saved over a note still on its way off
+   * the disk.
+   */
+  private fun ComposeUiTest.startNote() {
+    val button = hasText(NOTE_BUTTON) and isButton()
+    waitUntilAtLeastOneExists(button and isEnabled(), RENDER_TIMEOUT_MILLIS)
+    onNode(button).performClick()
+    noteEditor().assertIsDisplayed()
+  }
+
+  private fun ComposeUiTest.write(markdown: String) {
+    noteEditor().performTextInput(markdown)
+  }
+
+  private fun ComposeUiTest.save() {
+    onNode(hasText(SAVE_NOTE) and isButton()).performClick()
+  }
+
+  private fun ComposeUiTest.cancel() {
+    onNode(hasText(CANCEL_NOTE) and isButton()).performClick()
+  }
+
+  /** The box the markdown is typed into, which is the only thing in this window that takes typing. */
+  private fun ComposeUiTest.noteEditor(): SemanticsNodeInteraction =
+    onNodeWithContentDescription(NOTE_EDITOR_DESCRIPTION)
+
+  /** Where the note about the tab a window opens on is kept. */
+  private fun noteFile(
+    notesRoot: File,
+    heapDumpFile: File
+  ) = NoteDirectory(notesRoot, heapDumpFile).noteFile(Place.wholeHeapDump())
+
+  private fun isButton(): SemanticsMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+
+  private fun isTab(): SemanticsMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Tab)
+
+  /** A heap dump with one class and one instance of it, which is all a note has to name. */
+  private fun testHeapDump(): File {
+    val file = testFolder.newFile("heap.hprof")
+    file.dump {
+      val holder = "com.example.Holder" instance {
+        field["payload"] =
+          ReferenceHolder(objectArray(arrayClass("java.lang.Object"), LongArray(PAYLOAD_LENGTH)))
+      }
+      holderObjectId = holder.value
+      gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+    }
+    return file
+  }
+
+  companion object {
+    private const val PAYLOAD_LENGTH = 100
+
+    private const val HOLDER_ID = 0x82182c00L
+
+    /** Opening a heap dump and laying its tree out both happen on another thread. */
+    private const val OPEN_TIMEOUT_MILLIS = 10_000L
+
+    /** And so does asking it what the names in a saved note are. */
+    private const val RENDER_TIMEOUT_MILLIS = 5_000L
+
+    /** Saving is a file written, on another thread. */
+    private const val SAVE_TIMEOUT_MILLIS = 10_000L
+
+    /** What a link here names this window by, fixed so that a link can be spelled out in a test. */
+    private const val WINDOW_ID = "abcd2345"
+
+    private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/NoteSectionTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/NoteSectionTest.kt
@@ -36,13 +36,13 @@ import shark.explorer.Place
 import shark.explorer.hexObjectId
 
 /**
- * The note kept about the object a tab is on, and what makes it worth keeping: the names in it lead back into
- * the window it was written in, and it is there again the next time that object is.
+ * The note kept about where a tab is, and what makes it worth keeping: the names in it lead back into the
+ * window it was written in, and it is there again the next time a tab is there.
  *
  * The markdown itself is `NoteTest` in `shark-explorer-core`, and where a note is kept is `NoteFileTest`,
  * which is where anything about what a note means or is filed under belongs. What is only true here is what
  * saving and cancelling do, that a saved note is drawn with its links going where they say, that a note is
- * about the object its tab is on rather than about the tab, and that what was saved is on disk.
+ * about the place its tab is on rather than about the tab, and that what was saved is on disk.
  */
 @OptIn(ExperimentalTestApi::class)
 class NoteSectionTest {
@@ -56,8 +56,8 @@ class NoteSectionTest {
   /** The object id of the holder in [testHeapDump], recorded as the dump is written. */
   private var holderObjectId = 0L
 
-  /** Which is what keeps notes from costing a strip of window on every object nobody has written about. */
-  @Test fun `an object nobody has written about is a button under the title and nothing more`() {
+  /** Which is what keeps notes from costing a strip of window on every place nobody has written about. */
+  @Test fun `a place nobody has written about is a button under the title and nothing more`() {
     explorerUiTest {
       openHeapDump()
 
@@ -223,8 +223,8 @@ class NoteSectionTest {
     }
   }
 
-  /** Which is what a note being about an object means: another object's tab is another note. */
-  @Test fun `a note is only about what the tab it was written on is on`() {
+  /** Which is what a note being about a place means: a tab somewhere else is another note. */
+  @Test fun `a note is only about the place the tab it was written on is at`() {
     explorerUiTest {
       openHeapDump()
       startNote()
@@ -256,12 +256,12 @@ class NoteSectionTest {
     }
   }
 
-  /** The other half of that, and the reason a note is filed under the object: two tabs on one are one note. */
-  @Test fun `two tabs on one object are one note`() {
+  /** The other half of that, and the reason a note is filed under the place: two tabs on one are one note. */
+  @Test fun `two tabs on one place are one note`() {
     explorerUiTest {
       openHeapDump()
-      // The heap dump as an object, opened a second time: the buttons along the top always open a new tab, so
-      // this is two tabs on one object without there being two of anything else.
+      // The whole heap dump, opened a second time: the buttons along the top always open a new tab, so this is
+      // two tabs on one place without there being two of anything else.
       onNode(hasText(HeapDominatorTreemap.ROOT_LABEL) and isButton()).performClick()
       waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
         onAllNodes(isTab()).fetchSemanticsNodes().size == 2
@@ -274,7 +274,7 @@ class NoteSectionTest {
       onAllNodes(isTab())[0].performClick()
 
       // The note the other tab wrote, without a save having to be read back off the disk for it: the notepad
-      // is the object's and both tabs are writing on it.
+      // is the place's and both tabs are writing on it.
       waitUntilAtLeastOneExists(hasText("Written on the second tab"), RENDER_TIMEOUT_MILLIS)
       onNodeWithText(NOTE_BUTTON).assertDoesNotExist()
     }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/NoteSectionTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/NoteSectionTest.kt
@@ -30,18 +30,19 @@ import shark.explorer.Adb
 import shark.explorer.AdbOutput
 import shark.explorer.DeepLink
 import shark.explorer.DeviceHeapDumps
+import shark.explorer.HeapDominatorTreemap
 import shark.explorer.NoteDirectory
 import shark.explorer.Place
 import shark.explorer.hexObjectId
 
 /**
- * The note kept about a tab, and what makes it worth keeping: the names in it lead back into the window it
- * was written in, and it is there again the next time that tab is.
+ * The note kept about the object a tab is on, and what makes it worth keeping: the names in it lead back into
+ * the window it was written in, and it is there again the next time that object is.
  *
  * The markdown itself is `NoteTest` in `shark-explorer-core`, and where a note is kept is `NoteFileTest`,
  * which is where anything about what a note means or is filed under belongs. What is only true here is what
- * saving and cancelling do, that a saved note is drawn with its links going where they say, that the note
- * belongs to the tab it was written on, and that what was saved is on disk.
+ * saving and cancelling do, that a saved note is drawn with its links going where they say, that a note is
+ * about the object its tab is on rather than about the tab, and that what was saved is on disk.
  */
 @OptIn(ExperimentalTestApi::class)
 class NoteSectionTest {
@@ -55,8 +56,8 @@ class NoteSectionTest {
   /** The object id of the holder in [testHeapDump], recorded as the dump is written. */
   private var holderObjectId = 0L
 
-  /** Which is what keeps notes from costing a strip of window on every tab nobody has written about. */
-  @Test fun `a tab nobody has written about is a button in the row and nothing more`() {
+  /** Which is what keeps notes from costing a strip of window on every object nobody has written about. */
+  @Test fun `an object nobody has written about is a button under the title and nothing more`() {
     explorerUiTest {
       openHeapDump()
 
@@ -222,14 +223,14 @@ class NoteSectionTest {
     }
   }
 
-  /** The whole of what a note being on a tab means: it is the tab's, and it is there when the tab is. */
-  @Test fun `a note belongs to the tab it was written on`() {
+  /** Which is what a note being about an object means: another object's tab is another note. */
+  @Test fun `a note is only about what the tab it was written on is on`() {
     explorerUiTest {
       openHeapDump()
       startNote()
       write("Written about the heap dump")
       save()
-      // Marked on the tab, which is how a reader who moves away knows the note went with the tab rather
+      // Marked on the tab, which is how a reader who moves away knows the note went with the object rather
       // than with the window.
       waitUntilAtLeastOneExists(hasText(NOTE_MARK), RENDER_TIMEOUT_MILLIS)
       waitUntilAtLeastOneExists(
@@ -252,6 +253,30 @@ class NoteSectionTest {
         hasText("Written about the heap dump", substring = true),
         RENDER_TIMEOUT_MILLIS
       )
+    }
+  }
+
+  /** The other half of that, and the reason a note is filed under the object: two tabs on one are one note. */
+  @Test fun `two tabs on one object are one note`() {
+    explorerUiTest {
+      openHeapDump()
+      // The heap dump as an object, opened a second time: the buttons along the top always open a new tab, so
+      // this is two tabs on one object without there being two of anything else.
+      onNode(hasText(HeapDominatorTreemap.ROOT_LABEL) and isButton()).performClick()
+      waitUntil(timeoutMillis = RENDER_TIMEOUT_MILLIS) {
+        onAllNodes(isTab()).fetchSemanticsNodes().size == 2
+      }
+      startNote()
+      write("Written on the second tab")
+      save()
+      waitUntilAtLeastOneExists(hasText("Written on the second tab"), RENDER_TIMEOUT_MILLIS)
+
+      onAllNodes(isTab())[0].performClick()
+
+      // The note the other tab wrote, without a save having to be read back off the disk for it: the notepad
+      // is the object's and both tabs are writing on it.
+      waitUntilAtLeastOneExists(hasText("Written on the second tab"), RENDER_TIMEOUT_MILLIS)
+      onNodeWithText(NOTE_BUTTON).assertDoesNotExist()
     }
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -334,9 +334,9 @@ class HeapDominatorTreemap internal constructor(
     }
     val classId = graph.findClassByName(className)?.objectId
     if (classId == null) {
-      // Which leaves every object of that class as a rectangle of its own under the root rather than
-      // gathered with its siblings, so it's worth a line saying so.
-      SharkLog.d { "No class named $className in the heap dump, so nothing groups by it" }
+      // Worth a line whoever asked: nothing gathers under a class the dump hasn't got, so every object of
+      // it is a rectangle of its own under the root, and a name written in a note goes unlinked.
+      SharkLog.d { "No class named $className in the heap dump" }
     }
     classIdByName[className] = classId
     return classId
@@ -378,6 +378,29 @@ class HeapDominatorTreemap internal constructor(
     is HeapInstance -> instanceClassSimpleName
     is HeapObjectArray -> arrayClassSimpleName
     is HeapPrimitiveArray -> arrayClassName
+  }
+
+  /**
+   * The class object [className] names, or null for a name this heap dump has no class for.
+   *
+   * Which is how something written down elsewhere — a note, a leak trace, a bug report — is turned into a
+   * place in this window. Looked up once per name, see the memo in [classIdOf], but the first look is two
+   * scans over every string of the dump, so this belongs on the heap dump's thread.
+   */
+  fun classObjectIdOrNull(className: String): Long? = classIdOf(className)
+
+  /**
+   * What sits at [objectId], as `MainActivity instance`, or null for an address this heap dump has no
+   * object at.
+   *
+   * The simple class name and the kind, which is how every list and path here names an object, so that an
+   * address read out of one of them can be recognised again wherever it was written down. No node of the
+   * tree is needed, so this answers for an object the tree has no rectangle for — an uncollected one, or
+   * an object of another dump whose address happens to be one of ours.
+   */
+  fun objectNameOrNull(objectId: Long): String? {
+    val heapObject = graph.findObjectByIdOrNull(objectId) ?: return null
+    return "${heapObject.className().substringAfterLast('.')} ${heapObject.kind().typeName}"
   }
 
   /**

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NavigationHistory.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NavigationHistory.kt
@@ -34,6 +34,30 @@ data class NavigationHistory<T>(
   val canGoForward: Boolean get() = index < entries.lastIndex
 
   /**
+   * Everywhere this has been before [current], the most recent first.
+   *
+   * In that order because it is the order the back arrow visits them in, which is what a list of them is
+   * read as: the first entry is one click back, the second is two.
+   */
+  val backEntries: List<T> get() = entries.take(index).asReversed()
+
+  /** And everywhere it went after, the nearest first, for the same reason. */
+  val forwardEntries: List<T> get() = entries.drop(index + 1)
+
+  /**
+   * Goes back [steps] moves at once, for a click on the third entry of a back list rather than three clicks
+   * on the arrow.
+   *
+   * Clamped rather than checked, because the list a click came from and the history it came from are the
+   * same value one recomposition apart.
+   */
+  fun goBack(steps: Int): NavigationHistory<T> = copy(index = (index - steps).coerceAtLeast(0))
+
+  /** And forward, the same way. */
+  fun goForward(steps: Int): NavigationHistory<T> =
+    copy(index = (index + steps).coerceAtMost(entries.lastIndex))
+
+  /**
    * Records [entry] as where the view is now, which is what makes it the place the back arrow returns to
    * next.
    *

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Note.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Note.kt
@@ -1,0 +1,231 @@
+package shark.explorer
+
+/**
+ * What someone has written about one place in a heap dump, as blocks to draw.
+ *
+ * The point of it is that a note about a heap dump is mostly made of names out of that heap dump — a class,
+ * an address, a link to a tab — and typing those out again as prose is what makes notes not worth keeping.
+ * So the markdown a reader types is read here, and everything in it that this heap dump recognises becomes
+ * a way back into the window: a class name links to that class, an address links to that object, a
+ * `shark://` link opens the tab it was copied from. See [NoteMention].
+ *
+ * Immutable and in this module rather than in the UI, so that what a note means is unit tested rather than
+ * found out by typing one. Rendering it is `NoteSection`, and where it is kept is [NoteDirectory].
+ *
+ * The markdown is a subset, and deliberately: **one line is one block**, the way a comment box on GitHub
+ * reads it, because a note is written in lines rather than in paragraphs that reflow. What is understood is
+ * headings, bullet and numbered lists, quotes, fenced code, rules, and inline emphasis, code, links and
+ * bare URLs. Anything else is the text it was typed as.
+ */
+data class Note(val blocks: List<NoteBlock>) {
+
+  /**
+   * The class names and addresses written in it, which is the one thing about a note only the heap dump
+   * can answer. See [referencesOf].
+   */
+  val mentions: NoteMentions
+    get() {
+      val mentions = blocks.flatMap { block -> block.spans }.mapNotNull { it.mention }
+      return NoteMentions(
+        classNames = mentions.filterIsInstance<NoteMention.ClassName>().map { it.className }.toSet(),
+        objectIds = mentions.filterIsInstance<NoteMention.ObjectId>().flatMap { it.objectIds }.toSet()
+      )
+    }
+
+  /**
+   * The same note with everything [references] recognised turned into a link and shortened to read as one.
+   *
+   * Whatever it didn't recognise is left exactly as it was typed, which is the honest answer: a class name
+   * this heap dump has never heard of is a class name someone wrote, not a broken link.
+   */
+  fun resolvedWith(references: NoteReferences): Note =
+    Note(blocks.map { block -> block.mapSpans { it.resolvedWith(references) } })
+
+  companion object {
+
+    val EMPTY = Note(emptyList())
+
+    /** Reads [text] as markdown, with its mentions left for the heap dump to answer. See [resolvedWith]. */
+    fun of(text: String): Note = Note(noteBlocksOf(text))
+  }
+}
+
+/**
+ * One line's worth of a note, or one fenced block of code.
+ *
+ * A block rather than a paragraph because of the one-line-one-block rule above: what a reader typed on its
+ * own line is drawn on its own line.
+ */
+sealed interface NoteBlock {
+
+  /** The styled text of this block, which is empty for a block with no prose in it. */
+  val spans: List<NoteSpan>
+
+  /** A line of prose, or an empty one, which is the blank line between two of them. */
+  data class Paragraph(override val spans: List<NoteSpan>) : NoteBlock
+
+  /** `#` to `######`, drawn larger the fewer of them there were. */
+  data class Heading(
+    val level: Int,
+    override val spans: List<NoteSpan>
+  ) : NoteBlock
+
+  /** A `-`, `*`, `+` or numbered item, indented as far as it was written. */
+  data class Item(
+    /** What is drawn in front of it: a bullet, or the number as it was typed. */
+    val marker: String,
+    /** How many levels in it was written, so that a list under a list reads as one. */
+    val depth: Int,
+    override val spans: List<NoteSpan>
+  ) : NoteBlock
+
+  /** A `>` line, which is how something pasted from elsewhere is told from the note about it. */
+  data class Quote(override val spans: List<NoteSpan>) : NoteBlock
+
+  /**
+   * Everything between two ``` fences, drawn as it was typed.
+   *
+   * Nothing in it is linked or shortened: code is quoted rather than read, so a class name in it is
+   * whatever the code says and an address in it is a number.
+   */
+  data class Code(val text: String) : NoteBlock {
+    override val spans: List<NoteSpan> get() = emptyList()
+  }
+
+  /** A `---` line. */
+  data object Rule : NoteBlock {
+    override val spans: List<NoteSpan> get() = emptyList()
+  }
+
+  /** This block with [transform] applied to each of its spans. See [Note.resolvedWith]. */
+  fun mapSpans(transform: (NoteSpan) -> NoteSpan): NoteBlock = when (this) {
+    is Paragraph -> Paragraph(spans.map(transform))
+    is Heading -> Heading(level, spans.map(transform))
+    is Item -> Item(marker, depth, spans.map(transform))
+    is Quote -> Quote(spans.map(transform))
+    is Code, Rule -> this
+  }
+}
+
+/** A stretch of a block that is drawn one way and leads to one place. */
+data class NoteSpan(
+  /** What is drawn, which for a resolved [mention] is shorter than what was typed. */
+  val text: String,
+  val styles: Set<NoteStyle> = emptySet(),
+  /** Where clicking it goes, or null for text that leads nowhere. */
+  val link: NoteLink? = null,
+  /** What the heap dump has to be asked about before this can lead anywhere. See [NoteReferences]. */
+  val mention: NoteMention? = null
+) {
+
+  /**
+   * This span with its mention answered, or unchanged for one the heap dump didn't recognise.
+   *
+   * Idempotent, because a note is resolved again every time the heap dump is asked: what is drawn is built
+   * from the mention rather than from whatever this span is showing now.
+   *
+   * A span that already leads somewhere keeps leading there. Which is what makes a `shark://` link to an
+   * object read as that object without stopping being a link to the window it names.
+   */
+  internal fun resolvedWith(references: NoteReferences): NoteSpan = when (mention) {
+    null -> this
+    // Shortened to the simple class name, because that is what every other surface of this window draws:
+    // the package is what a note has room for and a rectangle doesn't, and reading it twice is reading it
+    // once too often.
+    is NoteMention.ClassName -> references.classObjectIds[mention.className]?.let { classObjectId ->
+      copy(
+        text = mention.className.substringAfterLast('.'),
+        link = link ?: NoteLink.Object(classObjectId)
+      )
+    } ?: this
+    // An address on its own says nothing, so a recognised one is drawn as what it points at, with the
+    // address it was typed as kept beside it: that is what the reader wrote and what they will search for.
+    is NoteMention.ObjectId -> mention.objectIds.firstNotNullOfOrNull { objectId ->
+      references.objectNames[objectId]?.let { name ->
+        copy(text = "$name (${hexObjectId(objectId)})", link = link ?: NoteLink.Object(objectId))
+      }
+    } ?: this
+  }
+}
+
+/** How a span is drawn, beyond the colour a link takes. */
+enum class NoteStyle { BOLD, ITALIC, CODE }
+
+/** Where clicking a span of a note goes. */
+sealed interface NoteLink {
+
+  /** Out of the app, into whatever the machine calls a browser. */
+  data class Web(val url: String) : NoteLink
+
+  /**
+   * Into the window the link names, as if the OS had handed it over.
+   *
+   * Which is the same window most of the time — a note about a heap dump is written beside it — and the
+   * point of following it the same way regardless is that a link works identically wherever it is read:
+   * in a note, in a chat message, in an issue. See [DeepLink].
+   */
+  data class Deep(val deepLink: DeepLink) : NoteLink
+
+  /** An object of this heap dump, which is also a class. Opens a tab of its own. */
+  data class Object(val objectId: Long) : NoteLink
+}
+
+/** Something written in a note that only the heap dump can say whether it exists. */
+sealed interface NoteMention {
+
+  /** A dotted name, which is a class of this heap dump or is prose that looks like one. */
+  data class ClassName(val className: String) : NoteMention
+
+  /**
+   * An address, as every reading of what was typed.
+   *
+   * Two of them, because a 32 bit heap dump records ids in four bytes and shark widens them by sign, so an
+   * object above the 2 GB mark has a negative id whose low 32 bits are what every tool prints. `0xffff8000`
+   * is therefore either of two [Long]s, and only the heap dump says which one it has. See [hexObjectId].
+   */
+  data class ObjectId(val objectIds: List<Long>) : NoteMention
+}
+
+/** What a note mentions, gathered so that the heap dump is asked once for all of it. */
+data class NoteMentions(
+  val classNames: Set<String>,
+  val objectIds: Set<Long>
+) {
+
+  val isEmpty: Boolean get() = classNames.isEmpty() && objectIds.isEmpty()
+
+  companion object {
+    val NONE = NoteMentions(emptySet(), emptySet())
+  }
+}
+
+/**
+ * What a note's mentions turned out to be in the heap dump, which is a read of it. See [referencesOf].
+ */
+data class NoteReferences(
+  /** The class object of each name the heap dump has a class for, and nothing for the names it hasn't. */
+  val classObjectIds: Map<String, Long>,
+  /** And what each address it has an object at is: `MainActivity instance`. */
+  val objectNames: Map<Long, String>
+) {
+
+  companion object {
+    val NONE = NoteReferences(emptyMap(), emptyMap())
+  }
+}
+
+/**
+ * What [mentions] stand for in this heap dump.
+ *
+ * Reads the heap dump — a class is found by name over every string in it, though only once per name — so
+ * this belongs on the heap dump's thread with every other read, and it is asked once the typing has
+ * stopped rather than per keystroke.
+ */
+fun HeapDominatorTreemap.referencesOf(mentions: NoteMentions): NoteReferences = NoteReferences(
+  classObjectIds = mentions.classNames.mapNotNull { className ->
+    classObjectIdOrNull(className)?.let { className to it }
+  }.toMap(),
+  objectNames = mentions.objectIds.mapNotNull { objectId ->
+    objectNameOrNull(objectId)?.let { objectId to it }
+  }.toMap()
+)

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NoteFile.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NoteFile.kt
@@ -1,0 +1,156 @@
+package shark.explorer
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * Where the notes about one heap dump are kept: a directory of this app's own, named after the dump, holding
+ * one markdown file per place written about.
+ *
+ * **Not beside the heap dump**, which is the tempting place and the wrong one. A dump is opened from
+ * wherever it came from — a directory pulled off a device, a temporary file, a read only mount, a checkout
+ * of this repository — and writing into all of those means littering some of them and failing on the rest.
+ * A directory under [root] always works and is always found again.
+ *
+ * Markdown on disk, and readable on its own, because a note about a leak outlives the window it was written
+ * in: it gets pasted into an issue, read by an agent, or opened in an editor months later. A format only
+ * this app can read would make that a chore, which is the same as making it not happen.
+ *
+ * A file each rather than one file with the places as sections, because notes are written one place at a
+ * time: separate files mean a save touches only the note that was typed into, nothing has to be parsed back
+ * out of a document that also holds someone's own headings, and the directory listing is the index — which
+ * is what [keysWithNotes] is, and what marks the tabs that have been written about.
+ */
+class NoteDirectory(
+  /** This app's own directory, which the caller decides. */
+  root: File,
+  /** The heap dump these notes are about, which names the directory and nothing more. */
+  heapDumpFile: File
+) {
+
+  /** The directory itself, shown in the window so that the notes can be found without this app. */
+  val directory: File = File(root, directoryNameFor(heapDumpFile))
+
+  /** Where what is written about [place] is kept. */
+  fun noteFile(place: Place): NoteFile = NoteFile(File(directory, "${place.noteKey()}$NOTES_SUFFIX"))
+
+  /**
+   * Which places this heap dump already has a note about, as [Place.noteKey] keys.
+   *
+   * A listing rather than a file opened per place, because this answers a question about every tab at once:
+   * whether the tab strip marks one. Reading the notes themselves waits until one is looked at.
+   */
+  fun keysWithNotes(): Set<String> =
+    directory.listFiles().orEmpty()
+      .filter { it.isFile && it.name.endsWith(NOTES_SUFFIX) }
+      .map { it.name.removeSuffix(NOTES_SUFFIX) }
+      .toSet()
+
+  companion object {
+
+    /**
+     * The dump's file name, and the directory it is in as a hash: `large-dump.hprof-1f3a9c0b`.
+     *
+     * The name first because these directories are read by people and listed by name, and a hash of the
+     * directory after it because two dumps called `large-dump.hprof` from two runs of the same app are two
+     * investigations. Which way round to solve that is the whole choice here — a path flattened into a
+     * directory name would be unreadable and would hit the 255 character limit, and the name alone would
+     * silently merge the notes of every dump ever called `heap.hprof`.
+     *
+     * [normalizedPath] rather than the path as given, because `./heap.hprof` is how a heap dump gets typed
+     * on a command line and it is the same dump as `heap.hprof`.
+     */
+    private fun directoryNameFor(heapDumpFile: File): String {
+      val heapDump = normalizedPath(heapDumpFile)
+      return "${heapDump.name}-${Integer.toHexString(heapDump.parent.orEmpty().hashCode())}"
+    }
+
+    /**
+     * One spelling of a heap dump's path, so that two ways of naming one file are one set of notes.
+     *
+     * Absolute, since the notes outlive the working directory the app was started in, and with the `.` and
+     * `..` steps taken out, since `./heap.hprof` and `heap.hprof` are what the same dump gets called on a
+     * command line. Not the canonical path: that resolves symlinks, which means asking the filesystem and
+     * getting a different answer once the dump has been deleted.
+     */
+    private fun normalizedPath(heapDumpFile: File): File = heapDumpFile.absoluteFile.normalize()
+
+    private const val NOTES_SUFFIX = ".md"
+  }
+}
+
+/**
+ * What a note is filed under, which is **what the tab is about rather than how it is arranged**.
+ *
+ * The distinction is the whole of this function. A place carries the state of the screen showing it as well
+ * as its subject — what the object list is filtered to, which leaks are unfolded, how many objects a pile of
+ * small ones stands for at this window width — and all of that changes while reading. Keyed on the place
+ * itself, a note would follow the filter box: typing a letter into it would be moving to a different
+ * notepad, and the note just written would be filed under a search nobody will run again.
+ *
+ * So: one note per object, one per pile, one for the object list however it is filtered, one for the leaks
+ * however they are unfolded, one for the starred objects. The whole heap dump is an object like any other
+ * here — the first tab of a window — and is the one to write the note that is about the dump rather than
+ * about anything in it.
+ */
+fun Place.noteKey(): String = when (this) {
+  is Place.Object ->
+    if (objectId == HeapDominatorTreemap.ROOT_OBJECT_ID) {
+      HEAP_DUMP_KEY
+    } else {
+      "object-${hexObjectId(objectId)}"
+    }
+  is Place.SmallerObjects -> "smaller-objects-${hexObjectId(parentObjectId)}"
+  is Place.Objects -> "object-list"
+  is Place.Leaks -> "leaks"
+  is Place.Starred -> "starred"
+}
+
+/** The note about the heap dump as a whole, which is the place its first tab opens on. */
+private const val HEAP_DUMP_KEY = "heap-dump"
+
+/**
+ * One note: a markdown file, read and written whole.
+ *
+ * Both halves throw [IOException] rather than swallowing it, so that a note which could not be read is
+ * never quietly saved over by an empty one.
+ */
+class NoteFile internal constructor(
+  /** The file itself, which is shown in the window so that the note can be found without this app. */
+  val file: File
+) {
+
+  /** What is on disk, or nothing at all for a place nobody has written about yet. */
+  fun read(): String = if (file.isFile) file.readText() else ""
+
+  /**
+   * Puts [text] on disk, through a file of its own and a rename, so that a run killed halfway through a
+   * save leaves the last note rather than half of one. The one thing in this app nobody else has a copy
+   * of is what someone typed into it.
+   *
+   * Nothing written is nothing kept: a note cleared out deletes the file rather than leaving an empty one
+   * behind for the next run to find and mark a tab with.
+   */
+  fun write(text: String) {
+    if (text.isEmpty()) {
+      if (file.isFile && !file.delete()) {
+        throw IOException("Could not delete $file, which is what an empty note is")
+      }
+      return
+    }
+    val directory = file.parentFile
+    if (!directory.isDirectory && !directory.mkdirs()) {
+      throw IOException("Could not create $directory to keep notes in")
+    }
+    val partial = File(directory, "${file.name}$PARTIAL_SUFFIX")
+    partial.writeText(text)
+    Files.move(partial.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+  }
+
+  companion object {
+    /** A save in flight, which is never the file a note is read from. */
+    private const val PARTIAL_SUFFIX = ".partial"
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NoteMarkdown.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NoteMarkdown.kt
@@ -1,0 +1,356 @@
+package shark.explorer
+
+/**
+ * Reading the markdown of a note. The other half of [Note], kept apart because a parser reads as one thing
+ * and a model as another.
+ *
+ * What is understood is deliberately a subset — see [Note] for which — and **one line is one block**: no
+ * paragraph reflows two lines someone wrote as two, no line has to be ended with two spaces to stay a line,
+ * and a list needs no blank line above it. Which is the way a comment box on GitHub reads markdown, and the
+ * way anyone typing a note about a heap dump expects it to be read.
+ *
+ * Nothing here reads the heap dump. What only the heap dump can answer is left as a [NoteMention] for
+ * [Note.resolvedWith], so that a note can be re-read on every keystroke and the dump asked once the typing
+ * has stopped.
+ *
+ * No line is logged from here for the same reason: this runs per keystroke, so a line about a link that
+ * doesn't parse would be a line per keystroke. A link this can't read stays the text it was typed as, which
+ * is what the window shows for it.
+ */
+internal fun noteBlocksOf(text: String): List<NoteBlock> {
+  if (text.isEmpty()) {
+    return emptyList()
+  }
+  val lines = text.split('\n').map { it.removeSuffix("\r") }
+  val blocks = mutableListOf<NoteBlock>()
+  var index = 0
+  while (index < lines.size) {
+    if (lines[index].trimStart().startsWith(CODE_FENCE)) {
+      val fenced = mutableListOf<String>()
+      index++
+      while (index < lines.size && !lines[index].trimStart().startsWith(CODE_FENCE)) {
+        fenced += lines[index]
+        index++
+      }
+      // A fence with nothing closing it is a block halfway through being typed rather than a mistake, so
+      // what is under it is code either way. Stepping past the closing fence, or past the end.
+      index++
+      blocks += NoteBlock.Code(fenced.joinToString("\n"))
+    } else {
+      blocks += blockOf(lines[index])
+      index++
+    }
+  }
+  return blocks
+}
+
+private fun blockOf(line: String): NoteBlock {
+  // Before the list, so that `---` is a rule rather than a bullet with nothing after it.
+  if (RULE.matches(line)) {
+    return NoteBlock.Rule
+  }
+  HEADING.matchEntire(line)?.let { heading ->
+    return NoteBlock.Heading(
+      level = heading.groupValues[1].length,
+      spans = inlineSpansOf(heading.groupValues[2])
+    )
+  }
+  QUOTE.matchEntire(line)?.let { quote ->
+    return NoteBlock.Quote(inlineSpansOf(quote.groupValues[1]))
+  }
+  ITEM.matchEntire(line)?.let { item ->
+    val number = item.groupValues[3]
+    return NoteBlock.Item(
+      // A number is drawn as it was typed rather than counted here, so that a list starting at 4 keeps
+      // saying 4 — a note is often a list of the objects of one leak, numbered from wherever they were.
+      marker = if (number.isEmpty()) BULLET else "$number.",
+      depth = item.groupValues[1].replace("\t", TAB_AS_SPACES).length / INDENT_WIDTH,
+      spans = inlineSpansOf(item.groupValues[4])
+    )
+  }
+  return NoteBlock.Paragraph(inlineSpansOf(line))
+}
+
+/**
+ * The styled and linked stretches of one line.
+ *
+ * Two passes rather than one regex: this one is what markdown spells — code, links, emphasis — and the text
+ * between and inside those goes through [mentionSpansOf], which is what this heap dump spells. So a class
+ * name is found in a bullet, in bold, and in `backticks`, and is not looked for inside a URL.
+ */
+private fun inlineSpansOf(
+  text: String,
+  styles: Set<NoteStyle> = emptySet()
+): List<NoteSpan> {
+  val spans = mutableListOf<NoteSpan>()
+  var index = 0
+  INLINE_TOKEN.findAll(text).forEach { token ->
+    if (token.range.first > index) {
+      spans += mentionSpansOf(text.substring(index, token.range.first), styles)
+    }
+    spans += tokenSpans(token, styles)
+    index = token.range.last + 1
+  }
+  if (index < text.length) {
+    spans += mentionSpansOf(text.substring(index), styles)
+  }
+  return spans
+}
+
+private fun tokenSpans(
+  token: MatchResult,
+  styles: Set<NoteStyle>
+): List<NoteSpan> {
+  val groups = token.groups
+  groups[CODE_GROUP]?.let { code ->
+    // Monospaced, and still read for what it mentions: `com.example.Thing` in backticks is how a class
+    // name gets written by anyone who writes markdown, so refusing to link it would be refusing the
+    // spelling most notes use.
+    return mentionSpansOf(code.value.trim('`'), styles + NoteStyle.CODE)
+  }
+  groups[LINK_GROUP]?.let { return listOf(markdownLinkSpan(it.value, styles)) }
+  groups[URL_GROUP]?.let { return listOf(urlSpan(it.value, styles)) }
+  groups[BOLD_GROUP]?.let { bold ->
+    return inlineSpansOf(bold.value.drop(BOLD_MARKER_LENGTH).dropLast(BOLD_MARKER_LENGTH), styles + NoteStyle.BOLD)
+  }
+  groups[ITALIC_GROUP]?.let { italic ->
+    return inlineSpansOf(italic.value.drop(1).dropLast(1), styles + NoteStyle.ITALIC)
+  }
+  return listOf(NoteSpan(text = token.value, styles = styles))
+}
+
+/** `[what it says](where it goes)`, which is the way to write a link whose text is prose. */
+private fun markdownLinkSpan(
+  token: String,
+  styles: Set<NoteStyle>
+): NoteSpan {
+  val target = token.substringAfterLast("](").removeSuffix(")")
+  val text = token.removePrefix("[").substringBeforeLast("](")
+  val link = when {
+    DeepLink.looksLikeOne(target) -> deepLinkOrNull(target)?.let { NoteLink.Deep(it) }
+    WEB_SCHEMES.any { target.startsWith(it) } -> NoteLink.Web(target)
+    // Anything else — a relative path, a file, a scheme this app has no business opening — is text.
+    else -> null
+  }
+  return NoteSpan(text = text.ifEmpty { target }, styles = styles, link = link)
+}
+
+/** A URL written out on its own, which is what pasting one does. */
+private fun urlSpan(
+  url: String,
+  styles: Set<NoteStyle>
+): NoteSpan {
+  if (DeepLink.looksLikeOne(url)) {
+    val deepLink = deepLinkOrNull(url)
+    // A `shark://` link that isn't one — a place this app has no screen for, a window missing from it — is
+    // left as typed rather than drawn as a link that goes nowhere.
+    return if (deepLink == null) NoteSpan(text = url, styles = styles) else deepLinkSpan(deepLink, styles)
+  }
+  return NoteSpan(text = shortWebText(url), styles = styles, link = NoteLink.Web(url))
+}
+
+/**
+ * A link to a place in a window, drawn as the place rather than as the URL.
+ *
+ * The link is kept exactly as it was typed, so it still leads to the window it names — which is usually
+ * this one and after a restart is none, and either way is not for a note to decide. See [NoteLink.Deep].
+ */
+private fun deepLinkSpan(
+  deepLink: DeepLink,
+  styles: Set<NoteStyle>
+): NoteSpan {
+  val place = deepLink.place
+  val link = NoteLink.Deep(deepLink)
+  if (place !is Place.Object) {
+    // Every other place says what it is. One that stops doing so shows the URL, which is at least what
+    // somebody pasted.
+    return NoteSpan(text = place.title ?: deepLink.toUri(), styles = styles, link = link)
+  }
+  if (place.objectId == HeapDominatorTreemap.ROOT_OBJECT_ID) {
+    return NoteSpan(text = HeapDominatorTreemap.ROOT_LABEL, styles = styles, link = link)
+  }
+  // Named by asking the heap dump, the same way a typed address is: a link to an object of the dump these
+  // notes are about reads as that object. See [NoteSpan.resolvedWith], which leaves the link alone.
+  return NoteSpan(
+    text = "$OBJECT_PREFIX${hexObjectId(place.objectId)}",
+    styles = styles,
+    link = link,
+    mention = NoteMention.ObjectId(listOf(place.objectId))
+  )
+}
+
+private fun deepLinkOrNull(url: String): DeepLink? = try {
+  DeepLink.parse(url)
+} catch (notALink: IllegalArgumentException) {
+  null
+}
+
+/**
+ * What a web URL is drawn as, which for GitHub is what GitHub itself would draw.
+ *
+ * `https://github.com/square/leakcanary/issues/2841` written out in full is nine tenths punctuation, and a
+ * note about a heap dump is mostly links to the issue it is about. GitHub shortens those in every comment
+ * box it has, so a note that didn't would be the one place they are unreadable. Everything else is drawn as
+ * it was typed: shortening an arbitrary URL hides where it goes.
+ */
+private fun shortWebText(url: String): String {
+  val path = url.substringAfter("://").removePrefix("www.")
+  if (!path.startsWith(GITHUB_HOST)) {
+    return url
+  }
+  val fragment = path.substringAfter('#', "")
+  val segments = path.removePrefix(GITHUB_HOST).substringBefore('?').substringBefore('#')
+    .split('/').filter { it.isNotEmpty() }
+  val repository = segments.take(2).joinToString("/")
+  return when {
+    segments.size == 2 -> repository
+    segments.size != 4 -> url
+    segments[2] == COMMIT_SEGMENT -> "$repository@${segments[3].take(SHORT_SHA_LENGTH)}"
+    segments[2] in NUMBERED_SEGMENTS && segments[3].toIntOrNull() != null ->
+      "$repository#${segments[3]}${if (isCommentFragment(fragment)) COMMENT_SUFFIX else ""}"
+    else -> url
+  }
+}
+
+/** Which part of an issue or a pull request a fragment points at: a comment, or a review of a diff. */
+private fun isCommentFragment(fragment: String): Boolean =
+  COMMENT_FRAGMENT_PREFIXES.any { fragment.startsWith(it) }
+
+/**
+ * The stretches of a line that only the heap dump can say anything about: a dotted name, and an address.
+ *
+ * Left as a [NoteMention] with the text as typed, so that a note reads exactly as it was written until the
+ * dump has been asked, and goes on doing so for whatever the dump doesn't have.
+ */
+private fun mentionSpansOf(
+  text: String,
+  styles: Set<NoteStyle>
+): List<NoteSpan> {
+  val spans = mutableListOf<NoteSpan>()
+  var index = 0
+  MENTION_TOKEN.findAll(text).forEach { token ->
+    if (token.range.first > index) {
+      spans += NoteSpan(text = text.substring(index, token.range.first), styles = styles)
+    }
+    spans += mentionSpan(token, styles)
+    index = token.range.last + 1
+  }
+  if (index < text.length) {
+    spans += NoteSpan(text = text.substring(index), styles = styles)
+  }
+  return spans
+}
+
+private fun mentionSpan(
+  token: MatchResult,
+  styles: Set<NoteStyle>
+): NoteSpan {
+  val address = token.groups[OBJECT_ID_GROUP]
+    ?: return NoteSpan(
+      text = token.value,
+      styles = styles,
+      mention = NoteMention.ClassName(token.value)
+    )
+  val objectIds = objectIdsOf(address.value)
+  return NoteSpan(
+    text = address.value,
+    styles = styles,
+    mention = if (objectIds.isEmpty()) null else NoteMention.ObjectId(objectIds)
+  )
+}
+
+/**
+ * Every [Long] `0x…` can mean, which is one of them or two.
+ *
+ * Two when it fits in 32 bits with the top one set: shark reads a 32 bit heap dump's four byte ids as
+ * [Long]s widened by sign, so the object every other tool calls `0xffff8000` is the negative id
+ * `0xffffffffffff8000` in the tree, and both readings have to be offered. See [NoteMention.ObjectId].
+ */
+private fun objectIdsOf(text: String): List<Long> {
+  val address = try {
+    java.lang.Long.parseUnsignedLong(text.substring(HEX_PREFIX.length), HEX_RADIX)
+  } catch (notAnAddress: NumberFormatException) {
+    return emptyList()
+  }
+  return if (address and INT_MASK == address && address and INT_SIGN_BIT != 0L) {
+    listOf(address, address.toInt().toLong())
+  } else {
+    listOf(address)
+  }
+}
+
+private const val CODE_FENCE = "```"
+
+/** What a bullet is drawn as, whichever of `-`, `*` and `+` was typed. */
+private const val BULLET = "•"
+
+private const val INDENT_WIDTH = 2
+private const val TAB_AS_SPACES = "  "
+private const val BOLD_MARKER_LENGTH = 2
+
+private const val OBJECT_PREFIX = "Object "
+
+private const val GITHUB_HOST = "github.com/"
+private const val COMMIT_SEGMENT = "commit"
+private val NUMBERED_SEGMENTS = setOf("issues", "pull", "discussions")
+private const val COMMENT_SUFFIX = " (comment)"
+
+/** As GitHub writes them: a comment on an issue, a review of a pull request, a reply under either. */
+private val COMMENT_FRAGMENT_PREFIXES =
+  listOf("issuecomment", "discussion_r", "pullrequestreview", "discussion-")
+
+private const val SHORT_SHA_LENGTH = 7
+
+private val WEB_SCHEMES = listOf("https://", "http://")
+
+private const val HEX_PREFIX = "0x"
+private const val HEX_RADIX = 16
+private const val INT_MASK = 0xffffffffL
+private const val INT_SIGN_BIT = 0x80000000L
+
+private val RULE = Regex(""" {0,3}(?:-{3,}|\*{3,}|_{3,}) *""")
+private val HEADING = Regex(""" {0,3}(#{1,6}) +(.*)""")
+private val QUOTE = Regex(""" {0,3}> ?(.*)""")
+private val ITEM = Regex("""([ \t]*)(?:([-*+])|(\d+)[.)]) +(.*)""")
+
+private const val CODE_GROUP = "code"
+private const val LINK_GROUP = "link"
+private const val URL_GROUP = "url"
+private const val BOLD_GROUP = "bold"
+private const val ITALIC_GROUP = "italic"
+
+/**
+ * What markdown spells inline, in the order it is looked for: whichever starts earliest in the line wins,
+ * and at one place in the line the first of these does.
+ *
+ * Emphasis asks for a non-space either side of the text, which is what keeps `2 * 3 * 4` from being a
+ * multiplication written in italics, and the underscore forms ask for a non-word character outside them,
+ * which is what keeps `mAttachInfo_2` in one piece.
+ */
+private val INLINE_TOKEN = Regex(
+  listOf(
+    """(?<$CODE_GROUP>`[^`\n]+`)""",
+    """(?<$LINK_GROUP>\[[^\]\n]*\]\([^)\s]+\))""",
+    // Trailing punctuation is left out, so that a link at the end of a sentence isn't a link to the
+    // sentence: `[^…]*` gives back whatever it has to for the last character to be part of the URL.
+    """(?<$URL_GROUP>(?:https?|${DeepLink.SCHEME})://[^\s<>()\[\]"'`]*[^\s<>()\[\]"'`.,;:!?])""",
+    """(?<$BOLD_GROUP>\*\*\S(?:[^*]*\S)?\*\*|(?<!\w)__\S(?:[^_]*\S)?__(?!\w))""",
+    """(?<$ITALIC_GROUP>\*\S(?:[^*]*\S)?\*|(?<!\w)_\S(?:[^_]*\S)?_(?!\w))"""
+  ).joinToString("|")
+)
+
+private const val OBJECT_ID_GROUP = "objectId"
+
+/** A dotted name as the JVM spells one, `${'$'}` and all: an inner class of a heap dump is `Outer${'$'}Inner`. */
+private const val IDENTIFIER = """[A-Za-z_${'$'}][\w${'$'}]*"""
+
+/**
+ * What this heap dump spells: an address, and a name with a package in front of it.
+ *
+ * Neither may start part way into a longer name, which is what the lookbehinds are for — the tail of
+ * `com.example.Thing` is not a class called `example.Thing`, and the tail of `0x1f` is not `x1f`.
+ */
+private val MENTION_TOKEN = Regex(
+  """(?<$OBJECT_ID_GROUP>(?<![\w.])0[xX][0-9a-fA-F]{1,16}\b)""" +
+    """|(?<![\w.${'$'}])$IDENTIFIER(?:\.$IDENTIFIER)+"""
+)

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Tabs.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Tabs.kt
@@ -64,6 +64,15 @@ data class Tabs(
   val canGoForward: Boolean get() = selected?.history?.canGoForward == true
 
   /**
+   * Where the back arrow leads, the nearest first, so that going back four moves is one click rather than
+   * four. See [NavigationHistory.backEntries].
+   */
+  val backPlaces: List<Place> get() = selected?.history?.backEntries.orEmpty()
+
+  /** And where the forward arrow leads. */
+  val forwardPlaces: List<Place> get() = selected?.history?.forwardEntries.orEmpty()
+
+  /**
    * Opens [place] in a tab of its own, beside the one it was opened from.
    *
    * Beside rather than at the end, the way a browser does it, so that the tabs opened while reading one
@@ -128,6 +137,11 @@ data class Tabs(
   fun goBack(): Tabs = mapSelected { it.goBack() }
 
   fun goForward(): Tabs = mapSelected { it.goForward() }
+
+  /** Back [steps] moves at once, which is what picking one out of [backPlaces] asks for. */
+  fun goBack(steps: Int): Tabs = mapSelected { it.goBack(steps) }
+
+  fun goForward(steps: Int): Tabs = mapSelected { it.goForward(steps) }
 
   private fun mapSelected(
     ifNoTabIsOpen: () -> Tabs = { this },

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NavigationHistoryTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NavigationHistoryTest.kt
@@ -68,6 +68,37 @@ class NavigationHistoryTest {
     assertThat(history.goBack().goBack().current).isEqualTo("root")
   }
 
+  /** What the right click menus on the arrows list, which is why the order they are in is part of it. */
+  @Test fun `everywhere it has been is listed nearest first`() {
+    val history = NavigationHistory("root").goTo("a").goTo("b").goTo("c").goBack()
+
+    assertThat(history.backEntries).containsExactly("a", "root")
+    assertThat(history.forwardEntries).containsExactly("c")
+  }
+
+  @Test fun `a history that has been nowhere lists nowhere`() {
+    val history = NavigationHistory("root")
+
+    assertThat(history.backEntries).isEmpty()
+    assertThat(history.forwardEntries).isEmpty()
+  }
+
+  /** Picking the third entry of a back list is going back three moves, which the arrow does one at a time. */
+  @Test fun `it goes back and forward several moves at once`() {
+    val history = NavigationHistory("root").goTo("a").goTo("b").goTo("c")
+
+    assertThat(history.goBack(3).current).isEqualTo("root")
+    assertThat(history.goBack(3).goForward(2).current).isEqualTo("b")
+  }
+
+  /** The list a click came from and the history it came from are the same value one recomposition apart. */
+  @Test fun `going further than it has been lands at the end of it`() {
+    val history = NavigationHistory("root").goTo("a")
+
+    assertThat(history.goBack(9).current).isEqualTo("root")
+    assertThat(history.goForward(9).current).isEqualTo("a")
+  }
+
   @Test fun `a history has to be somewhere`() {
     assertThatThrownBy { NavigationHistory<String>(entries = emptyList(), index = 0) }
       .isInstanceOf(IllegalArgumentException::class.java)

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NoteFileTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NoteFileTest.kt
@@ -1,0 +1,149 @@
+package shark.explorer
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class NoteFileTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Test fun `a place nobody has written about has no note`() {
+    assertThat(noteFile("heap.hprof", Place.wholeHeapDump()).read()).isEmpty()
+  }
+
+  @Test fun `what was written is read back`() {
+    val note = noteFile("heap.hprof", Place.wholeHeapDump())
+
+    note.write("# The tab strip\nHeld by com.example.Holder")
+
+    assertThat(note.read()).isEqualTo("# The tab strip\nHeld by com.example.Holder")
+  }
+
+  @Test fun `the same place is the same note in another run`() {
+    noteFile("heap.hprof", Place.Object(HOLDER_ID)).write("Written last time")
+
+    assertThat(noteFile("heap.hprof", Place.Object(HOLDER_ID)).read()).isEqualTo("Written last time")
+  }
+
+  @Test fun `two objects are two notes`() {
+    val holder = noteFile("heap.hprof", Place.Object(HOLDER_ID))
+    val payload = noteFile("heap.hprof", Place.Object(PAYLOAD_ID))
+
+    holder.write("What holds the payload")
+    payload.write("What the payload is")
+
+    assertThat(holder.read()).isEqualTo("What holds the payload")
+    assertThat(payload.read()).isEqualTo("What the payload is")
+  }
+
+  /** Two runs of one app produce two dumps of one name, and they are two investigations. */
+  @Test fun `two heap dumps of one name in two directories are two notes`() {
+    val monday = noteFile("dumps/monday/heap.hprof", Place.wholeHeapDump())
+    val tuesday = noteFile("dumps/tuesday/heap.hprof", Place.wholeHeapDump())
+
+    monday.write("Monday")
+    tuesday.write("Tuesday")
+
+    assertThat(monday.read()).isEqualTo("Monday")
+    assertThat(tuesday.read()).isEqualTo("Tuesday")
+  }
+
+  /** Which is how a heap dump gets typed on a command line, and it is the same heap dump. */
+  @Test fun `a path with a dot step in it is the same notes`() {
+    noteFile("dumps/heap.hprof", Place.wholeHeapDump()).write("Written the plain way")
+
+    assertThat(noteFile("dumps/./heap.hprof", Place.wholeHeapDump()).read())
+      .isEqualTo("Written the plain way")
+  }
+
+  /**
+   * Typing into the search box is a place of its own — the query is part of it — and it is not a notepad of
+   * its own: a note filed under a half typed search is one nobody will find again.
+   */
+  @Test fun `however the object list is filtered it is one note`() {
+    noteFile("heap.hprof", Place.Objects(ObjectListFilter(query = "Bit"))).write("Every bitmap here")
+
+    assertThat(noteFile("heap.hprof", Place.Objects(ObjectListFilter(query = "Bitmap"))).read())
+      .isEqualTo("Every bitmap here")
+  }
+
+  /** And the same for unfolding a leak, which is also a move to a place that is the same list. */
+  @Test fun `however the leaks are unfolded they are one note`() {
+    noteFile("heap.hprof", Place.Leaks()).write("Three of these are the same leak")
+
+    assertThat(noteFile("heap.hprof", Place.Leaks(expandedGroups = setOf("abc"))).read())
+      .isEqualTo("Three of these are the same leak")
+  }
+
+  /**
+   * How many objects a rectangle had no room for depends on how big the window is, so it cannot be part of
+   * what the note about that pile is filed under.
+   */
+  @Test fun `a pile of smaller objects is one note however many are in it`() {
+    noteFile("heap.hprof", Place.SmallerObjects(HOLDER_ID, nodeCount = 12, byteCount = 34)).write("Tiny")
+
+    assertThat(
+      noteFile("heap.hprof", Place.SmallerObjects(HOLDER_ID, nodeCount = 400, byteCount = 5)).read()
+    ).isEqualTo("Tiny")
+  }
+
+  /** So that a note can be found, opened and pasted from without going through this app. */
+  @Test fun `a note is a markdown file named after what it is about`() {
+    val directory = noteDirectory("large-dump.hprof")
+
+    assertThat(directory.directory.name).startsWith("large-dump.hprof")
+    assertThat(directory.noteFile(Place.wholeHeapDump()).file.name).isEqualTo("heap-dump.md")
+    assertThat(directory.noteFile(Place.Object(HOLDER_ID)).file.name)
+      .isEqualTo("object-${hexObjectId(HOLDER_ID)}.md")
+    assertThat(directory.noteFile(Place.Leaks()).file.name).isEqualTo("leaks.md")
+  }
+
+  @Test fun `the places written about are the notes on disk`() {
+    val directory = noteDirectory("heap.hprof")
+    directory.noteFile(Place.wholeHeapDump()).write("About the dump")
+    directory.noteFile(Place.Starred).write("About what is starred")
+
+    assertThat(directory.keysWithNotes()).containsExactlyInAnyOrder("heap-dump", "starred")
+  }
+
+  @Test fun `a note cleared out is a note deleted`() {
+    val directory = noteDirectory("heap.hprof")
+    val note = directory.noteFile(Place.Starred)
+    note.write("Written and thought better of")
+
+    note.write("")
+
+    assertThat(note.file.exists()).isFalse()
+    assertThat(note.read()).isEmpty()
+    assertThat(directory.keysWithNotes()).isEmpty()
+  }
+
+  /** The rename a save goes through is a file of its own, and it is not left in the directory. */
+  @Test fun `a save leaves nothing behind it`() {
+    val directory = noteDirectory("heap.hprof")
+    val note = directory.noteFile(Place.wholeHeapDump())
+
+    note.write("Saved")
+
+    assertThat(directory.directory.listFiles()!!.map { it.name }).containsExactly(note.file.name)
+  }
+
+  private fun noteFile(
+    heapDumpPath: String,
+    place: Place
+  ) = noteDirectory(heapDumpPath).noteFile(place)
+
+  private fun noteDirectory(heapDumpPath: String) =
+    NoteDirectory(notesRoot, File(testFolder.root, heapDumpPath))
+
+  private val notesRoot by lazy { testFolder.newFolder("notes") }
+
+  companion object {
+    private const val HOLDER_ID = 0x82182c00L
+    private const val PAYLOAD_ID = 0x1234L
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NoteReferencesTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NoteReferencesTest.kt
@@ -1,0 +1,66 @@
+package shark.explorer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The heap dump's half of a note: what the names and addresses written in one turn out to be. [NoteTest] is
+ * the other half, and it decides what gets asked here.
+ */
+class NoteReferencesTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Test fun `a class the heap dump has is answered with its class object`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+
+      val classObjectId = tree.classObjectIdOrNull("com.example.Holder")!!
+
+      val summary = tree.summarize(classObjectId)
+      assertThat(summary.className).isEqualTo("com.example.Holder")
+      assertThat(summary.kind).isEqualTo(HeapObjectKind.CLASS)
+    }
+  }
+
+  @Test fun `a class the heap dump has not got is nothing`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      assertThat(explorer.tree.classObjectIdOrNull("com.example.Absent")).isNull()
+    }
+  }
+
+  @Test fun `an object of the heap dump is named the way every list here names one`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+      val holder = tree.onlyInstanceOf("Holder")
+
+      assertThat(tree.objectNameOrNull(holder.objectId)).isEqualTo("Holder instance")
+    }
+  }
+
+  @Test fun `an address the heap dump has no object at is nothing`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      assertThat(explorer.tree.objectNameOrNull(0x1L)).isNull()
+    }
+  }
+
+  /** A note is read on every keystroke and the dump asked once, for everything in it at once. */
+  @Test fun `a note's mentions are answered together`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+      val holder = tree.onlyInstanceOf("Holder")
+      val note = Note.of(
+        "com.example.Holder holds ${hexObjectId(holder.objectId)}, and com.example.Absent holds 0x1"
+      )
+
+      val references = tree.referencesOf(note.mentions)
+
+      assertThat(references.classObjectIds.keys).containsExactly("com.example.Holder")
+      assertThat(references.objectNames).containsExactly(entry(holder.objectId, "Holder instance"))
+    }
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NoteTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/NoteTest.kt
@@ -1,0 +1,284 @@
+package shark.explorer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/**
+ * What a note means, which is everything about this feature that doesn't need a window or a heap dump: the
+ * markdown, the shortening, and which stretches of it lead somewhere.
+ *
+ * The heap dump's half is [NoteReferencesTest], and it is only ever asked about a [NoteMention] this file
+ * says was found.
+ */
+class NoteTest {
+
+  @Test fun `a note nobody has written is empty`() {
+    assertThat(Note.of("")).isEqualTo(Note.EMPTY)
+  }
+
+  @Test fun `a line of prose is a paragraph`() {
+    assertThat(Note.of("The tab strip holds them all")).isEqualTo(
+      Note(listOf(NoteBlock.Paragraph(listOf(NoteSpan("The tab strip holds them all")))))
+    )
+  }
+
+  /** No blank line between them, and no two spaces at the end of the first: a note is written in lines. */
+  @Test fun `two lines are two blocks`() {
+    val note = Note.of("What holds it\nThe tab strip")
+
+    assertThat(note.blocks).hasSize(2)
+    assertThat(textOf(note)).isEqualTo("What holds it\nThe tab strip")
+  }
+
+  @Test fun `a heading is drawn by how many hashes it was written with`() {
+    assertThat(Note.of("## What holds it").blocks)
+      .containsExactly(NoteBlock.Heading(level = 2, spans = listOf(NoteSpan("What holds it"))))
+  }
+
+  @Test fun `a list under a list is indented one level further`() {
+    val note = Note.of("- the activity\n  - the window\n* the view")
+
+    assertThat(note.blocks).containsExactly(
+      NoteBlock.Item(marker = "•", depth = 0, spans = listOf(NoteSpan("the activity"))),
+      NoteBlock.Item(marker = "•", depth = 1, spans = listOf(NoteSpan("the window"))),
+      NoteBlock.Item(marker = "•", depth = 0, spans = listOf(NoteSpan("the view")))
+    )
+  }
+
+  /** A note is often a list of the objects of one leak, numbered from wherever they were copied. */
+  @Test fun `a numbered item keeps the number it was written with`() {
+    assertThat(Note.of("4. the fourth step").blocks)
+      .containsExactly(NoteBlock.Item(marker = "4.", depth = 0, spans = listOf(NoteSpan("the fourth step"))))
+  }
+
+  @Test fun `a quote and a rule are what they were written as`() {
+    assertThat(Note.of("> pasted from the log\n---").blocks).containsExactly(
+      NoteBlock.Quote(listOf(NoteSpan("pasted from the log"))),
+      NoteBlock.Rule
+    )
+  }
+
+  @Test fun `fenced code is quoted rather than read`() {
+    val note = Note.of("```\nval leak = com.example.Holder at 0x12ab34cd\n```")
+
+    assertThat(note.blocks)
+      .containsExactly(NoteBlock.Code("val leak = com.example.Holder at 0x12ab34cd"))
+    // Nothing in it is a name of the heap dump, so nothing in it is linked or shortened.
+    assertThat(note.mentions).isEqualTo(NoteMentions.NONE)
+  }
+
+  @Test fun `a fence left open is code all the way down`() {
+    assertThat(Note.of("```\nstill typing").blocks).containsExactly(NoteBlock.Code("still typing"))
+  }
+
+  @Test fun `a web link opens in a browser`() {
+    val spans = spansOf("See https://example.com/leaks")
+
+    assertThat(spans).containsExactly(
+      NoteSpan("See "),
+      NoteSpan(text = "https://example.com/leaks", link = NoteLink.Web("https://example.com/leaks"))
+    )
+  }
+
+  @Test fun `a link at the end of a sentence is not a link to the sentence`() {
+    val spans = spansOf("See https://example.com/leaks.")
+
+    assertThat(spans.map { it.text }).containsExactly("See ", "https://example.com/leaks", ".")
+  }
+
+  @Test fun `a github issue is shortened the way github shortens it`() {
+    val url = "https://github.com/square/leakcanary/issues/2841"
+
+    assertThat(spansOf(url).single())
+      .isEqualTo(NoteSpan(text = "square/leakcanary#2841", link = NoteLink.Web(url)))
+  }
+
+  @Test fun `a link to a comment on an issue says it is one`() {
+    val url = "https://github.com/square/leakcanary/issues/2841#issuecomment-1234567"
+
+    assertThat(spansOf(url).single().text).isEqualTo("square/leakcanary#2841 (comment)")
+  }
+
+  @Test fun `a pull request is shortened like an issue`() {
+    assertThat(spansOf("https://github.com/square/leakcanary/pull/2950").single().text)
+      .isEqualTo("square/leakcanary#2950")
+  }
+
+  @Test fun `a commit is its first seven characters`() {
+    assertThat(spansOf("https://github.com/square/leakcanary/commit/ca8c455806f2b1e").single().text)
+      .isEqualTo("square/leakcanary@ca8c455")
+  }
+
+  @Test fun `a repository is the owner and the repository`() {
+    assertThat(spansOf("https://github.com/square/leakcanary").single().text)
+      .isEqualTo("square/leakcanary")
+  }
+
+  /** Shortening a URL whose shape github doesn't shorten would hide where it goes. */
+  @Test fun `anything else on github is left as it was typed`() {
+    val url = "https://github.com/square/leakcanary/blob/main/docs/changelog.md"
+
+    assertThat(spansOf(url).single()).isEqualTo(NoteSpan(text = url, link = NoteLink.Web(url)))
+  }
+
+  @Test fun `a markdown link is drawn as what it says`() {
+    val spans = spansOf("[the leak](https://example.com/leaks)")
+
+    assertThat(spans.single())
+      .isEqualTo(NoteSpan(text = "the leak", link = NoteLink.Web("https://example.com/leaks")))
+  }
+
+  @Test fun `emphasis is what markdown spells it as`() {
+    assertThat(spansOf("**held** and *not held* and `mAttachInfo`")).containsExactly(
+      NoteSpan(text = "held", styles = setOf(NoteStyle.BOLD)),
+      NoteSpan(" and "),
+      NoteSpan(text = "not held", styles = setOf(NoteStyle.ITALIC)),
+      NoteSpan(" and "),
+      NoteSpan(text = "mAttachInfo", styles = setOf(NoteStyle.CODE))
+    )
+  }
+
+  /** Emphasis asks for a non-space either side of it, which is what leaves arithmetic and names alone. */
+  @Test fun `a multiplication is not italics and a field name is not emphasis`() {
+    assertThat(spansOf("2 * 3 * 4").single().text).isEqualTo("2 * 3 * 4")
+    assertThat(spansOf("mAttachInfo_2 held it").single().text).isEqualTo("mAttachInfo_2 held it")
+  }
+
+  @Test fun `a class name of the heap dump is linked and shortened to its simple name`() {
+    val note = Note.of("Held by com.example.Holder").resolvedWith(
+      NoteReferences(classObjectIds = mapOf("com.example.Holder" to 0x42L), objectNames = emptyMap())
+    )
+
+    assertThat(note.blocks.single().spans).containsExactly(
+      NoteSpan("Held by "),
+      NoteSpan(
+        text = "Holder",
+        link = NoteLink.Object(0x42L),
+        mention = NoteMention.ClassName("com.example.Holder")
+      )
+    )
+  }
+
+  /** Which is the honest answer: a name this dump hasn't got is a name somebody wrote, not a broken link. */
+  @Test fun `a name the heap dump has never heard of stays as it was typed`() {
+    val note = Note.of("Held by com.example.Holder").resolvedWith(NoteReferences.NONE)
+
+    assertThat(note.blocks.single().spans.last())
+      .isEqualTo(NoteSpan(text = "com.example.Holder", mention = NoteMention.ClassName("com.example.Holder")))
+  }
+
+  @Test fun `a class name in backticks is linked and stays monospaced`() {
+    val note = Note.of("Held by `com.example.Holder`").resolvedWith(
+      NoteReferences(classObjectIds = mapOf("com.example.Holder" to 0x42L), objectNames = emptyMap())
+    )
+
+    assertThat(note.blocks.single().spans.last()).isEqualTo(
+      NoteSpan(
+        text = "Holder",
+        styles = setOf(NoteStyle.CODE),
+        link = NoteLink.Object(0x42L),
+        mention = NoteMention.ClassName("com.example.Holder")
+      )
+    )
+  }
+
+  @Test fun `an address is drawn as what the heap dump has at it`() {
+    val note = Note.of("Look at 0x12ab34cd").resolvedWith(
+      NoteReferences(classObjectIds = emptyMap(), objectNames = mapOf(0x12ab34cdL to "MainActivity instance"))
+    )
+
+    assertThat(note.blocks.single().spans.last()).isEqualTo(
+      NoteSpan(
+        text = "MainActivity instance (0x12ab34cd)",
+        link = NoteLink.Object(0x12ab34cdL),
+        mention = NoteMention.ObjectId(listOf(0x12ab34cdL))
+      )
+    )
+  }
+
+  /**
+   * An address above the 2 GB mark of a 32 bit dump is a negative id in the tree, and what every tool —
+   * including this app's own labels — prints for it is the low 32 bits. So both readings are offered and
+   * the dump picks.
+   */
+  @Test fun `an address of a 32 bit heap dump is the negative id it is stored as`() {
+    val negativeId = -2112345088L
+    val note = Note.of("Look at 0x82182c00").resolvedWith(
+      NoteReferences(classObjectIds = emptyMap(), objectNames = mapOf(negativeId to "Bitmap instance"))
+    )
+
+    val span = note.blocks.single().spans.last()
+    assertThat(span.text).isEqualTo("Bitmap instance (0x82182c00)")
+    assertThat(span.link).isEqualTo(NoteLink.Object(negativeId))
+  }
+
+  @Test fun `an address the heap dump has no object at stays as it was typed`() {
+    val note = Note.of("Look at 0x12ab34cd").resolvedWith(NoteReferences.NONE)
+
+    assertThat(note.blocks.single().spans.last().text).isEqualTo("0x12ab34cd")
+    assertThat(note.blocks.single().spans.last().link).isNull()
+  }
+
+  @Test fun `a shark link is followed inside the app and named after the place it leads to`() {
+    val spans = spansOf("Everything: shark://abcd2345/leaks")
+
+    assertThat(spans.last()).isEqualTo(
+      NoteSpan(text = "Leaks", link = NoteLink.Deep(DeepLink("abcd2345", Place.Leaks())))
+    )
+  }
+
+  /**
+   * The link is left alone by resolving, which is what keeps it a link to the window it names — the same
+   * dump is often open twice, and a note is not the place to decide which of them was meant.
+   */
+  @Test fun `a shark link to an object reads as the object and still leads to that window`() {
+    val note = Note.of("shark://abcd2345/object?id=0x12ab34cd").resolvedWith(
+      NoteReferences(classObjectIds = emptyMap(), objectNames = mapOf(0x12ab34cdL to "MainActivity instance"))
+    )
+
+    val span = note.blocks.single().spans.single()
+    assertThat(span.text).isEqualTo("MainActivity instance (0x12ab34cd)")
+    assertThat(span.link)
+      .isEqualTo(NoteLink.Deep(DeepLink("abcd2345", Place.Object(0x12ab34cdL))))
+  }
+
+  @Test fun `a shark link nobody has opened yet says which object it leads to`() {
+    assertThat(spansOf("shark://abcd2345/object?id=0x12ab34cd").single().text)
+      .isEqualTo("Object 0x12ab34cd")
+  }
+
+  @Test fun `a shark link to a place this app has no screen for stays as it was typed`() {
+    val spans = spansOf("shark://abcd2345/dominators")
+
+    assertThat(spans.single()).isEqualTo(NoteSpan("shark://abcd2345/dominators"))
+  }
+
+  @Test fun `everything the heap dump has to be asked about is gathered once`() {
+    val note = Note.of(
+      "com.example.Holder holds com.example.Holder at 0x1, and 0x2 holds nothing"
+    )
+
+    assertThat(note.mentions).isEqualTo(
+      NoteMentions(classNames = setOf("com.example.Holder"), objectIds = setOf(1L, 2L))
+    )
+  }
+
+  /**
+   * A note is resolved again every time the heap dump answers, so resolving one twice has to be the same
+   * note: anything built from what a span is showing rather than from its mention would compound.
+   */
+  @Test fun `resolving a note twice is resolving it once`() {
+    val references = NoteReferences(
+      classObjectIds = mapOf("com.example.Holder" to 0x42L),
+      objectNames = mapOf(1L to "Holder instance")
+    )
+    val resolved = Note.of("com.example.Holder at 0x1").resolvedWith(references)
+
+    assertThat(resolved.resolvedWith(references)).isEqualTo(resolved)
+  }
+
+  private fun spansOf(text: String): List<NoteSpan> = Note.of(text).blocks.single().spans
+
+  private fun textOf(note: Note): String =
+    note.blocks.joinToString("\n") { block -> block.spans.joinToString("") { it.text } }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TabsTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/TabsTest.kt
@@ -133,6 +133,31 @@ class TabsTest {
     assertThat(tabs.close(404)).isEqualTo(tabs)
   }
 
+  /** What the right click menu on an arrow lists, and what picking one out of it does. */
+  @Test fun `the tab on screen says everywhere it has been`() {
+    val tabs = Tabs.opening(WHOLE_HEAP_DUMP).goTo(objectAt(1)).goTo(objectAt(2))
+
+    assertThat(tabs.backPlaces).containsExactly(objectAt(1), WHOLE_HEAP_DUMP)
+    assertThat(tabs.forwardPlaces).isEmpty()
+    assertThat(tabs.goBack(2).place).isEqualTo(WHOLE_HEAP_DUMP)
+    assertThat(tabs.goBack(2).goForward(2).place).isEqualTo(objectAt(2))
+  }
+
+  /** Each tab has a history of its own, so what the arrows offer is the history of the one on screen. */
+  @Test fun `the other tabs histories are not on offer`() {
+    val tabs = Tabs.opening(WHOLE_HEAP_DUMP).goTo(objectAt(1)).open(objectAt(2))
+
+    assertThat(tabs.backPlaces).isEmpty()
+  }
+
+  @Test fun `a window with no tab open has been nowhere`() {
+    val tabs = Tabs.opening(WHOLE_HEAP_DUMP).close(0)
+
+    assertThat(tabs.backPlaces).isEmpty()
+    assertThat(tabs.forwardPlaces).isEmpty()
+    assertThat(tabs.goBack(1)).isEqualTo(tabs)
+  }
+
   @Test fun `a selected tab has to be one of the tabs`() {
     assertThatThrownBy {
       Tabs(tabs = emptyList(), selectedId = 0, nextId = 1)


### PR DESCRIPTION
An investigation is a series of questions about one heap dump, and the answers have so far lived in whatever the reader happened to have open beside the app. **Every location now takes a note.** Two smaller things the same window asked for came with it: the arrows list where they lead, and the window says what it is about.

**✎ Add Note** hangs under the title that says what the tab is on, and the note it starts is drawn under that row and above the three panes that read it — a note is about the whole of what the tab is showing, so under the title it is about and above everything that describes it. Clicking the button turns that space into a plain markdown box with **Save** and **Cancel**; saving draws the note where the box was. A location nobody has written about has nothing there at all, and the button goes away as soon as there is a note, which carries its own **✎ Edit** — so a section that is on every tab costs nothing on the tabs it has nothing to say about.

A note belongs to the **location**, not to the tab: two tabs on one location are one note, and both show what the other is typing. Location rather than object, because three of the keys are lists and one is a group of objects — `Place.noteKey` is the definition.

What makes it worth having in the app rather than in an editor is that the names written in it are read against the heap dump:

| What you write | What it reads as | What clicking it does |
| --- | --- | --- |
| `com.example.Holder` | `Holder` | opens the class in a new tab |
| `0x82182c00` | `Holder instance (0x82182c00)` | opens the object in a new tab |
| `shark://abcd2345/starred` | `Starred` | goes to that window's starred list, or explains that the window is gone |
| `https://github.com/square/leakcanary/pull/2941` | `square/leakcanary#2941` | opens it in the browser |
| `https://example.com/thing` | unchanged | opens it in the browser |

A class name that isn't in the dump, or an address nothing lives at, stays exactly as typed — the note is still readable when it's about a dump other than the one open, and nothing is ever rewritten on disk, only on screen. Reading the markdown is in memory; asking the heap dump what the names mean is a read, so it happens once per save, and not at all for a note that mentions nothing.

`shark://` links are followed through the same `DeepLinkPeers.follow` an OS link arrives through, so a link copied from a tab (⌘-click, or the right click menu) pasted into a note goes back to that tab, in that window, even across runs of the app.

### What a note is attached to

`Place.noteKey()` is the whole of it: a note is filed under **what its tab is about, not under the tab or the place**.

A place carries the state of its screen as well as its subject — what the object list is filtered to, which leaks are unfolded, how many objects a pile of small ones stands for at this window width. Keyed on the place itself, a note would follow the search box: typing a letter into it would be moving to a different notepad. Keyed on the tab, it would die with the tab. So: one note per object, one for the object list however it is filtered, one for the leaks however they are unfolded, one for the starred objects — and the whole heap dump is an object like any other here, so the tab a window opens with is where the note about the dump as a whole goes.

That also means the same object open in two tabs, or in two windows, is one note rather than two saving over each other.

The strip marks a tab whose place has a note with a `✎`, because a note nobody is reminded of is a note nobody comes back to. Which tabs those are is one directory listing rather than a file opened per tab.

### Where the notes live

Markdown files in the app's own directory: a directory per dump (`heap.hprof-1f3a9c0b/`), a file per place inside it (`heap-dump.md`, `object-0x82182c00.md`, `leaks.md`). Not beside the heap dump — a dump is opened from a temporary file, a read-only mount, a directory pulled off a device, or a checkout of this repository, so writing beside it means littering some places and failing on the rest. A file per place rather than one document with sections, so a save touches only the note that was typed into and nothing has to be parsed back out of a document that also holds someone's own headings. The box shows the path while you write, and the file is plain markdown, because a note about a leak gets pasted into an issue or read months later.

### Not losing what someone typed

The notes are the one thing in the app nobody else has a copy of, so:

- Nothing is written before the file has been read, and **✎ Add Note** is disabled until then. An empty box over a note still arriving off the disk is that note deleted a save later. The read is started by the window rather than by the section, since a section that has nothing to draw yet isn't there to start it.
- The draft is the run's rather than the screen's, held in `PlaceNotes`: clicking another tab half way through a sentence and coming back finds the sentence. It is not filed on the way out, which is the same answer **Cancel** gives.
- Writes go to a `.partial` file and are renamed over, so a run killed halfway through leaves the previous note rather than half of the new one.
- A read or write that fails says so in the section in red and in the log, and the draft is kept so the save can be tried again.

## List where an arrow leads on a right click

A tab that has walked twenty objects down a chain is one where getting back to where the walk started is twenty clicks and a guess about which of them it was. **Right clicking ← or →** now lists everywhere that arrow leads, nearest first and named the way the tab strip names a place, so any one of them is one click.

`NavigationHistory.backEntries`/`forwardEntries` are that list and `goBack(steps)` is the move, clamped rather than checked because the list a click came from and the history it lands in are the same value one recomposition apart. The nearest fifteen, since the menu is drawn where the pointer is and one taller than the window has entries nobody can reach. An arrow that leads nowhere keeps the disabled button it was: an empty menu under the pointer reads as the window having lost the history rather than as there being none.

## Say what the middle pane answers, and make the tab's subject a title

The panes either side of the map are headed "What holds it" and "What it is", and the map between them was headed nothing at all, which left the two of them reading as a pair with a picture wedged between rather than as three questions about one object. It gets **"What it holds"**, the name its fold button already used, and the fold control moves into that header like the other two.

That row is now two things with a rule between them: **how the tab got here** — the arrows — and **what it is on**, which is the title with what the notes offer under it. One undifferentiated strip of controls is what made anything at the end of it read as belonging to the window rather than to the object named beside it; the grouping says which, so nothing has to be labelled to say so. `IntrinsicSize.Min` on the row is what makes the rule as tall as the row, the title being one line on the whole heap dump and three on an object.

`✎ Add Note` sits inside the second of those, **under the title**, of the four places it could be: before the title puts the action ahead of its subject and moves the title depending on whether a note exists; hugging the end of the title moves the button on every click, the title being the object the tab is on; the far end of the row keeps one position but is as far from the title as the window is wide, and reads as the window's button rather than as this object's. Under the title is where its own result appears — the note opens exactly there — and it reads in the order it happens. What that costs is a line of every tab nobody has written about, so it is drawn small and with no padding of its own, which also lines its label up with the title.

The object the tab is on is set as a **title** where it is named above the panes — the one place in the window where it is the subject rather than a mention of an object among others, since everything under it is about that object. `ObjectIdentity` takes the style for its first line rather than picking one, so the same three lines are unchanged everywhere else.

## Tests

50 unit tests in `shark-explorer-core` over the markdown reading, the GitHub shortening, resolution against a real dump and where a note is filed — including that filtering the object list, unfolding a leak and resizing a pile of small objects all stay on one note. 7 more over the history a right click lists and moving several steps at once. 15 headless UI tests in `shark-explorer-app` cover each row of the table above, the tab a class link opens, that **Cancel** throws a draft away while **Save** puts it on disk, that changing a note starts from what was saved, that a note is only about the place its own tab is at, that two tabs on one place are one note, and that a place nobody has written about is the button and nothing else until saving takes the button away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

