### PR TITLE
Say whether an object is stuck, and which reference made it so

### DIFF
--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -30,11 +30,11 @@ uses, without the one for a newly recognized library leak:
   See [Take notes](shark-explorer.md#take-notes).
 * ✨ Right click ← or → for the list of everywhere that arrow leads, so going back four moves is one
   click rather than four.
-* ✨ **Verdict**: whether the object a tab is on leaked — `✗ Leaked`, `✓ Needed` or `? Unknown` — is the first
-  thing the **What it is** panel says, in the same colours a chain uses, and the pencil beside it overrules
-  the verdict: a reason is required, kept with it, and what you overruled is recorded beside it. Where a
-  verdict you set contradicts another one, every verdict it disagrees with is listed with the reason it was
-  given, and keeping yours flips them. The **Leaks** screen follows what you set, since marking an object as
-  leaked makes it a leak and takes whatever it holds off the list. Kept between runs in
+* ✨ **Verdict**: whether the object a tab is on is stuck in memory — `✗ Stuck`, `✓ Expected` or `? Unknown`
+  — is the first thing the **What it is** panel says, in the same colours a chain uses, and the pencil beside
+  it overrules the verdict: a reason is required, kept with it, and what you overruled is recorded beside it.
+  Where a verdict you set contradicts another one, every verdict it disagrees with is listed with the reason
+  it was given, and keeping yours flips them. The **Leaks** screen follows what you set, since marking an
+  object as stuck makes it a leak and takes whatever it holds off the list. Kept between runs in
   `~/.shark-explorer/leak-statuses`, one file per heap dump.
-  See [Say what leaked](shark-explorer.md#say-what-leaked).
+  See [The verdict](shark-explorer.md#the-verdict).

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -30,11 +30,11 @@ uses, without the one for a newly recognized library leak:
   See [Take notes](shark-explorer.md#take-notes).
 * ✨ Right click ← or → for the list of everywhere that arrow leads, so going back four moves is one
   click rather than four.
-* ✨ **Should it be here?**: whether the object a tab is on is meant to still be in memory is the first thing
-  the **What it is** panel says, in the same colours a chain uses, and the pencil beside it overrules the
-  answer — a reason is required, kept with it, and what you overruled is recorded beside it. Where a status
-  you set contradicts another one, every status it disagrees with is listed with the reason it was given, and
-  keeping yours flips them. The **Leaks** screen follows what you set, since marking an object as one that
-  shouldn't be here makes it a leak and takes whatever it holds off the list. Kept between runs in
+* ✨ **Verdict**: whether the object a tab is on leaked — `✗ Leaked`, `✓ Needed` or `? Unknown` — is the first
+  thing the **What it is** panel says, in the same colours a chain uses, and the pencil beside it overrules
+  the verdict: a reason is required, kept with it, and what you overruled is recorded beside it. Where a
+  verdict you set contradicts another one, every verdict it disagrees with is listed with the reason it was
+  given, and keeping yours flips them. The **Leaks** screen follows what you set, since marking an object as
+  leaked makes it a leak and takes whatever it holds off the list. Kept between runs in
   `~/.shark-explorer/leak-statuses`, one file per heap dump.
-  See [Say what should be here](shark-explorer.md#say-what-should-be-here).
+  See [Say what leaked](shark-explorer.md#say-what-leaked).

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -30,9 +30,11 @@ uses, without the one for a newly recognized library leak:
   See [Take notes](shark-explorer.md#take-notes).
 * ✨ Right click ← or → for the list of everywhere that arrow leads, so going back four moves is one
   click rather than four.
-* ✨ **Leaking status**: whether the object a tab is on should still be in memory is said under its name, in
-  the same colours a chain uses, and you can overrule it — a reason is required, kept with it, and what you
-  overruled is recorded beside it. Where a status you set contradicts another one, every status it disagrees
-  with is listed with the reason it was given, and keeping yours flips them. Kept between runs in
+* ✨ **Should it be here?**: whether the object a tab is on is meant to still be in memory is the first thing
+  the **What it is** panel says, in the same colours a chain uses, and the pencil beside it overrules the
+  answer — a reason is required, kept with it, and what you overruled is recorded beside it. Where a status
+  you set contradicts another one, every status it disagrees with is listed with the reason it was given, and
+  keeping yours flips them. The **Leaks** screen follows what you set, since marking an object as one that
+  shouldn't be here makes it a leak and takes whatever it holds off the list. Kept between runs in
   `~/.shark-explorer/leak-statuses`, one file per heap dump.
-  See [Say what is leaking](shark-explorer.md#say-what-is-leaking).
+  See [Say what should be here](shark-explorer.md#say-what-should-be-here).

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -30,3 +30,9 @@ uses, without the one for a newly recognized library leak:
   See [Take notes](shark-explorer.md#take-notes).
 * ✨ Right click ← or → for the list of everywhere that arrow leads, so going back four moves is one
   click rather than four.
+* ✨ **Leaking status**: whether the object a tab is on should still be in memory is said under its name, in
+  the same colours a chain uses, and you can overrule it — a reason is required, kept with it, and what you
+  overruled is recorded beside it. Where a status you set contradicts another one, every status it disagrees
+  with is listed with the reason it was given, and keeping yours flips them. Kept between runs in
+  `~/.shark-explorer/leak-statuses`, one file per heap dump.
+  See [Say what is leaking](shark-explorer.md#say-what-is-leaking).

--- a/docs/shark-explorer-changelog.md
+++ b/docs/shark-explorer-changelog.md
@@ -38,3 +38,9 @@ uses, without the one for a newly recognized library leak:
   object as stuck makes it a leak and takes whatever it holds off the list. Kept between runs in
   `~/.shark-explorer/leak-statuses`, one file per heap dump.
   See [The verdict](shark-explorer.md#the-verdict).
+* ✨ **The chain marks the faulty reference**: the one step going from an `Expected` object straight to a
+  `Stuck` one reads `Holder.activity · faulty reference`, which is the leak itself rather than one of the
+  objects it left behind, and the same reference the **Leaks** screen names that leak after. A chain whose
+  two verdicts are further apart than one step carries no mark, since which reference in between is at fault
+  is what isn't known — overrule a verdict in between and the mark appears.
+  See [The verdict](shark-explorer.md#the-verdict).

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -70,8 +70,8 @@ a few seconds.
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
-* **Whether the object a tab is on should still be in memory is said under its name**, and you can overrule
-  it — see [Say what is leaking](#say-what-is-leaking).
+* **Whether the object a tab is on is meant to still be in memory is the first thing "What it is" says**,
+  and you can overrule it — see [Say what should be here](#say-what-should-be-here).
 * Every location takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
 
 ## Link to a tab
@@ -149,46 +149,52 @@ Since a `shark://` link names a window, a link written into a note stops working
 — see above. Copy one for the tab you want to come back to *while you are writing about it*, and it will
 take you there for as long as that window is open.
 
-## Say what is leaking
+## Say what should be here
 
-Under the title saying where the tab is, **the window says whether that object should still be in memory** —
-`✗ Leaking`, `✓ Not leaking`, or a quiet `? Unknown` — with the reason beside it, in the same colours the chain
-on the left uses. Most objects in a heap dump are `Unknown`, which is why that one is drawn small: the two
-that mean something are the ones worth seeing across the room.
+At the top of **What it is**, under the object's name, the window answers **Should it be here?** —
+`✗ Shouldn't be here`, `✓ Meant to be here`, or a quiet `? Nobody knows` — with the reason under it, in the
+same colours the chain on the left uses. Most objects in a heap dump are `Nobody knows`, which is why that
+one is drawn small: the two that mean something are the ones worth seeing across the room. This is the same
+answer a LeakCanary leak trace prints as `Leaking: YES`, `NO` and `UNKNOWN`, said about the object rather
+than about the leak.
 
 The reason is the whole of the answer, because half of these are about another object: an activity is red
-because its own `mDestroyed` is true, and the view under it is red because the activity is. `Activity↑ is
-leaking` is the chain saying so.
+because its own `mDestroyed` is true, and the view under it is red because the activity is. `Activity↑
+shouldn't be here` is the chain saying so.
 
-**Set by hand…** overrules it. Pick one of the three statuses, type why, and **Set the status**:
+**The pencil beside it** overrules it. Pick one of the three statuses, type why, and **Set the status**:
 
 * **Your answer wins**, whatever the inspectors said. Overruling is the point — an inspector reads a field,
   you read the code, and a cache that is meant to hold what it holds is not something a field can say.
 * **The reason is required.** A status with no reason is one nobody who reads your heap dump next — a
   colleague, an agent, you in a month — can check, and one of those makes every other status in it worth
   less. What you overruled is kept beside your reason rather than thrown away.
-* **It reads as yours**, wherever it appears: `set by hand — the cache is bounded, this is fine`, on the
-  banner and on every chain that runs through the object.
-* **Everything below a leaking object is leaking, and everything above one that is still needed is still
-  needed**, so a status you set changes what the objects around it read as. Which is why setting one is
-  usually enough to make a whole chain make sense.
-* **Change…** on an object you have already decided about, and **Take it off** to hand it back to the heap
-  dump.
+* **It reads as yours**, wherever it appears: `set by hand — the cache is bounded, this is fine`, in the
+  panel and on every chain that runs through the object.
+* **Everything below an object that shouldn't be here shouldn't be here either, and everything above one
+  that is meant to be here is meant to be here too**, so a status you set changes what the objects around it
+  read as. Which is why setting one is usually enough to make a whole chain make sense.
+* **The pencil again** on an object you have already decided about, and **Take it off** to hand it back to
+  the heap dump.
 
-Because a status propagates along the chain, two of them can contradict each other: an object marked leaking
-that holds one marked still needed cannot both be read off the chain between them. When what you are setting
-does that, **the window lists every status it disagrees with before writing anything** — what the object is,
-which side of yours it is on, the reason it was given, and what it would become. **Keep this and flip those**
-keeps yours and sets them to the opposite status, with what they said kept as part of the new reason; **Undo**
-leaves the heap dump exactly as it was. Nothing is written until you pick one.
+Because a status propagates along the chain, two of them can contradict each other: an object marked as one
+that shouldn't be here, holding one marked as meant to be here, cannot both be read off the chain between
+them. When what you are setting does that, **the window lists every status it disagrees with before writing
+anything** — what the object is, which side of yours it is on, the reason it was given, and what it would
+become. **Keep this and flip those** keeps yours and sets them to the opposite status, with what they said
+kept as part of the new reason; **Undo** leaves the heap dump exactly as it was. Nothing is written until you
+pick one.
 
 The statuses live in `~/.shark-explorer/leak-statuses`, one tab separated file per heap dump, with the columns
 named at the top — so they can be read, edited, diffed or pasted into an issue without this app, and they are
 there again the next time you open that dump.
 
-The **Leaks** screen is not read through them. It is what the heap dump says, so that the leaks it lists and
-the names it gives them match what LeakCanary reports for the same leak; the status under a title is what
-whoever read the dump has concluded.
+**The Leaks screen follows what you set**, because a status changes which objects are leaks and not only how
+one of them reads: marking something as one that shouldn't be here makes it a leak, and whatever it holds
+stops being one — it is only still in memory because of the object you named, and that is the thing to fix.
+Marking a leak as meant to be here takes it off the list. The one thing this costs is that a leak's
+fingerprint matches the one LeakCanary reports only while nothing has been set by hand, since the fingerprint
+is the stretch of chain your status has just moved.
 
 ## Reporting a problem
 

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -70,8 +70,8 @@ a few seconds.
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
-* **Whether the object a tab is on leaked is the first thing "What it is" says**, and you can overrule it —
-  see [Say what leaked](#say-what-leaked).
+* **The verdict on the object a tab is on is the first thing "What it is" says** — `Stuck`, `Expected` or
+  `Unknown` — and you can overrule it, see [The verdict](#the-verdict).
 * Every location takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
 
 ## Link to a tab
@@ -149,51 +149,57 @@ Since a `shark://` link names a window, a link written into a note stops working
 — see above. Copy one for the tab you want to come back to *while you are writing about it*, and it will
 take you there for as long as that window is open.
 
-## Say what leaked
+## The verdict
 
-At the top of **What it is**, under the object's name, is the **Verdict** on it — `✗ Leaked`, `✓ Needed`, or
+At the top of **What it is**, under the object's name, is the **Verdict** on it — `✗ Stuck`, `✓ Expected`, or
 a quiet `? Unknown` — with the reason under it, in the same colours the chain on the left uses. Most objects
 in a heap dump are `Unknown`, which is why that one is drawn small: the two that mean something are the ones
-worth seeing across the room. This is the same answer a LeakCanary leak trace prints as `Leaking: YES`, `NO`
-and `UNKNOWN`, said about the object rather than about the leak — an object *leaked*, and a leak is the
-reference still holding it.
+worth seeing across the room.
 
-The reason is the whole of the answer, because half of these are about another object: an activity is red
-because its own `mDestroyed` is true, and the view under it is red because the activity is. `Activity↑
-leaked` is the chain saying so.
+`Stuck` says the object should be gone and something is holding it. `Expected` says its being in memory is
+legitimate at this point in the app's life. It is the same answer a LeakCanary leak trace prints as
+`Leaking: YES`, `NO` and `UNKNOWN`, in words that stop short of calling the object the leak — because
+**the leak is the faulty reference**, the one that should have been cleared, and everything under it is stuck
+by that single mistake. An object nothing reaches any more is `Stuck` as well: it was expected to be gone,
+and only the garbage collector not having run keeps it here. The verdict means the same thing everywhere.
 
-**The pencil beside it** overrules it. Pick one of the three statuses, type why, and **Set the status**:
+The reason is the rest of the answer, because half of these are about another object: an activity is red
+because its own `mDestroyed` is true, and the view under it is red because the activity is. `Activity↑ is
+stuck` is the chain saying so — and it is also how you find the faulty reference, which is the step between
+the last `Expected` object and the first `Stuck` one.
+
+**The pencil beside it** overrules the verdict. Pick one of the three, type why, and **Set the verdict**:
 
 * **Your answer wins**, whatever the inspectors said. Overruling is the point — an inspector reads a field,
   you read the code, and a cache that is meant to hold what it holds is not something a field can say.
-* **The reason is required.** A status with no reason is one nobody who reads your heap dump next — a
-  colleague, an agent, you in a month — can check, and one of those makes every other status in it worth
+* **The reason is required.** A verdict with no reason is one nobody who reads your heap dump next — a
+  colleague, an agent, you in a month — can check, and one of those makes every other verdict in it worth
   less. What you overruled is kept beside your reason rather than thrown away.
 * **It reads as yours**, wherever it appears: `set by hand — the cache is bounded, this is fine`, in the
   panel and on every chain that runs through the object.
-* **Everything a leaked object holds has leaked too, and everything holding a needed one is needed too**, so
-  a verdict you set changes what the objects around it read as. Which is why setting one is usually enough to
-  make a whole chain make sense.
+* **Everything a stuck object holds is stuck too, and everything holding an expected one is expected too**,
+  so a verdict you set changes what the objects around it read as. Which is why setting one is usually enough
+  to make a whole chain make sense.
 * **The pencil again** on an object you have already decided about, and **Take it off** to hand it back to
   the heap dump.
 
 Because a verdict propagates along the chain, two of them can contradict each other: an object marked as
-leaked, holding one marked as needed, cannot both be read off the chain between them. When what you are setting does that, **the window lists every status it disagrees with before writing
-anything** — what the object is, which side of yours it is on, the reason it was given, and what it would
-become. **Keep this and flip those** keeps yours and sets them to the opposite status, with what they said
-kept as part of the new reason; **Undo** leaves the heap dump exactly as it was. Nothing is written until you
-pick one.
+stuck, holding one marked as expected, cannot both be read off the chain between them. When what you are
+setting does that, **the window lists every verdict it disagrees with before writing anything** — what the
+object is, which side of yours it is on, the reason it was given, and what it would become. **Keep this and
+flip those** keeps yours and sets them to the opposite verdict, with what they said kept as part of the new
+reason; **Undo** leaves the heap dump exactly as it was. Nothing is written until you pick one.
 
-The statuses live in `~/.shark-explorer/leak-statuses`, one tab separated file per heap dump, with the columns
+The verdicts live in `~/.shark-explorer/leak-statuses`, one tab separated file per heap dump, with the columns
 named at the top — so they can be read, edited, diffed or pasted into an issue without this app, and they are
 there again the next time you open that dump.
 
-**The Leaks screen follows what you set**, because a status changes which objects are leaks and not only how
-one of them reads: marking something as leaked makes it a leak, and whatever it holds stops being one — it is
-only still in memory because of the object you named, and that is the thing to fix. Marking a leak as needed
-takes it off the list. The one thing this costs is that a leak's
-fingerprint matches the one LeakCanary reports only while nothing has been set by hand, since the fingerprint
-is the stretch of chain your status has just moved.
+**The Leaks screen follows what you set**, because a verdict changes which objects are leaks and not only how
+one of them reads: marking something as stuck makes it a leak, and whatever it holds stops being one — it is
+only still in memory because of the object you named, and that is the thing to fix. Marking a leak as
+expected takes it off the list. The one thing this costs is that a leak's fingerprint matches the one
+LeakCanary reports only while nothing has been set by hand, since the fingerprint is the stretch of chain your
+verdict has just moved.
 
 ## Reporting a problem
 

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -70,6 +70,8 @@ a few seconds.
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
+* **Whether the object a tab is on should still be in memory is said under its name**, and you can overrule
+  it — see [Say what is leaking](#say-what-is-leaking).
 * Every location takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
 
 ## Link to a tab
@@ -146,6 +148,47 @@ or resizing the window stays on the same note rather than starting a new one.
 Since a `shark://` link names a window, a link written into a note stops working once that window is closed
 — see above. Copy one for the tab you want to come back to *while you are writing about it*, and it will
 take you there for as long as that window is open.
+
+## Say what is leaking
+
+Under the title saying where the tab is, **the window says whether that object should still be in memory** —
+`✗ Leaking`, `✓ Not leaking`, or a quiet `? Unknown` — with the reason beside it, in the same colours the chain
+on the left uses. Most objects in a heap dump are `Unknown`, which is why that one is drawn small: the two
+that mean something are the ones worth seeing across the room.
+
+The reason is the whole of the answer, because half of these are about another object: an activity is red
+because its own `mDestroyed` is true, and the view under it is red because the activity is. `Activity↑ is
+leaking` is the chain saying so.
+
+**Set by hand…** overrules it. Pick one of the three statuses, type why, and **Set the status**:
+
+* **Your answer wins**, whatever the inspectors said. Overruling is the point — an inspector reads a field,
+  you read the code, and a cache that is meant to hold what it holds is not something a field can say.
+* **The reason is required.** A status with no reason is one nobody who reads your heap dump next — a
+  colleague, an agent, you in a month — can check, and one of those makes every other status in it worth
+  less. What you overruled is kept beside your reason rather than thrown away.
+* **It reads as yours**, wherever it appears: `set by hand — the cache is bounded, this is fine`, on the
+  banner and on every chain that runs through the object.
+* **Everything below a leaking object is leaking, and everything above one that is still needed is still
+  needed**, so a status you set changes what the objects around it read as. Which is why setting one is
+  usually enough to make a whole chain make sense.
+* **Change…** on an object you have already decided about, and **Take it off** to hand it back to the heap
+  dump.
+
+Because a status propagates along the chain, two of them can contradict each other: an object marked leaking
+that holds one marked still needed cannot both be read off the chain between them. When what you are setting
+does that, **the window lists every status it disagrees with before writing anything** — what the object is,
+which side of yours it is on, the reason it was given, and what it would become. **Keep this and flip those**
+keeps yours and sets them to the opposite status, with what they said kept as part of the new reason; **Undo**
+leaves the heap dump exactly as it was. Nothing is written until you pick one.
+
+The statuses live in `~/.shark-explorer/leak-statuses`, one tab separated file per heap dump, with the columns
+named at the top — so they can be read, edited, diffed or pasted into an issue without this app, and they are
+there again the next time you open that dump.
+
+The **Leaks** screen is not read through them. It is what the heap dump says, so that the leaks it lists and
+the names it gives them match what LeakCanary reports for the same leak; the status under a title is what
+whoever read the dump has concluded.
 
 ## Reporting a problem
 

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -165,8 +165,20 @@ and only the garbage collector not having run keeps it here. The verdict means t
 
 The reason is the rest of the answer, because half of these are about another object: an activity is red
 because its own `mDestroyed` is true, and the view under it is red because the activity is. `Activity↑ is
-stuck` is the chain saying so — and it is also how you find the faulty reference, which is the step between
-the last `Expected` object and the first `Stuck` one.
+stuck` is the chain saying so.
+
+**The chain marks the faulty reference itself**: `Holder.activity · faulty reference`, in bold red, on the one
+step that goes from an `Expected` object straight to a `Stuck` one. It is the one line of a chain that says
+where to go and change code — the shades on the objects are what the leak left behind, this is the leak — and
+it is the same reference the Leaks screen names that leak after, so a row there and the chain you open from it
+name one thing.
+
+**A chain with no such step carries no mark**, which is deliberate: what would be marked would be a guess
+drawn as an answer. With objects nothing knows either way about between the two verdicts, the fault is at one
+of those steps and nothing on the chain says which. With nothing `Expected` above the stuck object at all,
+what holds it may be something that should have let go of it too, so the fault can be further up than the
+chain reaches. Overruling a verdict is what closes either gap: say what you know about one object in between,
+and the mark appears on the step that leaves.
 
 **The pencil beside it** overrules the verdict. Pick one of the three, type why, and **Set the verdict**:
 

--- a/docs/shark-explorer.md
+++ b/docs/shark-explorer.md
@@ -70,8 +70,8 @@ a few seconds.
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
   come back to.
-* **Whether the object a tab is on is meant to still be in memory is the first thing "What it is" says**,
-  and you can overrule it — see [Say what should be here](#say-what-should-be-here).
+* **Whether the object a tab is on leaked is the first thing "What it is" says**, and you can overrule it —
+  see [Say what leaked](#say-what-leaked).
 * Every location takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
 
 ## Link to a tab
@@ -149,18 +149,18 @@ Since a `shark://` link names a window, a link written into a note stops working
 — see above. Copy one for the tab you want to come back to *while you are writing about it*, and it will
 take you there for as long as that window is open.
 
-## Say what should be here
+## Say what leaked
 
-At the top of **What it is**, under the object's name, the window answers **Should it be here?** —
-`✗ Shouldn't be here`, `✓ Meant to be here`, or a quiet `? Nobody knows` — with the reason under it, in the
-same colours the chain on the left uses. Most objects in a heap dump are `Nobody knows`, which is why that
-one is drawn small: the two that mean something are the ones worth seeing across the room. This is the same
-answer a LeakCanary leak trace prints as `Leaking: YES`, `NO` and `UNKNOWN`, said about the object rather
-than about the leak.
+At the top of **What it is**, under the object's name, is the **Verdict** on it — `✗ Leaked`, `✓ Needed`, or
+a quiet `? Unknown` — with the reason under it, in the same colours the chain on the left uses. Most objects
+in a heap dump are `Unknown`, which is why that one is drawn small: the two that mean something are the ones
+worth seeing across the room. This is the same answer a LeakCanary leak trace prints as `Leaking: YES`, `NO`
+and `UNKNOWN`, said about the object rather than about the leak — an object *leaked*, and a leak is the
+reference still holding it.
 
 The reason is the whole of the answer, because half of these are about another object: an activity is red
 because its own `mDestroyed` is true, and the view under it is red because the activity is. `Activity↑
-shouldn't be here` is the chain saying so.
+leaked` is the chain saying so.
 
 **The pencil beside it** overrules it. Pick one of the three statuses, type why, and **Set the status**:
 
@@ -171,15 +171,14 @@ shouldn't be here` is the chain saying so.
   less. What you overruled is kept beside your reason rather than thrown away.
 * **It reads as yours**, wherever it appears: `set by hand — the cache is bounded, this is fine`, in the
   panel and on every chain that runs through the object.
-* **Everything below an object that shouldn't be here shouldn't be here either, and everything above one
-  that is meant to be here is meant to be here too**, so a status you set changes what the objects around it
-  read as. Which is why setting one is usually enough to make a whole chain make sense.
+* **Everything a leaked object holds has leaked too, and everything holding a needed one is needed too**, so
+  a verdict you set changes what the objects around it read as. Which is why setting one is usually enough to
+  make a whole chain make sense.
 * **The pencil again** on an object you have already decided about, and **Take it off** to hand it back to
   the heap dump.
 
-Because a status propagates along the chain, two of them can contradict each other: an object marked as one
-that shouldn't be here, holding one marked as meant to be here, cannot both be read off the chain between
-them. When what you are setting does that, **the window lists every status it disagrees with before writing
+Because a verdict propagates along the chain, two of them can contradict each other: an object marked as
+leaked, holding one marked as needed, cannot both be read off the chain between them. When what you are setting does that, **the window lists every status it disagrees with before writing
 anything** — what the object is, which side of yours it is on, the reason it was given, and what it would
 become. **Keep this and flip those** keeps yours and sets them to the opposite status, with what they said
 kept as part of the new reason; **Undo** leaves the heap dump exactly as it was. Nothing is written until you
@@ -190,9 +189,9 @@ named at the top — so they can be read, edited, diffed or pasted into an issue
 there again the next time you open that dump.
 
 **The Leaks screen follows what you set**, because a status changes which objects are leaks and not only how
-one of them reads: marking something as one that shouldn't be here makes it a leak, and whatever it holds
-stops being one — it is only still in memory because of the object you named, and that is the thing to fix.
-Marking a leak as meant to be here takes it off the list. The one thing this costs is that a leak's
+one of them reads: marking something as leaked makes it a leak, and whatever it holds stops being one — it is
+only still in memory because of the object you named, and that is the thing to fix. Marking a leak as needed
+takes it off the list. The one thing this costs is that a leak's
 fingerprint matches the one LeakCanary reports only while nothing has been set by hand, since the fingerprint
 is the stretch of chain your status has just moved.
 

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -67,6 +67,23 @@ found, and the search for every way an object is held runs for the object clicke
 question the panels ask has to be measured before it goes in the hover path — `notes/decisions.md` has the
 numbers on the biggest dump in the repo, including how long a chain gets there.
 
+## A leaking status set by hand is an argument to every read, never state of the tree
+
+Someone reading a heap dump can overrule what the inspectors made of an object, and the statuses they set
+are a `LeakStatusOverrides` **passed into every question whose answer they change** — `summarize`,
+`rootPathTo`, `independentPathsBetween`, `independentPathsFromRoots` — rather than something the tree holds.
+It has to be that way round for the reason above: the tree is read from one thread and the window composed
+on another, so overrides in the tree would draw a chain from one set of them and the row above it from
+another.
+
+**The parameter defaults to `LeakStatusOverrides.NONE`**, so a new read that forgets it compiles and answers
+with the dump's own reading — which looks right, and is wrong the moment anybody has set a status. Thread it
+through, and key the `LaunchedEffect` that asks on the overrides, which is what makes setting one redraw.
+
+`findLeaks()` is the one read that means it: it takes no overrides, because a leak is named by
+`LeakTrace.leakFingerprint` and reading it through somebody's own statuses would print fingerprints that no
+longer match LeakCanary's for the same leak. `notes/decisions.md` has the rest.
+
 ## A heap dump can have `android.os.Build` and not the fields Shark reads off it
 
 `AndroidBuildMirror.fromHeapGraph` reads `MANUFACTURER`, `ID` and `VERSION.SDK_INT` with `!!`, and nearly

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -67,7 +67,14 @@ found, and the search for every way an object is held runs for the object clicke
 question the panels ask has to be measured before it goes in the hover path — `notes/decisions.md` has the
 numbers on the biggest dump in the repo, including how long a chain gets there.
 
-## A leaking status set by hand is an argument to every read, never state of the tree
+## A verdict set by hand is an argument to every read, never state of the tree
+
+**The window says `Verdict`, `Stuck`, `Expected` and "faulty reference"; the code says `LeakStatus`,
+`LEAKING`, `NOT_LEAKING` and `suspectPath`.** That's deliberate — the identifiers match
+`shark.LeakTraceObject.LeakingStatus` because they have to agree with Shark, and the words on screen
+deliberately avoid "leak" on an object, since a leak is one faulty reference and calling everything under it
+leaking points readers at the wrong thing. `LeakStatus.statusText` is the only place the two meet, so change
+a word there and nowhere else. `notes/decisions.md` has why each word won.
 
 Someone reading a heap dump can overrule what the inspectors made of an object, and the statuses they set
 are a `LeakStatusOverrides` **passed into every question whose answer they change** — `summarize`,

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -71,18 +71,23 @@ numbers on the biggest dump in the repo, including how long a chain gets there.
 
 Someone reading a heap dump can overrule what the inspectors made of an object, and the statuses they set
 are a `LeakStatusOverrides` **passed into every question whose answer they change** — `summarize`,
-`rootPathTo`, `independentPathsBetween`, `independentPathsFromRoots` — rather than something the tree holds.
-It has to be that way round for the reason above: the tree is read from one thread and the window composed
-on another, so overrides in the tree would draw a chain from one set of them and the row above it from
-another.
+`rootPathTo`, `independentPathsBetween`, `independentPathsFromRoots`, `findLeaks`, `isBelowLeakingObject` —
+rather than something the tree holds. It has to be that way round for the reason above: the tree is read from
+one thread and the window composed on another, so overrides in the tree would draw a chain from one set of
+them and the row above it from another.
 
 **The parameter defaults to `LeakStatusOverrides.NONE`**, so a new read that forgets it compiles and answers
 with the dump's own reading — which looks right, and is wrong the moment anybody has set a status. Thread it
 through, and key the `LaunchedEffect` that asks on the overrides, which is what makes setting one redraw.
 
-`findLeaks()` is the one read that means it: it takes no overrides, because a leak is named by
-`LeakTrace.leakFingerprint` and reading it through somebody's own statuses would print fingerprints that no
-longer match LeakCanary's for the same leak. `notes/decisions.md` has the rest.
+**`findLeaks` is one of them, and the least obvious**: setting a status changes *which objects are leaks*,
+not only how one of them reads. Mark something leaking halfway up a chain and it becomes a leak, while
+whatever it holds drops off the list — that object is now only in memory because of this one, which is what
+`foldedIntoWhatHoldsThem` folds. The list is worked out again per set of statuses and kept until the next,
+and `RootPathSearch` goes round what a hand marked leaking exactly as it goes round what the inspectors did,
+so the chain a leak is grouped by and the statuses drawn on that chain are one answer. The price is that a
+`LeakGroup.leakFingerprint` only matches LeakCanary's for the same objects while nothing is set by hand;
+`notes/decisions.md` has the rest.
 
 ## A heap dump can have `android.os.Build` and not the fields Shark reads off it
 

--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -76,6 +76,19 @@ deliberately avoid "leak" on an object, since a leak is one faulty reference and
 leaking points readers at the wrong thing. `LeakStatus.statusText` is the only place the two meet, so change
 a word there and nowhere else. `notes/decisions.md` has why each word won.
 
+**Which reference the leak is, is decided once, over the whole path** — `faultyReferenceIndexOrNull`, called
+from `withLeakStatuses` — and carried on `PathReference.isFaulty` for the drawing to read. Working it out in
+the window from the steps on screen looks equivalent and isn't: a pane draws stretches of a chain
+(`stepsBelow`, `stepsAfter`, a swapped-in `RootPathWay`), so the object that ends the stretch can be above
+what it shows.
+
+**And it marks nothing unless one step crosses from `Expected` to `Stuck`.** `suspectReferenceIndexes`, the
+whole stretch between the two verdicts, is what a leak is *named* after — `suspectSubpath`, and Shark's leak
+fingerprint — so it is tempting to mark the top of it, which is what the first version did and what
+`notes/decisions.md` records as wrong: a chain whose objects all have no verdict got its top reference marked
+for being where the walk started. A longer stretch is a fault at one of several steps with nothing saying
+which, and nothing drawn is the answer for that.
+
 Someone reading a heap dump can overrule what the inspectors made of an object, and the statuses they set
 are a `LeakStatusOverrides` **passed into every question whose answer they change** — `summarize`,
 `rootPathTo`, `independentPathsBetween`, `independentPathsFromRoots`, `findLeaks`, `isBelowLeakingObject` —

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -837,19 +837,25 @@ it uses (`LeakStatus.background` and `textColor` are shared with `PathDrawing` r
 it is the same answer read in one place instead of a dozen — a reader who has learnt the green and the red on
 a chain reads them here for free.
 
-**Under a header, because the panel labels every line**, and the header is the question the statuses answer:
-"Should it be here?". A question rather than a noun like the `Retained` and `Shallow` beside it, since this
-is the one line of the panel that is a judgement rather than a measurement.
+**Under a header, because the panel labels every line**: `Verdict`, one word like the `Retained` and
+`Shallow` beside it. It is the one line of the panel that is a judgement rather than a measurement, which is
+also what says the pencil beside it is allowed to disagree with it.
 
-**"Leaking" and "Not leaking" became "Shouldn't be here" and "Meant to be here"**, with `Unknown` becoming
-"Nobody knows". LeakCanary's leak traces say `Leaking: YES / NO / UNKNOWN`, and matching them was the case
-for keeping the old words — but calling an *object* leaking reads as that object leaking something as easily
-as being the thing left behind, and this repo's own rule is that a leak is a reference rather than an object.
-What the inspectors actually answer is whether the object is supposed to still be in memory, which is what
-these say, in the words the module's own prose already used. One `LeakStatus.statusText` is where they live,
-so the chain, the panel, the dialog and the reasons propagated along a chain (`Activity↓ is meant to be
-here`) all say the same thing. The identifiers didn't move: `LeakStatus`, `LEAKING`, `leakStatusesOf` stay
-Shark's names, because the code is where matching `shark.LeakTraceObject.LeakingStatus` matters.
+**"Leaking" and "Not leaking" became "Leaked" and "Needed"**, `Unknown` staying `Unknown`. LeakCanary's leak
+traces say `Leaking: YES / NO / UNKNOWN`, and matching them was the case for keeping the old words — but
+calling an *object* leaking reads as that object leaking something as easily as being the thing left behind,
+and this repo's own rule is that a leak is a reference rather than an object. `Leaked` is that rule in the
+tense: the object leaked, and the leak is the reference still holding it. `Needed` is what an inspector
+actually recognizes — something still needs this object.
+
+The first attempt at those two was `Shouldn't be here` and `Meant to be here`, taken from the module's own
+prose, and it was rejected on sight for the reason a status has to be read a dozen times down one chain:
+**a status is a label, not a sentence.** The header carries the question so the labels don't have to, which
+is also why they can be one word each. One `LeakStatus.statusText` is where they live, so the chain, the
+panel, the dialog, the checkbox that shades them over the map and the reasons propagated along a chain
+(`Activity↓ is needed`) all say the same thing. The identifiers didn't move: `LeakStatus`, `LEAKING`,
+`leakStatusesOf` stay Shark's names, because the code is where matching
+`shark.LeakTraceObject.LeakingStatus` matters.
 
 **A pencil, left of the status, rather than a "Set by hand…" button.** It is what changes the answer, so it
 belongs where the eye already is, and a text button pushed the reason onto a second line of a 320dp panel.
@@ -857,13 +863,13 @@ Disabled until the statuses have been read off disk, which is the same rule the 
 
 **From the last step of the chain when there is one**, and from the object's own reading until the walk up to
 the GC roots lands, since the chain's answer is the one with the objects above and below taken into account.
-So the panel can say `Nobody knows` for a beat and then say `Shouldn't be here` — the panes filling in, not
-the window changing its mind. Nothing at all for the tab a window opens with: the whole heap dump is no
+So the panel can say `Unknown` for a beat and then say `Leaked` — the panes filling in, not the window
+changing its mind. Nothing at all for the tab a window opens with: the whole heap dump is no
 object of it, and there is nothing to inspect or decide about.
 
 **Loud for the two statuses that mean something, quiet for the third.** Most of a heap dump is objects
-nothing knows either way about, so a shaded, bold `Nobody knows` on every object would be a line nobody reads
-by the time it says something. `UNKNOWN` is small, muted and unshaded; the other two are shaded in
+nothing knows either way about, so a shaded, bold `Unknown` on every object would be a line nobody reads by
+the time it says something. `UNKNOWN` is small, muted and unshaded; the other two are shaded in
 `TARGET_SHAPE`, the shape the chain marks its target with. A glyph as well as a colour (`✓ ? ✗`), so which
 status it is doesn't rest on colour alone.
 

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -877,8 +877,33 @@ window.
 
 **"Faulty reference" is the name for the culprit**, the reference between the last `Expected` object and the
 first `Stuck` one, which is what `LeakGroup.suspectPath` starts at and what the leaks screen names each row
-after. Only prose so far — nothing on a chain marks that step yet, and marking it is the change that would
-actually put a reader's eye on the reference rather than on the objects.
+after. **And the chain marks it**: `Holder.activity · faulty reference`, bold, in the red of the objects it
+left behind, which is the change that actually puts a reader's eye on the reference rather than on the
+objects. `PathReference.isFaulty`, worked out in `withLeakStatuses`, and `suspectSubpath` names the leaks
+screen's rows off the same statuses — so where a leak is a single reference, a row there and the chain opened
+from it name one thing.
+
+**Only a single step between the two verdicts is marked.** `faultyReferenceIndexOrNull` asks for an `Expected`
+object with a `Stuck` one directly under it, and marks nothing otherwise. The first attempt marked the top of
+the suspect stretch instead, the way LeakCanary underlines all of it, and it was wrong in the case that
+matters: a chain of `Cleaner`s with no verdict on any object of it had its top reference marked, which is a
+reference named for being where the walk started rather than for anything read off the heap dump. Two shapes
+make the stretch longer than a step and neither supports a mark — objects nothing knows either way about in
+between, where the fault is at one of those steps and nothing says which; and nothing `Expected` above the
+stuck object at all, where what holds it may be something that should have let go too, so the fault can be
+further up than the path reaches. A guess drawn in the same bold red as an answer costs more than no mark,
+because being the one line to act on is the whole of what the mark is for. Shortening the stretch is what
+setting a verdict by hand does, and the mark appears when it becomes one step.
+
+**Which makes the mark the exception on a real dump.** Measured over every `shark-android` test dump: 2 of
+their 12 app leaks carry one — `MainActivity$Lol.foo` and `DvFragment.mRoot` — and the other ten have between
+1 and 13 objects nothing knows either way about between the two verdicts, `AsyncTask.SERIAL_EXECUTOR` with its
+four being the usual shape. That is the number to weigh if the rule is ever loosened: a rule that marked the
+top of the stretch would put a bold red line on all twelve, and ten of them would be pointing at a reference
+picked for being highest rather than for being wrong.
+
+**Nothing is marked on a chain with nothing stuck on it**, which is most chains in a heap dump. A leak is a
+reference the evidence points at, and there is no evidence until something below it is known not to belong.
 
 **A pencil, left of the status, rather than a "Set by hand…" button.** It is what changes the answer, so it
 belongs where the eye already is, and a text button pushed the reason onto a second line of a 320dp panel.

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -841,21 +841,44 @@ a chain reads them here for free.
 `Shallow` beside it. It is the one line of the panel that is a judgement rather than a measurement, which is
 also what says the pencil beside it is allowed to disagree with it.
 
-**"Leaking" and "Not leaking" became "Leaked" and "Needed"**, `Unknown` staying `Unknown`. LeakCanary's leak
-traces say `Leaking: YES / NO / UNKNOWN`, and matching them was the case for keeping the old words — but
-calling an *object* leaking reads as that object leaking something as easily as being the thing left behind,
-and this repo's own rule is that a leak is a reference rather than an object. `Leaked` is that rule in the
-tense: the object leaked, and the leak is the reference still holding it. `Needed` is what an inspector
-actually recognizes — something still needs this object.
+**"Leaking" and "Not leaking" became `Stuck` and `Expected`**, `Unknown` staying `Unknown`, and **no word
+built on "leak" is allowed on an object**. A leak is one faulty reference that should have been cleared, and
+everything under it is retained by that one mistake — so `Leaking` or `Leaked` on twenty objects points a
+reader at the twenty rather than at the one thing to fix. `Stuck` names the object's situation without
+accusing it, and it is the only candidate that asks a question rather than closing one: something is holding
+this, what? `Expected` says its presence in memory is legitimate at this point in the app's life. The pair is
+deliberately not antonyms — an object in use can't be collected either, so the good side has to answer a
+different question than "can it leave".
 
-The first attempt at those two was `Shouldn't be here` and `Meant to be here`, taken from the module's own
-prose, and it was rejected on sight for the reason a status has to be read a dozen times down one chain:
-**a status is a label, not a sentence.** The header carries the question so the labels don't have to, which
-is also why they can be one word each. One `LeakStatus.statusText` is where they live, so the chain, the
-panel, the dialog, the checkbox that shades them over the map and the reasons propagated along a chain
-(`Activity↓ is needed`) all say the same thing. The identifiers didn't move: `LeakStatus`, `LEAKING`,
-`leakStatusesOf` stay Shark's names, because the code is where matching
+**No other analyser has a verdict like this**, so there were no words to borrow. Checked: JProfiler
+classifies objects by reference type (strongly referenced, retained by soft references) and by age (`Mark
+Heap`, then "new" and "old" objects); YourKit by reachability scope (strong, softly, weakly reachable,
+unreachable, pending finalization); Eclipse MAT names places rather than objects (*leak suspect*,
+*accumulation point*, *keep-alive path*); dotMemory has *key retention paths*. None labels an object leaking,
+because none has watched objects or framework inspectors to do it with — they rank by size and leave the
+judgement to the reader. What they do share is the frame: JProfiler asks whether objects "are still
+legitimately on the heap or if a **faulty reference** keeps them alive", which is where the name for the
+culprit edge comes from, and YourKit defines a leak as objects "not needed anymore according to the
+application logic".
+
+Two attempts came before this one. `Shouldn't be here` / `Meant to be here` was rejected on sight —
+**a verdict is a label, not a sentence**, since it is read a dozen times down one chain. `Leaked` / `Needed`
+was rejected for the misdirection above. One `LeakStatus.statusText` is where the words live, so the chain,
+the panel, the dialog, the checkbox that shades them over the map and the reasons propagated along a chain
+(`Activity↓ is expected`, `Activity↑ is stuck`) all say the same thing. The identifiers didn't move:
+`LeakStatus`, `LEAKING`, `leakStatusesOf` stay Shark's names, because the code is where matching
 `shark.LeakTraceObject.LeakingStatus` matters.
+
+**The verdict means the same thing on an unreachable object.** A watched object nothing reaches any more is
+`Stuck` like any other, even though what keeps it is the collector not having run rather than a faulty
+reference: it was expected to be gone. Where it sits on that scale is what the leaks screen's `Unreachable`
+section is for, and a fourth value would have made the verdict mean something different in one corner of the
+window.
+
+**"Faulty reference" is the name for the culprit**, the reference between the last `Expected` object and the
+first `Stuck` one, which is what `LeakGroup.suspectPath` starts at and what the leaks screen names each row
+after. Only prose so far — nothing on a chain marks that step yet, and marking it is the change that would
+actually put a reader's eye on the reference rather than on the objects.
 
 **A pencil, left of the status, rather than a "Set by hand…" button.** It is what changes the answer, so it
 belongs where the eye already is, and a text button pushed the reason onto a second line of a 320dp panel.
@@ -863,7 +886,7 @@ Disabled until the statuses have been read off disk, which is the same rule the 
 
 **From the last step of the chain when there is one**, and from the object's own reading until the walk up to
 the GC roots lands, since the chain's answer is the one with the objects above and below taken into account.
-So the panel can say `Unknown` for a beat and then say `Leaked` — the panes filling in, not the window
+So the panel can say `Unknown` for a beat and then say `Stuck` — the panes filling in, not the window
 changing its mind. Nothing at all for the tab a window opens with: the whole heap dump is no
 object of it, and there is nothing to inspect or decide about.
 

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -821,6 +821,98 @@ inside it, a file per `noteKey` rather than one document with a section per plac
 the note that was typed into, nothing has to be parsed back out of a document that also holds somebody's own
 headings, and the listing is the index.
 
+## A leaking status is the heap dump's answer until a hand overrules it
+
+Every chain already carried a `LeakStatus` per object, worked out by Shark's inspectors and then propagated
+along the chain — everything above an object still needed is still needed, everything a leaking object holds
+is leaking. Two things were added to that: the status of the object a tab is *on*, said where the tab says
+which object, and the ability to overrule it.
+
+**The banner is under the title, above the panes**, for the reason the note button is: it is about the whole
+of what the tab is showing, and the title is what it is about. In the colours the chain beside it uses
+(`LeakStatus.background` and `textColor` are shared with `PathDrawing` rather than copied), because it is the
+same answer read in one place instead of a dozen — a reader who has learnt the green and the red on a chain
+reads them here for free.
+
+**Loud for the two statuses that mean something, quiet for the third.** Most of a heap dump is objects
+nothing knows either way about, so a shaded, bold `Unknown` on every tab would be a banner nobody reads by
+the time it says something. `UNKNOWN` is small, muted and unshaded; the other two are shaded in
+`TARGET_SHAPE`, the shape the chain marks its target with. A glyph as well as a colour (`✓ ? ✗`), so which
+status it is doesn't rest on colour alone.
+
+**From the last step of the chain when there is one**, and from the object's own reading until the walk up to
+the GC roots lands, since the chain's answer is the one with the objects above and below taken into account.
+So the banner can say `Unknown` for a beat and then say `Leaking` — the panes filling in, not the window
+changing its mind. Nothing at all for the tab a window opens with: the whole heap dump is no object of it,
+and there is nothing to inspect or decide about.
+
+**Overriding always wins**, which is the one place this differs from how two inspectors disagreeing is
+settled. There, the object still being needed wins, because two inspectors are two halves of the same
+automated reading and the safer one is the one to believe. A hand is not that: someone who has read the code
+knows what the inspectors can't, and weighing the two would mean a status that can't be set to the one an
+inspector already picked. So `setByHandStatus` takes the reason someone typed and keeps the inspectors as the
+record of what was overruled, exactly the way a conflict between two inspectors is recorded.
+
+**A status without a reason is not a status.** `LeakStatusOverride` throws on a blank one and the dialog's
+button is disabled until there is one. A status set by hand overrules the heap dump, so without the why it is
+an assertion the next reader — a colleague, an agent, the same person in a month — has no way to check, and
+one of those makes every other status in the dump worth less. `SET_BY_HAND` marks the reason wherever it is
+read, so a green object somebody decided about is never mistaken for one an inspector recognized.
+
+**Nothing is recomputed, because nothing is cached.** The statuses of a chain are worked out on every read of
+it, so a status set by hand is an argument to the read rather than something to invalidate:
+`summarize`, `rootPathTo`, `independentPathsBetween` and `independentPathsFromRoots` take a
+`LeakStatusOverrides`, and the window's `LaunchedEffect`s are keyed on it — which is why that class has value
+equality. **A value rather than state on the tree**, because the tree is read from one thread while the
+window is composed on another: overrides living in the tree would mean a chain drawn from one set of them and
+the row above it from another, with no way to tell. The cost of that choice is that a new question about a
+path has to take the parameter or it silently answers with the dump's own reading, which looks right.
+
+**`findLeaks()` is deliberately not read through them.** It is Shark's own answer, and a leak's name is
+`LeakTrace.leakFingerprint` of the suspect stretch — the last object still needed down to the first one
+leaking — so reading it through statuses somebody set would produce fingerprints that no longer match the
+ones LeakCanary prints for the same leak. The list of leaks is what the dump says; the banner is what anyone
+reading it has concluded.
+
+**Two statuses set by hand can contradict each other, and the contradiction is shown rather than settled.**
+The propagation rules are what make it possible: a leaking object above forces everything it holds to be
+leaking, and an object still needed below forces everything holding it to be needed. So two hand-set statuses
+disagree exactly when one of the objects reaches the other, which is `HeapDominatorTreemap.reaches` —
+one walk up `ReferrerIndex` per status already set, a question somebody asked rather than one the pointer
+asks. `leakStatusConflictsWith` answers it before anything is written, and the dialog then lists every one of
+them by name, with the reason it was given, because whoever is about to overrule it is the only person who
+can weigh the two.
+
+- **Flipping to the opposite status always resolves it**, which is why solving a conflict is one button.
+  `NOT_LEAKING` propagates upwards only and `LEAKING` downwards only, so the pair that can disagree is
+  always those two, and agreeing with the new status is the same as being flipped.
+- **Flipped, not taken off**, so that what somebody typed is still in the file: the solved reason says which
+  status it was, what it said, and that this is why it changed.
+- **A status of `UNKNOWN` set by hand conflicts with nothing.** Nobody claiming to know overrules nobody, so
+  it is never one of the statuses a new one has to be settled against — though it can still be overruled by
+  the chain, and the reason then records what it was.
+- **Nothing is written until the choice is made**, which is what makes "Undo" free, and the write is one
+  `LeakStatusFile.write` of the lot rather than one per status: a save that stopped half way through would
+  leave a heap dump whose statuses contradict each other, which is the one state this step exists to
+  prevent. It runs `NonCancellable` because the dialog closes as soon as it has.
+
+**One tab separated file per heap dump, in `~/.shark-explorer/leak-statuses`.** Named after the dump the way
+its notes are, and beside them rather than next to the dump, for the same reason: dumps come from device
+pulls, temporary files and read only mounts. A file rather than a directory of files, which is the opposite
+of the notes — a note is a document somebody edits and a status is three fields the window writes, and every
+question here is about all of them at once. Columns named in a comment at the top, the reason's newlines and
+tabs escaped, the lines sorted by address, so that the file reads as evidence: two runs that set the same
+statuses write the same file, and a line of it can be pasted into an issue. A line that can't be read is
+skipped with a log line rather than thrown over — it is hand editable on purpose, and one typo must not be a
+heap dump whose other statuses have gone. Addresses are written with `exactHexObjectId`, not `hexObjectId`,
+since the latter gives up exactly what a file can't.
+
+**Nothing is applied that wasn't written**, which is also the opposite of the notes beside it: a status only
+this process knows about is a chain explained by a reason that will be gone next run. And nothing is saved
+before the file has been read — an empty set of statuses, written out because the disk was slow, is every
+status of that heap dump deleted — which is what the disabled button and the check in
+`HeapDumpLeakStatuses.save` are both for.
+
 ## Testing split
 
 Headless `runComposeUiTest` on the JVM covers the UI, so there's no emulator in the loop — a real

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -825,26 +825,47 @@ headings, and the listing is the index.
 
 Every chain already carried a `LeakStatus` per object, worked out by Shark's inspectors and then propagated
 along the chain — everything above an object still needed is still needed, everything a leaking object holds
-is leaking. Two things were added to that: the status of the object a tab is *on*, said where the tab says
-which object, and the ability to overrule it.
+is leaking. Two things were added to that: the status of the object a tab is *on*, said in the panel that
+says what the object is, and the ability to overrule it.
 
-**The banner is under the title, above the panes**, for the reason the note button is: it is about the whole
-of what the tab is showing, and the title is what it is about. In the colours the chain beside it uses
-(`LeakStatus.background` and `textColor` are shared with `PathDrawing` rather than copied), because it is the
-same answer read in one place instead of a dozen — a reader who has learnt the green and the red on a chain
-reads them here for free.
+**At the top of "What it is", under the object's name and above its size.** It went under the tab's title
+first, beside the note button, and that was the wrong pane: the title row is about the tab, and this is a
+conclusion about the object — the panel below it holds the evidence the conclusion was drawn from, so the
+answer belongs at the head of that column rather than in a row of its own. Above the bitmap preview too, so
+that a screenshot several hundred pixels tall can't push it out of the panel. In the colours the chain beside
+it uses (`LeakStatus.background` and `textColor` are shared with `PathDrawing` rather than copied), because
+it is the same answer read in one place instead of a dozen — a reader who has learnt the green and the red on
+a chain reads them here for free.
 
-**Loud for the two statuses that mean something, quiet for the third.** Most of a heap dump is objects
-nothing knows either way about, so a shaded, bold `Unknown` on every tab would be a banner nobody reads by
-the time it says something. `UNKNOWN` is small, muted and unshaded; the other two are shaded in
-`TARGET_SHAPE`, the shape the chain marks its target with. A glyph as well as a colour (`✓ ? ✗`), so which
-status it is doesn't rest on colour alone.
+**Under a header, because the panel labels every line**, and the header is the question the statuses answer:
+"Should it be here?". A question rather than a noun like the `Retained` and `Shallow` beside it, since this
+is the one line of the panel that is a judgement rather than a measurement.
+
+**"Leaking" and "Not leaking" became "Shouldn't be here" and "Meant to be here"**, with `Unknown` becoming
+"Nobody knows". LeakCanary's leak traces say `Leaking: YES / NO / UNKNOWN`, and matching them was the case
+for keeping the old words — but calling an *object* leaking reads as that object leaking something as easily
+as being the thing left behind, and this repo's own rule is that a leak is a reference rather than an object.
+What the inspectors actually answer is whether the object is supposed to still be in memory, which is what
+these say, in the words the module's own prose already used. One `LeakStatus.statusText` is where they live,
+so the chain, the panel, the dialog and the reasons propagated along a chain (`Activity↓ is meant to be
+here`) all say the same thing. The identifiers didn't move: `LeakStatus`, `LEAKING`, `leakStatusesOf` stay
+Shark's names, because the code is where matching `shark.LeakTraceObject.LeakingStatus` matters.
+
+**A pencil, left of the status, rather than a "Set by hand…" button.** It is what changes the answer, so it
+belongs where the eye already is, and a text button pushed the reason onto a second line of a 320dp panel.
+Disabled until the statuses have been read off disk, which is the same rule the button had.
 
 **From the last step of the chain when there is one**, and from the object's own reading until the walk up to
 the GC roots lands, since the chain's answer is the one with the objects above and below taken into account.
-So the banner can say `Unknown` for a beat and then say `Leaking` — the panes filling in, not the window
-changing its mind. Nothing at all for the tab a window opens with: the whole heap dump is no object of it,
-and there is nothing to inspect or decide about.
+So the panel can say `Nobody knows` for a beat and then say `Shouldn't be here` — the panes filling in, not
+the window changing its mind. Nothing at all for the tab a window opens with: the whole heap dump is no
+object of it, and there is nothing to inspect or decide about.
+
+**Loud for the two statuses that mean something, quiet for the third.** Most of a heap dump is objects
+nothing knows either way about, so a shaded, bold `Nobody knows` on every object would be a line nobody reads
+by the time it says something. `UNKNOWN` is small, muted and unshaded; the other two are shaded in
+`TARGET_SHAPE`, the shape the chain marks its target with. A glyph as well as a colour (`✓ ? ✗`), so which
+status it is doesn't rest on colour alone.
 
 **Overriding always wins**, which is the one place this differs from how two inspectors disagreeing is
 settled. There, the object still being needed wins, because two inspectors are two halves of the same
@@ -859,20 +880,32 @@ an assertion the next reader — a colleague, an agent, the same person in a mon
 one of those makes every other status in the dump worth less. `SET_BY_HAND` marks the reason wherever it is
 read, so a green object somebody decided about is never mistaken for one an inspector recognized.
 
-**Nothing is recomputed, because nothing is cached.** The statuses of a chain are worked out on every read of
-it, so a status set by hand is an argument to the read rather than something to invalidate:
-`summarize`, `rootPathTo`, `independentPathsBetween` and `independentPathsFromRoots` take a
-`LeakStatusOverrides`, and the window's `LaunchedEffect`s are keyed on it — which is why that class has value
-equality. **A value rather than state on the tree**, because the tree is read from one thread while the
-window is composed on another: overrides living in the tree would mean a chain drawn from one set of them and
-the row above it from another, with no way to tell. The cost of that choice is that a new question about a
-path has to take the parameter or it silently answers with the dump's own reading, which looks right.
+**A status set by hand is an argument to every read, not state of the tree.** The statuses of a chain are
+worked out on every read of it, so `summarize`, `rootPathTo`, `independentPathsBetween`,
+`independentPathsFromRoots`, `findLeaks` and `isBelowLeakingObject` all take a `LeakStatusOverrides`, and the
+window's `LaunchedEffect`s are keyed on it — which is why that class has value equality. **A value rather
+than state on the tree**, because the tree is read from one thread while the window is composed on another:
+overrides living in the tree would mean a chain drawn from one set of them and the row above it from another,
+with no way to tell. The cost of that choice is that a new question about a path has to take the parameter or
+it silently answers with the dump's own reading, which looks right.
 
-**`findLeaks()` is deliberately not read through them.** It is Shark's own answer, and a leak's name is
-`LeakTrace.leakFingerprint` of the suspect stretch — the last object still needed down to the first one
-leaking — so reading it through statuses somebody set would produce fingerprints that no longer match the
-ones LeakCanary prints for the same leak. The list of leaks is what the dump says; the banner is what anyone
-reading it has concluded.
+**The list of leaks is read through them too, which is the part that is easy to get wrong.** A chain is only
+redrawn; the leaks are a *different list*. Mark an object leaking halfway up a chain and it becomes a leak,
+and whatever it was holding drops off — that object is now only in memory because of this one, which is the
+rule `foldedIntoWhatHoldsThem` already applied to what the inspectors found. Mark an object the inspectors
+recognized as still needed and it leaves the list entirely, and what it was holding can become a leak of its
+own. So the candidate set is the dump's own minus everything set to anything but `LEAKING` plus everything
+set to it, `RootPathSearch` goes round what a hand marked exactly as it goes round what the inspectors did —
+otherwise a leak would be grouped by a chain that disagrees with the statuses drawn on it — and the answer is
+worked out per set of statuses and kept until the next one, since a status is set by hand and this is
+seconds. The window asks again by keying that `LaunchedEffect` on the overrides like the rest.
+
+**The price is the fingerprints.** A leak's name is `LeakTrace.leakFingerprint` of the suspect stretch — the
+last object still needed down to the first one that shouldn't be there — so reading the list through
+somebody's statuses moves both ends of that stretch and produces fingerprints that no longer match the ones
+LeakCanary prints for the same leak. That is the deal: they match while nothing is set by hand, and moving
+that stretch is the whole point of setting one. The alternative, a leaks screen that ignores what the reader
+has established, is a screen that goes on listing an object they have already explained.
 
 **Two statuses set by hand can contradict each other, and the contradiction is shown rather than settled.**
 The propagation rules are what make it possible: a leaking object above forces everything it holds to be

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/DetailsPanel.kt
@@ -59,6 +59,13 @@ internal fun DetailsPanel(
   /** The selected object's pixels, when it's a bitmap anything has the pixels of. */
   bitmap: ImageBitmap?,
   isStarred: Boolean,
+  /** Whether the selected object is meant to be in memory, and null when nothing is selected. */
+  leakStatus: ObjectLeakStatus?,
+  /** Whether the statuses set by hand have been read yet, which is what lets one be changed. */
+  isLeakStatusRead: Boolean,
+  /** What went wrong reading or writing them, shown under the status it is about. */
+  leakStatusProblem: String?,
+  onChangeLeakStatus: () -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
   /** Puts a link to a field's object on the clipboard, beside opening it. See [OpenTarget]. */
   onCopyLink: (Long) -> Unit,
@@ -91,6 +98,10 @@ internal fun DetailsPanel(
           stronglyReachableByteCount = stronglyReachableByteCount,
           bitmap = bitmap,
           isStarred = isStarred,
+          leakStatus = leakStatus,
+          isLeakStatusRead = isLeakStatusRead,
+          leakStatusProblem = leakStatusProblem,
+          onChangeLeakStatus = onChangeLeakStatus,
           onOpen = onOpen,
           onCopyLink = onCopyLink,
           onListInstances = onListInstances,
@@ -157,6 +168,10 @@ private fun ObjectDetails(
   stronglyReachableByteCount: Long,
   bitmap: ImageBitmap?,
   isStarred: Boolean,
+  leakStatus: ObjectLeakStatus?,
+  isLeakStatusRead: Boolean,
+  leakStatusProblem: String?,
+  onChangeLeakStatus: () -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
   onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
@@ -165,15 +180,26 @@ private fun ObjectDetails(
   Hint(if (isStarred) UNSTAR_HINT else STAR_HINT) {
     Text(
       if (isStarred) "$STARRED_GLYPH $STARRED" else "$UNSTARRED_GLYPH $NOT_STARRED",
-      Modifier.clickableRow(onToggleStar).padding(vertical = 2.dp),
+      Modifier.clickableRow(onClick = onToggleStar).padding(vertical = 2.dp),
       style = MaterialTheme.typography.bodyMedium
     )
   }
   summary.headline?.let { headline ->
     Text(headline, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Bold)
   }
-  // Right under the headline, which for a bitmap is its size and its format: the picture is what the
-  // bitmap is, and the sentence describing it stops just short of saying it.
+  // Above everything measured about the object, because it is the one line here that is a conclusion:
+  // the sizes and the fields below it are what it was concluded from. Above the picture of a bitmap too,
+  // so that a screenshot several hundred pixels tall can't push the conclusion out of the panel.
+  if (leakStatus != null) {
+    LeakStatusDetail(
+      status = leakStatus,
+      isRead = isLeakStatusRead,
+      problem = leakStatusProblem,
+      onChange = onChangeLeakStatus
+    )
+  }
+  // Under the headline, which for a bitmap is its size and its format: the picture is what the bitmap is,
+  // and the sentence describing it stops just short of saying it.
   BitmapPreview(bitmap)
   Row(
     horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerLeakStatuses.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ExplorerLeakStatuses.kt
@@ -1,0 +1,144 @@
+package shark.explorer.app
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import shark.SharkLog
+import shark.explorer.LeakStatusFile
+import shark.explorer.LeakStatusOverride
+import shark.explorer.LeakStatusOverrides
+import shark.explorer.hexObjectId
+
+/**
+ * The leaking statuses set by hand on every heap dump this run has open.
+ *
+ * Per run rather than per window, for the reason [ExplorerNotes] is: the same heap dump is often open in two
+ * windows, and two of these over one file would mean each window saving over the other's statuses. It also
+ * means a status set in one window is the status the other one draws, which is what makes the two windows two
+ * views of one heap dump rather than two readings of it.
+ *
+ * Plain state rather than a composable's, so that it can be handed to a window and to a test.
+ */
+internal class ExplorerLeakStatuses(private val root: File = LEAK_STATUSES_DIRECTORY) {
+
+  private val byFile = mutableMapOf<String, HeapDumpLeakStatuses>()
+
+  /** The statuses set on [heapDumpFile], the same ones every time they are asked for. */
+  fun of(heapDumpFile: File): HeapDumpLeakStatuses = synchronized(byFile) {
+    val file = LeakStatusFile(root, heapDumpFile)
+    byFile.getOrPut(file.file.path) { HeapDumpLeakStatuses(file) }
+  }
+
+  companion object {
+    /** Beside the notes, the logs and the published runs, which is everything else this app keeps. */
+    private val LEAK_STATUSES_DIRECTORY = File(SHARK_EXPLORER_DIRECTORY, "leak-statuses")
+  }
+}
+
+/**
+ * What has been set by hand about one heap dump: a status per object, and how to change one.
+ *
+ * **Nothing is applied that wasn't written**, which is the opposite way round from the notes beside it: a
+ * note is what someone is typing and a status is a conclusion the window then reads the heap dump through, so
+ * one that only lives in this process is a chain explained by a reason that will be gone next run. A save that
+ * fails leaves the heap dump as it was and says why.
+ */
+@Stable
+internal class HeapDumpLeakStatuses(private val statusFile: LeakStatusFile) {
+
+  /** Where these are kept, shown while setting one so they can be found without this app. */
+  val file: File get() = statusFile.file
+
+  /** Every status set by hand, which is what the window reads the heap dump with. */
+  var overrides: LeakStatusOverrides by mutableStateOf(LeakStatusOverrides.NONE)
+    private set
+
+  /**
+   * Whether the file has been read, which is what makes writing safe.
+   *
+   * Until it is true, [overrides] is empty because nothing has been read rather than because nothing was
+   * set — and saving over that would delete every status of the heap dump to say the disk was slow. Which is
+   * why the button that changes one is disabled until then.
+   */
+  var isRead by mutableStateOf(false)
+    private set
+
+  /** What went wrong reading or writing the file, shown where the status is. Null while nothing has. */
+  var problem: String? by mutableStateOf(null)
+    private set
+
+  /** Reads the file, once per run of the app. */
+  suspend fun read() {
+    if (isRead) {
+      return
+    }
+    val read = try {
+      withContext(Dispatchers.IO) { statusFile.read() }
+    } catch (throwable: Throwable) {
+      // In the window as well as in the log, because these are somebody's conclusions about this heap dump:
+      // a reader who is told nothing would take the inspectors' answer for the whole of it.
+      SharkLog.d(throwable) { "Could not read the statuses set by hand in $file" }
+      problem = "Could not read $file: $throwable"
+      return
+    }
+    isRead = true
+    problem = null
+    overrides = read
+  }
+
+  /**
+   * Sets [override], along with whatever solving its conflicts flipped, and puts the lot on disk.
+   *
+   * [NonCancellable] because the dialog that asked for this closes as soon as it has, and a save that stopped
+   * half way through would leave a heap dump whose statuses contradict each other — which is the one state
+   * the conflict step exists to prevent.
+   */
+  suspend fun set(
+    override: LeakStatusOverride,
+    /** The statuses that had to change for [override] to be true. See [shark.explorer.LeakStatusConflict]. */
+    solved: List<LeakStatusOverride> = emptyList()
+  ) {
+    save(overrides.with(listOf(override) + solved)) {
+      "Set ${override.status} on ${hexObjectId(override.objectId)} by hand, and " +
+        "${solved.size} statuses with it to solve what it disagreed with"
+    }
+  }
+
+  /** Takes the status off [objectId], so that the heap dump says what it says about it again. */
+  suspend fun clear(objectId: Long) {
+    save(overrides.without(objectId)) { "Took the status set by hand off ${hexObjectId(objectId)}" }
+  }
+
+  private suspend fun save(
+    next: LeakStatusOverrides,
+    what: () -> String
+  ) {
+    if (!isRead) {
+      // Which the disabled button already prevents; here too, because this is where it would cost every
+      // status of the heap dump.
+      SharkLog.d { "Not saving to $file: it has not been read yet" }
+      return
+    }
+    val written = withContext(Dispatchers.IO + NonCancellable) {
+      try {
+        statusFile.write(next)
+        true
+      } catch (throwable: Throwable) {
+        SharkLog.d(throwable) { "Could not save the statuses set by hand to $file" }
+        problem = "Could not save $file: $throwable"
+        false
+      }
+    }
+    if (!written) {
+      return
+    }
+    SharkLog.d { "${what()} in $file" }
+    overrides = next
+    problem = null
+  }
+}

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -211,8 +211,8 @@ internal fun HeapDumpExplorer(
    *
    * From the last step of the chain when there is one, because that is the status with everything above and
    * below the object taken into account, and from the object's own reading until the walk up to the GC roots
-   * lands — or for good, for an object nothing reaches. So this can say `Nobody knows` for a beat and then
-   * say `Shouldn't be here`, which is the panes filling in rather than the window changing its mind.
+   * lands — or for good, for an object nothing reaches. So this can say `Unknown` for a beat and then say
+   * `Leaked`, which is the panes filling in rather than the window changing its mind.
    *
    * Nothing for the whole heap dump, which is no object of it: there is nothing to inspect and nothing to
    * decide about.

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -117,7 +117,7 @@ internal fun HeapDumpExplorer(
   fetchedBitmapPixels: NativeBitmapPixels? = null,
   /** What has been written about the places of this heap dump, shared with every other window on it. */
   notes: HeapDumpNotes,
-  /** And what has been decided about its objects by hand, shared the same way. See [LeakStatusBanner]. */
+  /** And what has been decided about its objects by hand, shared the same way. See [LeakStatusDetail]. */
   leakStatuses: HeapDumpLeakStatuses,
   /** What a link to one of these tabs names this window by. See [DeepLink]. */
   deepLinkId: String = remember { DeepLink.newWindowId() },
@@ -206,12 +206,13 @@ internal fun HeapDumpExplorer(
   val hoveredCellDetails = hoveredDetails?.takeIf { it.place == hoveredPlace }
   val describedSummary = (details?.selection as? Selection.Object)?.summary
   /**
-   * Whether the object the tab is on is leaking, for the row above the panes and the dialog that changes it.
+   * Whether the object the tab is on is meant to be in memory, for the panel that says what it is and the
+   * dialog that overrules it.
    *
    * From the last step of the chain when there is one, because that is the status with everything above and
    * below the object taken into account, and from the object's own reading until the walk up to the GC roots
-   * lands — or for good, for an object nothing reaches. So this can say `Unknown` for a beat and then say
-   * `Leaking`, which is the panes filling in rather than the window changing its mind.
+   * lands — or for good, for an object nothing reaches. So this can say `Nobody knows` for a beat and then
+   * say `Shouldn't be here`, which is the panes filling in rather than the window changing its mind.
    *
    * Nothing for the whole heap dump, which is no object of it: there is nothing to inspect and nothing to
    * decide about.
@@ -450,14 +451,19 @@ internal fun HeapDumpExplorer(
   //
   // The leaks come with it, for the same reason and in the same breath: the map is shaded by them, so they
   // are what the window shows before anyone asks it anything, rather than what a checkbox goes looking for.
-  LaunchedEffect(session) {
+  //
+  // And again whenever a status is set by hand, because the list is read through those: marking something
+  // leaking halfway up a chain makes it a leak and takes what it was holding off the list, which is a
+  // different list rather than a different colour on the same one. See [HeapDominatorTreemap.findLeaks].
+  LaunchedEffect(session, overrides) {
     snapshotFlow { view }.first { it !== ViewState.EMPTY }
     val objectCount = session.read("the index of what points at what") { explorer ->
       explorer.tree.indexReferrers()
     }
     SharkLog.d { "Indexed what points at each of ${formatObjectCount(objectCount)}" }
+    isFindingLeaks = true
     leaks = session.read("the leaking objects of ${session.heapDumpFile.name}") { explorer ->
-      explorer.tree.findLeaks()
+      explorer.tree.findLeaks(overrides)
     }
     isFindingLeaks = false
   }
@@ -522,7 +528,7 @@ internal fun HeapDumpExplorer(
   LaunchedEffect(session, view.rootObjectId, leaks) {
     val rootNode = view.rootObjectId
     isRootLeaking = leaks != null && session.read("whether ${nodeIdText(rootNode)} is below a leak") {
-      it.tree.isBelowLeakingObject(rootNode)
+      it.tree.isBelowLeakingObject(rootNode, overrides)
     }
   }
 
@@ -666,17 +672,6 @@ internal fun HeapDumpExplorer(
       // one, because it is the one thing that is as true of a list of objects as of the map.
       Column(Modifier.weight(1f)) {
         DescribedObject(details?.selection)
-        // Directly under the name of the object, because it is the other half of what the tab is about: which
-        // object, and whether it should still be here. In the colours the chain beside it draws a status in,
-        // since it is the same answer read in one place rather than a dozen. See [LeakStatusBanner].
-        if (describedLeakStatus != null) {
-          LeakStatusBanner(
-            status = describedLeakStatus,
-            isRead = leakStatuses.isRead,
-            problem = leakStatuses.problem,
-            onChange = { setsLeakStatus = true }
-          )
-        }
         // Under the title, and only until there is a note: the note will be about what the title names, and
         // this is where it will appear, so the button is where its own result goes. Small, since that costs a
         // line of every tab nobody has written about. Once there is a note it is here instead and carries the
@@ -756,6 +751,10 @@ internal fun HeapDumpExplorer(
             sizes = sizes,
             bitmap = describedBitmap,
             isStarred = favourites.any { it.objectId == describedSummary?.objectId },
+            leakStatus = describedLeakStatus,
+            isLeakStatusRead = leakStatuses.isRead,
+            leakStatusProblem = leakStatuses.problem,
+            onChangeLeakStatus = { setsLeakStatus = true },
             onOpen = openObject,
             onCopyLink = copyObjectLink,
             onListInstances = { className ->
@@ -957,7 +956,10 @@ private fun RowScope.ViewPane(
   }
 }
 
-/** What the object is: its size, what the inspectors make of it, its fields. */
+/**
+ * What the object is: whether it is meant to be in memory, its size, what the inspectors make of it, and
+ * its fields.
+ */
 @Composable
 private fun RowScope.DetailsPane(
   panes: PanesState,
@@ -965,6 +967,10 @@ private fun RowScope.DetailsPane(
   sizes: HeapSizes,
   bitmap: ImageBitmap?,
   isStarred: Boolean,
+  leakStatus: ObjectLeakStatus?,
+  isLeakStatusRead: Boolean,
+  leakStatusProblem: String?,
+  onChangeLeakStatus: () -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
   onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
@@ -984,6 +990,10 @@ private fun RowScope.DetailsPane(
       stronglyReachableByteCount = sizes.stronglyReachableByteCount,
       bitmap = bitmap,
       isStarred = isStarred,
+      leakStatus = leakStatus,
+      isLeakStatusRead = isLeakStatusRead,
+      leakStatusProblem = leakStatusProblem,
+      onChangeLeakStatus = onChangeLeakStatus,
       onOpen = onOpen,
       onCopyLink = onCopyLink,
       onListInstances = onListInstances,

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -212,7 +212,7 @@ internal fun HeapDumpExplorer(
    * From the last step of the chain when there is one, because that is the status with everything above and
    * below the object taken into account, and from the object's own reading until the walk up to the GC roots
    * lands — or for good, for an object nothing reaches. So this can say `Unknown` for a beat and then say
-   * `Leaked`, which is the panes filling in rather than the window changing its mind.
+   * `Stuck`, which is the panes filling in rather than the window changing its mind.
    *
    * Nothing for the whole heap dump, which is no object of it: there is nothing to inspect and nothing to
    * decide about.

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/HeapDumpExplorer.kt
@@ -57,6 +57,7 @@ import shark.explorer.HeapLeaks
 import shark.explorer.HeapObjectKind
 import shark.explorer.HeapSizes
 import shark.explorer.LayoutCell
+import shark.explorer.LeakStatusOverrides
 import shark.explorer.NativeBitmapPixels
 import shark.explorer.Note
 import shark.explorer.NoteLink
@@ -78,6 +79,7 @@ import shark.explorer.TreemapRect
 import shark.explorer.detours
 import shark.explorer.formatObjectCount
 import shark.explorer.hexObjectId
+import shark.explorer.leakStatusConflictsWith
 import shark.explorer.nodeIdText
 import shark.explorer.referencesOf
 import shark.explorer.titleOf
@@ -115,6 +117,8 @@ internal fun HeapDumpExplorer(
   fetchedBitmapPixels: NativeBitmapPixels? = null,
   /** What has been written about the places of this heap dump, shared with every other window on it. */
   notes: HeapDumpNotes,
+  /** And what has been decided about its objects by hand, shared the same way. See [LeakStatusBanner]. */
+  leakStatuses: HeapDumpLeakStatuses,
   /** What a link to one of these tabs names this window by. See [DeepLink]. */
   deepLinkId: String = remember { DeepLink.newWindowId() },
   /** Places a link has asked for, opened as tabs. See [ExplorerWindow.linkedPlaces]. */
@@ -186,6 +190,10 @@ internal fun HeapDumpExplorer(
       subject = current.title ?: placeTitles[current] ?: NAMING_TAB
     )
   }
+  /** Which objects of this heap dump have a status someone set, which is what every chain is read with. */
+  val overrides = leakStatuses.overrides
+  /** Whether the dialog that sets one is open, for the object the tab is on. */
+  var setsLeakStatus by remember { mutableStateOf(false) }
 
   // Nothing is under the pointer while a list is showing: the view isn't there, so the rectangle it was on
   // last is neither where the pointer is now nor what the tab is about.
@@ -197,6 +205,31 @@ internal fun HeapDumpExplorer(
   // details of the cell before it belong to a rectangle the pointer has left.
   val hoveredCellDetails = hoveredDetails?.takeIf { it.place == hoveredPlace }
   val describedSummary = (details?.selection as? Selection.Object)?.summary
+  /**
+   * Whether the object the tab is on is leaking, for the row above the panes and the dialog that changes it.
+   *
+   * From the last step of the chain when there is one, because that is the status with everything above and
+   * below the object taken into account, and from the object's own reading until the walk up to the GC roots
+   * lands — or for good, for an object nothing reaches. So this can say `Unknown` for a beat and then say
+   * `Leaking`, which is the panes filling in rather than the window changing its mind.
+   *
+   * Nothing for the whole heap dump, which is no object of it: there is nothing to inspect and nothing to
+   * decide about.
+   */
+  val describedLeakStatus = describedSummary
+    ?.takeIf { it.objectId != HeapDominatorTreemap.ROOT_OBJECT_ID }
+    ?.let { summary ->
+      val onChain = details?.rootPath?.steps?.lastOrNull()?.step
+        ?.takeIf { it.objectId == summary.objectId }
+      ObjectLeakStatus(
+        objectId = summary.objectId,
+        objectName = summary.className.substringAfterLast('.') +
+          summary.kind?.let { " ${it.typeName}" }.orEmpty(),
+        status = onChain?.leakStatus ?: summary.leakStatus,
+        reason = onChain?.leakStatusReason ?: summary.leakStatusReason,
+        setByHand = overrides[summary.objectId]
+      )
+    }
 
   val treemapLayout = rememberTreemapLayout()
   val radialLayout = rememberRadialLayout()
@@ -339,25 +372,31 @@ internal fun HeapDumpExplorer(
   // What the tab is on, which is one read of the heap dump per move. Keyed on the place, so that nothing
   // else clears the panes — and because the place is the whole of where the tab is, there is no second
   // piece of state for this to fall out of step with.
-  LaunchedEffect(session, place) {
+  //
+  // And on the statuses set by hand, because they are half of what a chain says: setting one is asking the
+  // window to read the heap dump through it, which is this read again.
+  LaunchedEffect(session, place, overrides) {
+    // Whatever was being decided was being decided about the object this is leaving, and a dialog that
+    // outlived the tab it was opened from would set a status on an object nobody is looking at.
+    setsLeakStatus = false
     if (place == null || place.viewRootObjectId == null) {
       details = null
       return@LaunchedEffect
     }
-    session.describing(place) { details = it }
+    session.describing(place, overrides) { details = it }
   }
 
   // The same for the cell under the pointer, once it has stayed on one long enough to be looking at it.
   // Without that wait, a sweep across the map would ask about every rectangle it crossed: the reads that
   // are no longer wanted do get called off, but only where they next read the heap dump.
-  LaunchedEffect(session, hoveredPlace) {
+  LaunchedEffect(session, hoveredPlace, overrides) {
     if (hoveredPlace == null) {
       // Whatever was read for the last cell stays where it is: nothing is waiting for it, and the panes
       // are showing the tab's own place again anyway.
       return@LaunchedEffect
     }
     delay(HOVER_SETTLE_MILLIS)
-    session.describing(hoveredPlace) { hoveredDetails = it }
+    session.describing(hoveredPlace, overrides) { hoveredDetails = it }
   }
 
   // The panel shows the bitmap it describes as big as the panel is wide, so its pixels are read again at
@@ -395,9 +434,9 @@ internal fun HeapDumpExplorer(
       detours.associate { detour ->
         val from = detour.fromObjectId
         val found = if (from == null) {
-          explorer.tree.independentPathsFromRoots(detour.toObjectId)
+          explorer.tree.independentPathsFromRoots(detour.toObjectId, overrides)
         } else {
-          explorer.tree.independentPathsBetween(from, detour.toObjectId)
+          explorer.tree.independentPathsBetween(from, detour.toObjectId, overrides)
         }
         detour.fromIndex to path.waysOf(detour, found)
       }
@@ -446,6 +485,11 @@ internal fun HeapDumpExplorer(
   // Which places have been written about, once per run of the app: a directory listing rather than a note
   // opened per tab, since what it answers is a question about the whole strip. See [HeapDumpNotes.list].
   LaunchedEffect(notes) { notes.list() }
+
+  // And what has been decided about this heap dump's objects by hand, also once per run: one small file,
+  // read before anything is drawn from it, because a chain read without it would be the heap dump's own
+  // answer where someone has already recorded another. See [HeapDumpLeakStatuses].
+  LaunchedEffect(leakStatuses) { leakStatuses.read() }
 
   // And what the note about this one says, once per run of the app. Here rather than in the section that draws
   // it, because a place nobody has written about has no section at all until the read says it has none.
@@ -574,6 +618,22 @@ internal fun HeapDumpExplorer(
     )
   }
 
+  if (setsLeakStatus && describedLeakStatus != null) {
+    LeakStatusDialog(
+      status = describedLeakStatus,
+      // A walk up the references per status already set, which is a read of the heap dump like any other —
+      // and one asked for, so it is not on the path the pointer takes. See [leakStatusConflictsWith].
+      onFindConflicts = { override ->
+        session.read("what setting ${hexObjectId(override.objectId)} to ${override.status} disagrees with") {
+          it.tree.leakStatusConflictsWith(override, overrides)
+        }
+      },
+      onSet = { override, solved -> leakStatuses.set(override, solved) },
+      onClear = { leakStatuses.clear(describedLeakStatus.objectId) },
+      onDismiss = { setsLeakStatus = false }
+    )
+  }
+
   Column(modifier) {
     ScreenBar(
       starredCount = favourites.size,
@@ -606,6 +666,17 @@ internal fun HeapDumpExplorer(
       // one, because it is the one thing that is as true of a list of objects as of the map.
       Column(Modifier.weight(1f)) {
         DescribedObject(details?.selection)
+        // Directly under the name of the object, because it is the other half of what the tab is about: which
+        // object, and whether it should still be here. In the colours the chain beside it draws a status in,
+        // since it is the same answer read in one place rather than a dozen. See [LeakStatusBanner].
+        if (describedLeakStatus != null) {
+          LeakStatusBanner(
+            status = describedLeakStatus,
+            isRead = leakStatuses.isRead,
+            problem = leakStatuses.problem,
+            onChange = { setsLeakStatus = true }
+          )
+        }
         // Under the title, and only until there is a note: the note will be about what the title names, and
         // this is where it will appear, so the button is where its own result goes. Small, since that costs a
         // line of every tab nobody has written about. Once there is a note it is here instead and carries the
@@ -1416,6 +1487,8 @@ private class PlaceDetails(
  */
 private suspend fun HeapDumpSession.describing(
   place: Place,
+  /** The statuses set by hand, which decide half of what the chain and the row above the panes say. */
+  overrides: LeakStatusOverrides,
   onDetails: (PlaceDetails) -> Unit
 ) {
   val placeDetails = read(place.description()) { explorer ->
@@ -1425,7 +1498,7 @@ private suspend fun HeapDumpSession.describing(
         val group = tree.groupOrNull(place.objectId)
         when {
           group != null -> Selection.ObjectGroup(group)
-          place.objectId in tree -> Selection.Object(tree.summarize(place.objectId))
+          place.objectId in tree -> Selection.Object(tree.summarize(place.objectId, overrides))
           // Which is why the panel goes back to saying nothing is selected.
           else -> {
             SharkLog.d {
@@ -1456,7 +1529,7 @@ private suspend fun HeapDumpSession.describing(
   onDetails(placeDetails)
   val objectId = (placeDetails.selection as? Selection.Object)?.summary?.objectId ?: return
   val rootPath = read("what holds ${hexObjectId(objectId)}") { explorer ->
-    explorer.tree.rootPathTo(objectId)
+    explorer.tree.rootPathTo(objectId, overrides)
   }
   onDetails(
     PlaceDetails(

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
@@ -44,8 +44,8 @@ import shark.explorer.statusText
  * answer, and a reader who has learnt the green and the red on one surface reads them on the other.
  *
  * **Loud for the two statuses that mean something and quiet for the third**: a heap dump is mostly objects
- * nothing knows either way about, so shouting "Nobody knows" on every object would be a line nobody reads by
- * the time it says something. Which is also why the reason is here rather than in a tooltip: the status is a
+ * nothing knows either way about, so shouting `Unknown` on every object would be a line nobody reads by the
+ * time it says something. Which is also why the reason is here rather than in a tooltip: the status is a
  * conclusion, and half the objects on a chain are green or red because of what another object is.
  */
 @Composable
@@ -63,8 +63,8 @@ internal fun LeakStatusDetail(
 ) {
   val isKnown = status.status != LeakStatus.UNKNOWN
   Column(modifier.fillMaxWidth()) {
-    // The question, the way every other line of this panel names what is under it. Which is what makes the
-    // two answers that matter readable on their own: they are answers to a question that is on screen.
+    // Named the way every other line of this panel is, because one word over a status is what lets the
+    // status itself be one word: a label nobody reads twice, on a line that repeats down a whole chain.
     Text(STATUS_LABEL, style = MaterialTheme.typography.labelSmall)
     Row(
       Modifier.fillMaxWidth(),
@@ -81,8 +81,8 @@ internal fun LeakStatusDetail(
           color = if (isRead) LINK_COLOR else MaterialTheme.colorScheme.outline
         )
       }
-      // The status behind its own shade, the way a step of a chain is drawn, so that the object being one
-      // that shouldn't be there is something you see before reading anything.
+      // The status behind its own shade, the way a step of a chain is drawn, so that the object having
+      // leaked is something you see before reading anything.
       Text(
         "${status.status.glyph} ${status.status.statusText}",
         Modifier.then(
@@ -404,15 +404,15 @@ private val LeakStatus.glyph: String
   }
 
 /**
- * What the panel calls the line, which is the question the three statuses answer.
+ * What the panel calls the line, in one word like every other label in that panel.
  *
- * A question rather than a noun, unlike every other label in that panel, because this is the one line of it
- * that is a conclusion rather than a measurement — and the answers are only readable on a chain, where no
- * label fits, if they are answers to something.
+ * A verdict rather than a measurement, which is the difference between this line and the rest of them: a
+ * number is read off the heap dump, and this is what somebody — an inspector or a reader — made of it. Which
+ * is also what says the pencil beside it is allowed to disagree.
  */
-internal const val STATUS_LABEL = "Should it be here?"
+internal const val STATUS_LABEL = "Verdict"
 
-internal fun statusDialogTitle(objectName: String) = "Should $objectName be here?"
+internal fun statusDialogTitle(objectName: String) = "Verdict on $objectName"
 
 /** What opens the dialog, set or not: the same mark the app writes a note with. */
 internal const val EDIT_STATUS_GLYPH = "✎"
@@ -435,8 +435,7 @@ private const val WRITING_STATUS = "Keeping it…"
 private const val NOW_LABEL = "Now:"
 
 private const val SET_STATUS_HINT =
-  "Say whether this object should be here, whatever the heap dump says. Kept between runs, and the reason " +
-    "with it."
+  "Say whether this object leaked, whatever the heap dump says. Kept between runs, and the reason with it."
 
 private const val CHANGE_STATUS_HINT = "Change or take off the status set by hand for this object."
 
@@ -452,10 +451,9 @@ private const val CONFLICT_ONE = "status set by hand cannot be true alongside"
 private const val CONFLICT_MANY = "statuses set by hand cannot be true alongside"
 
 private const val CONFLICT_EXPLANATION =
-  "Everything held by an object that shouldn't be here shouldn't be here either, and everything holding " +
-    "one that is meant to be here is meant to be here too — so these and the status being set contradict " +
-    "each other. Keeping this one flips them to the opposite status, with what they said kept as part of " +
-    "the new reason."
+  "Everything a leaked object holds has leaked too, and everything holding a needed one is needed too — so " +
+    "these and the status being set contradict each other. Keeping this one flips them to the opposite " +
+    "status, with what they said kept as part of the new reason."
 
 private const val CONFLICT_ABOVE = "holds it"
 private const val CONFLICT_BELOW = "is held by it"

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
@@ -37,7 +37,7 @@ import shark.explorer.LeakStatusOverride
 import shark.explorer.statusText
 
 /**
- * Whether the object the tab is on is meant to be in memory, and the pencil that overrules the answer.
+ * The verdict on the object the tab is on, and the pencil that overrules it.
  *
  * At the top of what the object is, under its name and above its size, because it is the conclusion the
  * rest of that panel is the evidence for. In the colours a chain draws a status in — because it is the same
@@ -81,8 +81,8 @@ internal fun LeakStatusDetail(
           color = if (isRead) LINK_COLOR else MaterialTheme.colorScheme.outline
         )
       }
-      // The status behind its own shade, the way a step of a chain is drawn, so that the object having
-      // leaked is something you see before reading anything.
+      // The verdict behind its own shade, the way a step of a chain is drawn, so that an object being
+      // stuck is something you see before reading anything.
       Text(
         "${status.status.glyph} ${status.status.statusText}",
         Modifier.then(
@@ -379,7 +379,7 @@ private sealed interface Decision {
 }
 
 /**
- * The leaking status of the object a tab is on, from wherever the window knows it.
+ * The verdict on the object a tab is on, from wherever the window knows it.
  *
  * Which is either of two reads, and they answer slightly different questions: the last step of the chain from
  * a GC root, which is the status with the objects above and below it taken into account, or the object's own
@@ -417,7 +417,7 @@ internal fun statusDialogTitle(objectName: String) = "Verdict on $objectName"
 /** What opens the dialog, set or not: the same mark the app writes a note with. */
 internal const val EDIT_STATUS_GLYPH = "✎"
 
-internal const val SAVE_STATUS = "Set the status"
+internal const val SAVE_STATUS = "Set the verdict"
 internal const val CANCEL_STATUS = "Cancel"
 internal const val CLEAR_STATUS = "Take it off"
 
@@ -428,16 +428,16 @@ internal const val SOLVE_CONFLICTS = "Keep this and flip those"
 internal const val UNDO_STATUS = "Undo"
 
 internal const val CHECKING_CONFLICTS =
-  "Looking for statuses set by hand that this one could not be true alongside…"
+  "Looking for verdicts set by hand that this one could not be true alongside…"
 
 private const val WRITING_STATUS = "Keeping it…"
 
 private const val NOW_LABEL = "Now:"
 
 private const val SET_STATUS_HINT =
-  "Say whether this object leaked, whatever the heap dump says. Kept between runs, and the reason with it."
+  "Say whether this object is stuck, whatever the heap dump says. Kept between runs, and the reason with it."
 
-private const val CHANGE_STATUS_HINT = "Change or take off the status set by hand for this object."
+private const val CHANGE_STATUS_HINT = "Change or take off the verdict set by hand for this object."
 
 private const val REASON_LABEL = "Why"
 
@@ -445,15 +445,15 @@ private const val REASON_PLACEHOLDER =
   "What you know that the heap dump doesn't: whoever reads this next has only this sentence to go on."
 
 /** What the box is called, which is also how a test finds it: there is no other text field in the dialog. */
-internal const val REASON_DESCRIPTION = "Why this object is being given that status."
+internal const val REASON_DESCRIPTION = "Why this object is being given that verdict."
 
-private const val CONFLICT_ONE = "status set by hand cannot be true alongside"
-private const val CONFLICT_MANY = "statuses set by hand cannot be true alongside"
+private const val CONFLICT_ONE = "verdict set by hand cannot be true alongside"
+private const val CONFLICT_MANY = "verdicts set by hand cannot be true alongside"
 
 private const val CONFLICT_EXPLANATION =
-  "Everything a leaked object holds has leaked too, and everything holding a needed one is needed too — so " +
-    "these and the status being set contradict each other. Keeping this one flips them to the opposite " +
-    "status, with what they said kept as part of the new reason."
+  "Everything a stuck object holds is stuck too, and everything holding an expected one is expected too — " +
+    "so these and the verdict being set contradict each other. Keeping this one flips them to the opposite " +
+    "verdict, with what they said kept as part of the new reason."
 
 private const val CONFLICT_ABOVE = "holds it"
 private const val CONFLICT_BELOW = "is held by it"

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
@@ -1,0 +1,466 @@
+package shark.explorer.app
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import shark.SharkLog
+import shark.explorer.LeakStatus
+import shark.explorer.LeakStatusConflict
+import shark.explorer.LeakStatusOverride
+import shark.explorer.statusText
+
+/**
+ * What the object the tab is on is: leaking, still needed, or nothing known either way.
+ *
+ * Under the title that says which object, in the colours a chain draws a status in — because it is the same
+ * answer. A chain says it about a dozen objects at once and this says it about the one the whole window is
+ * about, so a reader who has learnt the green and the red on one surface reads them on the other.
+ *
+ * **Loud for the two statuses that mean something and quiet for the third**: a heap dump is mostly objects
+ * nothing knows either way about, so a banner that shouted "Unknown" on every tab would be a banner nobody
+ * reads by the time it says something. Which is also why the reason is here rather than in a tooltip: the
+ * status is a conclusion, and half the objects on a chain are green or red because of what another object is.
+ */
+@Composable
+internal fun LeakStatusBanner(
+  status: ObjectLeakStatus,
+  /**
+   * Whether the statuses of this heap dump have been read off the disk, which is what makes changing one
+   * safe. See [HeapDumpLeakStatuses.isRead].
+   */
+  isRead: Boolean,
+  /** What went wrong reading or writing them, which is the one thing this window can say about it. */
+  problem: String?,
+  onChange: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val isKnown = status.status != LeakStatus.UNKNOWN
+  Column(modifier.fillMaxWidth()) {
+    Row(
+      Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      // The status behind its own shade, the way a step of a chain is drawn, so that what the window is
+      // about being a leak is something you see before reading anything.
+      Text(
+        "${status.status.glyph} ${status.status.statusText}",
+        Modifier.then(
+          if (isKnown) {
+            Modifier.background(status.status.background!!, TARGET_SHAPE)
+              .padding(horizontal = TARGET_PADDING, vertical = 1.dp)
+          } else {
+            Modifier
+          }
+        ),
+        style = if (isKnown) {
+          MaterialTheme.typography.bodyMedium
+        } else {
+          MaterialTheme.typography.bodySmall
+        },
+        color = status.status.textColor,
+        fontWeight = if (isKnown) FontWeight.Bold else FontWeight.Normal
+      )
+      // Why, which is most of the answer: an object is red because of what it is, or because of what
+      // something holding it is, and only the reason says which.
+      status.reason?.let { reason ->
+        Text(
+          reason,
+          Modifier.weight(1f),
+          style = MaterialTheme.typography.bodySmall,
+          color = status.status.textColor,
+          maxLines = REASON_LINES
+        )
+      }
+      Hint(if (status.setByHand == null) SET_STATUS_HINT else CHANGE_STATUS_HINT) {
+        TextButton(
+          onClick = onChange,
+          modifier = Modifier.height(STATUS_BUTTON_HEIGHT),
+          enabled = isRead,
+          contentPadding = PaddingValues(horizontal = 4.dp)
+        ) {
+          Text(
+            if (status.setByHand == null) SET_STATUS_BUTTON else CHANGE_STATUS_BUTTON,
+            style = MaterialTheme.typography.bodySmall
+          )
+        }
+      }
+    }
+    if (problem != null) {
+      Text(
+        problem,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error
+      )
+    }
+  }
+}
+
+/**
+ * Sets the leaking status of one object by hand, and settles what that disagrees with.
+ *
+ * Two steps, and the second one only when it has to be: a status, with the reason that makes it worth
+ * keeping, and then whatever else was set by hand that it cannot be true alongside. The reader decides which
+ * of the two readings to keep — nothing is flipped without being shown, and nothing is written until it is.
+ *
+ * Finding the disagreements is a walk up the heap dump's references, so it happens on the heap dump's thread
+ * like everything else here and this waits for it. See [shark.explorer.leakStatusConflictsWith].
+ */
+@Composable
+internal fun LeakStatusDialog(
+  status: ObjectLeakStatus,
+  /** What the new status would disagree with, read off the heap dump. See [HeapDumpExplorer]. */
+  onFindConflicts: suspend (LeakStatusOverride) -> List<LeakStatusConflict>,
+  /** Sets it, along with whatever had to change for it to be true. */
+  onSet: suspend (LeakStatusOverride, List<LeakStatusOverride>) -> Unit,
+  /** Takes the status off the object, so that the heap dump says what it says about it again. */
+  onClear: suspend () -> Unit,
+  onDismiss: () -> Unit
+) {
+  var chosen: LeakStatus by remember { mutableStateOf(status.setByHand?.status ?: status.status) }
+  var reason by remember { mutableStateOf(status.setByHand?.reason.orEmpty()) }
+  var step: SetStep by remember { mutableStateOf(SetStep.Choosing) }
+  /** What has been asked for, and null while nothing has: the ask is what the reading below follows. */
+  var requested: LeakStatusOverride? by remember { mutableStateOf(null) }
+
+  LaunchedEffect(requested) {
+    val override = requested ?: return@LaunchedEffect
+    step = SetStep.Checking
+    val conflicts = onFindConflicts(override)
+    step = if (conflicts.isEmpty()) {
+      // Nothing to settle, so the status someone typed is the whole of what they were asked for.
+      SetStep.Writing(Decision.Set(override, emptyList()))
+    } else {
+      SetStep.Conflicts(override, conflicts)
+    }
+    requested = null
+  }
+
+  // Every write goes through here, and closing the dialog is the last thing it does: a save started from a
+  // button and a dialog that goes away in the same breath is a save whose result nothing is left to keep.
+  val writing = (step as? SetStep.Writing)?.decision
+  LaunchedEffect(writing) {
+    when (val decision = writing ?: return@LaunchedEffect) {
+      is Decision.Set -> onSet(decision.override, decision.solved)
+      Decision.Clear -> onClear()
+    }
+    onDismiss()
+  }
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text("$STATUS_DIALOG_TITLE ${status.objectName}") },
+    text = {
+      Column(
+        Modifier.heightIn(max = DIALOG_MAX_HEIGHT).verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+      ) {
+        when (val currentStep = step) {
+          SetStep.Choosing -> ChoosingStatus(
+            status = status,
+            chosen = chosen,
+            reason = reason,
+            onChoose = { chosen = it },
+            onReason = { reason = it }
+          )
+          SetStep.Checking -> Waiting(CHECKING_CONFLICTS)
+          is SetStep.Conflicts -> Conflicts(currentStep.requested, currentStep.conflicts)
+          is SetStep.Writing -> Waiting(WRITING_STATUS)
+        }
+      }
+    },
+    confirmButton = {
+      when (val currentStep = step) {
+        SetStep.Choosing -> TextButton(
+          onClick = {
+            requested = LeakStatusOverride(
+              objectId = status.objectId,
+              status = chosen,
+              reason = reason.trim()
+            )
+          },
+          // A status set by hand overrules the heap dump, so it is worth nothing to whoever reads it next
+          // without the why — which is why this waits for one rather than filling one in.
+          enabled = reason.isNotBlank()
+        ) {
+          Text(SAVE_STATUS)
+        }
+        is SetStep.Conflicts -> TextButton(
+          onClick = {
+            SharkLog.d {
+              "Keeping ${currentStep.requested.status} for ${status.objectName} and flipping the " +
+                "${currentStep.conflicts.size} statuses set by hand that disagreed with it"
+            }
+            step = SetStep.Writing(
+              Decision.Set(currentStep.requested, currentStep.conflicts.map { it.solved })
+            )
+          }
+        ) {
+          Text(SOLVE_CONFLICTS)
+        }
+        // Nothing to confirm while the heap dump is being read or written: both of them are already the
+        // answer to a button someone pressed.
+        SetStep.Checking, is SetStep.Writing -> Unit
+      }
+    },
+    dismissButton = {
+      Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        // Only for a status a hand set: there is nothing to take off an object the inspectors alone spoke
+        // about, and a button that says there is would read as a way to silence them.
+        if (step == SetStep.Choosing && status.setByHand != null) {
+          TextButton(onClick = { step = SetStep.Writing(Decision.Clear) }) {
+            Text(CLEAR_STATUS)
+          }
+        }
+        if (step !is SetStep.Writing) {
+          TextButton(
+            onClick = {
+              if (step is SetStep.Conflicts) {
+                // Which is a reader who read what they were about to overrule and decided not to, and is
+                // worth as much in the log as the other choice.
+                SharkLog.d {
+                  "Left the statuses of this heap dump as they were rather than setting " +
+                    "${status.objectName} to $chosen"
+                }
+              }
+              onDismiss()
+            }
+          ) {
+            Text(if (step is SetStep.Conflicts) UNDO_STATUS else CANCEL_STATUS)
+          }
+        }
+      }
+    }
+  )
+}
+
+/** What the object is now, the three statuses it could be, and the reason that has to come with a change. */
+@Composable
+private fun ChoosingStatus(
+  status: ObjectLeakStatus,
+  chosen: LeakStatus,
+  reason: String,
+  onChoose: (LeakStatus) -> Unit,
+  onReason: (String) -> Unit
+) {
+  // What it is now and why, so that overruling it is done while reading it rather than from memory.
+  Text(
+    "${NOW_LABEL} ${status.status.statusText.lowercase()}${status.reason?.let { ": $it" }.orEmpty()}",
+    style = MaterialTheme.typography.bodySmall,
+    color = status.status.textColor
+  )
+  HorizontalDivider()
+  LeakStatus.values().forEach { option ->
+    Row(
+      Modifier.fillMaxWidth().clickable { onChoose(option) },
+      horizontalArrangement = Arrangement.spacedBy(4.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      // No click of its own, so that the row is the one thing to press: a mark beside a line of text is
+      // easier to hit as the line than as the mark.
+      RadioButton(selected = option == chosen, onClick = null)
+      Text(
+        option.statusText,
+        style = MaterialTheme.typography.bodyMedium,
+        color = option.textColor,
+        fontWeight = if (option == chosen) FontWeight.Bold else FontWeight.Normal
+      )
+    }
+  }
+  OutlinedTextField(
+    value = reason,
+    onValueChange = onReason,
+    label = { Text(REASON_LABEL, style = MaterialTheme.typography.bodySmall) },
+    placeholder = { Text(REASON_PLACEHOLDER, style = MaterialTheme.typography.bodySmall) },
+    textStyle = MaterialTheme.typography.bodyMedium,
+    modifier = Modifier.fillMaxWidth().height(REASON_HEIGHT)
+      .semantics { contentDescription = REASON_DESCRIPTION }
+  )
+}
+
+/**
+ * Everything set by hand that the new status cannot be true alongside, and what keeping it would do to them.
+ *
+ * Every one of them rather than a count, with the reason each was given, because that reason is the case for
+ * the other reading: whoever is about to overrule it is the one person who can weigh the two, and they can
+ * only do that if they can read what they are overruling.
+ */
+@Composable
+private fun Conflicts(
+  requested: LeakStatusOverride,
+  conflicts: List<LeakStatusConflict>
+) {
+  Text(
+    "${conflicts.size} ${if (conflicts.size == 1) CONFLICT_ONE else CONFLICT_MANY} " +
+      "${requested.status.statusText.lowercase()}.",
+    style = MaterialTheme.typography.bodyMedium,
+    fontWeight = FontWeight.Bold
+  )
+  Text(CONFLICT_EXPLANATION, style = MaterialTheme.typography.bodySmall)
+  conflicts.forEach { conflict ->
+    Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+      Text(
+        "${conflict.objectName} ${if (conflict.isAbove) CONFLICT_ABOVE else CONFLICT_BELOW}",
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.Bold
+      )
+      Text(
+        "${conflict.existing.status.statusText}: ${conflict.existing.reason}",
+        style = MaterialTheme.typography.bodySmall,
+        color = conflict.existing.status.textColor
+      )
+      Text(
+        "$CONFLICT_BECOMES ${conflict.solved.status.statusText.lowercase()}",
+        style = MaterialTheme.typography.bodySmall,
+        color = conflict.solved.status.textColor
+      )
+    }
+  }
+}
+
+/**
+ * Where the dialog is: choosing a status, waiting on the heap dump, or asking about what it disagrees with.
+ *
+ * Nothing has been written in any of the three. What is on disk changes once, when the last of them is
+ * answered.
+ */
+private sealed interface SetStep {
+
+  object Choosing : SetStep
+
+  object Checking : SetStep
+
+  class Conflicts(
+    /** What was asked for, which is what the conflicts are conflicts with. */
+    val requested: LeakStatusOverride,
+    val conflicts: List<LeakStatusConflict>
+  ) : SetStep
+
+  /** The one step that changes what is on disk, and the last: the dialog closes when it is done. */
+  class Writing(val decision: Decision) : SetStep
+}
+
+/** What was decided, which is the whole of what a dialog full of choices comes down to. */
+private sealed interface Decision {
+
+  class Set(
+    val override: LeakStatusOverride,
+    /** What had to be flipped for it to be true, which is empty unless something disagreed. */
+    val solved: List<LeakStatusOverride>
+  ) : Decision
+
+  object Clear : Decision
+}
+
+/**
+ * The leaking status of the object a tab is on, from wherever the window knows it.
+ *
+ * Which is either of two reads, and they answer slightly different questions: the last step of the chain from
+ * a GC root, which is the status with the objects above and below it taken into account, or the object's own
+ * if no chain reaches it. See [shark.explorer.HeapObjectSummary.leakStatus].
+ */
+internal class ObjectLeakStatus(
+  val objectId: Long,
+  /** What the object is called, for a dialog that has to name what is being changed. */
+  val objectName: String,
+  val status: LeakStatus,
+  val reason: String?,
+  /** What a hand set, and null for a status the heap dump alone decided. */
+  val setByHand: LeakStatusOverride?
+)
+
+/** A mark beside the words, so that which status this is doesn't rest on the colour alone. */
+private val LeakStatus.glyph: String
+  get() = when (this) {
+    LeakStatus.NOT_LEAKING -> "✓"
+    LeakStatus.UNKNOWN -> "?"
+    LeakStatus.LEAKING -> "✗"
+  }
+
+internal const val STATUS_DIALOG_TITLE = "The leaking status of"
+
+/** What starts one, on a tab whose object nobody has decided anything about. */
+internal const val SET_STATUS_BUTTON = "Set by hand…"
+
+/** And what opens the one that was set, which is the only way to take it back off. */
+internal const val CHANGE_STATUS_BUTTON = "Change…"
+
+internal const val SAVE_STATUS = "Set the status"
+internal const val CANCEL_STATUS = "Cancel"
+internal const val CLEAR_STATUS = "Take it off"
+
+/** What keeping the new status and flipping everything that disagrees with it is called. */
+internal const val SOLVE_CONFLICTS = "Keep this and flip those"
+
+/** And what leaving the heap dump as it was is called, which is what the reader came in able to do. */
+internal const val UNDO_STATUS = "Undo"
+
+internal const val CHECKING_CONFLICTS =
+  "Looking for statuses set by hand that this one could not be true alongside…"
+
+private const val WRITING_STATUS = "Keeping it…"
+
+private const val NOW_LABEL = "Now"
+
+private const val SET_STATUS_HINT =
+  "Say whether this object is leaking, whatever the heap dump says. Kept between runs, and the reason with it."
+
+private const val CHANGE_STATUS_HINT = "Change or take off the status set by hand for this object."
+
+private const val REASON_LABEL = "Why"
+
+private const val REASON_PLACEHOLDER =
+  "What you know that the heap dump doesn't: whoever reads this next has only this sentence to go on."
+
+/** What the box is called, which is also how a test finds it: there is no other text field in the dialog. */
+internal const val REASON_DESCRIPTION = "Why this object is being given that status."
+
+private const val CONFLICT_ONE = "status set by hand cannot be true with this one being"
+private const val CONFLICT_MANY = "statuses set by hand cannot be true with this one being"
+
+private const val CONFLICT_EXPLANATION =
+  "Everything a leaking object holds is leaking, and everything holding an object that is still needed is " +
+    "still needed too — so these and the status being set contradict each other. Keeping this one flips " +
+    "them to the opposite status, with what they said kept as part of the new reason."
+
+private const val CONFLICT_ABOVE = "holds it"
+private const val CONFLICT_BELOW = "is held by it"
+
+private const val CONFLICT_BECOMES = "Would become"
+
+/** As many lines of it as a reason takes, up to where the banner would be taking the panes' room. */
+private const val REASON_LINES = 2
+
+/** A line under the title rather than a row of its own, like the button that starts a note. */
+private val STATUS_BUTTON_HEIGHT = 20.dp
+
+/** Enough for the sentence someone is expected to type, and no more: the panes below keep the window. */
+private val REASON_HEIGHT = 90.dp

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeakStatusSection.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -38,19 +37,19 @@ import shark.explorer.LeakStatusOverride
 import shark.explorer.statusText
 
 /**
- * What the object the tab is on is: leaking, still needed, or nothing known either way.
+ * Whether the object the tab is on is meant to be in memory, and the pencil that overrules the answer.
  *
- * Under the title that says which object, in the colours a chain draws a status in — because it is the same
- * answer. A chain says it about a dozen objects at once and this says it about the one the whole window is
- * about, so a reader who has learnt the green and the red on one surface reads them on the other.
+ * At the top of what the object is, under its name and above its size, because it is the conclusion the
+ * rest of that panel is the evidence for. In the colours a chain draws a status in — because it is the same
+ * answer, and a reader who has learnt the green and the red on one surface reads them on the other.
  *
  * **Loud for the two statuses that mean something and quiet for the third**: a heap dump is mostly objects
- * nothing knows either way about, so a banner that shouted "Unknown" on every tab would be a banner nobody
- * reads by the time it says something. Which is also why the reason is here rather than in a tooltip: the
- * status is a conclusion, and half the objects on a chain are green or red because of what another object is.
+ * nothing knows either way about, so shouting "Nobody knows" on every object would be a line nobody reads by
+ * the time it says something. Which is also why the reason is here rather than in a tooltip: the status is a
+ * conclusion, and half the objects on a chain are green or red because of what another object is.
  */
 @Composable
-internal fun LeakStatusBanner(
+internal fun LeakStatusDetail(
   status: ObjectLeakStatus,
   /**
    * Whether the statuses of this heap dump have been read off the disk, which is what makes changing one
@@ -64,13 +63,26 @@ internal fun LeakStatusBanner(
 ) {
   val isKnown = status.status != LeakStatus.UNKNOWN
   Column(modifier.fillMaxWidth()) {
+    // The question, the way every other line of this panel names what is under it. Which is what makes the
+    // two answers that matter readable on their own: they are answers to a question that is on screen.
+    Text(STATUS_LABEL, style = MaterialTheme.typography.labelSmall)
     Row(
       Modifier.fillMaxWidth(),
       horizontalArrangement = Arrangement.spacedBy(6.dp),
       verticalAlignment = Alignment.CenterVertically
     ) {
-      // The status behind its own shade, the way a step of a chain is drawn, so that what the window is
-      // about being a leak is something you see before reading anything.
+      // Left of the answer rather than after it, because it is what changes that answer: reading the status
+      // and reaching for the pencil is one movement, and a pencil at the end of a wrapping line is not.
+      Hint(if (status.setByHand == null) SET_STATUS_HINT else CHANGE_STATUS_HINT) {
+        Text(
+          EDIT_STATUS_GLYPH,
+          Modifier.clickableRow(enabled = isRead, onClick = onChange).padding(horizontal = 2.dp),
+          style = MaterialTheme.typography.bodyMedium,
+          color = if (isRead) LINK_COLOR else MaterialTheme.colorScheme.outline
+        )
+      }
+      // The status behind its own shade, the way a step of a chain is drawn, so that the object being one
+      // that shouldn't be there is something you see before reading anything.
       Text(
         "${status.status.glyph} ${status.status.statusText}",
         Modifier.then(
@@ -89,30 +101,16 @@ internal fun LeakStatusBanner(
         color = status.status.textColor,
         fontWeight = if (isKnown) FontWeight.Bold else FontWeight.Normal
       )
-      // Why, which is most of the answer: an object is red because of what it is, or because of what
-      // something holding it is, and only the reason says which.
-      status.reason?.let { reason ->
-        Text(
-          reason,
-          Modifier.weight(1f),
-          style = MaterialTheme.typography.bodySmall,
-          color = status.status.textColor,
-          maxLines = REASON_LINES
-        )
-      }
-      Hint(if (status.setByHand == null) SET_STATUS_HINT else CHANGE_STATUS_HINT) {
-        TextButton(
-          onClick = onChange,
-          modifier = Modifier.height(STATUS_BUTTON_HEIGHT),
-          enabled = isRead,
-          contentPadding = PaddingValues(horizontal = 4.dp)
-        ) {
-          Text(
-            if (status.setByHand == null) SET_STATUS_BUTTON else CHANGE_STATUS_BUTTON,
-            style = MaterialTheme.typography.bodySmall
-          )
-        }
-      }
+    }
+    // Why, which is most of the answer: an object is red because of what it is, or because of what
+    // something holding it is, and only the reason says which. On its own line and whole, because this
+    // panel is a column narrow enough that any of these would wrap anyway.
+    status.reason?.let { reason ->
+      Text(
+        reason,
+        style = MaterialTheme.typography.bodySmall,
+        color = status.status.textColor
+      )
     }
     if (problem != null) {
       Text(
@@ -177,7 +175,7 @@ internal fun LeakStatusDialog(
 
   AlertDialog(
     onDismissRequest = onDismiss,
-    title = { Text("$STATUS_DIALOG_TITLE ${status.objectName}") },
+    title = { Text(statusDialogTitle(status.objectName)) },
     text = {
       Column(
         Modifier.heightIn(max = DIALOG_MAX_HEIGHT).verticalScroll(rememberScrollState()),
@@ -273,7 +271,7 @@ private fun ChoosingStatus(
 ) {
   // What it is now and why, so that overruling it is done while reading it rather than from memory.
   Text(
-    "${NOW_LABEL} ${status.status.statusText.lowercase()}${status.reason?.let { ": $it" }.orEmpty()}",
+    "$NOW_LABEL ${status.status.statusText}${status.reason?.let { " — $it" }.orEmpty()}",
     style = MaterialTheme.typography.bodySmall,
     color = status.status.textColor
   )
@@ -320,7 +318,7 @@ private fun Conflicts(
 ) {
   Text(
     "${conflicts.size} ${if (conflicts.size == 1) CONFLICT_ONE else CONFLICT_MANY} " +
-      "${requested.status.statusText.lowercase()}.",
+      "\"${requested.status.statusText}\".",
     style = MaterialTheme.typography.bodyMedium,
     fontWeight = FontWeight.Bold
   )
@@ -338,7 +336,7 @@ private fun Conflicts(
         color = conflict.existing.status.textColor
       )
       Text(
-        "$CONFLICT_BECOMES ${conflict.solved.status.statusText.lowercase()}",
+        "$CONFLICT_BECOMES ${conflict.solved.status.statusText}",
         style = MaterialTheme.typography.bodySmall,
         color = conflict.solved.status.textColor
       )
@@ -405,13 +403,19 @@ private val LeakStatus.glyph: String
     LeakStatus.LEAKING -> "✗"
   }
 
-internal const val STATUS_DIALOG_TITLE = "The leaking status of"
+/**
+ * What the panel calls the line, which is the question the three statuses answer.
+ *
+ * A question rather than a noun, unlike every other label in that panel, because this is the one line of it
+ * that is a conclusion rather than a measurement — and the answers are only readable on a chain, where no
+ * label fits, if they are answers to something.
+ */
+internal const val STATUS_LABEL = "Should it be here?"
 
-/** What starts one, on a tab whose object nobody has decided anything about. */
-internal const val SET_STATUS_BUTTON = "Set by hand…"
+internal fun statusDialogTitle(objectName: String) = "Should $objectName be here?"
 
-/** And what opens the one that was set, which is the only way to take it back off. */
-internal const val CHANGE_STATUS_BUTTON = "Change…"
+/** What opens the dialog, set or not: the same mark the app writes a note with. */
+internal const val EDIT_STATUS_GLYPH = "✎"
 
 internal const val SAVE_STATUS = "Set the status"
 internal const val CANCEL_STATUS = "Cancel"
@@ -428,10 +432,11 @@ internal const val CHECKING_CONFLICTS =
 
 private const val WRITING_STATUS = "Keeping it…"
 
-private const val NOW_LABEL = "Now"
+private const val NOW_LABEL = "Now:"
 
 private const val SET_STATUS_HINT =
-  "Say whether this object is leaking, whatever the heap dump says. Kept between runs, and the reason with it."
+  "Say whether this object should be here, whatever the heap dump says. Kept between runs, and the reason " +
+    "with it."
 
 private const val CHANGE_STATUS_HINT = "Change or take off the status set by hand for this object."
 
@@ -443,24 +448,19 @@ private const val REASON_PLACEHOLDER =
 /** What the box is called, which is also how a test finds it: there is no other text field in the dialog. */
 internal const val REASON_DESCRIPTION = "Why this object is being given that status."
 
-private const val CONFLICT_ONE = "status set by hand cannot be true with this one being"
-private const val CONFLICT_MANY = "statuses set by hand cannot be true with this one being"
+private const val CONFLICT_ONE = "status set by hand cannot be true alongside"
+private const val CONFLICT_MANY = "statuses set by hand cannot be true alongside"
 
 private const val CONFLICT_EXPLANATION =
-  "Everything a leaking object holds is leaking, and everything holding an object that is still needed is " +
-    "still needed too — so these and the status being set contradict each other. Keeping this one flips " +
-    "them to the opposite status, with what they said kept as part of the new reason."
+  "Everything held by an object that shouldn't be here shouldn't be here either, and everything holding " +
+    "one that is meant to be here is meant to be here too — so these and the status being set contradict " +
+    "each other. Keeping this one flips them to the opposite status, with what they said kept as part of " +
+    "the new reason."
 
 private const val CONFLICT_ABOVE = "holds it"
 private const val CONFLICT_BELOW = "is held by it"
 
-private const val CONFLICT_BECOMES = "Would become"
-
-/** As many lines of it as a reason takes, up to where the banner would be taking the panes' room. */
-private const val REASON_LINES = 2
-
-/** A line under the title rather than a row of its own, like the button that starts a note. */
-private val STATUS_BUTTON_HEIGHT = 20.dp
+private const val CONFLICT_BECOMES = "Would become:"
 
 /** Enough for the sentence someone is expected to type, and no more: the panes below keep the window. */
 private val REASON_HEIGHT = 90.dp

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
@@ -218,7 +218,7 @@ private fun OnTheWayOutHeader(
     HorizontalDivider(thickness = SECTION_RULE_WIDTH, color = SECTION_RULE_COLOR)
     Column(
       Modifier.fillMaxWidth()
-        .clickableRow(onToggle)
+        .clickableRow(onClick = onToggle)
         .padding(start = 8.dp, end = 12.dp, top = 6.dp, bottom = 6.dp),
       verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
@@ -622,7 +622,9 @@ internal const val NAME_HINT =
     "which is where to look on the chain to see it. They are one reference for most leaks. Everything " +
     "above the first is the app working as intended and everything below the last is what the leak is " +
     "holding, so neither is part of what makes this leak this leak. For an object on its way out it is " +
-    "the one reference the collector hasn't cleared yet, which is the whole of why it is still here."
+    "the one reference the collector hasn't cleared yet, which is the whole of why it is still here. Where " +
+    "a leak is a single reference, the chain drawn for an object under this row marks it, so the row and " +
+    "the step are one thing said twice."
 
 internal const val LEAK_FINGERPRINT_HINT =
   "A hash of how this leak is held, which is the same for the same leak in the next heap dump of this app " +

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
@@ -416,8 +416,8 @@ private fun LeakingObjectRow(
                 overflow = TextOverflow.Ellipsis
               )
             }
-            // Why *this* object shouldn't be here, which the inspector that recognized it read off the object
-            // itself: two objects of one leak can be leaking for reasons that don't read the same.
+            // Why *this* object is stuck, which the inspector that recognized it read off the object
+            // itself: two objects of one leak can be stuck for reasons that don't read the same.
             leakingObject.leakingReason?.let { reason ->
               Text(
                 reason,
@@ -595,7 +595,7 @@ private const val MILLIS_PER_SECOND = 1000L
 private const val LOOKING_FOR_LEAKS = "Going through the heap dump…"
 
 /** No full stop, since what is on their way out is said after it on the same line. */
-private const val NOTHING_LEAKING = "Nothing in this heap dump leaked"
+private const val NOTHING_LEAKING = "Nothing in this heap dump is stuck"
 private const val NONE_FOUND = "none"
 
 private const val LEAK = "leak"
@@ -605,7 +605,7 @@ private const val OBJECTS = "objects"
 
 /** What the row opening the rest of a leak says, since a bare count would read as a count of leaks. */
 internal const val MORE = "more"
-internal const val LEAKING_THE_SAME_WAY = "leaking the same way"
+internal const val LEAKING_THE_SAME_WAY = "stuck the same way"
 
 /** Its key in the list, which is one per leak and so can't be an object id. */
 private const val MORE_KEY = "more"
@@ -617,12 +617,12 @@ private const val WATCHED_GLYPH = "◉"
 internal const val LEAK_FINGERPRINT = "Leak fingerprint:"
 
 internal const val NAME_HINT =
-  "The references this leak is: the first is the one that shouldn't be holding any more, which is what " +
-    "LeakCanary calls the leak, and the last is the one that points straight at what leaked, which is " +
-    "where to look on the chain to see it. They are one reference for most leaks. Everything above the " +
-    "first is the app working as intended and everything below the last is what the leak is holding, so " +
-    "neither is part of what makes this leak this leak. For an object on its way out it is the one " +
-    "reference the collector hasn't cleared yet, which is the whole of why the object is still here."
+  "The references this leak is: the first is the faulty reference, the one that should have been cleared " +
+    "and what LeakCanary calls the leak, and the last is the one that points straight at what is stuck, " +
+    "which is where to look on the chain to see it. They are one reference for most leaks. Everything " +
+    "above the first is the app working as intended and everything below the last is what the leak is " +
+    "holding, so neither is part of what makes this leak this leak. For an object on its way out it is " +
+    "the one reference the collector hasn't cleared yet, which is the whole of why it is still here."
 
 internal const val LEAK_FINGERPRINT_HINT =
   "A hash of how this leak is held, which is the same for the same leak in the next heap dump of this app " +

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
@@ -333,7 +333,7 @@ private fun MoreObjectsRow(
     Spacer(Modifier.width(INSTANCE_INSET - SECTION_BAR_WIDTH))
     InstanceRule(isLast = !isExpanded)
     Row(
-      Modifier.weight(1f).clickableRow(onToggle)
+      Modifier.weight(1f).clickableRow(onClick = onToggle)
         .padding(start = 8.dp, end = 12.dp, top = 4.dp, bottom = 4.dp),
       horizontalArrangement = Arrangement.spacedBy(4.dp),
       verticalAlignment = Alignment.CenterVertically

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
@@ -595,7 +595,7 @@ private const val MILLIS_PER_SECOND = 1000L
 private const val LOOKING_FOR_LEAKS = "Going through the heap dump…"
 
 /** No full stop, since what is on their way out is said after it on the same line. */
-private const val NOTHING_LEAKING = "Nothing in this heap dump is leaking"
+private const val NOTHING_LEAKING = "Nothing in this heap dump leaked"
 private const val NONE_FOUND = "none"
 
 private const val LEAK = "leak"

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/Main.kt
@@ -142,6 +142,9 @@ private fun explorerApplication(windows: ExplorerWindows) = application {
   // One notepad per place for the whole run, so that a heap dump open in two windows is one set of notes
   // rather than two that overwrite each other. See [ExplorerNotes].
   val notes = remember { ExplorerNotes() }
+  // And one set of statuses set by hand per heap dump, for the same reason: a status is a conclusion about
+  // the dump rather than about a window, so both windows on one dump read the heap through the same ones.
+  val leakStatuses = remember { ExplorerLeakStatuses() }
   // Once per run, not once per window, and off the UI thread: this is a network request, and a window that
   // waits for GitHub to answer before it draws is a window that hangs when GitHub is unreachable.
   LaunchedEffect(updateNotice) {
@@ -183,6 +186,7 @@ private fun explorerApplication(windows: ExplorerWindows) = application {
             },
             updateNotice = updateNotice,
             notes = notes,
+            leakStatuses = leakStatuses,
             deepLinkId = window.deepLinkId,
             // The same way a link arriving from the OS is followed, which is what makes a `shark://` link
             // written in a note work wherever it is read from.
@@ -220,6 +224,11 @@ internal fun ExplorerApp(
    * that a test writes into a directory it was given rather than into the notes of whoever is running it.
    */
   notes: ExplorerNotes = remember { ExplorerNotes() },
+  /**
+   * The leaking statuses set by hand on every heap dump this run has open, shared the same way. Its own by
+   * default for the same reason: a test that took whoever is running it would rewrite their conclusions.
+   */
+  leakStatuses: ExplorerLeakStatuses = remember { ExplorerLeakStatuses() },
   /** What a link to a place in this window names it by. See [shark.explorer.DeepLink]. */
   deepLinkId: String = remember { DeepLink.newWindowId() },
   /** Places a link has asked this window for, which its tabs open. See [ExplorerWindow.linkedPlaces]. */
@@ -328,6 +337,7 @@ internal fun ExplorerApp(
         deviceHeapDumps = deviceHeapDumps,
         fetchedBitmapPixels = currentState.bitmapPixels,
         notes = notes.of(currentState.session.heapDumpFile),
+        leakStatuses = leakStatuses.of(currentState.session.heapDumpFile),
         deepLinkId = deepLinkId,
         linkedPlaces = linkedPlaces,
         onLinkedPlaceOpened = onLinkedPlaceOpened,

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -457,6 +457,12 @@ private fun ReferenceLine(reference: PathReference) {
         ) {
           append(reference.displayName())
         }
+        // The one line of a chain that says where to go and change code, so it is the one thing on a
+        // chain drawn bold: the shades on the objects say what a leak left behind, and this says what the
+        // leak is. See [shark.explorer.PathReference.isFaulty].
+        if (reference.isFaulty) {
+          withStyle(FAULTY_REFERENCE_SPAN) { append(" $FAULTY_REFERENCE") }
+        }
         // Which is what makes a chain through a known leak readable as one: the objects below this
         // reference are held by code the app doesn't control, and this is the reference that does it.
         if (reference.libraryLeak != null) {
@@ -466,12 +472,16 @@ private fun ReferenceLine(reference: PathReference) {
       style = MaterialTheme.typography.bodySmall
     )
   }
-  // What is known about the leak is a paragraph, which belongs on hover rather than in the chain.
-  val description = reference.libraryLeak?.description?.takeIf { it.isNotEmpty() }
-  if (description == null) {
+  // Why this reference and not another, and what is known about a leak somebody else's code holds: both are
+  // paragraphs, so both belong on hover rather than in the chain.
+  val explanation = listOfNotNull(
+    FAULTY_REFERENCE_HINT.takeIf { reference.isFaulty },
+    reference.libraryLeak?.description?.takeIf { it.isNotEmpty() }
+  )
+  if (explanation.isEmpty()) {
     line()
   } else {
-    Hint(description, line)
+    Hint(explanation.joinToString("\n\n"), line)
   }
 }
 
@@ -628,6 +638,20 @@ private const val LOCAL_VARIABLE = "<local variable>"
 /** What a reference Shark knows leaks in code the app doesn't control says about itself. */
 internal const val LIBRARY_LEAK = "· known library leak"
 
+/**
+ * And what the reference the leak is says about itself, which is the one thing on a chain to go and fix.
+ *
+ * Two words rather than a sentence, in the red of the objects it left behind: a chain is read as a column
+ * of names, and this is the line to stop on.
+ */
+internal const val FAULTY_REFERENCE = "· faulty reference"
+
+/** Why this reference of the chain and not another, which is a paragraph and so sits on hover. */
+internal const val FAULTY_REFERENCE_HINT =
+  "The leak itself: what this reference is read on is expected to be in memory, what it points at should " +
+    "have been gone, so this is the one reference that should have been cleared. Everything under it is " +
+    "only still here because of it, and clearing this one is what would let all of it go."
+
 /** Wide enough for the line, its arrow head and a ring to sit clear of the text beside it. */
 private val GUTTER_WIDTH = 26.dp
 
@@ -720,6 +744,9 @@ private val MUTED_SPAN = SpanStyle(color = MUTED_TEXT, fontWeight = FontWeight.N
 
 /** And for the words saying a reference is a known library leak, in the red of the leaks it explains. */
 private val LIBRARY_LEAK_SPAN = SpanStyle(color = LEAKING_TEXT, fontWeight = FontWeight.Normal)
+
+/** The same red for the reference the leak is, bold: nothing else on a chain is the thing to fix. */
+private val FAULTY_REFERENCE_SPAN = SpanStyle(color = LEAKING_TEXT, fontWeight = FontWeight.Bold)
 
 /** The letter drawn in an object's circle, which is what kind of object it is. */
 private val HeapObjectKind.badgeLetter: String

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -47,6 +47,7 @@ import shark.explorer.ReachabilityStrength
 import shark.explorer.formatByteSizeOfTotal
 import shark.explorer.formatObjectCount
 import shark.explorer.hexObjectId
+import shark.explorer.statusText
 
 /**
  * How a chain of objects is drawn: a column of them with a line running through it, what each one is on
@@ -662,23 +663,19 @@ private val BADGE_LETTER_COLOR = Color.White
  * line naming it, and the lines a row is made of already mean things by their colour. Faint enough that a
  * column of them still reads as a chain: the shade says where along the chain something went wrong, and
  * the reason under the object says what.
+ *
+ * Reachable from outside this drawing, because the row above the panes says what the object the whole window
+ * is about is in these same colours: what a status looks like is one thing, whether it is being read on a
+ * chain or over the panes. See [LeakStatusBanner].
  */
-private val LeakStatus.background: Color?
+internal val LeakStatus.background: Color?
   get() = when (this) {
     LeakStatus.NOT_LEAKING -> ALIVE_BACKGROUND
     LeakStatus.UNKNOWN -> null
     LeakStatus.LEAKING -> LEAKING_BACKGROUND
   }
 
-/** How the reason line names the status it is the reason for. */
-private val LeakStatus.statusText: String
-  get() = when (this) {
-    LeakStatus.NOT_LEAKING -> "Not leaking"
-    LeakStatus.UNKNOWN -> "Unknown"
-    LeakStatus.LEAKING -> "Leaking"
-  }
-
-private val LeakStatus.textColor: Color
+internal val LeakStatus.textColor: Color
   get() = when (this) {
     LeakStatus.NOT_LEAKING -> ALIVE_TEXT
     LeakStatus.UNKNOWN -> MUTED_TEXT
@@ -695,8 +692,8 @@ private val LEAKING_TEXT = Color(0xFFC62828)
 
 /** What the object the panel is describing is drawn behind, which is the end of the chain. */
 private val TARGET_BACKGROUND = Color(0x1A2196F3)
-private val TARGET_SHAPE = RoundedCornerShape(4.dp)
-private val TARGET_PADDING = 4.dp
+internal val TARGET_SHAPE = RoundedCornerShape(4.dp)
+internal val TARGET_PADDING = 4.dp
 
 /** The purple LeakCanary draws a leak trace in, which this is the same shape as. */
 private val CONNECTOR_COLOR = Color(0xFF7E57C2)

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -481,8 +481,13 @@ private fun ReferenceLine(reference: PathReference) {
  * The hand is the whole of how it says so, rather than a colour: which object a step is, is drawn the same
  * way everywhere the window names one, and half of those places are nothing to click.
  */
-internal fun Modifier.clickableRow(onClick: () -> Unit): Modifier =
-  pointerHoverIcon(PointerIcon.Hand).clickable(onClick = onClick)
+internal fun Modifier.clickableRow(
+  /** Off while what the click would need hasn't been read yet, which leaves the row as plain text. */
+  enabled: Boolean = true,
+  onClick: () -> Unit
+): Modifier =
+  pointerHoverIcon(if (enabled) PointerIcon.Hand else PointerIcon.Default)
+    .clickable(enabled = enabled, onClick = onClick)
 
 /** The class the field is read on, with no dot before an array index: `Tile.view`, `Object[][3]`. */
 private fun PathReference.ownerPrefix(): String =

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ViewControls.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ViewControls.kt
@@ -231,11 +231,17 @@ private val REFERENCE_STRENGTHS = ReachabilityStrength.values().toList() - setOf
   ReachabilityStrength.UNREACHABLE
 )
 
-/** What the checkbox that shades the objects that shouldn't be in memory says, before their count. */
-internal const val LEAKING = "Leaking"
+/**
+ * What the checkbox that shades the objects that leaked says, before their count.
+ *
+ * The same word the panel and every chain call one of them, because it shades exactly the objects they call
+ * that: two spellings of one status, one of them over the map and the other beside it, would read as two
+ * different things being shaded.
+ */
+internal const val LEAKING = "Leaked"
 
 /** And while the pass over the heap dump that finds them runs, which is what ticking it starts. */
-internal const val FINDING_LEAKS = "Leaking: looking…"
+internal const val FINDING_LEAKS = "Leaked: looking…"
 
 internal const val LEAKING_HINT =
   "Shade the objects that shouldn't be in memory, and everything they hold with them — anything a " +

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ViewControls.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/ViewControls.kt
@@ -232,23 +232,23 @@ private val REFERENCE_STRENGTHS = ReachabilityStrength.values().toList() - setOf
 )
 
 /**
- * What the checkbox that shades the objects that leaked says, before their count.
+ * What the checkbox that shades the stuck objects says, before their count.
  *
  * The same word the panel and every chain call one of them, because it shades exactly the objects they call
- * that: two spellings of one status, one of them over the map and the other beside it, would read as two
+ * that: two spellings of one verdict, one of them over the map and the other beside it, would read as two
  * different things being shaded.
  */
-internal const val LEAKING = "Leaked"
+internal const val LEAKING = "Stuck"
 
 /** And while the pass over the heap dump that finds them runs, which is what ticking it starts. */
-internal const val FINDING_LEAKS = "Leaked: looking…"
+internal const val FINDING_LEAKS = "Stuck: looking…"
 
 internal const val LEAKING_HINT =
-  "Shade the objects that shouldn't be in memory, and everything they hold with them — anything a " +
-    "leaking object dominates is only still there because it is. Greys the rest of the map, so that the " +
-    "shade is the only colour on it. There is no colour for the objects that are meant to be alive: a " +
-    "treemap draws what retains what, and most of a heap dump is objects nothing knows either way about. " +
-    "The chain beside the map says which is which, object by object."
+  "Shade the objects that are stuck in memory, and everything they hold with them — anything a stuck " +
+    "object dominates is only still there because it is. Greys the rest of the map, so that the shade is " +
+    "the only colour on it. There is no colour for the objects that are expected: a treemap draws what " +
+    "retains what, and most of a heap dump is objects nothing knows either way about. The chain beside " +
+    "the map says which is which, object by object."
 
 /**
  * Shown when every object a `java.lang.ref.Reference` points at is also reachable some stronger way,

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeakStatusSectionTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeakStatusSectionTest.kt
@@ -39,12 +39,13 @@ import shark.explorer.statusText
 
 /**
  * Whether the object a tab is on is meant to be in memory, said at the top of the panel that says what the
- * object is, and changed by hand from there.
+ * object is, changed by hand from there, and what the answer marks on the chain beside it.
  *
  * What the statuses mean and how two of them disagree is `LeakStatusTest` and `HeapLeakStatusTest` in
  * `shark-explorer-core`, and where they are kept is `LeakStatusFileTest`. What is only true here is that the
- * panel says what the heap dump says, that changing one asks for the reason before it writes anything, and
- * that a status which cannot be true alongside another is shown rather than settled quietly.
+ * panel says what the heap dump says, that changing one asks for the reason before it writes anything, that
+ * a status which cannot be true alongside another is shown rather than settled quietly, and that the chain
+ * says which reference the leak is.
  */
 @OptIn(ExperimentalTestApi::class)
 class LeakStatusSectionTest {
@@ -208,6 +209,34 @@ class LeakStatusSectionTest {
   }
 
   /**
+   * What the verdicts are for: they are about objects, and the thing to go and fix is the one reference going
+   * from an object that belongs in memory to one that doesn't.
+   *
+   * Both halves in one window, because they are one answer: the reference is marked from the verdicts either
+   * side of it, so a verdict set by hand is what puts the mark on the chain and what takes it off again.
+   */
+  @Test fun `the chain marks which reference the leak is, and a hand can take the mark off`() {
+    explorerUiTest {
+      // Set in a run before this one, and what leaves a single reference below it: with nothing on this
+      // chain known to belong in memory, the fault is at either of its two steps and neither is marked.
+      openHeapDump(setAlready = { holderIsExpected() }) { it.activityObjectId }
+
+      onNodeWithText("$FAULTY_STEP $FAULTY_REFERENCE").assertIsDisplayed()
+
+      changeStatus()
+      choose(LeakStatus.NOT_LEAKING)
+      write(TYPED_REASON)
+      set()
+
+      // Nothing on this chain is stuck any more, so there is no reference to point at — and the step is
+      // still drawn, which is the mark being about the leak rather than about the reference.
+      waitUntilAtLeastOneExists(hasText(TYPED_REASON, substring = true), SAVE_TIMEOUT_MILLIS)
+      onNodeWithText(FAULTY_REFERENCE, substring = true).assertDoesNotExist()
+      onNodeWithText(FAULTY_STEP).assertIsDisplayed()
+    }
+  }
+
+  /**
    * The other half of setting a status: the leaks are read through them, so the list changes rather than
    * only the colour of one object. See [shark.explorer.HeapDominatorTreemap.findLeaks].
    */
@@ -302,14 +331,22 @@ class LeakStatusSectionTest {
   }
 
   /** A status set on the holder in a run before the one under test, which is the file being there. */
-  private fun holderIsLeaking() {
+  private fun holderIsLeaking() = holderWasSetTo(LeakStatus.LEAKING, HOLDER_REASON)
+
+  /** And the other way: a holder that belongs in memory, with the activity below it still stuck. */
+  private fun holderIsExpected() = holderWasSetTo(LeakStatus.NOT_LEAKING, HOLDER_EXPECTED_REASON)
+
+  private fun holderWasSetTo(
+    status: LeakStatus,
+    reason: String
+  ) {
     statusFile().write(
       LeakStatusOverrides.of(
         listOf(
           LeakStatusOverride(
             objectId = heapDump.holderObjectId,
-            status = LeakStatus.LEAKING,
-            reason = HOLDER_REASON
+            status = status,
+            reason = reason
           )
         )
       )
@@ -352,8 +389,14 @@ class LeakStatusSectionTest {
     /** And what the object holding it is called, where the dialog names that one. */
     private const val HOLDER_NAME = "Holder instance"
 
+    /** The step of the chain that holds the destroyed activity, which is the reference to clear. */
+    private const val FAULTY_STEP = "Holder.activity"
+
     /** And what it was given as its reason, which the dialog has to show to be overruled. */
     private const val HOLDER_REASON = "this holder is the one to fix"
+
+    /** The reason for the other status a run before this one set on the holder. */
+    private const val HOLDER_EXPECTED_REASON = "this holder is the app's own cache"
 
     /** What the dialog says about a status set on an object that holds the one being changed. */
     private const val CONFLICT_ABOVE = "holds it"

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeakStatusSectionTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeakStatusSectionTest.kt
@@ -34,15 +34,16 @@ import shark.explorer.LeakStatusFile
 import shark.explorer.LeakStatusOverride
 import shark.explorer.LeakStatusOverrides
 import shark.explorer.Place
+import shark.explorer.hexObjectId
 import shark.explorer.statusText
 
 /**
- * Whether the object a tab is on should still be in memory, said where the tab says which object, and
- * changed by hand from there.
+ * Whether the object a tab is on is meant to be in memory, said at the top of the panel that says what the
+ * object is, and changed by hand from there.
  *
  * What the statuses mean and how two of them disagree is `LeakStatusTest` and `HeapLeakStatusTest` in
  * `shark-explorer-core`, and where they are kept is `LeakStatusFileTest`. What is only true here is that the
- * banner says what the heap dump says, that changing one asks for the reason before it writes anything, and
+ * panel says what the heap dump says, that changing one asks for the reason before it writes anything, and
  * that a status which cannot be true alongside another is shown rather than settled quietly.
  */
 @OptIn(ExperimentalTestApi::class)
@@ -59,23 +60,24 @@ class LeakStatusSectionTest {
 
   private lateinit var heapDump: LeakyChainHeapDump
 
-  @Test fun `an object the inspectors say should be gone says so above the panes`() {
+  @Test fun `an object the inspectors say should be gone says so in the panel`() {
     explorerUiTest {
       openHeapDump { it.activityObjectId }
 
-      onNode(banner(LeakStatus.LEAKING)).assertIsDisplayed()
+      onNodeWithText(STATUS_LABEL).assertIsDisplayed()
+      onNode(shows(LeakStatus.LEAKING)).assertIsDisplayed()
       // And why, because a status is a conclusion and half of them are about another object. The reason as
-      // the banner has it, which is what the chain beside it prefixes with the status.
+      // the panel has it, which is what the chain beside it prefixes with the status.
       onNodeWithText(DESTROYED_REASON).assertIsDisplayed()
     }
   }
 
-  /** Quietly, because most of a heap dump is this and a banner that shouted it would be read by nobody. */
+  /** Quietly, because most of a heap dump is this and a line that shouted it would be read by nobody. */
   @Test fun `an object nothing knows either way about says that`() {
     explorerUiTest {
       openHeapDump { it.holderObjectId }
 
-      onNode(banner(LeakStatus.UNKNOWN)).assertIsDisplayed()
+      onNode(shows(LeakStatus.UNKNOWN)).assertIsDisplayed()
     }
   }
 
@@ -84,12 +86,12 @@ class LeakStatusSectionTest {
     explorerUiTest {
       openHeapDump()
 
-      onNodeWithText(SET_STATUS_BUTTON).assertDoesNotExist()
-      onNode(banner(LeakStatus.UNKNOWN)).assertDoesNotExist()
+      onNodeWithText(EDIT_STATUS_GLYPH).assertDoesNotExist()
+      onNode(shows(LeakStatus.UNKNOWN)).assertDoesNotExist()
     }
   }
 
-  @Test fun `a status set by hand is what the banner says, and it is on disk`() {
+  @Test fun `a status set by hand is what the panel says, and it is on disk`() {
     explorerUiTest {
       openHeapDump { it.activityObjectId }
       changeStatus()
@@ -98,7 +100,7 @@ class LeakStatusSectionTest {
       write(TYPED_REASON)
       set()
 
-      waitUntilAtLeastOneExists(banner(LeakStatus.NOT_LEAKING), SAVE_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(shows(LeakStatus.NOT_LEAKING), SAVE_TIMEOUT_MILLIS)
       // Marked as somebody's rather than the heap dump's, which is the difference between reading the dump
       // and reading a conclusion about it, and with what it overruled after it.
       onNodeWithText("$SET_BY_HAND$TYPED_REASON. Conflicts with $DESTROYED_REASON").assertIsDisplayed()
@@ -130,14 +132,14 @@ class LeakStatusSectionTest {
       choose(LeakStatus.NOT_LEAKING)
       write("this screen is deliberately kept")
       set()
-      waitUntilAtLeastOneExists(banner(LeakStatus.NOT_LEAKING), SAVE_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(shows(LeakStatus.NOT_LEAKING), SAVE_TIMEOUT_MILLIS)
 
       // Which is the one thing only the dialog of a status already set offers.
-      onNode(hasText(CHANGE_STATUS_BUTTON) and isButton()).performClick()
+      changeStatus()
       onNode(hasText(CLEAR_STATUS) and isButton()).performClick()
 
       // And the heap dump says what it said about the object again.
-      waitUntilAtLeastOneExists(banner(LeakStatus.LEAKING), SAVE_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(shows(LeakStatus.LEAKING), SAVE_TIMEOUT_MILLIS)
       waitUntil(timeoutMillis = SAVE_TIMEOUT_MILLIS) { statusFile().read().isEmpty }
     }
   }
@@ -156,7 +158,7 @@ class LeakStatusSectionTest {
       // overrule it is the only person who can weigh the two, and only if they can read it.
       waitUntilAtLeastOneExists(hasText("$HOLDER_NAME $CONFLICT_ABOVE"), SAVE_TIMEOUT_MILLIS)
       onNodeWithText("${LeakStatus.LEAKING.statusText}: $HOLDER_REASON").assertIsDisplayed()
-      onNodeWithText("$CONFLICT_BECOMES ${LeakStatus.NOT_LEAKING.statusText.lowercase()}")
+      onNodeWithText("$CONFLICT_BECOMES ${LeakStatus.NOT_LEAKING.statusText}")
         .assertIsDisplayed()
       // And nothing written while the question is open, which is what makes undoing it free.
       assertThat(statusFile().read().all.map { it.status }).containsExactly(LeakStatus.LEAKING)
@@ -206,6 +208,25 @@ class LeakStatusSectionTest {
   }
 
   /**
+   * The other half of setting a status: the leaks are read through them, so the list changes rather than
+   * only the colour of one object. See [shark.explorer.HeapDominatorTreemap.findLeaks].
+   */
+  @Test fun `an object set to leaking by hand is what the leaks screen lists`() {
+    explorerUiTest {
+      // Nothing is wrong with the holder as far as the heap dump is concerned: without this the list is the
+      // destroyed activity it holds.
+      openHeapDump(setAlready = { holderIsLeaking() })
+
+      screenButton(Place.LEAKS_LABEL).performClick()
+
+      waitUntilAtLeastOneExists(namesObject(heapDump.holderObjectId), OPEN_TIMEOUT_MILLIS)
+      // And the activity is not on it any more: it is only still in memory because of the holder, so the
+      // holder is the one thing to fix and the activity is listed under it.
+      assertThat(onAllNodes(namesObject(heapDump.activityObjectId)).fetchSemanticsNodes()).isEmpty()
+    }
+  }
+
+  /**
    * Opens the window on the heap dump, on a tab showing [objectId] the way a link to that object does, or on
    * the heap dump itself when it is null.
    *
@@ -237,8 +258,8 @@ class LeakStatusSectionTest {
     waitForTheTree(OPEN_TIMEOUT_MILLIS)
     if (place != null) {
       // The panes describe the object a little after the tab opens, since describing it is a read of the heap
-      // dump: the button that changes its status is the first thing that says they have.
-      waitUntilAtLeastOneExists(hasText(SET_STATUS_BUTTON), OPEN_TIMEOUT_MILLIS)
+      // dump: the pencil that changes its status is the first thing that says they have.
+      waitUntilAtLeastOneExists(hasText(EDIT_STATUS_GLYPH), OPEN_TIMEOUT_MILLIS)
     }
   }
 
@@ -249,10 +270,10 @@ class LeakStatusSectionTest {
    * has been read, which is what keeps a save from deleting statuses still on their way off the disk.
    */
   private fun ComposeUiTest.changeStatus() {
-    val button = (hasText(SET_STATUS_BUTTON) or hasText(CHANGE_STATUS_BUTTON)) and isButton()
-    waitUntilAtLeastOneExists(button and isEnabled(), RENDER_TIMEOUT_MILLIS)
-    onNode(button).performClick()
-    onNodeWithText(STATUS_DIALOG_TITLE, substring = true).assertIsDisplayed()
+    val pencil = hasText(EDIT_STATUS_GLYPH) and hasClickAction()
+    waitUntilAtLeastOneExists(pencil and isEnabled(), RENDER_TIMEOUT_MILLIS)
+    onNode(pencil).performClick()
+    onNodeWithText(statusDialogTitle(ACTIVITY_NAME)).assertIsDisplayed()
   }
 
   /** Picks one of the three statuses, by the row it is on rather than by the mark beside it. */
@@ -270,10 +291,8 @@ class LeakStatusSectionTest {
 
   private fun ComposeUiTest.setButton() = onNode(hasText(SAVE_STATUS) and isButton())
 
-  /** The banner above the panes, which is the glyph and the status and nothing else. */
-  private fun bannerText(status: LeakStatus) = "${status.glyphOf()} ${status.statusText}"
-
-  private fun banner(status: LeakStatus) = hasText(bannerText(status))
+  /** The status at the top of the panel, which is the glyph and the status and nothing else. */
+  private fun shows(status: LeakStatus) = hasText("${status.glyphOf()} ${status.statusText}")
 
   /** Repeated from the section rather than shared: a glyph is one of the words the window says. */
   private fun LeakStatus.glyphOf() = when (this) {
@@ -299,6 +318,12 @@ class LeakStatusSectionTest {
 
   private fun statusFile() = LeakStatusFile(statusesRoot, heapDump.file)
 
+  /** A row of the leaks screen, which names the object it is about by its address. */
+  private fun namesObject(objectId: Long) = hasText(hexObjectId(objectId), substring = true)
+
+  /** A button on the row of screens an open heap dump can be read through. See [ExplorerAppTest]. */
+  private fun ComposeUiTest.screenButton(label: String) = onNode(hasText(label) and isButton())
+
   private fun isButton(): SemanticsMatcher =
     SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
 
@@ -321,7 +346,10 @@ class LeakStatusSectionTest {
     /** What the inspector says about the destroyed activity, which is what a hand overrules. */
     private const val DESTROYED_REASON = "Activity#mDestroyed is true"
 
-    /** What the object holding the leaking one is called where the dialog names it. */
+    /** What the object the tab is on is called where the dialog names it. */
+    private const val ACTIVITY_NAME = "MainActivity instance"
+
+    /** And what the object holding it is called, where the dialog names that one. */
     private const val HOLDER_NAME = "Holder instance"
 
     /** And what it was given as its reason, which the dialog has to show to be overruled. */
@@ -330,7 +358,7 @@ class LeakStatusSectionTest {
     /** What the dialog says about a status set on an object that holds the one being changed. */
     private const val CONFLICT_ABOVE = "holds it"
 
-    private const val CONFLICT_BECOMES = "Would become"
+    private const val CONFLICT_BECOMES = "Would become:"
 
     /** An `adb` connected to nothing, so that a test doesn't answer for whatever is plugged in. */
     private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeakStatusSectionTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeakStatusSectionTest.kt
@@ -1,0 +1,377 @@
+package shark.explorer.app
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.GcRoot.JniGlobal
+import shark.ValueHolder.BooleanHolder
+import shark.ValueHolder.ReferenceHolder
+import shark.dump
+import shark.explorer.Adb
+import shark.explorer.AdbOutput
+import shark.explorer.DeviceHeapDumps
+import shark.explorer.LeakStatus
+import shark.explorer.LeakStatusFile
+import shark.explorer.LeakStatusOverride
+import shark.explorer.LeakStatusOverrides
+import shark.explorer.Place
+import shark.explorer.statusText
+
+/**
+ * Whether the object a tab is on should still be in memory, said where the tab says which object, and
+ * changed by hand from there.
+ *
+ * What the statuses mean and how two of them disagree is `LeakStatusTest` and `HeapLeakStatusTest` in
+ * `shark-explorer-core`, and where they are kept is `LeakStatusFileTest`. What is only true here is that the
+ * banner says what the heap dump says, that changing one asks for the reason before it writes anything, and
+ * that a status which cannot be true alongside another is shown rather than settled quietly.
+ */
+@OptIn(ExperimentalTestApi::class)
+class LeakStatusSectionTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  /** Every UI test here records what Shark logged. See [RecordedLog]. */
+  @get:Rule val logged = RecordedLog()
+
+  /** Where the statuses of the heap dump under test are kept, which is this test's own directory. */
+  private val statusesRoot by lazy { testFolder.newFolder("leak-statuses") }
+
+  private lateinit var heapDump: LeakyChainHeapDump
+
+  @Test fun `an object the inspectors say should be gone says so above the panes`() {
+    explorerUiTest {
+      openHeapDump { it.activityObjectId }
+
+      onNode(banner(LeakStatus.LEAKING)).assertIsDisplayed()
+      // And why, because a status is a conclusion and half of them are about another object. The reason as
+      // the banner has it, which is what the chain beside it prefixes with the status.
+      onNodeWithText(DESTROYED_REASON).assertIsDisplayed()
+    }
+  }
+
+  /** Quietly, because most of a heap dump is this and a banner that shouted it would be read by nobody. */
+  @Test fun `an object nothing knows either way about says that`() {
+    explorerUiTest {
+      openHeapDump { it.holderObjectId }
+
+      onNode(banner(LeakStatus.UNKNOWN)).assertIsDisplayed()
+    }
+  }
+
+  /** There is nothing to inspect about the heap dump as a whole, and nothing to decide about it either. */
+  @Test fun `the tab on the whole heap dump has no status`() {
+    explorerUiTest {
+      openHeapDump()
+
+      onNodeWithText(SET_STATUS_BUTTON).assertDoesNotExist()
+      onNode(banner(LeakStatus.UNKNOWN)).assertDoesNotExist()
+    }
+  }
+
+  @Test fun `a status set by hand is what the banner says, and it is on disk`() {
+    explorerUiTest {
+      openHeapDump { it.activityObjectId }
+      changeStatus()
+
+      choose(LeakStatus.NOT_LEAKING)
+      write(TYPED_REASON)
+      set()
+
+      waitUntilAtLeastOneExists(banner(LeakStatus.NOT_LEAKING), SAVE_TIMEOUT_MILLIS)
+      // Marked as somebody's rather than the heap dump's, which is the difference between reading the dump
+      // and reading a conclusion about it, and with what it overruled after it.
+      onNodeWithText("$SET_BY_HAND$TYPED_REASON. Conflicts with $DESTROYED_REASON").assertIsDisplayed()
+      waitUntil(timeoutMillis = SAVE_TIMEOUT_MILLIS) {
+        statusFile().read()[heapDump.activityObjectId]?.status == LeakStatus.NOT_LEAKING
+      }
+      assertThat(statusFile().read()[heapDump.activityObjectId]!!.reason).isEqualTo(TYPED_REASON)
+    }
+  }
+
+  /** The whole of why a status set by hand is worth keeping: without the why it is a colour somebody chose. */
+  @Test fun `a status cannot be set without a reason`() {
+    explorerUiTest {
+      openHeapDump { it.activityObjectId }
+      changeStatus()
+
+      choose(LeakStatus.NOT_LEAKING)
+
+      setButton().assertIsNotEnabled()
+      write("because I read the code")
+      setButton().assertIsEnabled()
+    }
+  }
+
+  @Test fun `a status set by hand can be taken back off`() {
+    explorerUiTest {
+      openHeapDump { it.activityObjectId }
+      changeStatus()
+      choose(LeakStatus.NOT_LEAKING)
+      write("this screen is deliberately kept")
+      set()
+      waitUntilAtLeastOneExists(banner(LeakStatus.NOT_LEAKING), SAVE_TIMEOUT_MILLIS)
+
+      // Which is the one thing only the dialog of a status already set offers.
+      onNode(hasText(CHANGE_STATUS_BUTTON) and isButton()).performClick()
+      onNode(hasText(CLEAR_STATUS) and isButton()).performClick()
+
+      // And the heap dump says what it said about the object again.
+      waitUntilAtLeastOneExists(banner(LeakStatus.LEAKING), SAVE_TIMEOUT_MILLIS)
+      waitUntil(timeoutMillis = SAVE_TIMEOUT_MILLIS) { statusFile().read().isEmpty }
+    }
+  }
+
+  @Test fun `a status that cannot be true alongside another is shown before anything is written`() {
+    explorerUiTest {
+      // Set in a run before this one: the holder above the activity is leaking, so everything it holds is.
+      openHeapDump(setAlready = { holderIsLeaking() }) { it.activityObjectId }
+      changeStatus()
+
+      choose(LeakStatus.NOT_LEAKING)
+      write("this screen is deliberately kept")
+      set()
+
+      // The one it disagrees with, by name, with what it was given as its reason: whoever is about to
+      // overrule it is the only person who can weigh the two, and only if they can read it.
+      waitUntilAtLeastOneExists(hasText("$HOLDER_NAME $CONFLICT_ABOVE"), SAVE_TIMEOUT_MILLIS)
+      onNodeWithText("${LeakStatus.LEAKING.statusText}: $HOLDER_REASON").assertIsDisplayed()
+      onNodeWithText("$CONFLICT_BECOMES ${LeakStatus.NOT_LEAKING.statusText.lowercase()}")
+        .assertIsDisplayed()
+      // And nothing written while the question is open, which is what makes undoing it free.
+      assertThat(statusFile().read().all.map { it.status }).containsExactly(LeakStatus.LEAKING)
+    }
+  }
+
+  @Test fun `keeping the new status flips every status that disagreed with it`() {
+    explorerUiTest {
+      openHeapDump(setAlready = { holderIsLeaking() }) { it.activityObjectId }
+      changeStatus()
+      choose(LeakStatus.NOT_LEAKING)
+      write("this screen is deliberately kept")
+      set()
+      waitUntilAtLeastOneExists(hasText(SOLVE_CONFLICTS), SAVE_TIMEOUT_MILLIS)
+
+      onNode(hasText(SOLVE_CONFLICTS) and isButton()).performClick()
+
+      waitUntil(timeoutMillis = SAVE_TIMEOUT_MILLIS) {
+        statusFile().read()[heapDump.activityObjectId] != null
+      }
+      val overrides = statusFile().read()
+      assertThat(overrides[heapDump.activityObjectId]!!.status).isEqualTo(LeakStatus.NOT_LEAKING)
+      val flipped = overrides[heapDump.holderObjectId]!!
+      assertThat(flipped.status).isEqualTo(LeakStatus.NOT_LEAKING)
+      // Flipped rather than taken off, so that what was typed about it is still in the file.
+      assertThat(flipped.reason).contains(HOLDER_REASON)
+    }
+  }
+
+  @Test fun `undoing leaves every status as it was`() {
+    explorerUiTest {
+      openHeapDump(setAlready = { holderIsLeaking() }) { it.activityObjectId }
+      changeStatus()
+      choose(LeakStatus.NOT_LEAKING)
+      write("this screen is deliberately kept")
+      set()
+      waitUntilAtLeastOneExists(hasText(UNDO_STATUS), SAVE_TIMEOUT_MILLIS)
+
+      onNode(hasText(UNDO_STATUS) and isButton()).performClick()
+
+      onNodeWithText(SOLVE_CONFLICTS).assertDoesNotExist()
+      val overrides = statusFile().read()
+      assertThat(overrides.all.map { it.objectId }).containsExactly(heapDump.holderObjectId)
+      assertThat(overrides[heapDump.holderObjectId]!!.status).isEqualTo(LeakStatus.LEAKING)
+      assertThat(overrides[heapDump.activityObjectId]).isNull()
+    }
+  }
+
+  /**
+   * Opens the window on the heap dump, on a tab showing [objectId] the way a link to that object does, or on
+   * the heap dump itself when it is null.
+   *
+   * Which object is asked for as a function of the dump, since an address only exists once it is written.
+   */
+  private fun ComposeUiTest.openHeapDump(
+    setAlready: () -> Unit = {},
+    objectId: (LeakyChainHeapDump) -> Long? = { null }
+  ) {
+    heapDump = testFolder.leakyChainHeapDump()
+    setAlready()
+    val place = objectId(heapDump)?.let { Place.Object(it) }
+    setContent {
+      MaterialTheme {
+        ExplorerApp(
+          heapDumpFile = heapDump.file,
+          linkedPlaces = listOfNotNull(place),
+          // A directory of this test's, never `~/.shark-explorer`: a test that saved into the real one would
+          // rewrite the conclusions of whoever is running it.
+          leakStatuses = ExplorerLeakStatuses(statusesRoot),
+          // Nothing here opens a second heap dump, and which window one would land in is
+          // `ExplorerWindowTest`'s.
+          onHeapDumpChosen = { _, _ -> },
+          // An `adb` connected to nothing, rather than the one on this machine.
+          deviceHeapDumps = DeviceHeapDumps(NO_DEVICE_ADB)
+        )
+      }
+    }
+    waitForTheTree(OPEN_TIMEOUT_MILLIS)
+    if (place != null) {
+      // The panes describe the object a little after the tab opens, since describing it is a read of the heap
+      // dump: the button that changes its status is the first thing that says they have.
+      waitUntilAtLeastOneExists(hasText(SET_STATUS_BUTTON), OPEN_TIMEOUT_MILLIS)
+    }
+  }
+
+  /**
+   * Opens the dialog that sets a status.
+   *
+   * Waits for the button to be enabled rather than pressing it as it is: it stays disabled until the file
+   * has been read, which is what keeps a save from deleting statuses still on their way off the disk.
+   */
+  private fun ComposeUiTest.changeStatus() {
+    val button = (hasText(SET_STATUS_BUTTON) or hasText(CHANGE_STATUS_BUTTON)) and isButton()
+    waitUntilAtLeastOneExists(button and isEnabled(), RENDER_TIMEOUT_MILLIS)
+    onNode(button).performClick()
+    onNodeWithText(STATUS_DIALOG_TITLE, substring = true).assertIsDisplayed()
+  }
+
+  /** Picks one of the three statuses, by the row it is on rather than by the mark beside it. */
+  private fun ComposeUiTest.choose(status: LeakStatus) {
+    onNode(hasText(status.statusText) and hasClickAction()).performClick()
+  }
+
+  private fun ComposeUiTest.write(reason: String) {
+    onNodeWithContentDescription(REASON_DESCRIPTION).performTextInput(reason)
+  }
+
+  private fun ComposeUiTest.set() {
+    setButton().performClick()
+  }
+
+  private fun ComposeUiTest.setButton() = onNode(hasText(SAVE_STATUS) and isButton())
+
+  /** The banner above the panes, which is the glyph and the status and nothing else. */
+  private fun bannerText(status: LeakStatus) = "${status.glyphOf()} ${status.statusText}"
+
+  private fun banner(status: LeakStatus) = hasText(bannerText(status))
+
+  /** Repeated from the section rather than shared: a glyph is one of the words the window says. */
+  private fun LeakStatus.glyphOf() = when (this) {
+    LeakStatus.NOT_LEAKING -> "✓"
+    LeakStatus.UNKNOWN -> "?"
+    LeakStatus.LEAKING -> "✗"
+  }
+
+  /** A status set on the holder in a run before the one under test, which is the file being there. */
+  private fun holderIsLeaking() {
+    statusFile().write(
+      LeakStatusOverrides.of(
+        listOf(
+          LeakStatusOverride(
+            objectId = heapDump.holderObjectId,
+            status = LeakStatus.LEAKING,
+            reason = HOLDER_REASON
+          )
+        )
+      )
+    )
+  }
+
+  private fun statusFile() = LeakStatusFile(statusesRoot, heapDump.file)
+
+  private fun isButton(): SemanticsMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+
+  companion object {
+    /** Opening a heap dump and laying its tree out both happen on another thread. */
+    private const val OPEN_TIMEOUT_MILLIS = 10_000L
+
+    /** And so does describing an object of it. */
+    private const val RENDER_TIMEOUT_MILLIS = 5_000L
+
+    /** Setting a status is the heap dump read for what it disagrees with, and then a file written. */
+    private const val SAVE_TIMEOUT_MILLIS = 10_000L
+
+    /** How the window says a status is somebody's rather than the heap dump's. */
+    private const val SET_BY_HAND = "set by hand — "
+
+    /** What a test types as the reason, which is the sentence the file has to come back with. */
+    private const val TYPED_REASON = "this screen is deliberately kept for one more frame"
+
+    /** What the inspector says about the destroyed activity, which is what a hand overrules. */
+    private const val DESTROYED_REASON = "Activity#mDestroyed is true"
+
+    /** What the object holding the leaking one is called where the dialog names it. */
+    private const val HOLDER_NAME = "Holder instance"
+
+    /** And what it was given as its reason, which the dialog has to show to be overruled. */
+    private const val HOLDER_REASON = "this holder is the one to fix"
+
+    /** What the dialog says about a status set on an object that holds the one being changed. */
+    private const val CONFLICT_ABOVE = "holds it"
+
+    private const val CONFLICT_BECOMES = "Would become"
+
+    /** An `adb` connected to nothing, so that a test doesn't answer for whatever is plugged in. */
+    private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }
+  }
+}
+
+/**
+ * A heap dump with a destroyed activity in it and the object holding it, which is the smallest chain two
+ * statuses can disagree along: what a leaking object holds is leaking, so a holder that is leaking and an
+ * activity that isn't cannot both be read off it.
+ */
+private fun TemporaryFolder.leakyChainHeapDump(): LeakyChainHeapDump {
+  val file = newFile("leaky-chain.hprof")
+  var activityObjectId = 0L
+  var holderObjectId = 0L
+  file.dump {
+    val activityClassId = clazz(
+      className = LEAKING_ACTIVITY_CLASS_NAME,
+      // Field values are written most derived class first, and the subclass declares none, so an instance
+      // of it is written with the one field it inherits.
+      superclassId = clazz(
+        className = "android.app.Activity",
+        fields = listOf("mDestroyed" to BooleanHolder::class)
+      )
+    )
+    val activity = instance(activityClassId, fields = listOf(BooleanHolder(true)))
+    val holder = instance(
+      clazz(className = "com.example.Holder", fields = listOf("activity" to ReferenceHolder::class)),
+      fields = listOf(activity)
+    )
+    gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+    activityObjectId = activity.value
+    holderObjectId = holder.value
+  }
+  return LeakyChainHeapDump(file, activityObjectId, holderObjectId)
+}
+
+private class LeakyChainHeapDump(
+  val file: File,
+  /** The destroyed activity, which the inspectors recognize on their own. */
+  val activityObjectId: Long,
+  /** And what holds it, which nothing knows either way about. */
+  val holderObjectId: Long
+)

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeaksScreenTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeaksScreenTest.kt
@@ -30,11 +30,13 @@ import shark.explorer.HeapLeaks
 import shark.explorer.HeapObjectKind
 import shark.explorer.LeakGroup
 import shark.explorer.LeakKind
+import shark.explorer.LeakStatus
 import shark.explorer.LeakSection
 import shark.explorer.LeakingObject
 import shark.explorer.Place
 import shark.explorer.ReachabilityStrength
 import shark.explorer.hexObjectId
+import shark.explorer.statusText
 
 /**
  * The screen listing what shouldn't be in memory, and the colouring that shades the map by it.
@@ -233,7 +235,8 @@ class LeaksScreenTest {
 
       onAllNodesWithText(listed)[0].performClick()
 
-      waitUntilAtLeastOneExists(hasText("$LEAKING: ", substring = true), OPEN_TIMEOUT_MILLIS)
+      val leaking = LeakStatus.LEAKING.statusText
+      waitUntilAtLeastOneExists(hasText("$leaking: ", substring = true), OPEN_TIMEOUT_MILLIS)
       assertThat(onAllNodesWithText("mDestroyed", substring = true).fetchSemanticsNodes()).isNotEmpty()
     }
   }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DominatorPaths.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DominatorPaths.kt
@@ -125,7 +125,23 @@ data class PathReference(
   val ownerClassName: String,
   val locationType: ReferenceLocationType,
   /** Set for the references Shark knows leak in code an app doesn't control, null for the rest. */
-  val libraryLeak: LibraryLeakPattern?
+  val libraryLeak: LibraryLeakPattern?,
+  /**
+   * Whether this is the reference the leak *is*: the one step of the path that goes from an object expected
+   * to be in memory to a stuck one.
+   *
+   * **The one thing on a chain that says where to go and change code.** A status is about an object, and
+   * every object below this reference reads as stuck because of it — so a reader following the statuses is
+   * being pointed at what a leak left behind, and this is being pointed at the leak. The same reference the
+   * leaks screen names a leak after, wherever a leak is a single reference. See
+   * [faultyReferenceIndexOrNull], which is where the rule and the three ways a path has no faulty reference
+   * are, and [LeakGroup.suspectPath].
+   *
+   * False for every reference of most paths of a heap dump, since it takes the two verdicts either side of
+   * one reference to be true. Worked out once the whole path is known, like [PathStep.leakStatus], for the
+   * same reason: the statuses of the objects either side of it are what decide it.
+   */
+  val isFaulty: Boolean = false
 )
 
 /**

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -895,7 +895,7 @@ class HeapDominatorTreemap internal constructor(
    *
    * The price is that a [LeakGroup.leakFingerprint] only matches the one LeakCanary computes for the same
    * objects while nothing is set by hand: the fingerprint hashes the stretch of chain between the last
-   * object still needed and the first that shouldn't be there, and moving either end is the point of
+   * expected object and the first stuck one, and moving either end is the point of
    * setting a status. Nothing else compares fingerprints across the two. See [LeakStatusOverride].
    *
    * Worked out again per set of statuses and kept until the next one, since a status is set by hand and
@@ -964,7 +964,7 @@ class HeapDominatorTreemap internal constructor(
   private val watchers: Map<Long, WatchedObject> by lazy { WatchedObjects.readFrom(graph) }
 
   /**
-   * The objects that shouldn't be in memory, before anything is known about how they are held.
+   * The objects that are stuck in memory, before anything is known about how they are held.
    *
    * Its own pass because both the leaks screen and every chain drawn in the window want it, and it costs a
    * read of every instance of the heap dump — see [leakingObjectIds] and [rootPathSearch].
@@ -972,7 +972,7 @@ class HeapDominatorTreemap internal constructor(
   private val leakingCandidateIds: Set<Long> by lazy {
     val startNanos = System.nanoTime()
     val ids = leakingObjectIds(watchers)
-    SharkLog.d { "Found ${ids.size} objects that leaked in ${millisSince(startNanos)} ms" }
+    SharkLog.d { "Found ${ids.size} stuck objects in ${millisSince(startNanos)} ms" }
     ids
   }
 
@@ -1062,7 +1062,7 @@ class HeapDominatorTreemap internal constructor(
       rootPathObjectIdsTo(objectId, overrides)
     }
     // The whole chain rather than the part of it a pane draws, since a leak is named and grouped by the
-    // stretch of it between the last object still needed and the first that shouldn't be there, and
+    // stretch of it between the last expected object and the first stuck one, and
     // cutting the top off a chain moves that stretch.
     val steps = stepsAlong(pathObjectIds, overrides)
     val target = steps.lastOrNull()
@@ -1127,7 +1127,7 @@ class HeapDominatorTreemap internal constructor(
         leakingObject = leakingObject
       )
     }
-    // The whole of it, since the row is named after both ends: the reference that shouldn't be holding,
+    // The whole of it, since the row is named after both ends: the faulty reference,
     // which is what LeakCanary calls the leak, and the one the object that leaked hangs off.
     val suspectSubpath = suspectSubpath(steps)
     // The first one on the way down, so a chain through two known leaks is named after the one nearest
@@ -1155,7 +1155,7 @@ class HeapDominatorTreemap internal constructor(
       // objects reached through the same suspect stretch of references are two instances of one leak,
       // whatever their classes and however far below it they are.
       leakFingerprint = steps.leakFingerprint(),
-      // The reference that shouldn't be holding, which is the leak itself rather than one of the objects
+      // The faulty reference, which is the leak itself rather than one of the objects
       // it left behind. Those are the rows under it, and each says what it is.
       title = suspectSubpath.firstOrNull() ?: simpleClassName,
       suspectPath = suspectSubpath,
@@ -1169,8 +1169,8 @@ class HeapDominatorTreemap internal constructor(
 
   /**
    * The suspect stretch of a chain, as `Class.field` per reference: how the last object known to still be
-   * needed reaches the first one that shouldn't be there. What a leak is named after, since the first of
-   * them is the reference that shouldn't be holding.
+   * expected reaches the first stuck one. What a leak is named after, since the first of them is the
+   * faulty reference.
    *
    * What everything leaking for one reason has in common. The references below the first leaking object are
    * left out because they are what the leak is holding rather than why: a leaked activity holds its window,
@@ -1226,7 +1226,7 @@ class HeapDominatorTreemap internal constructor(
    * that shouldn't be in memory — but there is one thing to fix, and it is the one nearest the GC roots:
    * let go of the activity and the other two go with it.
    *
-   * **A leak is a reference that shouldn't be there, not an object**, which is what makes this the right
+   * **A leak is a faulty reference, not an object**, which is what makes this the right
    * rule rather than "unless some other leak dominates it". An object held two ways, each of them through a
    * different leak, has no leaking dominator and would survive that rule as a leak of its own — but there
    * is nothing to fix about it that isn't already on the list twice over, and fixing both references takes

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -972,7 +972,7 @@ class HeapDominatorTreemap internal constructor(
   private val leakingCandidateIds: Set<Long> by lazy {
     val startNanos = System.nanoTime()
     val ids = leakingObjectIds(watchers)
-    SharkLog.d { "Found ${ids.size} objects that shouldn't be here in ${millisSince(startNanos)} ms" }
+    SharkLog.d { "Found ${ids.size} objects that leaked in ${millisSince(startNanos)} ms" }
     ids
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -125,14 +125,59 @@ class HeapDominatorTreemap internal constructor(
    * screen is free of it if a chain was drawn first.
    */
   private val rootPathSearch: RootPathSearch by lazy {
-    val leakingIndexes = BooleanArray(referrerIndex.objectCount)
-    leakingCandidateIds.forEach { objectId ->
-      val index = referrerIndex.indexOf(objectId)
-      if (index != ReferrerIndex.NOT_AN_OBJECT) {
-        leakingIndexes[index] = true
-      }
-    }
     RootPathSearch(referrerIndex, treeRootIndexes, leakingIndexes)
+  }
+
+  /**
+   * Which objects a chain is worth going round, by object index. See [RootPathSearch].
+   *
+   * The heap dump's own answer, with the statuses set by hand written over it, and edited in place rather
+   * than built again per read: [rootPathSearch] holds on to this array and four more the size of the heap
+   * dump, so undoing a handful of ids costs nothing where building another walk costs the dump twice over.
+   * Which is only sound because one thread reads the tree — see [rootPathSearchThrough].
+   */
+  private val leakingIndexes: BooleanArray by lazy {
+    val indexes = BooleanArray(referrerIndex.objectCount)
+    leakingCandidateIds.forEach { objectId -> indexes.markLeaking(objectId, true) }
+    indexes
+  }
+
+  /** Which statuses set by hand [leakingIndexes] is written over by, so that they can be taken back off. */
+  private var indexedOverrides = LeakStatusOverrides.NONE
+
+  /**
+   * The walk up to the roots, going round what [overrides] say shouldn't be in memory as well as what the
+   * heap dump does: a status set by hand is the answer everything else here is read through, so a chain
+   * that could have avoided an object someone marked leaking is the chain to draw.
+   *
+   * Every read of a tree is on that heap dump's one thread, which is what makes editing [leakingIndexes]
+   * between reads safe: no walk is in flight while this runs.
+   */
+  private fun rootPathSearchThrough(overrides: LeakStatusOverrides): RootPathSearch {
+    val search = rootPathSearch
+    if (overrides != indexedOverrides) {
+      // Back to what the heap dump said about the objects the last read was through, before writing this
+      // read's over it: an id can be in both, and one that was leaking by hand may be a candidate anyway.
+      indexedOverrides.all.forEach { override ->
+        leakingIndexes.markLeaking(override.objectId, override.objectId in leakingCandidateIds)
+      }
+      overrides.all.forEach { override ->
+        leakingIndexes.markLeaking(override.objectId, override.status == LeakStatus.LEAKING)
+      }
+      indexedOverrides = overrides
+    }
+    return search
+  }
+
+  /** Silently ignores an object of another heap dump, which is what a status set on one is here. */
+  private fun BooleanArray.markLeaking(
+    objectId: Long,
+    isLeaking: Boolean
+  ) {
+    val index = referrerIndex.indexOf(objectId)
+    if (index != ReferrerIndex.NOT_AN_OBJECT) {
+      this[index] = isLeaking
+    }
   }
 
   /**
@@ -712,7 +757,7 @@ class HeapDominatorTreemap internal constructor(
     objectId: Long,
     /** The statuses set by hand, which win over what the inspectors make of the objects on this chain. */
     overrides: LeakStatusOverrides = LeakStatusOverrides.NONE
-  ): RootPath = rootPathAlong(rootPathObjectIdsTo(objectId), overrides)
+  ): RootPath = rootPathAlong(rootPathObjectIdsTo(objectId, overrides), overrides)
 
   /**
    * Whether [fromObjectId] holds [toObjectId], through any chain of the references this tree was built by.
@@ -754,7 +799,10 @@ class HeapDominatorTreemap internal constructor(
    * does, so the walk is separate: a question about the whole chain that ids alone answer — whether another
    * leak is above this object on it — is asked here rather than of the steps that ended up drawn.
    */
-  private fun rootPathObjectIdsTo(objectId: Long): List<Long> {
+  private fun rootPathObjectIdsTo(
+    objectId: Long,
+    overrides: LeakStatusOverrides
+  ): List<Long> {
     if (objectId == root || objectId !in nodes) {
       return emptyList()
     }
@@ -767,7 +815,7 @@ class HeapDominatorTreemap internal constructor(
       }
       return emptyList()
     }
-    val found = rootPathSearch.findPath(targetIndex)
+    val found = rootPathSearchThrough(overrides).findPath(targetIndex)
     if (found == null) {
       // The tree hangs every object off one of the roots it walked from, so there is a path by
       // construction. Not finding one means this walk and that one followed different references, which
@@ -839,19 +887,45 @@ class HeapDominatorTreemap internal constructor(
    * asked for, like the list of every object, rather than anywhere near the pointer. Worked out once per
    * heap dump and kept.
    *
-   * **What Shark found, and no status anyone set by hand**, which is the one place in this app that ignores
-   * them: this list is the reading the heap dump itself supports, and a leak someone has decided is not one
-   * is still a leak the inspectors recognized. Which also keeps a [LeakGroup.leakFingerprint] comparable to
-   * the one LeakCanary computes for the same objects — the two are checked against each other, and a list
-   * that folded someone's conclusions in would make them disagree for a reason no report could explain. A
-   * status set by hand is on the object and on every chain drawn through it. See [LeakStatusOverride].
+   * **Read through the statuses set by hand**, like everything else here: an object someone marked leaking
+   * is one of these however it reads, and one they marked anything else is none of them, whatever an
+   * inspector recognized it as. Which is a list that changes as they are set rather than only a colour on
+   * an object — marking something leaking halfway up a chain puts it on this list and takes what it holds
+   * off, because that object is now only in memory because of this one. See [foldedIntoWhatHoldsThem].
+   *
+   * The price is that a [LeakGroup.leakFingerprint] only matches the one LeakCanary computes for the same
+   * objects while nothing is set by hand: the fingerprint hashes the stretch of chain between the last
+   * object still needed and the first that shouldn't be there, and moving either end is the point of
+   * setting a status. Nothing else compares fingerprints across the two. See [LeakStatusOverride].
+   *
+   * Worked out again per set of statuses and kept until the next one, since a status is set by hand and
+   * this is seconds: the window asks for the leaks again when someone sets one, and asks for the same
+   * statuses over and over while nobody is.
    */
-  fun findLeaks(): HeapLeaks = leaks
+  fun findLeaks(
+    /** The statuses set by hand, which win over what the inspectors make of these objects. */
+    overrides: LeakStatusOverrides = LeakStatusOverrides.NONE
+  ): HeapLeaks = leaksThrough(overrides).leaks
 
-  private val leaks: HeapLeaks by lazy { computeLeaks() }
+  /** The leaks as one set of statuses reads them, kept until another set is asked for. */
+  private class ReadLeaks(
+    val overrides: LeakStatusOverrides,
+    val leaks: HeapLeaks,
+    /** The same objects as a set, kept because [isBelowLeakingObject] asks about the ids per read. */
+    val leakingObjectIds: Set<Long>
+  )
 
-  /** The same thing as a set, kept because shading the treemap by it asks per rectangle drawn. */
-  private val leakingObjectIds: Set<Long> by lazy { leaks.leakingObjectIds }
+  private var lastLeaks: ReadLeaks? = null
+
+  private fun leaksThrough(overrides: LeakStatusOverrides): ReadLeaks {
+    lastLeaks?.let { read ->
+      if (read.overrides == overrides) {
+        return read
+      }
+    }
+    val leaks = computeLeaks(overrides)
+    return ReadLeaks(overrides, leaks, leaks.leakingObjectIds).also { lastLeaks = it }
+  }
 
   /**
    * Whether a leaking object dominates [node], which makes everything drawn inside it leaking too:
@@ -862,7 +936,12 @@ class HeapDominatorTreemap internal constructor(
    * one that dominates it, so the map only has to be told about the object at the top of each leak, and
    * this is for the view that is already rooted inside one.
    */
-  fun isBelowLeakingObject(node: Long): Boolean {
+  fun isBelowLeakingObject(
+    node: Long,
+    /** The statuses set by hand, which are as much a reason to shade a rectangle as an inspector is. */
+    overrides: LeakStatusOverrides = LeakStatusOverrides.NONE
+  ): Boolean {
+    val leakingObjectIds = leaksThrough(overrides).leakingObjectIds
     if (leakingObjectIds.isEmpty()) {
       return false
     }
@@ -890,22 +969,42 @@ class HeapDominatorTreemap internal constructor(
    * Its own pass because both the leaks screen and every chain drawn in the window want it, and it costs a
    * read of every instance of the heap dump — see [leakingObjectIds] and [rootPathSearch].
    */
-  private val leakingCandidateIds: List<Long> by lazy {
+  private val leakingCandidateIds: Set<Long> by lazy {
     val startNanos = System.nanoTime()
     val ids = leakingObjectIds(watchers)
     SharkLog.d { "Found ${ids.size} objects that shouldn't be here in ${millisSince(startNanos)} ms" }
     ids
   }
 
-  private fun computeLeaks(): HeapLeaks {
+  /**
+   * The same objects with the statuses set by hand written over them, which is what [findLeaks] lists: one
+   * marked leaking belongs on the list whatever the heap dump makes of it, and one marked anything else is
+   * someone saying the heap dump is wrong about it.
+   */
+  private fun leakingCandidateIdsThrough(overrides: LeakStatusOverrides): Collection<Long> {
+    if (overrides.isEmpty) {
+      return leakingCandidateIds
+    }
+    val ids = LinkedHashSet(leakingCandidateIds)
+    overrides.all.forEach { override ->
+      if (override.status == LeakStatus.LEAKING) {
+        ids += override.objectId
+      } else {
+        ids -= override.objectId
+      }
+    }
+    return ids
+  }
+
+  private fun computeLeaks(overrides: LeakStatusOverrides): HeapLeaks {
     val startNanos = System.nanoTime()
-    val candidateIds = leakingCandidateIds
+    val candidateIds = leakingCandidateIdsThrough(overrides)
     // Largest first, and capped: the walk up to the GC roots per object is what this costs, and a heap
     // dump with thousands of leaking objects has a handful of leaks with thousands of instances each.
     val found = candidateIds
       .sortedByDescending { nodes[it]?.retainedSize ?: 0L }
       .take(MAX_LEAKING_OBJECTS)
-      .map { objectId -> foundLeak(objectId, watchers[objectId]) }
+      .map { objectId -> foundLeak(objectId, watchers[objectId], overrides) }
       .foldedIntoWhatHoldsThem()
     if (candidateIds.size > MAX_LEAKING_OBJECTS) {
       SharkLog.d {
@@ -930,7 +1029,7 @@ class HeapDominatorTreemap internal constructor(
    * the object inspectors' own filters, over the instances of the dump rather than every object of it,
    * because every one of those filters is about an instance of an Android class.
    */
-  private fun leakingObjectIds(watchers: Map<Long, WatchedObject>): List<Long> {
+  private fun leakingObjectIds(watchers: Map<Long, WatchedObject>): Set<Long> {
     val leakingIds = watchers.values.filter { it.isRetained }.mapTo(LinkedHashSet()) {
       it.referentObjectId
     }
@@ -940,13 +1039,14 @@ class HeapDominatorTreemap internal constructor(
         leakingIds += instance.objectId
       }
     }
-    return leakingIds.toList()
+    return leakingIds
   }
 
   /** Which leak one leaking object is an instance of, which takes walking up to the GC roots. */
   private fun foundLeak(
     objectId: Long,
-    watcher: WatchedObject?
+    watcher: WatchedObject?,
+    overrides: LeakStatusOverrides
   ): FoundLeak {
     val strength = strengthOf(objectId)
     // Which section it goes in, when that is decided by how firmly it is held rather than by what holds
@@ -959,13 +1059,12 @@ class HeapDominatorTreemap internal constructor(
     val pathObjectIds = if (strength == ReachabilityStrength.UNREACHABLE) {
       emptyList()
     } else {
-      rootPathObjectIdsTo(objectId)
+      rootPathObjectIdsTo(objectId, overrides)
     }
     // The whole chain rather than the part of it a pane draws, since a leak is named and grouped by the
     // stretch of it between the last object still needed and the first that shouldn't be there, and
-    // cutting the top off a chain moves that stretch. Read with no status anyone set by hand: see
-    // [findLeaks].
-    val steps = stepsAlong(pathObjectIds, LeakStatusOverrides.NONE)
+    // cutting the top off a chain moves that stretch.
+    val steps = stepsAlong(pathObjectIds, overrides)
     val target = steps.lastOrNull()
     // The last step of the chain is this object, already read while the chain was. Only a leak with no
     // chain to read it off is read here, which is why this is read on demand.

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -409,18 +409,32 @@ class HeapDominatorTreemap internal constructor(
    * Reads the object and runs Shark's object inspectors over it, so call it for the selected object
    * rather than for every rectangle.
    */
-  fun summarize(objectId: Long): HeapObjectSummary {
+  fun summarize(
+    objectId: Long,
+    /** The statuses set by hand, which win over what the inspectors make of this object. */
+    overrides: LeakStatusOverrides = LeakStatusOverrides.NONE
+  ): HeapObjectSummary {
     require(group(objectId) == null) {
       "$objectId stands for a pile of objects rather than for one. Ask groupOrNull() first, and " +
         "describe it with what that returns."
     }
     val node = nodeOf(objectId)
     val heapObject = if (objectId == root) null else graph.findObjectById(objectId)
+    val className = heapObject?.className()
     val fields = heapObject?.fieldsOf() ?: FieldList(emptyList(), totalCount = 0)
+    val reporter = heapObject?.inspect()
+    // What this object is by itself, which is a path of one: the two rules that decide the rest of a status
+    // are about the objects above and below, and here there are none. See [leakStatusesOf]. Null for the
+    // virtual root above the heap dump, which is no object and has nothing to inspect.
+    val own = if (className == null || reporter == null) {
+      null
+    } else {
+      leakStatusesOf(listOf(reporter.inspected(className, overrides))).single()
+    }
     return HeapObjectSummary(
       objectId = objectId,
       label = label(objectId),
-      className = heapObject?.className() ?: ROOT_LABEL,
+      className = className ?: ROOT_LABEL,
       kind = heapObject?.kind(),
       headline = heapObject?.headline(),
       strength = strengthOf(objectId),
@@ -428,7 +442,9 @@ class HeapDominatorTreemap internal constructor(
       retainedSize = node.retainedSize,
       retainedCount = node.retainedCount,
       dominatedObjectCount = node.dominatedObjectIds.size,
-      inspectorLabels = heapObject?.inspect()?.labels?.toList() ?: emptyList(),
+      inspectorLabels = reporter?.labels?.toList() ?: emptyList(),
+      leakStatus = own?.status ?: LeakStatus.UNKNOWN,
+      leakStatusReason = own?.reason,
       fields = fields.shown,
       hiddenFieldCount = fields.totalCount - fields.shown.size
     )
@@ -447,6 +463,21 @@ class HeapDominatorTreemap internal constructor(
     AndroidObjectInspectors.appDefaults.forEach { it.inspect(reporter) }
     return reporter
   }
+
+  /**
+   * What one object is before a path is taken into account: what the inspectors said, and whatever a hand
+   * set instead. See [leakStatusesOf].
+   */
+  private fun ObjectReporter.inspected(
+    /** Read already by whoever asked, since naming the object is most of what they were reading it for. */
+    className: String,
+    overrides: LeakStatusOverrides
+  ): InspectedPathObject = InspectedPathObject(
+    simpleClassName = className.substringAfterLast('.'),
+    leakingReasons = leakingReasons,
+    notLeakingReasons = notLeakingReasons,
+    setByHand = overrides[heapObject.objectId]
+  )
 
   /**
    * The objects of the heap dump [filter] matches, the largest [limit] of them, largest first.
@@ -580,7 +611,9 @@ class HeapDominatorTreemap internal constructor(
    */
   fun independentPathsBetween(
     fromObjectId: Long,
-    toObjectId: Long
+    toObjectId: Long,
+    /** The statuses set by hand, which win over what the inspectors make of the objects on these paths. */
+    overrides: LeakStatusOverrides = LeakStatusOverrides.NONE
   ): IndependentPaths {
     val fromIndex = referrerIndex.indexOf(fromObjectId)
     if (fromIndex == ReferrerIndex.NOT_AN_OBJECT) {
@@ -589,7 +622,9 @@ class HeapDominatorTreemap internal constructor(
       }
       return IndependentPaths.NONE
     }
-    return independentPathsTo(toObjectId, isBelowGroup = false) { index -> index == fromIndex }
+    return independentPathsTo(toObjectId, isBelowGroup = false, overrides = overrides) { index ->
+      index == fromIndex
+    }
   }
 
   /**
@@ -601,13 +636,19 @@ class HeapDominatorTreemap internal constructor(
    * anyone is after, and the cache is why the dominator tree had nowhere to put its bytes but the whole
    * heap.
    */
-  fun independentPathsFromRoots(toObjectId: Long): IndependentPaths =
-    independentPathsTo(toObjectId, isBelowGroup = true) { index -> index in treeRootIndexes }
+  fun independentPathsFromRoots(
+    toObjectId: Long,
+    overrides: LeakStatusOverrides = LeakStatusOverrides.NONE
+  ): IndependentPaths =
+    independentPathsTo(toObjectId, isBelowGroup = true, overrides = overrides) { index ->
+      index in treeRootIndexes
+    }
 
   private fun independentPathsTo(
     toObjectId: Long,
     /** Whether a path starts at a GC rooted object, which is then a step of it rather than left out. */
     isBelowGroup: Boolean,
+    overrides: LeakStatusOverrides,
     isSource: (Int) -> Boolean
   ): IndependentPaths {
     if (toObjectId == root || toObjectId !in nodes) {
@@ -626,12 +667,12 @@ class HeapDominatorTreemap internal constructor(
     // A GC root's own object, or a piece of garbage nothing points at: what holds it is the root or nothing
     // at all, and walking up its referrers can't say so, because it has none.
     if (isSource(targetIndex)) {
-      paths += path(intArrayOf(targetIndex), isBelowGroup)
+      paths += path(intArrayOf(targetIndex), isBelowGroup, overrides)
     }
     val search = PathSearch(targetIndex)
     while (paths.size < MAX_INDEPENDENT_PATHS) {
       val found = search.findPath(isSource) ?: break
-      paths += path(found, isBelowGroup)
+      paths += path(found, isBelowGroup, overrides)
     }
     if (paths.isEmpty()) {
       // Asked between two objects one of which dominates the other, or from the roots the tree was walked
@@ -667,7 +708,43 @@ class HeapDominatorTreemap internal constructor(
    * walk over as much of the graph as it takes to reach a root, then a read of the heap dump per step of
    * the chain it found.
    */
-  fun rootPathTo(objectId: Long): RootPath = rootPathAlong(rootPathObjectIdsTo(objectId))
+  fun rootPathTo(
+    objectId: Long,
+    /** The statuses set by hand, which win over what the inspectors make of the objects on this chain. */
+    overrides: LeakStatusOverrides = LeakStatusOverrides.NONE
+  ): RootPath = rootPathAlong(rootPathObjectIdsTo(objectId), overrides)
+
+  /**
+   * Whether [fromObjectId] holds [toObjectId], through any chain of the references this tree was built by.
+   *
+   * What "above" and "below" mean when they are asked about two objects rather than about one chain: a
+   * status decides what the objects it holds are, so two statuses set by hand disagree exactly when one of
+   * the objects reaches the other. See [leakStatusConflictsWith].
+   *
+   * One walk up the referrers from [toObjectId], which on an object the whole heap dump holds is a walk over
+   * everything above it — the same cost as asking every way an object is held. So this is for a question
+   * someone asked, not for the pointer moving.
+   */
+  fun reaches(
+    fromObjectId: Long,
+    toObjectId: Long
+  ): Boolean {
+    if (fromObjectId == toObjectId) {
+      return false
+    }
+    val fromIndex = referrerIndex.indexOf(fromObjectId)
+    val toIndex = referrerIndex.indexOf(toObjectId)
+    if (fromIndex == ReferrerIndex.NOT_AN_OBJECT || toIndex == ReferrerIndex.NOT_AN_OBJECT) {
+      // One of them is no object of this heap dump, which is what a status set on another dump's object is:
+      // an address is only an address of the dump it was written down in.
+      SharkLog.d {
+        "${hexObjectId(fromObjectId)} does not reach ${hexObjectId(toObjectId)}: one of them is no object " +
+          "of this heap dump"
+      }
+      return false
+    }
+    return PathSearch(toIndex).findPath { index -> index == fromIndex } != null
+  }
 
   /**
    * That same chain as object ids, the whole of it, from the GC rooted object down to [objectId]. Empty
@@ -704,14 +781,17 @@ class HeapDominatorTreemap internal constructor(
   }
 
   /** The steps of [pathObjectIds], read out of the heap dump, with what dominates it marked. */
-  private fun rootPathAlong(pathObjectIds: List<Long>): RootPath {
+  private fun rootPathAlong(
+    pathObjectIds: List<Long>,
+    overrides: LeakStatusOverrides
+  ): RootPath {
     if (pathObjectIds.isEmpty()) {
       return RootPath.NONE
     }
     val dominatorIds = dominatorIdsOf(pathObjectIds.last())
     return RootPath(
       gcRootLabel = gcRootLabelOf(pathObjectIds.first()),
-      steps = stepsAlong(pathObjectIds)
+      steps = stepsAlong(pathObjectIds, overrides)
         .map { RootPathStep(it, isDominator = it.objectId in dominatorIds) }
     )
   }
@@ -720,13 +800,16 @@ class HeapDominatorTreemap internal constructor(
    * Every step of [pathObjectIds], read out of the heap dump. What both a drawn chain and the questions a
    * leak asks of one are built from, since both are about all of it.
    */
-  private fun stepsAlong(pathObjectIds: List<Long>): List<PathStep> =
+  private fun stepsAlong(
+    pathObjectIds: List<Long>,
+    overrides: LeakStatusOverrides
+  ): List<PathStep> =
     pathObjectIds.mapIndexed { index, stepObjectId ->
       if (index == 0) {
         // The GC root's own object, which no field of the heap dump points at.
-        step(stepObjectId, reference = null)
+        step(stepObjectId, reference = null, overrides = overrides)
       } else {
-        stepTo(stepObjectId, referrerId = pathObjectIds[index - 1])
+        stepTo(stepObjectId, referrerId = pathObjectIds[index - 1], overrides = overrides)
       }
     }.withLeakStatuses()
 
@@ -755,6 +838,13 @@ class HeapDominatorTreemap internal constructor(
    * GC roots per object found, so this is seconds on a large dump — it belongs behind a screen someone
    * asked for, like the list of every object, rather than anywhere near the pointer. Worked out once per
    * heap dump and kept.
+   *
+   * **What Shark found, and no status anyone set by hand**, which is the one place in this app that ignores
+   * them: this list is the reading the heap dump itself supports, and a leak someone has decided is not one
+   * is still a leak the inspectors recognized. Which also keeps a [LeakGroup.leakFingerprint] comparable to
+   * the one LeakCanary computes for the same objects — the two are checked against each other, and a list
+   * that folded someone's conclusions in would make them disagree for a reason no report could explain. A
+   * status set by hand is on the object and on every chain drawn through it. See [LeakStatusOverride].
    */
   fun findLeaks(): HeapLeaks = leaks
 
@@ -873,8 +963,9 @@ class HeapDominatorTreemap internal constructor(
     }
     // The whole chain rather than the part of it a pane draws, since a leak is named and grouped by the
     // stretch of it between the last object still needed and the first that shouldn't be there, and
-    // cutting the top off a chain moves that stretch.
-    val steps = stepsAlong(pathObjectIds)
+    // cutting the top off a chain moves that stretch. Read with no status anyone set by hand: see
+    // [findLeaks].
+    val steps = stepsAlong(pathObjectIds, LeakStatusOverrides.NONE)
     val target = steps.lastOrNull()
     // The last step of the chain is this object, already read while the chain was. Only a leak with no
     // chain to read it off is read here, which is why this is read on demand.
@@ -1087,14 +1178,15 @@ class HeapDominatorTreemap internal constructor(
    */
   private fun path(
     objectIndexes: IntArray,
-    isBelowGroup: Boolean
+    isBelowGroup: Boolean,
+    overrides: LeakStatusOverrides
   ): IndependentPath {
     val objectIds = objectIndexes.map { referrerIndex.objectIdAt(it) }
     val steps = objectIds.mapIndexedNotNull { index, objectId ->
       when {
-        index > 0 -> stepTo(objectId, referrerId = objectIds[index - 1])
+        index > 0 -> stepTo(objectId, referrerId = objectIds[index - 1], overrides = overrides)
         // The GC root's own object, which no field of the heap dump points at.
-        isBelowGroup -> step(objectId, reference = null)
+        isBelowGroup -> step(objectId, reference = null, overrides = overrides)
         else -> null
       }
     }
@@ -1147,7 +1239,8 @@ class HeapDominatorTreemap internal constructor(
   /** How [referrerId] points at [objectId], which takes reading the referrer's references again. */
   private fun stepTo(
     objectId: Long,
-    referrerId: Long
+    referrerId: Long,
+    overrides: LeakStatusOverrides
   ): InspectedStep {
     val details = pathReferenceReader.read(graph.findObjectById(referrerId))
       .firstOrNull { it.valueObjectId == objectId }
@@ -1164,6 +1257,7 @@ class HeapDominatorTreemap internal constructor(
     }
     return step(
       objectId = objectId,
+      overrides = overrides,
       reference = details?.let { resolved ->
         PathReference(
           name = resolved.name,
@@ -1185,7 +1279,8 @@ class HeapDominatorTreemap internal constructor(
 
   private fun step(
     objectId: Long,
-    reference: PathReference?
+    reference: PathReference?,
+    overrides: LeakStatusOverrides
   ): InspectedStep {
     val node = nodes[objectId]
     // Every step of a path is an object of the heap dump, unlike a node of the tree, which can stand for a
@@ -1212,11 +1307,7 @@ class HeapDominatorTreemap internal constructor(
         reference = reference,
         isInspectable = objectId in nodes
       ),
-      inspected = InspectedPathObject(
-        simpleClassName = className.substringAfterLast('.'),
-        leakingReasons = reporter.leakingReasons,
-        notLeakingReasons = reporter.notLeakingReasons
-      )
+      inspected = reporter.inspected(className, overrides)
     )
   }
 
@@ -1707,6 +1798,19 @@ data class HeapObjectSummary(
   val dominatedObjectCount: Int,
   /** What Shark's object inspectors have to say, e.g. that an activity is destroyed. */
   val inspectorLabels: List<String>,
+  /**
+   * Whether this object is meant to still be in memory, as far as **this object alone** says: what the
+   * inspectors made of it, or what someone set by hand instead.
+   *
+   * The other half of the answer is on the chain that holds it — everything holding an object that is still
+   * needed is still needed too, and everything a leaking object holds is leaking — so a status here and the
+   * one the last step of a [RootPath] carries are two different questions, and the chain's is the fuller one.
+   * This is what the window has to go on for an object no chain reaches: a piece of uncollected garbage, or
+   * one whose walk up to the GC roots hasn't come back yet. See [LeakStatus].
+   */
+  val leakStatus: LeakStatus,
+  /** Why, in the same words a chain gives. Null when nothing is known about it either way. */
+  val leakStatusReason: String?,
   /** Its fields, or an array's elements, in the order the heap dump records them. */
   val fields: List<ObjectFieldValue>,
   /** How many more fields there are than [fields] holds, which only an array reaches. */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -1127,8 +1127,8 @@ class HeapDominatorTreemap internal constructor(
         leakingObject = leakingObject
       )
     }
-    // The whole of it, since the row is named after both ends: the faulty reference,
-    // which is what LeakCanary calls the leak, and the one the object that leaked hangs off.
+    // The whole of it, since the row is named after both ends: the reference LeakCanary
+    // calls the leak, and the one the object that leaked hangs off.
     val suspectSubpath = suspectSubpath(steps)
     // The first one on the way down, so a chain through two known leaks is named after the one nearest
     // the root, which is the one holding the other. A chain goes through a known leaking reference only
@@ -1155,7 +1155,7 @@ class HeapDominatorTreemap internal constructor(
       // objects reached through the same suspect stretch of references are two instances of one leak,
       // whatever their classes and however far below it they are.
       leakFingerprint = steps.leakFingerprint(),
-      // The faulty reference, which is the leak itself rather than one of the objects
+      // The top of the stretch, which is the leak itself rather than one of the objects
       // it left behind. Those are the rows under it, and each says what it is.
       title = suspectSubpath.firstOrNull() ?: simpleClassName,
       suspectPath = suspectSubpath,
@@ -1182,15 +1182,14 @@ class HeapDominatorTreemap internal constructor(
    * the way `LeakTrace.leakFingerprint` spells one: by the class that declares the field, so that the name
    * of a leak is a string that is also on the chain drawn for it. Which is why the name is no substitute
    * for the leak fingerprint and the two are both on the row.
+   *
+   * The stretch the chain marks the faulty reference in — see [faultyReferenceIndexOrNull] — so that where
+   * it is a single reference, which is most leaks, the name of a leak here and the mark on the chain someone
+   * opens from it are one reference said twice. Where it isn't, the row names the whole stretch and the chain
+   * marks nothing, since which of those references is at fault is exactly what isn't known.
    */
-  private fun suspectSubpath(steps: List<PathStep>): List<String> {
-    val lastNotLeaking = steps.indexOfLast { it.leakStatus == LeakStatus.NOT_LEAKING }
-    val firstLeaking = steps.indexOfFirst { it.leakStatus == LeakStatus.LEAKING }
-      .let { if (it == -1) steps.lastIndex else it }
-    return (lastNotLeaking + 1..firstLeaking)
-      .mapNotNull { steps[it].reference }
-      .map { it.genericLabel() }
-  }
+  private fun suspectSubpath(steps: List<PathStep>): List<String> =
+    steps.suspectReferenceIndexes().map { steps[it].reference!!.genericLabel() }
 
   /**
    * A reference spelled the way the chain pane spells it — `Tile.view`, `Object[][x]` — with an array index
@@ -1327,11 +1326,21 @@ class HeapDominatorTreemap internal constructor(
    */
   private fun List<InspectedStep>.withLeakStatuses(): List<PathStep> {
     val statuses = leakStatusesOf(map { it.inspected })
-    return mapIndexed { index, inspected ->
+    val steps = mapIndexed { index, inspected ->
       inspected.step.copy(
         leakStatus = statuses[index].status,
         leakStatusReason = statuses[index].reason
       )
+    }
+    // And which of its references the leak is, when the same statuses say: one step from an object expected
+    // to be in memory to a stuck one, which no step knows on its own. See [PathReference.isFaulty].
+    val faultyIndex = steps.faultyReferenceIndexOrNull() ?: return steps
+    return steps.mapIndexed { index, step ->
+      if (index == faultyIndex) {
+        step.copy(reference = step.reference!!.copy(isFaulty = true))
+      } else {
+        step
+      }
     }
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDumpFiles.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDumpFiles.kt
@@ -1,0 +1,73 @@
+package shark.explorer
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * How this app names what it keeps about one heap dump, and how it writes it.
+ *
+ * **Not beside the heap dump**, which is the tempting place and the wrong one. A dump is opened from
+ * wherever it came from — a directory pulled off a device, a temporary file, a read only mount, a checkout
+ * of this repository — and writing into all of those means littering some of them and failing on the rest. A
+ * directory of this app's own always works and is always found again. See [NoteDirectory] and
+ * [LeakStatusFile], which are the two things kept that way.
+ */
+
+/**
+ * The dump's file name, and the directory it is in as a hash: `large-dump.hprof-1f3a9c0b`.
+ *
+ * The name first because these are read by people and listed by name, and a hash of the directory after it
+ * because two dumps called `large-dump.hprof` from two runs of the same app are two investigations. Which way
+ * round to solve that is the whole choice here — a path flattened into a file name would be unreadable and
+ * would hit the 255 character limit, and the name alone would silently merge what was written about every
+ * dump ever called `heap.hprof`.
+ *
+ * [normalizedHeapDumpPath] rather than the path as given, because `./heap.hprof` is how a heap dump gets
+ * typed on a command line and it is the same dump as `heap.hprof`.
+ */
+internal fun heapDumpFileKey(heapDumpFile: File): String {
+  val heapDump = normalizedHeapDumpPath(heapDumpFile)
+  return "${heapDump.name}-${Integer.toHexString(heapDump.parent.orEmpty().hashCode())}"
+}
+
+/**
+ * One spelling of a heap dump's path, so that two ways of naming one file are one set of notes and one set
+ * of statuses.
+ *
+ * Absolute, since what is written about a dump outlives the working directory the app was started in, and
+ * with the `.` and `..` steps taken out, since `./heap.hprof` and `heap.hprof` are what the same dump gets
+ * called on a command line. Not the canonical path: that resolves symlinks, which means asking the
+ * filesystem and getting a different answer once the dump has been deleted.
+ */
+private fun normalizedHeapDumpPath(heapDumpFile: File): File = heapDumpFile.absoluteFile.normalize()
+
+/**
+ * Puts [text] in [file], through a file of its own and a rename, so that a run killed halfway through a
+ * save leaves what was last written rather than half of it.
+ *
+ * Nothing written is nothing kept: a file whose content has been cleared out is deleted rather than left
+ * empty for the next run to find.
+ */
+internal fun writeWholeFile(
+  file: File,
+  text: String
+) {
+  if (text.isEmpty()) {
+    if (file.isFile && !file.delete()) {
+      throw IOException("Could not delete $file, which is what writing nothing to it is")
+    }
+    return
+  }
+  val directory = file.parentFile
+  if (!directory.isDirectory && !directory.mkdirs()) {
+    throw IOException("Could not create $directory to write $file in")
+  }
+  val partial = File(directory, "${file.name}$PARTIAL_SUFFIX")
+  partial.writeText(text)
+  Files.move(partial.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+}
+
+/** A save in flight, which is never a file anything reads. */
+private const val PARTIAL_SUFFIX = ".partial"

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
@@ -3,7 +3,7 @@ package shark.explorer
 import java.security.MessageDigest
 
 /**
- * Every object of a heap dump that shouldn't be there, gathered into the leaks they are instances of. See
+ * Every stuck object of a heap dump, gathered into the leaks they are instances of. See
  * [HeapDominatorTreemap.findLeaks].
  *
  * The same answer LeakCanary's analysis gives, computed here instead so that every row keeps the object id
@@ -199,14 +199,14 @@ data class LeakGroup(
    */
   val title: String,
   /**
-   * The references the leak *is*, as `Foo.bar` each: from the one that shouldn't be holding any more down
-   * to the one that points straight at what leaked. A single reference for a leak on its way out, that one
-   * being what still holds it rather than what shouldn't.
+   * The references the leak *is*, as `Foo.bar` each: from the faulty reference, the one that should have
+   * been cleared, down to the one that points straight at what is stuck. A single reference for a leak on
+   * its way out, that one being what still holds it rather than what should have let go.
    *
    * The stretch of the chain [leakFingerprint] hashes, which is what makes these objects one leak, and
    * the same for every object in the group. Both ends are worth reading — the first says what to stop
    * holding, the last says where on the chain to find what it left behind — and they are the same
-   * reference for a leak held one step below something still needed, which is most leaks.
+   * reference for a leak held one step below something expected, which is most leaks.
    *
    * Empty for the leaks named some other way: a library leak is named by the pattern that recognized it,
    * and a leak nothing holds any more has no chain to read references off.
@@ -237,7 +237,7 @@ internal fun String.sha1Hex(): String =
   MessageDigest.getInstance("SHA-1").digest(toByteArray(Charsets.UTF_8))
     .joinToString(separator = "") { byte -> "%02x".format(byte) }
 
-/** One object that shouldn't be in memory. See [LeakGroup]. */
+/** One object that is stuck in memory. See [LeakGroup]. */
 data class LeakingObject(
   val objectId: Long,
   /** Fully qualified class name, or array type. */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
@@ -199,14 +199,14 @@ data class LeakGroup(
    */
   val title: String,
   /**
-   * The references the leak *is*, as `Foo.bar` each: from the faulty reference, the one that should have
+   * The references the leak *is*, as `Foo.bar` each: from the highest one that could be what should have
    * been cleared, down to the one that points straight at what is stuck. A single reference for a leak on
    * its way out, that one being what still holds it rather than what should have let go.
    *
    * The stretch of the chain [leakFingerprint] hashes, which is what makes these objects one leak, and
    * the same for every object in the group. Both ends are worth reading — the first says what to stop
-   * holding, the last says where on the chain to find what it left behind — and they are the same
-   * reference for a leak held one step below something expected, which is most leaks.
+   * holding, the last says where on the chain to find what it left behind — and where they are one
+   * reference, that reference is the faulty one and the chain marks it. See [PathReference.isFaulty].
    *
    * Empty for the leaks named some other way: a library leak is named by the pattern that recognized it,
    * and a leak nothing holds any more has no chain to read references off.

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakFingerprint.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakFingerprint.kt
@@ -10,7 +10,7 @@ import shark.ReferenceLocationType
 
 /**
  * The leak fingerprint LeakCanary prints under a leak, computed for a chain the explorer found: a SHA-1 of
- * the stretch of the chain between the last object still needed and the first one that shouldn't be there,
+ * the stretch of the chain between the last expected object and the first stuck one,
  * spelled by the class of each object and the name of the reference out of it.
  *
  * **Shark's own [LeakTrace.leakFingerprint] rather than a rule of the same shape.** A leak fingerprint is

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
@@ -21,10 +21,28 @@ enum class LeakStatus {
   LEAKING
 }
 
+/**
+ * How a status is named where it is read: on a chain, in the reason another object gives, in the row above
+ * the panes.
+ *
+ * In this module rather than in the window, because the reasons worked out here are sentences that name
+ * statuses — a status set by hand says which status it was set from — and two spellings of "not leaking"
+ * would show up in one line of one window.
+ */
+val LeakStatus.statusText: String
+  get() = when (this) {
+    LeakStatus.NOT_LEAKING -> "Not leaking"
+    LeakStatus.UNKNOWN -> "Unknown"
+    LeakStatus.LEAKING -> "Leaking"
+  }
+
 /** What one object of a path is, and why. See [LeakStatus]. */
 internal class LeakStatusAndReason(
   val status: LeakStatus,
-  /** In words, e.g. `Activity#mDestroyed is true`. Null for [LeakStatus.UNKNOWN]. */
+  /**
+   * In words, e.g. `Activity#mDestroyed is true`. Null for [LeakStatus.UNKNOWN], unless a hand set it: an
+   * object someone said nothing is known about has a reason for that too.
+   */
   val reason: String?
 )
 
@@ -33,7 +51,12 @@ internal class InspectedPathObject(
   /** For naming it in another object's reason: `MainActivity↓ is not leaking`. */
   val simpleClassName: String,
   val leakingReasons: Set<String>,
-  val notLeakingReasons: Set<String>
+  val notLeakingReasons: Set<String>,
+  /**
+   * What someone reading this heap dump decided this object is, which wins over the reasons above it.
+   * Null for every object nobody has said anything about, which is all of them to start with.
+   */
+  val setByHand: LeakStatusOverride? = null
 )
 
 /**
@@ -52,6 +75,11 @@ internal class InspectedPathObject(
  * answers to the same question. One rule of it is left out — **the object a path ends at is not forced to
  * be leaking**. A leak trace ends where the leak is, so forcing it is right there; a path here ends
  * wherever the reader clicked, and calling whatever that was leaking would be the window inventing leaks.
+ *
+ * A status someone set by hand is what that object is — see [setByHandStatus] — and then these two rules
+ * run over it like over any other: what an object is decides what the objects above and below it are, and
+ * that is as true of an object a person recognized as of one an inspector did. Which is what makes two
+ * statuses set by hand able to disagree, and [leakStatusConflictsWith] what finds it before they do.
  */
 internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatusAndReason> {
   if (objects.isEmpty()) {
@@ -83,7 +111,9 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
     statuses[index] = LeakStatusAndReason(
       status = LeakStatus.NOT_LEAKING,
       reason = when (statuses[index].status) {
-        LeakStatus.UNKNOWN -> "$nextNotLeakingName is not leaking"
+        // With a reason of its own only when a hand gave it one, which the path is then overruling: an
+        // object someone said nothing is known about is one of the two statuses this can disagree with.
+        LeakStatus.UNKNOWN -> "$nextNotLeakingName is not leaking".conflicting(reason)
         LeakStatus.NOT_LEAKING -> "$nextNotLeakingName is not leaking and $reason"
         LeakStatus.LEAKING -> "$nextNotLeakingName is not leaking. Conflicts with $reason"
       }
@@ -97,7 +127,7 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
     statuses[index] = LeakStatusAndReason(
       status = LeakStatus.LEAKING,
       reason = when (statuses[index].status) {
-        LeakStatus.UNKNOWN -> "$previousLeakingName is leaking"
+        LeakStatus.UNKNOWN -> "$previousLeakingName is leaking".conflicting(reason)
         LeakStatus.LEAKING -> "$previousLeakingName is leaking and $reason"
         // No object below the first leaking one is left not leaking: the first leaking index is reset
         // past every object that isn't, and the loop above turned the rest into not leaking already.
@@ -111,13 +141,23 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
   return statuses
 }
 
+/** The same sentence with what it is overruling recorded after it, when there is anything to record. */
+private fun String.conflicting(overruled: String?): String =
+  if (overruled == null) this else "$this. Conflicts with $overruled"
+
 /**
  * What the inspectors said about one object, on its own, and what an object both sides recognize is:
  * still needed, unless it is the object the path is about.
+ *
+ * Unless a hand set it, in which case that is the answer and the inspectors are what it is recorded as
+ * disagreeing with. See [setByHandStatus].
  */
 private fun InspectedPathObject.ownStatus(leakingWins: Boolean): LeakStatusAndReason {
   val notLeaking = notLeakingReasons.joinToString(" and ").takeIf { notLeakingReasons.isNotEmpty() }
   val leaking = leakingReasons.joinToString(" and ").takeIf { leakingReasons.isNotEmpty() }
+  if (setByHand != null) {
+    return setByHandStatus(setByHand, leaking = leaking, notLeaking = notLeaking)
+  }
   return when {
     leaking != null && notLeaking != null -> if (leakingWins) {
       LeakStatusAndReason(LeakStatus.LEAKING, "$leaking. Conflicts with $notLeaking")
@@ -129,3 +169,42 @@ private fun InspectedPathObject.ownStatus(leakingWins: Boolean): LeakStatusAndRe
     else -> LeakStatusAndReason(LeakStatus.UNKNOWN, null)
   }
 }
+
+/**
+ * What an object someone set the status of by hand is: whatever they said, whoever says otherwise.
+ *
+ * **Overriding always wins**, which is the one place this differs from how two inspectors disagreeing is
+ * settled: there the object being still needed wins, because two inspectors are two pieces of the same
+ * automated reading and the safer of them is the one to believe. A hand is not that — someone who has read
+ * the heap dump and typed a reason knows something the inspectors don't, and a rule that weighed the two
+ * would mean a status that can't be changed to the one the inspectors already picked.
+ *
+ * So the inspectors become the record of what was overruled, the way a conflict between two of them is
+ * recorded, and the reason is the one that was typed.
+ */
+private fun setByHandStatus(
+  setByHand: LeakStatusOverride,
+  leaking: String?,
+  notLeaking: String?
+): LeakStatusAndReason {
+  val overruled = when (setByHand.status) {
+    LeakStatus.LEAKING -> notLeaking
+    LeakStatus.NOT_LEAKING -> leaking
+    // Both of them, since saying nothing is known about an object overrules anything that claimed to know.
+    LeakStatus.UNKNOWN -> listOfNotNull(notLeaking, leaking).joinToString(" and ").takeIf { it.isNotEmpty() }
+  }
+  return LeakStatusAndReason(
+    status = setByHand.status,
+    reason = "$SET_BY_HAND${setByHand.reason}".conflicting(overruled)
+  )
+}
+
+/**
+ * In front of the reason someone typed, wherever their status is read.
+ *
+ * Because the reason is the whole of what a chain says about an object, and a status a hand set has to be
+ * readable as one there: half the objects of a chain are green or red because of an inspector, and which of
+ * them is there because someone decided so is the difference between reading the heap dump and reading
+ * someone's conclusion about it.
+ */
+internal const val SET_BY_HAND = "set by hand — "

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
@@ -26,14 +26,20 @@ enum class LeakStatus {
  * the panes.
  *
  * In this module rather than in the window, because the reasons worked out here are sentences that name
- * statuses — a status set by hand says which status it was set from — and two spellings of "not leaking"
+ * statuses — a status set by hand says which status it was set from — and two spellings of one status
  * would show up in one line of one window.
+ *
+ * **Said about the object rather than about the leak**, which is why these are not LeakCanary's `Leaking:
+ * YES / NO / UNKNOWN`. A leak is a reference that shouldn't be there, and calling an object "leaking" reads
+ * as that object leaking something as easily as being the thing left behind — the ambiguity is in the word,
+ * not in the reader. What the inspectors actually answer is whether the object is supposed to still be in
+ * memory, so that is what these say, in the words the rest of this module already explains it in.
  */
 val LeakStatus.statusText: String
   get() = when (this) {
-    LeakStatus.NOT_LEAKING -> "Not leaking"
-    LeakStatus.UNKNOWN -> "Unknown"
-    LeakStatus.LEAKING -> "Leaking"
+    LeakStatus.NOT_LEAKING -> "Meant to be here"
+    LeakStatus.UNKNOWN -> "Nobody knows"
+    LeakStatus.LEAKING -> "Shouldn't be here"
   }
 
 /** What one object of a path is, and why. See [LeakStatus]. */
@@ -48,7 +54,7 @@ internal class LeakStatusAndReason(
 
 /** What Shark's inspectors made of one object of a path, before the path decides what it means. */
 internal class InspectedPathObject(
-  /** For naming it in another object's reason: `MainActivity↓ is not leaking`. */
+  /** For naming it in another object's reason: `MainActivity↓ is meant to be here`. */
   val simpleClassName: String,
   val leakingReasons: Set<String>,
   val notLeakingReasons: Set<String>,
@@ -113,9 +119,9 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
       reason = when (statuses[index].status) {
         // With a reason of its own only when a hand gave it one, which the path is then overruling: an
         // object someone said nothing is known about is one of the two statuses this can disagree with.
-        LeakStatus.UNKNOWN -> "$nextNotLeakingName is not leaking".conflicting(reason)
-        LeakStatus.NOT_LEAKING -> "$nextNotLeakingName is not leaking and $reason"
-        LeakStatus.LEAKING -> "$nextNotLeakingName is not leaking. Conflicts with $reason"
+        LeakStatus.UNKNOWN -> "$nextNotLeakingName is meant to be here".conflicting(reason)
+        LeakStatus.NOT_LEAKING -> "$nextNotLeakingName is meant to be here and $reason"
+        LeakStatus.LEAKING -> "$nextNotLeakingName is meant to be here. Conflicts with $reason"
       }
     )
   }
@@ -127,13 +133,13 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
     statuses[index] = LeakStatusAndReason(
       status = LeakStatus.LEAKING,
       reason = when (statuses[index].status) {
-        LeakStatus.UNKNOWN -> "$previousLeakingName is leaking".conflicting(reason)
-        LeakStatus.LEAKING -> "$previousLeakingName is leaking and $reason"
+        LeakStatus.UNKNOWN -> "$previousLeakingName shouldn't be here".conflicting(reason)
+        LeakStatus.LEAKING -> "$previousLeakingName shouldn't be here and $reason"
         // No object below the first leaking one is left not leaking: the first leaking index is reset
         // past every object that isn't, and the loop above turned the rest into not leaking already.
         LeakStatus.NOT_LEAKING -> error(
-          "${objects[index].simpleClassName} at $index is not leaking, below the leaking " +
-            "${objects[previousLeakingIndex].simpleClassName} at $previousLeakingIndex"
+          "${objects[index].simpleClassName} at $index is meant to be here, below " +
+            "${objects[previousLeakingIndex].simpleClassName} at $previousLeakingIndex, which shouldn't be"
         )
       }
     )

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
@@ -29,17 +29,18 @@ enum class LeakStatus {
  * statuses — a status set by hand says which status it was set from — and two spellings of one status
  * would show up in one line of one window.
  *
- * **Said about the object rather than about the leak**, which is why these are not LeakCanary's `Leaking:
- * YES / NO / UNKNOWN`. A leak is a reference that shouldn't be there, and calling an object "leaking" reads
- * as that object leaking something as easily as being the thing left behind — the ambiguity is in the word,
- * not in the reader. What the inspectors actually answer is whether the object is supposed to still be in
- * memory, so that is what these say, in the words the rest of this module already explains it in.
+ * **One word each, said about the object rather than about the leak.** `Leaked` rather than LeakCanary's
+ * `Leaking: YES`, because a leak is a reference that shouldn't be there and "leaking" reads as that object
+ * leaking something as easily as being the thing left behind — the ambiguity is in the word, not in the
+ * reader. `Needed` rather than `Not leaking`, since what an inspector recognizes is that something still
+ * needs this object, and a status is read a dozen times down one chain: it has to be a label, not a
+ * sentence.
  */
 val LeakStatus.statusText: String
   get() = when (this) {
-    LeakStatus.NOT_LEAKING -> "Meant to be here"
-    LeakStatus.UNKNOWN -> "Nobody knows"
-    LeakStatus.LEAKING -> "Shouldn't be here"
+    LeakStatus.NOT_LEAKING -> "Needed"
+    LeakStatus.UNKNOWN -> "Unknown"
+    LeakStatus.LEAKING -> "Leaked"
   }
 
 /** What one object of a path is, and why. See [LeakStatus]. */
@@ -54,7 +55,7 @@ internal class LeakStatusAndReason(
 
 /** What Shark's inspectors made of one object of a path, before the path decides what it means. */
 internal class InspectedPathObject(
-  /** For naming it in another object's reason: `MainActivity↓ is meant to be here`. */
+  /** For naming it in another object's reason: `MainActivity↓ is needed`. */
   val simpleClassName: String,
   val leakingReasons: Set<String>,
   val notLeakingReasons: Set<String>,
@@ -119,9 +120,9 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
       reason = when (statuses[index].status) {
         // With a reason of its own only when a hand gave it one, which the path is then overruling: an
         // object someone said nothing is known about is one of the two statuses this can disagree with.
-        LeakStatus.UNKNOWN -> "$nextNotLeakingName is meant to be here".conflicting(reason)
-        LeakStatus.NOT_LEAKING -> "$nextNotLeakingName is meant to be here and $reason"
-        LeakStatus.LEAKING -> "$nextNotLeakingName is meant to be here. Conflicts with $reason"
+        LeakStatus.UNKNOWN -> "$nextNotLeakingName is needed".conflicting(reason)
+        LeakStatus.NOT_LEAKING -> "$nextNotLeakingName is needed and $reason"
+        LeakStatus.LEAKING -> "$nextNotLeakingName is needed. Conflicts with $reason"
       }
     )
   }
@@ -133,13 +134,13 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
     statuses[index] = LeakStatusAndReason(
       status = LeakStatus.LEAKING,
       reason = when (statuses[index].status) {
-        LeakStatus.UNKNOWN -> "$previousLeakingName shouldn't be here".conflicting(reason)
-        LeakStatus.LEAKING -> "$previousLeakingName shouldn't be here and $reason"
+        LeakStatus.UNKNOWN -> "$previousLeakingName leaked".conflicting(reason)
+        LeakStatus.LEAKING -> "$previousLeakingName leaked and $reason"
         // No object below the first leaking one is left not leaking: the first leaking index is reset
         // past every object that isn't, and the loop above turned the rest into not leaking already.
         LeakStatus.NOT_LEAKING -> error(
-          "${objects[index].simpleClassName} at $index is meant to be here, below " +
-            "${objects[previousLeakingIndex].simpleClassName} at $previousLeakingIndex, which shouldn't be"
+          "${objects[index].simpleClassName} at $index is needed, below " +
+            "${objects[previousLeakingIndex].simpleClassName} at $previousLeakingIndex, which leaked"
         )
       }
     )

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
@@ -162,6 +162,63 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
   return statuses
 }
 
+/**
+ * Which references of a path the leak could be, as indexes into it: the stretch [leakStatusesOf] leaves in
+ * the middle, from the last object expected to be in memory down to the first stuck one.
+ *
+ * **What a leak is named after**, and what makes two objects instances of the same leak — the same stretch
+ * LeakCanary underlines in a leak trace and hashes into a leak fingerprint. The fault is at one of these
+ * references and the objects between them are the ones nothing knows either way about, so which one of them
+ * it is only reads off the path when there is a single one: that one is [faultyReferenceIndexOrNull], and
+ * narrowing a longer stretch to it is a person reading code, which is what setting a status by hand is for.
+ *
+ * Empty for a path with nothing stuck on it, which is most paths of a heap dump: the rules can point at a
+ * reference only once something below it is known not to belong. And the references of steps that have none
+ * are left out, which is the object a GC root reaches: a root holds its object through no field, so there is
+ * nothing there to have cleared.
+ */
+internal fun List<PathStep>.suspectReferenceIndexes(): List<Int> {
+  val firstStuck = indexOfFirst { it.leakStatus == LeakStatus.LEAKING }
+  if (firstStuck == -1) {
+    return emptyList()
+  }
+  // Never below the first stuck object: [leakStatusesOf] pushes that one past every object expected to be
+  // in memory, so the stretch between the two ends is never empty and never runs backwards.
+  val lastExpected = indexOfLast { it.leakStatus == LeakStatus.NOT_LEAKING }
+  return (lastExpected + 1..firstStuck).filter { this[it].reference != null }
+}
+
+/**
+ * Which reference of a path is **the faulty reference** — the one that should have been cleared — as an index
+ * into it, or null when the path doesn't say which one that is.
+ *
+ * The single reference that crosses from an object expected to be in memory to a stuck one: above it
+ * everything is legitimately held, below it everything is in memory only because of it, so that one
+ * reference is the whole of what there is to change in code.
+ *
+ * Null for most paths, and the three ways it is null are worth telling apart:
+ *
+ * - **Nothing stuck on the path.** There is no fault to point at, which is most of a heap dump.
+ * - **Nothing expected above the stuck object**, a chain of `Cleaner`s no inspector recognizes being the
+ *   shape of it. What holds the stuck object may be something that should have let go of it too, and then
+ *   the fault is further up than this path knows — so marking the top of the path would be naming a
+ *   reference for being where the walk stopped.
+ * - **Objects nothing is known about in between.** The fault is at one of those steps and the path doesn't
+ *   say which, so marking one of them would be a guess drawn as an answer. They are
+ *   [suspectReferenceIndexes], which is what a leak is named after, and a status set by hand is what turns
+ *   that stretch into a single reference.
+ */
+internal fun List<PathStep>.faultyReferenceIndexOrNull(): Int? {
+  val firstStuck = indexOfFirst { it.leakStatus == LeakStatus.LEAKING }
+  val lastExpected = indexOfLast { it.leakStatus == LeakStatus.NOT_LEAKING }
+  if (firstStuck == -1 || lastExpected == -1 || firstStuck != lastExpected + 1) {
+    return null
+  }
+  // A step below the first can still be missing its reference, when reading the referrer again doesn't find
+  // the reference the referrer index walked through — see `stepTo`. Nothing to mark then.
+  return firstStuck.takeIf { this[firstStuck].reference != null }
+}
+
 /** The same sentence with what it is overruling recorded after it, when there is anything to record. */
 private fun String.conflicting(overruled: String?): String =
   if (overruled == null) this else "$this. Conflicts with $overruled"

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatus.kt
@@ -17,7 +17,14 @@ enum class LeakStatus {
   /** Nothing knows either way, which is most of a heap dump. */
   UNKNOWN,
 
-  /** Something knows this object should be gone: a destroyed activity, a watched object still there. */
+  /**
+   * Something knows this object should be gone: a destroyed activity, a watched object still there.
+   *
+   * **Including one nothing reaches any more**, which the leaks screen lists apart under
+   * [LeakKind.UNREACHABLE]. It was still expected to be gone, and what keeps it here is only that the
+   * garbage collector hasn't run — so this is the same verdict, said the same way, and where an object sits
+   * on that scale is what the leaks screen is for rather than what this says.
+   */
   LEAKING
 }
 
@@ -29,18 +36,24 @@ enum class LeakStatus {
  * statuses — a status set by hand says which status it was set from — and two spellings of one status
  * would show up in one line of one window.
  *
- * **One word each, said about the object rather than about the leak.** `Leaked` rather than LeakCanary's
- * `Leaking: YES`, because a leak is a reference that shouldn't be there and "leaking" reads as that object
- * leaking something as easily as being the thing left behind — the ambiguity is in the word, not in the
- * reader. `Needed` rather than `Not leaking`, since what an inspector recognizes is that something still
- * needs this object, and a status is read a dozen times down one chain: it has to be a label, not a
- * sentence.
+ * **One word each, and neither of the two built on "leak".** A leak is one faulty reference that should
+ * have been cleared, and everything under it is retained by that one mistake — so a word like `Leaking` or
+ * `Leaked` on twenty objects points a reader at the twenty rather than at the one thing to fix. `Stuck`
+ * says what is true of the object without accusing it: it should be gone and something is holding it,
+ * which is the question worth asking. `Expected` says its being in memory is legitimate at this point in
+ * the app's life, which is what an inspector actually recognizes.
+ *
+ * No heap analyser has a verdict like this to borrow words from — JProfiler classifies objects by
+ * reference type and by age, YourKit by reachability scope, and both leave the judgement to the reader,
+ * because neither has watched objects or framework inspectors to make it with. What JProfiler's prose asks
+ * is whether objects "are still legitimately on the heap or if a faulty reference keeps them alive", which
+ * is the same split these two words are, and where the **faulty reference** gets its name.
  */
 val LeakStatus.statusText: String
   get() = when (this) {
-    LeakStatus.NOT_LEAKING -> "Needed"
+    LeakStatus.NOT_LEAKING -> "Expected"
     LeakStatus.UNKNOWN -> "Unknown"
-    LeakStatus.LEAKING -> "Leaked"
+    LeakStatus.LEAKING -> "Stuck"
   }
 
 /** What one object of a path is, and why. See [LeakStatus]. */
@@ -55,7 +68,7 @@ internal class LeakStatusAndReason(
 
 /** What Shark's inspectors made of one object of a path, before the path decides what it means. */
 internal class InspectedPathObject(
-  /** For naming it in another object's reason: `MainActivity↓ is needed`. */
+  /** For naming it in another object's reason: `MainActivity↓ is expected`. */
   val simpleClassName: String,
   val leakingReasons: Set<String>,
   val notLeakingReasons: Set<String>,
@@ -75,7 +88,8 @@ internal class InspectedPathObject(
  * below a leaking object is leaking, because the only thing keeping it in memory is an object that
  * shouldn't be there. So the inspectors have to recognize one object of a chain for the whole chain to
  * read, and what's left in the middle — between the last [LeakStatus.NOT_LEAKING] and the first
- * [LeakStatus.LEAKING] — is where the leak is.
+ * [LeakStatus.LEAKING] — is where the **faulty reference** is: the one reference that should have been
+ * cleared, and the whole of what there is to fix.
  *
  * This is [shark.RealLeakTracerFactory]'s algorithm, kept in step with it deliberately: a chain here and
  * a LeakCanary leak trace of the same objects that disagreed about which of them are leaking would be two
@@ -120,9 +134,9 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
       reason = when (statuses[index].status) {
         // With a reason of its own only when a hand gave it one, which the path is then overruling: an
         // object someone said nothing is known about is one of the two statuses this can disagree with.
-        LeakStatus.UNKNOWN -> "$nextNotLeakingName is needed".conflicting(reason)
-        LeakStatus.NOT_LEAKING -> "$nextNotLeakingName is needed and $reason"
-        LeakStatus.LEAKING -> "$nextNotLeakingName is needed. Conflicts with $reason"
+        LeakStatus.UNKNOWN -> "$nextNotLeakingName is expected".conflicting(reason)
+        LeakStatus.NOT_LEAKING -> "$nextNotLeakingName is expected and $reason"
+        LeakStatus.LEAKING -> "$nextNotLeakingName is expected. Conflicts with $reason"
       }
     )
   }
@@ -134,13 +148,13 @@ internal fun leakStatusesOf(objects: List<InspectedPathObject>): List<LeakStatus
     statuses[index] = LeakStatusAndReason(
       status = LeakStatus.LEAKING,
       reason = when (statuses[index].status) {
-        LeakStatus.UNKNOWN -> "$previousLeakingName leaked".conflicting(reason)
-        LeakStatus.LEAKING -> "$previousLeakingName leaked and $reason"
+        LeakStatus.UNKNOWN -> "$previousLeakingName is stuck".conflicting(reason)
+        LeakStatus.LEAKING -> "$previousLeakingName is stuck and $reason"
         // No object below the first leaking one is left not leaking: the first leaking index is reset
         // past every object that isn't, and the loop above turned the rest into not leaking already.
         LeakStatus.NOT_LEAKING -> error(
-          "${objects[index].simpleClassName} at $index is needed, below " +
-            "${objects[previousLeakingIndex].simpleClassName} at $previousLeakingIndex, which leaked"
+          "${objects[index].simpleClassName} at $index is expected, below " +
+            "${objects[previousLeakingIndex].simpleClassName} at $previousLeakingIndex, which is stuck"
         )
       }
     )

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusFile.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusFile.kt
@@ -1,0 +1,151 @@
+package shark.explorer
+
+import java.io.File
+import shark.SharkLog
+
+/**
+ * Where the leaking statuses set by hand on one heap dump are kept: one file of this app's own, named after
+ * the dump the way its notes are. See [heapDumpFileKey].
+ *
+ * One file for the whole dump rather than a file per object, which is the other way round from the notes
+ * beside it — and for the reason the notes are split: a note is a document someone edits, and a status is
+ * three fields the window writes. Every question here is about all of them at once (which objects have one,
+ * whether a new one disagrees with another), so a file per object would be a directory to list and a file to
+ * open per answer, and nothing would be easier to read.
+ *
+ * Tab separated, one status per line, with the columns named in a comment at the top, because this file is
+ * evidence: a status set by hand is someone's conclusion about the heap dump, and the next reader may well be
+ * a script, an agent or a colleague who doesn't have this app open. The reason is whatever they typed, so its
+ * newlines and tabs are escaped rather than allowed to end the line.
+ */
+class LeakStatusFile(
+  /** This app's own directory, which the caller decides. */
+  root: File,
+  /** The heap dump these statuses are about, which names the file and nothing more. */
+  heapDumpFile: File
+) {
+
+  /** The file itself, shown in the window so that the statuses can be found without this app. */
+  val file: File = File(root, "${heapDumpFileKey(heapDumpFile)}$STATUSES_SUFFIX")
+
+  /**
+   * What is on disk, or nothing at all for a heap dump nobody has set a status on.
+   *
+   * A line that can't be read is skipped rather than thrown over, and says so in the log: this file is
+   * hand editable on purpose, and one typo in it must not be a heap dump whose other statuses have gone.
+   */
+  fun read(): LeakStatusOverrides {
+    if (!file.isFile) {
+      return LeakStatusOverrides.NONE
+    }
+    val overrides = file.readLines().mapIndexedNotNull { index, line ->
+      if (line.isBlank() || line.startsWith(COMMENT)) null else overrideOf(line, index + 1)
+    }
+    SharkLog.d { "Read ${overrides.size} statuses set by hand from $file" }
+    return LeakStatusOverrides.of(overrides)
+  }
+
+  /** Puts [overrides] on disk, all of them, replacing whatever was there. See [writeWholeFile]. */
+  fun write(overrides: LeakStatusOverrides) {
+    val text = if (overrides.isEmpty) {
+      // Which deletes the file: a heap dump whose last status has been taken off is one nobody has set one
+      // on, and an empty file left behind would be a heap dump that reads as annotated.
+      ""
+    } else {
+      // Sorted, so that the file two runs write for the same statuses is the same file: this ends up in
+      // issues and in diffs, and a line order that follows whatever a map handed out reads as a change.
+      overrides.all.sortedBy { it.objectId }.joinToString(
+        separator = "\n",
+        prefix = "$HEADER\n",
+        postfix = "\n"
+      ) { it.line() }
+    }
+    writeWholeFile(file, text)
+  }
+
+  private fun overrideOf(
+    line: String,
+    lineNumber: Int
+  ): LeakStatusOverride? {
+    val columns = line.split(SEPARATOR)
+    if (columns.size != COLUMN_COUNT) {
+      SharkLog.d {
+        "Skipping line $lineNumber of $file: ${columns.size} columns rather than $COLUMN_COUNT"
+      }
+      return null
+    }
+    val (address, status, reason) = columns
+    val objectId = objectIdOfHex(address)
+    val leakStatus = LeakStatus.values().firstOrNull { it.name == status }
+    if (objectId == null || leakStatus == null) {
+      SharkLog.d {
+        "Skipping line $lineNumber of $file: \"$address\" is no object address, or \"$status\" is no status"
+      }
+      return null
+    }
+    val unescaped = reason.unescaped()
+    if (unescaped.isBlank()) {
+      // Which the window can't write and [LeakStatusOverride] won't hold: a status with no reason is one
+      // nobody can check, and the file having one means it was edited by hand into a state the app doesn't
+      // allow.
+      SharkLog.d { "Skipping line $lineNumber of $file: ${hexObjectId(objectId)} has no reason" }
+      return null
+    }
+    return LeakStatusOverride(objectId = objectId, status = leakStatus, reason = unescaped)
+  }
+
+  private fun LeakStatusOverride.line(): String =
+    listOf(exactHexObjectId(objectId), status.name, reason.escaped()).joinToString(SEPARATOR)
+
+  companion object {
+    private const val STATUSES_SUFFIX = ".leak-statuses.tsv"
+
+    private const val SEPARATOR = "\t"
+    private const val COLUMN_COUNT = 3
+
+    private const val COMMENT = "#"
+
+    /** What the columns are, for whoever opens this file without the app that wrote it. */
+    private const val HEADER =
+      "# Leaking statuses set by hand in Shark Explorer.\n" +
+        "# object\tstatus\treason, with \\n \\t \\\\ escaped"
+  }
+}
+
+/**
+ * Whatever was typed, on one line: the escapes a tab separated file needs, and no others.
+ *
+ * The backslash first, so that a reason that already has one comes back as itself rather than as an escape
+ * of whatever followed it.
+ */
+private fun String.escaped(): String = replace("\\", "\\\\")
+  .replace("\n", "\\n")
+  .replace("\r", "\\r")
+  .replace("\t", "\\t")
+
+/**
+ * And back, in one pass, because the pairs undone one at a time would read `\\n` — an escaped backslash
+ * followed by an `n` — as a newline.
+ */
+private fun String.unescaped(): String {
+  val unescaped = StringBuilder(length)
+  var index = 0
+  while (index < length) {
+    val character = this[index]
+    if (character != '\\' || index == lastIndex) {
+      unescaped.append(character)
+      index++
+      continue
+    }
+    when (val escaped = this[index + 1]) {
+      'n' -> unescaped.append('\n')
+      'r' -> unescaped.append('\r')
+      't' -> unescaped.append('\t')
+      '\\' -> unescaped.append('\\')
+      // Not an escape this app writes, so it is a backslash someone typed and whatever they typed after it.
+      else -> unescaped.append('\\').append(escaped)
+    }
+    index += 2
+  }
+  return unescaped.toString()
+}

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
@@ -180,8 +180,8 @@ private fun LeakStatusOverride.solvedBy(
       "${hexObjectId(objectId)} is unknown, so it does not conflict with ${hexObjectId(override.objectId)}"
     )
   },
-  // Both statuses in quotes, because they are labels rather than words of the sentence: "can be needed"
-  // reads as a claim of the sentence and "can be \"Needed\"" as the status it is.
+  // Both statuses in quotes, because they are labels rather than words of the sentence: "can be expected"
+  // reads as a claim of the sentence and "can be \"Expected\"" as the status it is.
   reason = "so that $overrideName ${if (isAbove) "below" else "above"} this can be " +
     "\"${override.status.statusText}\", which it was set to. Was \"${status.statusText}\": $reason"
 )

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
@@ -180,8 +180,8 @@ private fun LeakStatusOverride.solvedBy(
       "${hexObjectId(objectId)} is unknown, so it does not conflict with ${hexObjectId(override.objectId)}"
     )
   },
-  // Both statuses in quotes, because they are labels rather than words of the sentence: "can be meant to
-  // be here" reads as a claim about the sentence and "can be \"Meant to be here\"" as the status it is.
+  // Both statuses in quotes, because they are labels rather than words of the sentence: "can be needed"
+  // reads as a claim of the sentence and "can be \"Needed\"" as the status it is.
   reason = "so that $overrideName ${if (isAbove) "below" else "above"} this can be " +
     "\"${override.status.statusText}\", which it was set to. Was \"${status.statusText}\": $reason"
 )

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
@@ -180,7 +180,8 @@ private fun LeakStatusOverride.solvedBy(
       "${hexObjectId(objectId)} is unknown, so it does not conflict with ${hexObjectId(override.objectId)}"
     )
   },
+  // Both statuses in quotes, because they are labels rather than words of the sentence: "can be meant to
+  // be here" reads as a claim about the sentence and "can be \"Meant to be here\"" as the status it is.
   reason = "so that $overrideName ${if (isAbove) "below" else "above"} this can be " +
-    "${override.status.statusText.lowercase()}, which it was set to. " +
-    "Was ${status.statusText.lowercase()}: $reason"
+    "\"${override.status.statusText}\", which it was set to. Was \"${status.statusText}\": $reason"
 )

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
@@ -1,0 +1,186 @@
+package shark.explorer
+
+import shark.SharkLog
+
+/**
+ * A leaking status someone reading the heap dump set on one object, which wins over what Shark's inspectors
+ * made of it. See [leakStatusesOf].
+ *
+ * The thing the inspectors can't know: whether an object being in memory is a problem is often a question
+ * about the app rather than about the heap dump — a cache that is meant to hold what it holds, a singleton
+ * that is supposed to outlive the screen, a destroyed activity that is deliberately kept for one more frame.
+ * An inspector reads a field; a person reads the code.
+ *
+ * **The reason is not optional**, which is the whole of why this is worth keeping rather than a colour
+ * someone toggled: a status with no reason is an assertion the next reader — a colleague, an agent, the same
+ * person in a month — has no way to check, and one of those in a heap dump makes every other status in it
+ * worth less.
+ */
+data class LeakStatusOverride(
+  val objectId: Long,
+  val status: LeakStatus,
+  /** Why, in whoever set it's own words. */
+  val reason: String
+) {
+  init {
+    require(reason.isNotBlank()) {
+      "${hexObjectId(objectId)} was set to $status with no reason. A status set by hand overrules what " +
+        "the heap dump itself says, so what it is is no use to anyone without why."
+    }
+  }
+}
+
+/**
+ * Every leaking status set by hand on one heap dump, by object id.
+ *
+ * A value rather than something the heap dump's tree holds, and passed into every question whose answer it
+ * changes, because a tree is read from one thread while the window is composed on another: overrides that
+ * lived in the tree would mean a chain drawn from one set of them and the row above it from another. As a
+ * value, whatever asked has the answer to what it asked.
+ *
+ * Two of these are equal when they hold the same statuses, which is what lets a Compose effect be keyed on
+ * one: setting a status is what makes the window read the heap dump again.
+ */
+class LeakStatusOverrides private constructor(private val byObjectId: Map<Long, LeakStatusOverride>) {
+
+  /** Every one of them, in no particular order. */
+  val all: Collection<LeakStatusOverride> get() = byObjectId.values
+
+  val isEmpty: Boolean get() = byObjectId.isEmpty()
+
+  /** What was set on [objectId], or null for an object nobody has said anything about. */
+  operator fun get(objectId: Long): LeakStatusOverride? = byObjectId[objectId]
+
+  /** These and [override], which replaces whatever was set on the same object. */
+  fun with(override: LeakStatusOverride): LeakStatusOverrides = with(listOf(override))
+
+  /** The same for several at once, which is what solving a conflict sets. See [LeakStatusConflict]. */
+  fun with(overrides: List<LeakStatusOverride>): LeakStatusOverrides {
+    if (overrides.isEmpty()) {
+      return this
+    }
+    return LeakStatusOverrides(byObjectId + overrides.associateBy { it.objectId })
+  }
+
+  /** These without whatever was set on [objectId], which is what taking a status back off an object is. */
+  fun without(objectId: Long): LeakStatusOverrides =
+    if (objectId in byObjectId) LeakStatusOverrides(byObjectId - objectId) else this
+
+  override fun equals(other: Any?): Boolean =
+    this === other || (other is LeakStatusOverrides && byObjectId == other.byObjectId)
+
+  override fun hashCode(): Int = byObjectId.hashCode()
+
+  override fun toString(): String = "LeakStatusOverrides(${byObjectId.values})"
+
+  companion object {
+    /** Nothing set by hand, which is every heap dump nobody has read yet. */
+    val NONE = LeakStatusOverrides(emptyMap())
+
+    fun of(overrides: List<LeakStatusOverride>): LeakStatusOverrides = NONE.with(overrides)
+  }
+}
+
+/**
+ * One status set by hand that a new one disagrees with, and what solving the disagreement would set it to.
+ *
+ * Two statuses set by hand conflict when the path rules make them contradict each other, which is a
+ * question about how the two objects are held rather than about either of them: everything a leaking object
+ * holds is leaking, and everything holding an object that is still needed is still needed. So a leaking
+ * object above and an object that is not leaking below are two statuses that cannot both be read off the
+ * chain running through them, whichever of them a hand set. See [leakStatusConflictsWith].
+ */
+class LeakStatusConflict(
+  /** The status already set by hand, which the new one disagrees with. */
+  val existing: LeakStatusOverride,
+  /** What that object is, for a dialog that has to name it: `MainActivity instance`. */
+  val objectName: String,
+  /** Whether it holds the object being set, as against being held by it. */
+  val isAbove: Boolean,
+  /**
+   * What it becomes if the new status is the one to keep: the opposite of what it was, with the reason
+   * saying that this is why.
+   *
+   * The opposite rather than nothing at all, because a conflict is only ever between the two statuses that
+   * are opposites — so agreeing with the new one is the same as being flipped, and a status taken off the
+   * object instead would leave the reason someone typed nowhere.
+   */
+  val solved: LeakStatusOverride
+)
+
+/**
+ * Which of [overrides] the new [override] would disagree with, once the path rules have run over both.
+ *
+ * Asked before a status is set, so that the window can offer the choice the reader has to make: keep the
+ * new one and flip the others to agree, or leave the heap dump as it was. Nothing is decided here — this
+ * only says what the disagreements are.
+ *
+ * A walk up the referrers per status already set, which is what asking whether one object holds another
+ * costs: see [HeapDominatorTreemap.reaches]. There are a handful of statuses in a heap dump, so this is a
+ * handful of walks, and it belongs on the heap dump's thread like every other read.
+ */
+fun HeapDominatorTreemap.leakStatusConflictsWith(
+  override: LeakStatusOverride,
+  overrides: LeakStatusOverrides
+): List<LeakStatusConflict> {
+  val conflicts = overrides.all.mapNotNull { existing ->
+    if (existing.objectId == override.objectId) {
+      // Setting a status on an object that already has one replaces it, so it can't disagree with itself.
+      return@mapNotNull null
+    }
+    // A leaking object above forces everything it holds to be leaking, so it disagrees with anything else
+    // down here.
+    val holdsIt = existing.status == LeakStatus.LEAKING &&
+      override.status != LeakStatus.LEAKING &&
+      reaches(existing.objectId, override.objectId)
+    // And an object below that is still needed forces everything holding it to be needed too, so it
+    // disagrees with anything else up here.
+    val heldByIt = existing.status == LeakStatus.NOT_LEAKING &&
+      override.status != LeakStatus.NOT_LEAKING &&
+      reaches(override.objectId, existing.objectId)
+    if (!holdsIt && !heldByIt) {
+      return@mapNotNull null
+    }
+    LeakStatusConflict(
+      existing = existing,
+      objectName = objectNameOrNull(existing.objectId) ?: hexObjectId(existing.objectId),
+      isAbove = holdsIt,
+      solved = existing.solvedBy(
+        override = override,
+        overrideName = objectNameOrNull(override.objectId) ?: hexObjectId(override.objectId),
+        isAbove = holdsIt
+      )
+    )
+  }
+  SharkLog.d {
+    "Setting ${hexObjectId(override.objectId)} to ${override.status} disagrees with " +
+      "${conflicts.size} of the ${overrides.all.size} statuses set by hand"
+  }
+  return conflicts
+}
+
+/**
+ * The same object set to the opposite status, because the one it disagreed with is the one being kept.
+ *
+ * The reason says which status was flipped and what it said, so that solving a conflict never loses what
+ * someone typed: the status is the window's, the sentence under it is theirs.
+ */
+private fun LeakStatusOverride.solvedBy(
+  override: LeakStatusOverride,
+  overrideName: String,
+  isAbove: Boolean
+): LeakStatusOverride = LeakStatusOverride(
+  objectId = objectId,
+  status = when (status) {
+    LeakStatus.LEAKING -> LeakStatus.NOT_LEAKING
+    LeakStatus.NOT_LEAKING -> LeakStatus.LEAKING
+    // Nothing to flip: an object nobody claims to know about overrules nothing, so it is never one of the
+    // statuses a new one has to be solved against.
+    LeakStatus.UNKNOWN -> error(
+      "${hexObjectId(objectId)} is unknown, so it does not conflict with ${hexObjectId(override.objectId)}"
+    )
+  },
+  reason = "so that $overrideName ${if (isAbove) "below" else "above"} this can be " +
+    "${override.status.statusText.lowercase()}, which it was set to. " +
+    "Was ${status.statusText.lowercase()}: $reason"
+)

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NodeIds.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NodeIds.kt
@@ -17,6 +17,32 @@ fun hexObjectId(objectId: Long): String {
 }
 
 /**
+ * The same address, written so that it reads back as the same [Long] — for the files this app keeps between
+ * runs. See [LeakStatusFile].
+ *
+ * The one thing [hexObjectId] gives up to be recognisable is exactly what a file can't: it prints a
+ * sign-widened id as the 32 bit address it is, and `0xffff8000` is then two ids, the negative one of a 32 bit
+ * dump and the positive one a 64 bit dump could have. So a file that meant to carry one object's address and
+ * is read back against another dump — or the same dump on a machine that reads it the other way — would name
+ * an object nobody chose. This is all 16 digits of it for such an id, and identical to [hexObjectId] for every
+ * other, which is every object of every 64 bit dump below the 8 exabyte mark.
+ */
+internal fun exactHexObjectId(objectId: Long): String = "0x${java.lang.Long.toHexString(objectId)}"
+
+/** And back, or null for text that is no address at all. See [exactHexObjectId]. */
+internal fun objectIdOfHex(text: String): Long? {
+  if (!text.startsWith(HEX_PREFIX)) {
+    return null
+  }
+  return try {
+    // Unsigned, since an address that fills all 64 bits is a number no signed Long holds.
+    java.lang.Long.parseUnsignedLong(text.substring(HEX_PREFIX.length), HEX_RADIX)
+  } catch (notAnAddress: NumberFormatException) {
+    null
+  }
+}
+
+/**
  * How a node of a [HeapDominatorTreemap] reads in a message: the address of an object, or which pile of
  * objects it is.
  *
@@ -31,3 +57,6 @@ fun nodeIdText(nodeId: Long): String = when {
 }
 
 private const val LOW_32_BITS = 0xFFFFFFFFL
+
+private const val HEX_PREFIX = "0x"
+private const val HEX_RADIX = 16

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NoteFile.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/NoteFile.kt
@@ -2,17 +2,13 @@ package shark.explorer
 
 import java.io.File
 import java.io.IOException
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 
 /**
  * Where the notes about one heap dump are kept: a directory of this app's own, named after the dump, holding
  * one markdown file per place written about.
  *
- * **Not beside the heap dump**, which is the tempting place and the wrong one. A dump is opened from
- * wherever it came from — a directory pulled off a device, a temporary file, a read only mount, a checkout
- * of this repository — and writing into all of those means littering some of them and failing on the rest.
- * A directory under [root] always works and is always found again.
+ * Under [root] rather than beside the heap dump, and named [heapDumpFileKey] the way everything this app
+ * keeps about a dump is.
  *
  * Markdown on disk, and readable on its own, because a note about a leak outlives the window it was written
  * in: it gets pasted into an issue, read by an agent, or opened in an editor months later. A format only
@@ -31,7 +27,7 @@ class NoteDirectory(
 ) {
 
   /** The directory itself, shown in the window so that the notes can be found without this app. */
-  val directory: File = File(root, directoryNameFor(heapDumpFile))
+  val directory: File = File(root, heapDumpFileKey(heapDumpFile))
 
   /** Where what is written about [place] is kept. */
   fun noteFile(place: Place): NoteFile = NoteFile(File(directory, "${place.noteKey()}$NOTES_SUFFIX"))
@@ -49,34 +45,6 @@ class NoteDirectory(
       .toSet()
 
   companion object {
-
-    /**
-     * The dump's file name, and the directory it is in as a hash: `large-dump.hprof-1f3a9c0b`.
-     *
-     * The name first because these directories are read by people and listed by name, and a hash of the
-     * directory after it because two dumps called `large-dump.hprof` from two runs of the same app are two
-     * investigations. Which way round to solve that is the whole choice here — a path flattened into a
-     * directory name would be unreadable and would hit the 255 character limit, and the name alone would
-     * silently merge the notes of every dump ever called `heap.hprof`.
-     *
-     * [normalizedPath] rather than the path as given, because `./heap.hprof` is how a heap dump gets typed
-     * on a command line and it is the same dump as `heap.hprof`.
-     */
-    private fun directoryNameFor(heapDumpFile: File): String {
-      val heapDump = normalizedPath(heapDumpFile)
-      return "${heapDump.name}-${Integer.toHexString(heapDump.parent.orEmpty().hashCode())}"
-    }
-
-    /**
-     * One spelling of a heap dump's path, so that two ways of naming one file are one set of notes.
-     *
-     * Absolute, since the notes outlive the working directory the app was started in, and with the `.` and
-     * `..` steps taken out, since `./heap.hprof` and `heap.hprof` are what the same dump gets called on a
-     * command line. Not the canonical path: that resolves symlinks, which means asking the filesystem and
-     * getting a different answer once the dump has been deleted.
-     */
-    private fun normalizedPath(heapDumpFile: File): File = heapDumpFile.absoluteFile.normalize()
-
     private const val NOTES_SUFFIX = ".md"
   }
 }
@@ -130,27 +98,8 @@ class NoteFile internal constructor(
    * save leaves the last note rather than half of one. The one thing in this app nobody else has a copy
    * of is what someone typed into it.
    *
-   * Nothing written is nothing kept: a note cleared out deletes the file rather than leaving an empty one
-   * behind for the next run to find and mark a tab with.
+   * A note cleared out deletes the file rather than leaving an empty one behind for the next run to find
+   * and mark a tab with. See [writeWholeFile].
    */
-  fun write(text: String) {
-    if (text.isEmpty()) {
-      if (file.isFile && !file.delete()) {
-        throw IOException("Could not delete $file, which is what an empty note is")
-      }
-      return
-    }
-    val directory = file.parentFile
-    if (!directory.isDirectory && !directory.mkdirs()) {
-      throw IOException("Could not create $directory to keep notes in")
-    }
-    val partial = File(directory, "${file.name}$PARTIAL_SUFFIX")
-    partial.writeText(text)
-    Files.move(partial.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
-  }
-
-  companion object {
-    /** A save in flight, which is never the file a note is read from. */
-    private const val PARTIAL_SUFFIX = ".partial"
-  }
+  fun write(text: String) = writeWholeFile(file, text)
 }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
@@ -141,7 +141,7 @@ class HeapLeakStatusTest {
       // Solving it flips the one already set, and the reason says that this is why.
       assertThat(conflict.solved.status).isEqualTo(NOT_LEAKING)
       assertThat(conflict.solved.reason)
-        .contains("below this can be \"Needed\"", "Was \"Leaked\": this screen was closed")
+        .contains("below this can be \"Expected\"", "Was \"Stuck\": this screen was closed")
     }
   }
 
@@ -159,7 +159,7 @@ class HeapLeakStatusTest {
       assertThat(conflict.existing.objectId).isEqualTo(dump.windowObjectId)
       assertThat(conflict.isAbove).isFalse()
       assertThat(conflict.solved.status).isEqualTo(LEAKING)
-      assertThat(conflict.solved.reason).contains("above this can be \"Leaked\"")
+      assertThat(conflict.solved.reason).contains("above this can be \"Stuck\"")
     }
   }
 
@@ -237,7 +237,7 @@ class HeapLeakStatusTest {
     }
   }
 
-  @Test fun `an object set to needed is no longer a leak, and what it held becomes one`() {
+  @Test fun `an object set to expected is no longer a leak, and what it held becomes one`() {
     val dump = testFolder.nestedLeaksHeapDump()
 
     HeapExplorer.open(dump.file).use { explorer ->
@@ -263,7 +263,7 @@ class HeapLeakStatusTest {
   }
 
   /** A chain goes round what shouldn't be in memory, and a hand saying it should be is what decides that. */
-  @Test fun `a chain stops going round an object once a hand says it is needed`() {
+  @Test fun `a chain stops going round an object once a hand says it is expected`() {
     val dump = testFolder.leakAlsoHeldAnotherWayHeapDump()
 
     HeapExplorer.open(dump.file).use { explorer ->

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
@@ -141,7 +141,7 @@ class HeapLeakStatusTest {
       // Solving it flips the one already set, and the reason says that this is why.
       assertThat(conflict.solved.status).isEqualTo(NOT_LEAKING)
       assertThat(conflict.solved.reason)
-        .contains("below this can be \"Meant to be here\"", "Was \"Shouldn't be here\": this screen was closed")
+        .contains("below this can be \"Needed\"", "Was \"Leaked\": this screen was closed")
     }
   }
 
@@ -159,7 +159,7 @@ class HeapLeakStatusTest {
       assertThat(conflict.existing.objectId).isEqualTo(dump.windowObjectId)
       assertThat(conflict.isAbove).isFalse()
       assertThat(conflict.solved.status).isEqualTo(LEAKING)
-      assertThat(conflict.solved.reason).contains("above this can be \"Shouldn't be here\"")
+      assertThat(conflict.solved.reason).contains("above this can be \"Leaked\"")
     }
   }
 
@@ -237,7 +237,7 @@ class HeapLeakStatusTest {
     }
   }
 
-  @Test fun `an object set to meant to be here is no longer a leak, and what it held becomes one`() {
+  @Test fun `an object set to needed is no longer a leak, and what it held becomes one`() {
     val dump = testFolder.nestedLeaksHeapDump()
 
     HeapExplorer.open(dump.file).use { explorer ->
@@ -263,7 +263,7 @@ class HeapLeakStatusTest {
   }
 
   /** A chain goes round what shouldn't be in memory, and a hand saying it should be is what decides that. */
-  @Test fun `a chain stops going round an object once a hand says it is meant to be here`() {
+  @Test fun `a chain stops going round an object once a hand says it is needed`() {
     val dump = testFolder.leakAlsoHeldAnotherWayHeapDump()
 
     HeapExplorer.open(dump.file).use { explorer ->

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
@@ -141,7 +141,7 @@ class HeapLeakStatusTest {
       // Solving it flips the one already set, and the reason says that this is why.
       assertThat(conflict.solved.status).isEqualTo(NOT_LEAKING)
       assertThat(conflict.solved.reason)
-        .contains("below this can be not leaking", "Was leaking: this screen was closed")
+        .contains("below this can be \"Meant to be here\"", "Was \"Shouldn't be here\": this screen was closed")
     }
   }
 
@@ -159,7 +159,7 @@ class HeapLeakStatusTest {
       assertThat(conflict.existing.objectId).isEqualTo(dump.windowObjectId)
       assertThat(conflict.isAbove).isFalse()
       assertThat(conflict.solved.status).isEqualTo(LEAKING)
-      assertThat(conflict.solved.reason).contains("above this can be leaking")
+      assertThat(conflict.solved.reason).contains("above this can be \"Shouldn't be here\"")
     }
   }
 
@@ -215,6 +215,71 @@ class HeapLeakStatusTest {
       )
 
       assertThat(conflicts).isEmpty()
+    }
+  }
+
+  @Test fun `an object set to leaking is a leak, and what it holds is folded under it`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val holderObjectId = explorer.tree.findByLabel(HOLDER_CLASS_NAME.substringAfterLast('.')).objectId
+      // Nothing is wrong with the holder as far as the heap dump is concerned: the destroyed activity it
+      // holds is the leak, and the window under that is folded into it.
+      assertThat(explorer.tree.findLeaks().leakingObjectIds).containsExactly(dump.activityObjectId)
+
+      val leaks = explorer.tree.findLeaks(
+        overrides(holderObjectId, LEAKING, "this cache is never emptied")
+      )
+
+      // The activity is now only in memory because of an object that shouldn't be there, which is the one
+      // thing to fix — so it is listed under the holder rather than beside it.
+      assertThat(leaks.leakingObjectIds).containsExactly(holderObjectId)
+    }
+  }
+
+  @Test fun `an object set to meant to be here is no longer a leak, and what it held becomes one`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val leaks = explorer.tree.findLeaks(
+        overrides(dump.activityObjectId, NOT_LEAKING, "kept for one more frame on purpose")
+      )
+
+      // What the activity was holding is still a destroyed window, and nothing above it is a leak any
+      // more, so it stops being one leak's collateral and becomes the leak.
+      assertThat(leaks.leakingObjectIds).containsExactly(dump.windowObjectId)
+    }
+  }
+
+  /** The list is read through them, so taking a status off has to give the heap dump's answer back. */
+  @Test fun `the leaks are what the heap dump says again once a status is taken off`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      explorer.tree.findLeaks(overrides(dump.activityObjectId, NOT_LEAKING, "kept on purpose"))
+
+      assertThat(explorer.tree.findLeaks().leakingObjectIds).containsExactly(dump.activityObjectId)
+    }
+  }
+
+  /** A chain goes round what shouldn't be in memory, and a hand saying it should be is what decides that. */
+  @Test fun `a chain stops going round an object once a hand says it is meant to be here`() {
+    val dump = testFolder.leakAlsoHeldAnotherWayHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      // The window is held another way as well, so the chain to it gives up a step to avoid the destroyed
+      // activity.
+      assertThat(explorer.tree.rootPathTo(dump.windowObjectId).steps.map { it.step.objectId })
+        .doesNotContain(dump.activityObjectId)
+
+      val path = explorer.tree.rootPathTo(
+        objectId = dump.windowObjectId,
+        overrides = overrides(dump.activityObjectId, NOT_LEAKING, "this screen is coming back")
+      )
+
+      // And takes the short way through it once there is nothing to avoid, which is the chain and the
+      // statuses drawn on it being the same answer.
+      assertThat(path.steps.map { it.step.objectId }).contains(dump.activityObjectId)
     }
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
@@ -1,0 +1,237 @@
+package shark.explorer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import shark.explorer.LeakStatus.LEAKING
+import shark.explorer.LeakStatus.NOT_LEAKING
+import shark.explorer.LeakStatus.UNKNOWN
+
+/**
+ * What a heap dump says about its objects once somebody has said something about them by hand: the panel,
+ * the chain, and which statuses can't both be true. See [LeakStatusOverride].
+ */
+class HeapLeakStatusTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Test fun `an object the inspectors recognize is leaking on its own`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val summary = explorer.tree.summarize(dump.activityObjectId)
+
+      assertThat(summary.leakStatus).isEqualTo(LEAKING)
+      assertThat(summary.leakStatusReason).contains("mDestroyed")
+    }
+  }
+
+  @Test fun `a status set by hand is what the panel says instead`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val summary = explorer.tree.summarize(
+        objectId = dump.activityObjectId,
+        overrides = overrides(dump.activityObjectId, NOT_LEAKING, "kept for one more frame on purpose")
+      )
+
+      assertThat(summary.leakStatus).isEqualTo(NOT_LEAKING)
+      // What the inspector said is kept as the record of what the hand overruled.
+      assertThat(summary.leakStatusReason)
+        .isEqualTo("set by hand — kept for one more frame on purpose. Conflicts with Activity#mDestroyed is true")
+    }
+  }
+
+  /** The panel is about one object, so nothing above or below it changes what it says. */
+  @Test fun `a status set on another object is not what the panel says`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val summary = explorer.tree.summarize(
+        objectId = dump.windowObjectId,
+        overrides = overrides(dump.activityObjectId, NOT_LEAKING, "kept for one more frame on purpose")
+      )
+
+      assertThat(summary.leakStatus).isEqualTo(LEAKING)
+    }
+  }
+
+  @Test fun `a chain is read through the statuses set by hand`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val path = explorer.tree.rootPathTo(
+        objectId = dump.windowObjectId,
+        overrides = overrides(dump.activityObjectId, NOT_LEAKING, "kept for one more frame on purpose")
+      )
+
+      val activity = path.steps.single { it.step.objectId == dump.activityObjectId }.step
+      assertThat(activity.leakStatus).isEqualTo(NOT_LEAKING)
+      assertThat(activity.leakStatusReason).contains(SET_BY_HAND)
+      // And what a chain reads off it: the object above the activity is holding something still needed.
+      assertThat(path.steps.first().step.leakStatus).isEqualTo(NOT_LEAKING)
+    }
+  }
+
+  /** Which is the whole point of setting one: the objects below stop being read as leaking. */
+  @Test fun `what a hand set decides the objects below it on the chain`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val plain = explorer.tree.rootPathTo(dump.windowObjectId)
+      // The holder above the destroyed activity is where the leak starts, so it is left unknown.
+      assertThat(plain.steps.first().step.leakStatus).isEqualTo(UNKNOWN)
+      assertThat(plain.steps.single { it.step.objectId == dump.activityObjectId }.step.leakStatus)
+        .isEqualTo(LEAKING)
+
+      val read = explorer.tree.rootPathTo(
+        objectId = dump.windowObjectId,
+        overrides = overrides(dump.activityObjectId, UNKNOWN, "this activity is not the problem")
+      )
+
+      // The window is still leaking on its own account — an inspector recognized it — so what the activity
+      // no longer being leaking changes is the activity, not the object the chain leads to.
+      assertThat(read.steps.last().step.leakStatus).isEqualTo(LEAKING)
+      assertThat(read.steps.single { it.step.objectId == dump.activityObjectId }.step.leakStatus)
+        .isEqualTo(UNKNOWN)
+    }
+  }
+
+  @Test fun `an object holds the ones it reaches and not the other way round`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      assertThat(explorer.tree.reaches(dump.activityObjectId, dump.windowObjectId)).isTrue()
+      assertThat(explorer.tree.reaches(dump.windowObjectId, dump.activityObjectId)).isFalse()
+    }
+  }
+
+  @Test fun `an object does not hold itself`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      assertThat(explorer.tree.reaches(dump.activityObjectId, dump.activityObjectId)).isFalse()
+    }
+  }
+
+  @Test fun `an address that is no object of this heap dump reaches nothing`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      assertThat(explorer.tree.reaches(NOT_AN_ADDRESS, dump.windowObjectId)).isFalse()
+      assertThat(explorer.tree.reaches(dump.activityObjectId, NOT_AN_ADDRESS)).isFalse()
+    }
+  }
+
+  @Test fun `a leaking object above and one that is still needed below cannot both be true`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.windowObjectId, NOT_LEAKING, "this window is reused deliberately"),
+        overrides = overrides(dump.activityObjectId, LEAKING, "this screen was closed")
+      )
+
+      val conflict = conflicts.single()
+      assertThat(conflict.existing.objectId).isEqualTo(dump.activityObjectId)
+      assertThat(conflict.objectName).contains(ACTIVITY_CLASS_NAME.substringAfterLast('.'))
+      assertThat(conflict.isAbove).isTrue()
+      // Solving it flips the one already set, and the reason says that this is why.
+      assertThat(conflict.solved.status).isEqualTo(NOT_LEAKING)
+      assertThat(conflict.solved.reason)
+        .contains("below this can be not leaking", "Was leaking: this screen was closed")
+    }
+  }
+
+  /** The same disagreement, set the other way round: the object below is the one already set. */
+  @Test fun `a status set below the new one conflicts too, and says it is held by it`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.activityObjectId, LEAKING, "this screen was closed"),
+        overrides = overrides(dump.windowObjectId, NOT_LEAKING, "this window is reused deliberately")
+      )
+
+      val conflict = conflicts.single()
+      assertThat(conflict.existing.objectId).isEqualTo(dump.windowObjectId)
+      assertThat(conflict.isAbove).isFalse()
+      assertThat(conflict.solved.status).isEqualTo(LEAKING)
+      assertThat(conflict.solved.reason).contains("above this can be leaking")
+    }
+  }
+
+  @Test fun `two statuses that agree do not conflict`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.windowObjectId, LEAKING, "and so is the window it holds"),
+        overrides = overrides(dump.activityObjectId, LEAKING, "this screen was closed")
+      )
+
+      assertThat(conflicts).isEmpty()
+    }
+  }
+
+  /** Neither holds the other, so the two are answers about two things and nothing has to be settled. */
+  @Test fun `two statuses on objects neither of which holds the other do not conflict`() {
+    // Three activities under three holders of their own, so no chain runs through two of them.
+    HeapExplorer.open(testFolder.destroyedActivitiesHeapDump()).use { explorer ->
+      val (one, other) = explorer.tree.findLeaks().leakingObjectIds.toList()
+
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(one, NOT_LEAKING, "this screen is meant to be kept"),
+        overrides = overrides(other, LEAKING, "and that one is not")
+      )
+
+      assertThat(conflicts).isEmpty()
+    }
+  }
+
+  @Test fun `setting a status again on the same object disagrees with nothing`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.activityObjectId, NOT_LEAKING, "changed my mind"),
+        overrides = overrides(dump.activityObjectId, LEAKING, "this screen was closed")
+      )
+
+      assertThat(conflicts).isEmpty()
+    }
+  }
+
+  /** Nobody claiming to know overrules nobody, so it is never one of the statuses to settle against. */
+  @Test fun `a status of unknown set by hand conflicts with nothing below or above it`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.windowObjectId, LEAKING, "the window is the problem"),
+        overrides = overrides(dump.activityObjectId, UNKNOWN, "no idea about this activity")
+      )
+
+      assertThat(conflicts).isEmpty()
+    }
+  }
+
+  private fun override(
+    objectId: Long,
+    status: LeakStatus,
+    reason: String
+  ) = LeakStatusOverride(objectId = objectId, status = status, reason = reason)
+
+  private fun overrides(
+    objectId: Long,
+    status: LeakStatus,
+    reason: String
+  ) = LeakStatusOverrides.of(listOf(override(objectId, status, reason)))
+
+  companion object {
+    /** An address no dump these tests write has an object at, since they start at 1. */
+    private const val NOT_AN_ADDRESS = -0x1234L
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
@@ -99,6 +99,30 @@ class HeapLeakStatusTest {
     }
   }
 
+  /**
+   * The other half of what a status decides: which reference the leak is, which is read off the objects
+   * either side of it and so is a hand's to change. See [PathReference.isFaulty].
+   */
+  @Test fun `a chain marks a faulty reference once a hand says an object is expected`() {
+    val dump = testFolder.nestedLeaksHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      // Nothing on this chain is known to belong in memory — a holder nothing knows either way about, then
+      // two destroyed objects — so the fault is at one of two steps and the chain marks neither.
+      assertThat(explorer.tree.rootPathTo(dump.windowObjectId).faultyReferences()).isEmpty()
+
+      val path = explorer.tree.rootPathTo(
+        objectId = dump.windowObjectId,
+        overrides = overrides(dump.activityObjectId, NOT_LEAKING, "kept for one more frame on purpose")
+      )
+
+      // And saying the activity belongs there is what leaves one step between the two verdicts: the window
+      // it is still holding is the leak, and there is now nothing else it could be. Named after the class
+      // that declares the field, which is the framework's `Activity` rather than the app's subclass of it.
+      assertThat(path.faultyReferences()).containsExactly("Activity.mWindow")
+    }
+  }
+
   @Test fun `an object holds the ones it reaches and not the other way round`() {
     val dump = testFolder.nestedLeaksHeapDump()
 
@@ -294,6 +318,12 @@ class HeapLeakStatusTest {
     status: LeakStatus,
     reason: String
   ) = LeakStatusOverrides.of(listOf(override(objectId, status, reason)))
+
+  /** The references of a chain marked as the leak, spelled the way a leak of the leaks screen is named. */
+  private fun RootPath.faultyReferences(): List<String> =
+    steps.mapNotNull { it.step.reference }
+      .filter { it.isFaulty }
+      .map { "${it.ownerClassName}.${it.name}" }
 
   companion object {
     /** An address no dump these tests write has an object at, since they start at 1. */

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
@@ -94,6 +94,51 @@ class HeapLeaksTest {
     }
   }
 
+  @Test fun `the reference a leak is named after is the one its chain marks as the leak`() {
+    HeapExplorer.open(testFolder.applicationHoldsActivityHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val group = tree.findLeaks().sectionOf(APPLICATION).groups.single()
+
+      val steps = tree.rootPathTo(group.objects.single().objectId).steps.map { it.step }
+
+      // One reference of the chain and no other, and the same string the row on the leaks screen is named
+      // by: whoever goes from that row to this chain is looking for the step they were just reading.
+      assertThat(group.title).isEqualTo(APPLICATION_LEAK_REFERENCE)
+      assertThat(steps.faultyReferences()).containsExactly(APPLICATION_LEAK_REFERENCE)
+    }
+  }
+
+  @Test fun `a chain with nothing expected above what is stuck marks no reference`() {
+    HeapExplorer.open(testFolder.destroyedActivitiesHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val group = tree.findLeaks().sectionOf(APPLICATION).groups.single()
+
+      val steps = tree.rootPathTo(group.objects.first().objectId).steps.map { it.step }
+
+      // The leak is named after one reference and that reference is still not marked, because nothing above
+      // the activity is known to belong in memory: what holds it may be something that should have let go
+      // of it too, so the fault can be further up than this chain reaches. A mark on the top of it would be
+      // a reference named for being where the walk started.
+      assertThat(group.suspectPath).containsExactly("Holder.activity")
+      assertThat(steps.faultyReferences()).isEmpty()
+    }
+  }
+
+  @Test fun `a chain marks nothing where more than one reference could be the leak`() {
+    HeapExplorer.open(testFolder.applicationHoldsActivityThroughHolderHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val group = tree.findLeaks().sectionOf(APPLICATION).groups.single()
+
+      val steps = tree.rootPathTo(group.objects.single().objectId).steps.map { it.step }
+
+      // Two references between the object expected to be in memory and the stuck one, with an object
+      // nothing knows either way about between them: the fault is at one of those two steps and the heap
+      // dump doesn't say which, so the row names both and the chain marks neither.
+      assertThat(group.suspectPath).containsExactly(APPLICATION_HOLDER_REFERENCE, "Holder.activity")
+      assertThat(steps.faultyReferences()).isEmpty()
+    }
+  }
+
   @Test fun `objects in two slots of one array are instances of one leak`() {
     HeapExplorer.open(testFolder.leaksInOneArrayHeapDump()).use { explorer ->
       val group = explorer.tree.findLeaks().sectionOf(APPLICATION).groups.single()
@@ -333,9 +378,27 @@ class HeapLeaksTest {
       assertThat(tree.findByLabel("Object[]").objectId).matches { !tree.isBelowLeakingObject(it) }
     }
   }
+
+  /** Which is most chains of a heap dump, and the whole of why the mark is worth reading on the few. */
+  @Test fun `a chain with nothing stuck on it marks no reference as the leak`() {
+    testFolder.openTestHeapDump().use { explorer ->
+      val tree = explorer.tree
+
+      val steps = tree.rootPathTo(tree.findByLabel("Object[]").objectId).steps.map { it.step }
+
+      assertThat(steps).isNotEmpty
+      assertThat(steps.faultyReferences()).isEmpty()
+    }
+  }
 }
 
 private fun HeapLeaks.sectionOf(kind: LeakKind): LeakSection = sections.single { it.kind == kind }
 
 private fun HeapLeaks.objectsOf(kind: LeakKind): List<LeakingObject> =
   sectionOf(kind).groups.flatMap { it.objects }
+
+/** The references of a chain marked as the leak, spelled the way a leak of the leaks screen is named. */
+private fun List<PathStep>.faultyReferences(): List<String> =
+  mapNotNull { it.reference }
+    .filter { it.isFaulty }
+    .map { "${it.ownerClassName}.${it.name}" }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
@@ -67,6 +67,42 @@ internal fun TemporaryFolder.destroyedActivitiesHeapDump(): File {
 }
 
 /**
+ * A heap dump where the app's `Application` holds a destroyed activity: the object above the reference is one
+ * an inspector knows belongs in memory, the object below it one it knows shouldn't be.
+ *
+ * Which is the shape of a leak that takes no guessing — that one reference is the faulty one and no other
+ * reference of the chain can be — and so the one shape a chain marks. Every other dump here has objects
+ * nothing knows either way about between the GC root and the leak, which is the ordinary case. See
+ * [PathReference.isFaulty].
+ */
+internal fun TemporaryFolder.applicationHoldsActivityHeapDump(): File {
+  val file = newFile("application-holds-activity.hprof")
+  file.dump {
+    val activity = instance(activityClass(), fields = listOf(BooleanHolder(true)))
+    gcRoot(JniGlobal(id = applicationHolding(activity, "activity").value, jniGlobalRefId = 0))
+  }
+  return file
+}
+
+/**
+ * The same leak with one object nothing knows either way about in between, so that the two verdicts are two
+ * references apart instead of one.
+ *
+ * The fault is at one of those two steps — the app should have let go of the holder, or the holder of the
+ * activity — and nothing in the heap dump says which, which is what LeakCanary underlines the whole stretch
+ * for and what a chain here marks none of.
+ */
+internal fun TemporaryFolder.applicationHoldsActivityThroughHolderHeapDump(): File {
+  val file = newFile("application-holds-activity-through-holder.hprof")
+  file.dump {
+    val activity = instance(activityClass(), fields = listOf(BooleanHolder(true)))
+    val holder = HOLDER_CLASS_NAME instance { field["activity"] = activity }
+    gcRoot(JniGlobal(id = applicationHolding(holder, "holder").value, jniGlobalRefId = 0))
+  }
+  return file
+}
+
+/**
  * A heap dump where a destroyed activity holds a destroyed window: two objects that shouldn't be in memory,
  * and one of them only still there because the other is.
  *
@@ -403,6 +439,25 @@ private fun HprofWriterHelper.activityClass(): Long = clazz(
 )
 
 /**
+ * The app's own `Application`, holding [held] through a field named [fieldName], which is what the leaks of
+ * those dumps are named after.
+ *
+ * `android.app.Application` and nothing else is what the inspector recognizing it looks for, so the class it
+ * declares here has none of the fields a real one inherits.
+ */
+private fun HprofWriterHelper.applicationHolding(
+  held: ReferenceHolder,
+  fieldName: String
+): ReferenceHolder = instance(
+  clazz(
+    className = APPLICATION_CLASS_NAME,
+    superclassId = clazz(className = "android.app.Application"),
+    fields = listOf(fieldName to ReferenceHolder::class)
+  ),
+  fields = listOf(held)
+)
+
+/**
  * What `android.os.Build` looks like in a dump, which is what Shark matches its library leak patterns
  * against: a dump without the three fields `AndroidBuildMirror` reads is one no known library leak can be
  * recognized in. See `ReferenceStrengthReader`.
@@ -425,6 +480,14 @@ internal const val WATCHED_CLASS_NAME = "com.example.LeakingPresenter"
 internal const val ACTIVITY_CLASS_NAME = "com.example.MainActivity"
 
 internal const val HOLDER_CLASS_NAME = "com.example.Holder"
+
+internal const val APPLICATION_CLASS_NAME = "com.example.ExampleApplication"
+
+/** How a chain spells the one reference of [applicationHoldsActivityHeapDump], which is its whole leak. */
+internal const val APPLICATION_LEAK_REFERENCE = "ExampleApplication.activity"
+
+/** And the first of the two of [applicationHoldsActivityThroughHolderHeapDump], neither of which is marked. */
+internal const val APPLICATION_HOLDER_REFERENCE = "ExampleApplication.holder"
 
 /** How a chain names the class a field is read on, which is how a leak named after that field is spelled. */
 internal const val HOLDER_SIMPLE_CLASS_NAME = "Holder"

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusFileTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusFileTest.kt
@@ -1,0 +1,135 @@
+package shark.explorer
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class LeakStatusFileTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Test fun `a heap dump nobody has set a status on has none`() {
+    assertThat(statusFile("heap.hprof").read().isEmpty).isTrue()
+  }
+
+  @Test fun `what was set is read back`() {
+    val file = statusFile("heap.hprof")
+
+    file.write(LeakStatusOverrides.of(listOf(override(HOLDER_ID, LeakStatus.LEAKING, "the screen is gone"))))
+
+    val read = file.read()[HOLDER_ID]!!
+    assertThat(read.status).isEqualTo(LeakStatus.LEAKING)
+    assertThat(read.reason).isEqualTo("the screen is gone")
+  }
+
+  @Test fun `the same heap dump is the same statuses in another run`() {
+    statusFile("heap.hprof").write(LeakStatusOverrides.of(listOf(override(HOLDER_ID))))
+
+    assertThat(statusFile("heap.hprof").read()[HOLDER_ID]).isNotNull()
+  }
+
+  /** Two runs of one app produce two dumps of one name, and they are two investigations. */
+  @Test fun `two heap dumps of one name in two directories are two sets of statuses`() {
+    statusFile("dumps/monday/heap.hprof").write(LeakStatusOverrides.of(listOf(override(HOLDER_ID, reason = "Monday"))))
+
+    assertThat(statusFile("dumps/tuesday/heap.hprof").read().isEmpty).isTrue()
+  }
+
+  /**
+   * An object address is unsigned, and half the addresses of a 64 bit heap dump don't fit in a signed long
+   * the right way round. One written as a negative number and read back as another object would be a status
+   * quietly moved onto something else.
+   */
+  @Test fun `an object above the middle of the address space is the object it was set on`() {
+    val file = statusFile("heap.hprof")
+
+    file.write(LeakStatusOverrides.of(listOf(override(HIGH_ID))))
+
+    assertThat(file.read().all.single().objectId).isEqualTo(HIGH_ID)
+  }
+
+  @Test fun `a reason with tabs and newlines in it comes back as it was typed`() {
+    val typed = "Two things:\n\t- a back slash \\n, which is not a newline\r\n\t- and a tab\there"
+    val file = statusFile("heap.hprof")
+
+    file.write(LeakStatusOverrides.of(listOf(override(HOLDER_ID, reason = typed))))
+
+    assertThat(file.read()[HOLDER_ID]!!.reason).isEqualTo(typed)
+    // Because a line that wrapped would be a line the next one is read from.
+    assertThat(file.file.readLines().last { it.isNotBlank() }).contains("\\n", "\\t", "\\\\n")
+  }
+
+  @Test fun `the last status taken off is the file deleted`() {
+    val file = statusFile("heap.hprof")
+    file.write(LeakStatusOverrides.of(listOf(override(HOLDER_ID))))
+
+    file.write(LeakStatusOverrides.NONE)
+
+    assertThat(file.file.exists()).isFalse()
+    assertThat(file.read().isEmpty).isTrue()
+  }
+
+  /** So that the file two runs write for the same statuses is the same file, in a diff and in an issue. */
+  @Test fun `the statuses are written in one order however they were set`() {
+    val one = statusFile("dumps/one/heap.hprof")
+    val other = statusFile("dumps/other/heap.hprof")
+
+    one.write(LeakStatusOverrides.of(listOf(override(HOLDER_ID), override(PAYLOAD_ID))))
+    other.write(LeakStatusOverrides.of(listOf(override(PAYLOAD_ID), override(HOLDER_ID))))
+
+    assertThat(one.file.readText()).isEqualTo(other.file.readText())
+  }
+
+  /** This file is hand editable on purpose, so one typo in it must not be a heap dump whose statuses went. */
+  @Test fun `a line that cannot be read is skipped and the rest are kept`() {
+    val file = statusFile("heap.hprof")
+    file.write(LeakStatusOverrides.of(listOf(override(HOLDER_ID), override(PAYLOAD_ID))))
+    file.file.writeText(
+      file.file.readText() +
+        "not an address\tLEAKING\ttyped over the address\n" +
+        "0x1\tSORT_OF_LEAKING\tno such status\n" +
+        "0x2\tLEAKING\n" +
+        "0x3\tLEAKING\t   \n" +
+        "\n" +
+        "# A comment somebody left\n"
+    )
+
+    assertThat(file.read().all.map { it.objectId }).containsExactlyInAnyOrder(HOLDER_ID, PAYLOAD_ID)
+  }
+
+  @Test fun `a status with no reason is not a status`() {
+    assertThatIllegalArgumentException().isThrownBy {
+      LeakStatusOverride(objectId = HOLDER_ID, status = LeakStatus.LEAKING, reason = "  ")
+    }.withMessageContaining("no reason")
+  }
+
+  /** So that they can be read, edited and pasted from without going through this app. */
+  @Test fun `the statuses are one file named after the heap dump`() {
+    assertThat(statusFile("large-dump.hprof").file.name)
+      .startsWith("large-dump.hprof")
+      .endsWith(".leak-statuses.tsv")
+  }
+
+  private fun statusFile(heapDumpPath: String) =
+    LeakStatusFile(statusesRoot, File(testFolder.root, heapDumpPath))
+
+  private fun override(
+    objectId: Long,
+    status: LeakStatus = LeakStatus.LEAKING,
+    reason: String = "because I read the code"
+  ) = LeakStatusOverride(objectId = objectId, status = status, reason = reason)
+
+  private val statusesRoot by lazy { testFolder.newFolder("leak-statuses") }
+
+  companion object {
+    private const val HOLDER_ID = 0x82182c00L
+    private const val PAYLOAD_ID = 0x1234L
+
+    /** Which is what a `long` holds an address of `0xffff…` as. */
+    private const val HIGH_ID = -0x1234L
+  }
+}

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
@@ -23,7 +23,7 @@ class LeakStatusTest {
     assertThat(statuses.map { it.status })
       .containsExactly(NOT_LEAKING, NOT_LEAKING, NOT_LEAKING, UNKNOWN)
     // Named after the object that decided it, and which way along the path it is.
-    assertThat(statuses[0].reason).isEqualTo("Activity↓ is not leaking")
+    assertThat(statuses[0].reason).isEqualTo("Activity↓ is meant to be here")
     assertThat(statuses[2].reason).isEqualTo("Activity#mDestroyed is false")
   }
 
@@ -33,7 +33,7 @@ class LeakStatusTest {
     )
 
     assertThat(statuses.map { it.status }).containsExactly(UNKNOWN, LEAKING, LEAKING, LEAKING)
-    assertThat(statuses[2].reason).isEqualTo("Activity↑ is leaking")
+    assertThat(statuses[2].reason).isEqualTo("Activity↑ shouldn't be here")
   }
 
   @Test fun `what is left between the two is where the leak is`() {
@@ -77,7 +77,7 @@ class LeakStatusTest {
 
     assertThat(statuses.map { it.status }).containsExactly(NOT_LEAKING, NOT_LEAKING, UNKNOWN)
     assertThat(statuses.first().reason)
-      .isEqualTo("Activity↓ is not leaking. Conflicts with Cache#entry is stale")
+      .isEqualTo("Activity↓ is meant to be here. Conflicts with Cache#entry is stale")
   }
 
   @Test fun `a path with no objects has no statuses`() {
@@ -123,7 +123,7 @@ class LeakStatusTest {
     )
 
     assertThat(statuses.map { it.status }).containsExactly(UNKNOWN, LEAKING, LEAKING)
-    assertThat(statuses.last().reason).isEqualTo("Presenter↑ is leaking")
+    assertThat(statuses.last().reason).isEqualTo("Presenter↑ shouldn't be here")
   }
 
   @Test fun `the path overruling a status set by hand says what it overruled`() {
@@ -135,7 +135,7 @@ class LeakStatusTest {
 
     assertThat(statuses.last().status).isEqualTo(LEAKING)
     assertThat(statuses.last().reason)
-      .isEqualTo("Activity↑ is leaking. Conflicts with set by hand — no idea what this is")
+      .isEqualTo("Activity↑ shouldn't be here. Conflicts with set by hand — no idea what this is")
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
@@ -23,7 +23,7 @@ class LeakStatusTest {
     assertThat(statuses.map { it.status })
       .containsExactly(NOT_LEAKING, NOT_LEAKING, NOT_LEAKING, UNKNOWN)
     // Named after the object that decided it, and which way along the path it is.
-    assertThat(statuses[0].reason).isEqualTo("Activity↓ is needed")
+    assertThat(statuses[0].reason).isEqualTo("Activity↓ is expected")
     assertThat(statuses[2].reason).isEqualTo("Activity#mDestroyed is false")
   }
 
@@ -33,7 +33,7 @@ class LeakStatusTest {
     )
 
     assertThat(statuses.map { it.status }).containsExactly(UNKNOWN, LEAKING, LEAKING, LEAKING)
-    assertThat(statuses[2].reason).isEqualTo("Activity↑ leaked")
+    assertThat(statuses[2].reason).isEqualTo("Activity↑ is stuck")
   }
 
   @Test fun `what is left between the two is where the leak is`() {
@@ -77,7 +77,7 @@ class LeakStatusTest {
 
     assertThat(statuses.map { it.status }).containsExactly(NOT_LEAKING, NOT_LEAKING, UNKNOWN)
     assertThat(statuses.first().reason)
-      .isEqualTo("Activity↓ is needed. Conflicts with Cache#entry is stale")
+      .isEqualTo("Activity↓ is expected. Conflicts with Cache#entry is stale")
   }
 
   @Test fun `a path with no objects has no statuses`() {
@@ -123,7 +123,7 @@ class LeakStatusTest {
     )
 
     assertThat(statuses.map { it.status }).containsExactly(UNKNOWN, LEAKING, LEAKING)
-    assertThat(statuses.last().reason).isEqualTo("Presenter↑ leaked")
+    assertThat(statuses.last().reason).isEqualTo("Presenter↑ is stuck")
   }
 
   @Test fun `the path overruling a status set by hand says what it overruled`() {
@@ -135,7 +135,7 @@ class LeakStatusTest {
 
     assertThat(statuses.last().status).isEqualTo(LEAKING)
     assertThat(statuses.last().reason)
-      .isEqualTo("Activity↑ leaked. Conflicts with set by hand — no idea what this is")
+      .isEqualTo("Activity↑ is stuck. Conflicts with set by hand — no idea what this is")
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
@@ -83,6 +83,60 @@ class LeakStatusTest {
   @Test fun `a path with no objects has no statuses`() {
     assertThat(leakStatusesOf(emptyList())).isEmpty()
   }
+
+  @Test fun `a status set by hand wins over the inspector that disagreed with it`() {
+    val statuses = leakStatusesOf(
+      listOf(unknown("Holder"), setByHand(leaking("Activity"), NOT_LEAKING, "kept for one more frame"))
+    )
+
+    assertThat(statuses.last().status).isEqualTo(NOT_LEAKING)
+    assertThat(statuses.last().reason)
+      .isEqualTo("set by hand — kept for one more frame. Conflicts with Activity#mDestroyed is true")
+  }
+
+  @Test fun `a status set by hand on an object nothing knew about has only its own reason`() {
+    val statuses = leakStatusesOf(listOf(setByHand(unknown("Cache"), LEAKING, "this cache is unbounded")))
+
+    assertThat(statuses.single().status).isEqualTo(LEAKING)
+    assertThat(statuses.single().reason).isEqualTo("set by hand — this cache is unbounded")
+  }
+
+  @Test fun `an object set to unknown by hand overrules both sides of what was known about it`() {
+    val statuses = leakStatusesOf(
+      listOf(unknown("Holder"), setByHand(conflicted("Activity"), UNKNOWN, "the inspectors are both wrong"))
+    )
+
+    assertThat(statuses.last().status).isEqualTo(UNKNOWN)
+    assertThat(statuses.last().reason).isEqualTo(
+      "set by hand — the inspectors are both wrong. Conflicts with Activity#mDestroyed is false and " +
+        "Activity#mDestroyed is true"
+    )
+  }
+
+  @Test fun `what a hand set decides the objects above and below it, like any other status`() {
+    val statuses = leakStatusesOf(
+      listOf(
+        unknown("Thread"),
+        setByHand(unknown("Presenter"), LEAKING, "this screen was closed"),
+        unknown("View")
+      )
+    )
+
+    assertThat(statuses.map { it.status }).containsExactly(UNKNOWN, LEAKING, LEAKING)
+    assertThat(statuses.last().reason).isEqualTo("Presenter↑ is leaking")
+  }
+
+  @Test fun `the path overruling a status set by hand says what it overruled`() {
+    // Someone said nothing is known about this object, and the path then reads it off the leaking object
+    // above: the status is the path's, and what they typed is what the reason records.
+    val statuses = leakStatusesOf(
+      listOf(leaking("Activity"), setByHand(unknown("View"), UNKNOWN, "no idea what this is"))
+    )
+
+    assertThat(statuses.last().status).isEqualTo(LEAKING)
+    assertThat(statuses.last().reason)
+      .isEqualTo("Activity↑ is leaking. Conflicts with set by hand — no idea what this is")
+  }
 }
 
 private fun unknown(simpleClassName: String) = inspected(simpleClassName)
@@ -107,3 +161,15 @@ private fun inspected(
   leakingReasons: Set<String> = emptySet(),
   notLeakingReasons: Set<String> = emptySet()
 ) = InspectedPathObject(simpleClassName, leakingReasons, notLeakingReasons)
+
+/** The same object with someone's own answer on it. The object id is only what the reason is filed under. */
+private fun setByHand(
+  inspected: InspectedPathObject,
+  status: LeakStatus,
+  reason: String
+) = InspectedPathObject(
+  simpleClassName = inspected.simpleClassName,
+  leakingReasons = inspected.leakingReasons,
+  notLeakingReasons = inspected.notLeakingReasons,
+  setByHand = LeakStatusOverride(objectId = 0x42, status = status, reason = reason)
+)

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakStatusTest.kt
@@ -23,7 +23,7 @@ class LeakStatusTest {
     assertThat(statuses.map { it.status })
       .containsExactly(NOT_LEAKING, NOT_LEAKING, NOT_LEAKING, UNKNOWN)
     // Named after the object that decided it, and which way along the path it is.
-    assertThat(statuses[0].reason).isEqualTo("Activity↓ is meant to be here")
+    assertThat(statuses[0].reason).isEqualTo("Activity↓ is needed")
     assertThat(statuses[2].reason).isEqualTo("Activity#mDestroyed is false")
   }
 
@@ -33,7 +33,7 @@ class LeakStatusTest {
     )
 
     assertThat(statuses.map { it.status }).containsExactly(UNKNOWN, LEAKING, LEAKING, LEAKING)
-    assertThat(statuses[2].reason).isEqualTo("Activity↑ shouldn't be here")
+    assertThat(statuses[2].reason).isEqualTo("Activity↑ leaked")
   }
 
   @Test fun `what is left between the two is where the leak is`() {
@@ -77,7 +77,7 @@ class LeakStatusTest {
 
     assertThat(statuses.map { it.status }).containsExactly(NOT_LEAKING, NOT_LEAKING, UNKNOWN)
     assertThat(statuses.first().reason)
-      .isEqualTo("Activity↓ is meant to be here. Conflicts with Cache#entry is stale")
+      .isEqualTo("Activity↓ is needed. Conflicts with Cache#entry is stale")
   }
 
   @Test fun `a path with no objects has no statuses`() {
@@ -123,7 +123,7 @@ class LeakStatusTest {
     )
 
     assertThat(statuses.map { it.status }).containsExactly(UNKNOWN, LEAKING, LEAKING)
-    assertThat(statuses.last().reason).isEqualTo("Presenter↑ shouldn't be here")
+    assertThat(statuses.last().reason).isEqualTo("Presenter↑ leaked")
   }
 
   @Test fun `the path overruling a status set by hand says what it overruled`() {
@@ -135,7 +135,7 @@ class LeakStatusTest {
 
     assertThat(statuses.last().status).isEqualTo(LEAKING)
     assertThat(statuses.last().reason)
-      .isEqualTo("Activity↑ shouldn't be here. Conflicts with set by hand — no idea what this is")
+      .isEqualTo("Activity↑ leaked. Conflicts with set by hand — no idea what this is")
   }
 }
 


### PR DESCRIPTION
Shark Explorer already worked out a `LeakStatus` for every object of every chain it drew. Two things were missing: the status of the object the tab is *on*, and any way to disagree with it.

## The verdict on an object is the first thing "What it is" says

At the top of the details panel, under the object's name, above its size — a conclusion at the head of the column that holds the evidence for it — in the colours the chain beside it uses, with the reason under it, because half of these are about another object: an activity is red because its own `mDestroyed` is true, and the view under it is red because the activity is.

Loud for the two statuses that mean something, quiet for the third. Most of a heap dump is objects nothing knows either way about, so a shaded, bold answer on every one of them would be a line nobody reads by the time it says something. A glyph as well as a colour (`✓ ? ✗`), so it doesn't rest on the colour alone. Nothing at all on the tab a window opens with: the whole heap dump is no object of it.

**The words are new, and no word built on "leak" is on an object.** `Leaking` / `Not leaking` / `Unknown` became **Stuck** / **Expected** / **Unknown**, under a header saying `Verdict` — one word each, like the `Retained` and `Shallow` labels beside them, because a verdict is read a dozen times down one chain and once per row of the leaks screen.

A leak is one faulty reference that should have been cleared, and everything under it is retained by that single mistake — so `Leaking` or `Leaked` on twenty objects points a reader at the twenty rather than at the one thing to fix. `Stuck` says the object's situation without accusing it, and it is the only candidate that asks a question instead of closing one: something is holding this, what? `Expected` says its presence in memory is legitimate at this point in the app's life. The two aren't antonyms on purpose — an object in use can't be collected either, so the good side has to answer a different question than "can it leave".

**No other analyser has a verdict like this to borrow words from**, which is worth knowing before bikeshedding it. JProfiler classifies objects by reference type ("strongly referenced", "retained by soft references") and by age (`Mark Heap`, then "new" and "old"); YourKit by reachability scope (strong, softly, weakly reachable, unreachable, pending finalization); Eclipse MAT names places rather than objects (*leak suspect*, *accumulation point*, *keep-alive path*); dotMemory has *key retention paths*. None of them labels an object as leaking, because none has watched objects or framework inspectors to do it with. What they share is the frame, and JProfiler says it outright: whether objects "are still legitimately on the heap or if a **faulty reference** keeps them alive". That is now what this repo calls the culprit — the reference between the last `Expected` object and the first `Stuck` one, which is what `LeakGroup.suspectPath` starts at and what every row of the Leaks screen is named after.

**The verdict means the same thing everywhere**, including on a watched object nothing reaches any more: it was expected to be gone, and only the collector not having run keeps it here, so it reads `Stuck` like the rest. Where it sits on that scale is what the Leaks screen's `Unreachable` section is for; a fourth value would have made the verdict mean something different in one corner of the window.

One `LeakStatus.statusText` is where the words live, so the chain, the panel, the dialog, the checkbox that shades them over the map and the reasons propagated along a chain (`Activity↓ is expected`, `Activity↑ is stuck`) all say the same thing. The identifiers don't move: `LeakStatus`, `LEAKING`, `leakStatusesOf` stay Shark's names, because the code is where agreeing with `shark.LeakTraceObject.LeakingStatus` matters.

## The chain marks the faulty reference

A verdict is about an object, and propagation paints every object under a leak as stuck — twenty rows of red for one mistake, which is the shape of the misdirection the words above were changed to avoid. So the chain marks the reference itself: `Holder.activity · faulty reference`, bold, in the red of the objects it left behind, on the one step that goes from an `Expected` object straight to a `Stuck` one. It is the one line of a chain that says where to go and change code, and where a leak is a single reference it is the same one the Leaks screen names that leak after, so a row there and the chain opened from it name one thing.

It is decided once, over the whole path — `faultyReferenceIndexOrNull`, called from `withLeakStatuses` — and carried on `PathReference.isFaulty` for the drawing to read. Deciding it in the window from the steps on screen looks equivalent and isn't: a pane draws stretches of a chain (`stepsBelow`, `stepsAfter`, a swapped-in way round), so the object that ends the stretch can sit above what it shows.

**Nothing is marked unless one step crosses between the two verdicts.** LeakCanary underlines the whole stretch between them, and `suspectSubpath` still names a leak after all of it — but a *mark* is a claim about one reference, and there are two shapes where the path doesn't support one. With objects nothing knows either way about in between, the fault is at one of those steps and the heap dump doesn't say which. With nothing `Expected` above the stuck object at all, what holds it may be something that should have let go too, so the fault can be further up than the path reaches — the first version of this marked the top of the stretch and put `· faulty reference` on the top reference of a chain of `Cleaner`s with no verdict on any object of it, which is a reference named for being where the walk started. A guess drawn in the same bold red as an answer costs more than no mark, because being the one line to act on is the whole of what the mark is for. Overruling a verdict is what closes either gap: say what you know about an object in between, and the mark appears on the step that leaves.

## A pencil overrules it

Left of the answer, where the eye already is, rather than a "Set by hand…" button after it. It takes one of the three statuses and a reason, and the reason is not optional: a status set by hand overrules the heap dump, so without the why it is an assertion the next reader — a colleague, an agent, the same person in a month — has no way to check. What the inspectors said is kept as the record of what was overruled, exactly the way a conflict between two inspectors is recorded, and `set by hand — …` marks it wherever it is read.

**Overriding always wins**, which is the one place this differs from two inspectors disagreeing. There the object still being needed wins, because two inspectors are two halves of one automated reading. A hand is not that, and a rule that weighed the two would mean a status that can't be set to the one an inspector already picked.

## And what it contradicts is shown, not settled quietly

A status decides what the objects it holds or is held by are, so two hand-set statuses disagree exactly when one of the objects reaches the other. When the one being set does that, every status it disagrees with is listed by name, with the reason it was given and what it would become. **Keep this and flip those** keeps the new one and flips them, with what they said kept as part of the new reason; **Undo** leaves the heap dump exactly as it was. Nothing is written until one of the two is picked, and then it is one write of the lot.

Flipping always resolves it, which is why solving is one button: `NOT_LEAKING` propagates upwards only and `LEAKING` downwards only, so the pair that can disagree is always those two.

## The leaks are read through them too

Setting a verdict changes **which objects are leaks**, not only how one of them reads. Mark an object as stuck halfway up a chain and it becomes a leak, while whatever it was holding drops off the list — that object is now only in memory because of this one, which is the rule `foldedIntoWhatHoldsThem` already applied to what the inspectors found. Mark a leak as expected and it leaves the list, and what it held can become a leak of its own.

So the candidate set is the dump's own minus everything set to anything but `LEAKING` plus everything set to it; `RootPathSearch` goes round what a hand marked exactly as it goes round what the inspectors did, or a leak would be grouped by a chain that disagrees with the statuses drawn on it; and the list is worked out again per set of statuses and kept until the next one, since a status is set by hand and this is seconds.

The price is that a `LeakGroup.leakFingerprint` matches the one LeakCanary prints for the same objects only while nothing is set by hand — the fingerprint hashes the stretch between the last expected object and the first stuck one, and moving that stretch is what setting a verdict is for.

## Notes on the shape of it

- **A status set by hand is an argument to every read, never state on the tree.** `summarize`, `rootPathTo`, `independentPathsBetween`, `independentPathsFromRoots`, `findLeaks` and `isBelowLeakingObject` all take a `LeakStatusOverrides`, and the window's effects are keyed on it. A value rather than state, because the tree is read from one thread while the window is composed on another: overrides in the tree would mean a chain drawn from one set of them and the panel beside it from another.
- **One tab separated file per heap dump** in `~/.shark-explorer/leak-statuses`, columns named at the top, reasons escaped, lines sorted by address — so it reads as evidence and can be diffed or pasted into an issue. A line that can't be read is skipped with a log line rather than thrown over, since it is hand editable on purpose.
- Nothing is applied that wasn't written, and nothing is written before the file has been read: an empty set of statuses saved because the disk was slow is every status of that dump deleted.

## Testing

`LeakStatusTest` for the propagation with statuses set by hand in it, `HeapLeakStatusTest` for the panel, the chain, `reaches`, the conflicts and the leaks list changing under a status — including a chain that stops going round an object once a hand says it is expected — `LeakStatusFileTest` for the round trip through disk, and `LeakStatusSectionTest` for the panel, the pencil, the reason being required, taking one back off, the conflict flow both ways, and the leaks screen following a status set before the window opened.

For the mark: `HeapLeaksTest` for it being the very reference the Leaks screen names the leak after, and for the three ways a chain carries none — nothing stuck on it, nothing `Expected` above what is stuck, and two references between the two verdicts; `HeapLeakStatusTest` for it appearing one step further down once a hand says the activity is expected; and `LeakStatusSectionTest` for the window drawing it and for it going away — the step still drawn — once the verdict under it is overruled. Two heap dumps in `LeakHeapDumps.kt` are new, an `Application` holding a destroyed activity directly and through a holder, since every dump there until now had objects nothing knows either way about above the leak.

`./gradlew :shark:shark-explorer:shark-explorer-core:check :shark:shark-explorer:shark-explorer-app:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




