### PR TITLE
Give each way out of memory its own section on the leaks screen

### DIFF
--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/LeaksScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -36,13 +37,15 @@ import shark.explorer.LeakGroup
 import shark.explorer.LeakKind
 import shark.explorer.LeakSection
 import shark.explorer.LeakingObject
+import shark.explorer.Place
 import shark.explorer.WatchedObject
 import shark.explorer.formatByteSize
 import shark.explorer.hexObjectId
 
 /**
- * Every leaking object of the heap dump, in three parts: the app's own leaks, the ones in code it doesn't
- * control, and the objects that were meant to be gone and are.
+ * Every leaking object of the heap dump, in two halves: the leaks to do something about, which is the app's
+ * own and the ones in code it doesn't control, and under one folded heading the objects that shouldn't be in
+ * memory and are already leaving it.
  *
  * One row per leak rather than per object, because a leak with fifty instances is one thing to fix; the row
  * unfolds into them when there is more than one. Every row leads into the object explorer — a leak is a
@@ -77,50 +80,80 @@ internal fun LeaksScreen(
       }
       HorizontalDivider()
       LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
-        leaks.sections.forEachIndexed { sectionIndex, section ->
-          // Pinned while its own leaks scroll under it, which is what says they are its: a heading that
-          // scrolls away leaves a list of rows with nothing above them saying which of the three they are.
-          stickyHeader(key = section.kind.name) {
-            SectionHeader(section, isFirst = sectionIndex == 0)
+        leaks.leakSections.forEachIndexed { sectionIndex, section ->
+          leakSection(section, sectionIndex == 0, expandedGroups, onToggleGroup, onOpen, onCopyLink)
+        }
+        val onTheWayOut = leaks.onTheWayOutSections
+        val isOnTheWayOutExpanded = Place.Leaks.ON_THE_WAY_OUT in expandedGroups
+        // Not pinned, unlike the headings under it: what a heading is pinned for is the rows scrolling under
+        // it, and there are none of its own — it is a heading over headings, and each of those pins itself
+        // as it comes up.
+        item(key = Place.Leaks.ON_THE_WAY_OUT) {
+          OnTheWayOutHeader(
+            sections = onTheWayOut,
+            isExpanded = isOnTheWayOutExpanded,
+            onToggle = { onToggleGroup(Place.Leaks.ON_THE_WAY_OUT) }
+          )
+        }
+        if (isOnTheWayOutExpanded) {
+          onTheWayOut.forEachIndexed { sectionIndex, section ->
+            leakSection(section, sectionIndex == 0, expandedGroups, onToggleGroup, onOpen, onCopyLink)
           }
-          section.groups.forEach { group ->
-            val groupKey = section.kind.groupKey(group)
-            val isExpanded = groupKey in expandedGroups
-            val hasMore = group.objects.size > 1
-            item(key = groupKey) { GroupRow(group) }
-            // The first object always: a leak is a reference, and a reference with nothing under it says
-            // what shouldn't be holding without ever saying what it is holding.
-            item(key = "$groupKey ${group.objects.first().objectId}") {
-              LeakingObjectRow(
-                leakingObject = group.objects.first(),
-                isLast = !hasMore,
-                onOpen = onOpen,
-                onCopyLink = onCopyLink
-              )
-            }
-            if (hasMore) {
-              // The rest are one item each behind this, so that a leak with five hundred instances costs
-              // the list two rows until someone asks to see them.
-              item(key = "$groupKey $MORE_KEY") {
-                MoreObjectsRow(
-                  count = group.objects.size - 1,
-                  isExpanded = isExpanded,
-                  onToggle = { onToggleGroup(groupKey) }
-                )
-              }
-              if (isExpanded) {
-                group.objects.drop(1).forEachIndexed { index, leakingObject ->
-                  item(key = "$groupKey ${leakingObject.objectId}") {
-                    LeakingObjectRow(
-                      leakingObject = leakingObject,
-                      isLast = index == group.objects.size - 2,
-                      onOpen = onOpen,
-                      onCopyLink = onCopyLink
-                    )
-                  }
-                }
-              }
-            }
+        }
+      }
+    }
+  }
+}
+
+/** One part of the list: its heading, and a leak of it per row with the objects of that leak inside it. */
+private fun LazyListScope.leakSection(
+  section: LeakSection,
+  /** Whether it opens whatever it is under, where there is nothing above it to be told apart from. */
+  isFirst: Boolean,
+  expandedGroups: Set<String>,
+  onToggleGroup: (String) -> Unit,
+  onOpen: (Long, OpenIn) -> Unit,
+  onCopyLink: (Long) -> Unit
+) {
+  // Pinned while its own leaks scroll under it, which is what says they are its: a heading that scrolls away
+  // leaves a list of rows with nothing above them saying which part they are.
+  stickyHeader(key = section.kind.name) {
+    SectionHeader(section, isFirst = isFirst)
+  }
+  section.groups.forEach { group ->
+    val groupKey = section.kind.groupKey(group)
+    val isExpanded = groupKey in expandedGroups
+    val hasMore = group.objects.size > 1
+    item(key = groupKey) { GroupRow(group) }
+    // The first object always: a leak is a reference, and a reference with nothing under it says
+    // what shouldn't be holding without ever saying what it is holding.
+    item(key = "$groupKey ${group.objects.first().objectId}") {
+      LeakingObjectRow(
+        leakingObject = group.objects.first(),
+        isLast = !hasMore,
+        onOpen = onOpen,
+        onCopyLink = onCopyLink
+      )
+    }
+    if (hasMore) {
+      // The rest are one item each behind this, so that a leak with five hundred instances costs
+      // the list two rows until someone asks to see them.
+      item(key = "$groupKey $MORE_KEY") {
+        MoreObjectsRow(
+          count = group.objects.size - 1,
+          isExpanded = isExpanded,
+          onToggle = { onToggleGroup(groupKey) }
+        )
+      }
+      if (isExpanded) {
+        group.objects.drop(1).forEachIndexed { index, leakingObject ->
+          item(key = "$groupKey ${leakingObject.objectId}") {
+            LeakingObjectRow(
+              leakingObject = leakingObject,
+              isLast = index == group.objects.size - 2,
+              onOpen = onOpen,
+              onCopyLink = onCopyLink
+            )
           }
         }
       }
@@ -129,7 +162,7 @@ internal fun LeaksScreen(
 }
 
 /**
- * What one of the three parts is, and how much of the heap dump is in it.
+ * What one part of the list is, and how much of the heap dump is in it.
  *
  * The gap and the rule are above it and nothing is below it, which is the whole of what says the leaks
  * under it are its: a heading the same distance from the section above and the one below belongs to
@@ -138,7 +171,7 @@ internal fun LeaksScreen(
 @Composable
 private fun SectionHeader(
   section: LeakSection,
-  /** Whether it opens the list, where there is nothing above to be told apart from. */
+  /** Whether it opens what it is under, where there is nothing above to be told apart from. */
   isFirst: Boolean
 ) {
   Column(
@@ -161,6 +194,61 @@ private fun SectionHeader(
         style = MaterialTheme.typography.bodySmall,
         color = MUTED_TEXT
       )
+    }
+  }
+}
+
+/**
+ * The heading over the half of the list nobody has to act on, and the one thing on this screen that hides
+ * rows rather than showing them.
+ *
+ * Folded to start with, and quieter than a section heading — no band, no bar down its rows, muted text —
+ * because the answer these sections give is that there is nothing to do: a screen that draws them like the
+ * app's own leaks says a heap dump with nothing wrong in it has five more kinds of problem. What it does say
+ * while folded is how many objects of each kind are in there, so that folding hides the rows and never the
+ * answer, and pressing it is what asks why they are still in memory.
+ */
+@Composable
+private fun OnTheWayOutHeader(
+  sections: List<LeakSection>,
+  isExpanded: Boolean,
+  onToggle: () -> Unit
+) {
+  Column(Modifier.fillMaxWidth().padding(top = SECTION_GAP)) {
+    HorizontalDivider(thickness = SECTION_RULE_WIDTH, color = SECTION_RULE_COLOR)
+    Column(
+      Modifier.fillMaxWidth()
+        .clickableRow(onToggle)
+        .padding(start = 8.dp, end = 12.dp, top = 6.dp, bottom = 6.dp),
+      verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        Text(
+          if (isExpanded) EXPANDED_ARROW else FOLDED_ARROW,
+          Modifier.width(TOGGLE_WIDTH),
+          style = MaterialTheme.typography.titleSmall,
+          color = MUTED_TEXT,
+          textAlign = TextAlign.Center
+        )
+        Text(
+          "${LeakKind.ON_THE_WAY_OUT_TITLE} · ${sections.summaryByKind()}",
+          style = MaterialTheme.typography.titleSmall,
+          color = MUTED_TEXT
+        )
+      }
+      // Only once it is open, since a paragraph is attention and what these sections are is not worth any
+      // until someone has asked for them.
+      if (isExpanded) {
+        Text(
+          LeakKind.ON_THE_WAY_OUT_EXPLANATION,
+          Modifier.padding(start = TOGGLE_WIDTH + 4.dp),
+          style = MaterialTheme.typography.bodySmall,
+          color = MUTED_TEXT
+        )
+      }
     }
   }
 }
@@ -422,9 +510,33 @@ private fun LeakSection.summary(): String = when {
     "$objectCount ${if (objectCount == 1) OBJECT else OBJECTS}"
 }
 
-private fun HeapLeaks.countText(): String = when (objectCount) {
-  0 -> NOTHING_LEAKING
-  else -> "$objectCount leaking ${if (objectCount == 1) OBJECT else OBJECTS}"
+/**
+ * What is in the folded half, per section: `3 phantom reachable, 2 unreachable`.
+ *
+ * Which sections rather than a count of the lot, because the sections are the answer — an object waiting to
+ * be finalized and one nothing reaches at all are both leaving, and only one of them has run any code yet.
+ */
+private fun List<LeakSection>.summaryByKind(): String =
+  filter { it.objectCount > 0 }
+    .joinToString { "${it.objectCount} ${it.kind.title.lowercase()}" }
+    .ifEmpty { NONE_FOUND }
+
+/**
+ * How many leaks there are to do something about, and then how many objects are on their way out.
+ *
+ * The two counts are kept apart for the same reason the list is: a dump whose leaks have all been collected
+ * is a dump with nothing to fix, and one number over both halves says the opposite.
+ */
+private fun HeapLeaks.countText(): String {
+  val leaking = when (leakingObjectCount) {
+    0 -> NOTHING_LEAKING
+    else -> "$leakingObjectCount leaking ${if (leakingObjectCount == 1) OBJECT else OBJECTS}"
+  }
+  val onTheWayOut = onTheWayOutSections.sumOf { it.objectCount }
+  return when (onTheWayOut) {
+    0 -> leaking
+    else -> "$leaking · $onTheWayOut ${LeakKind.ON_THE_WAY_OUT_TITLE.lowercase()}"
+  }
 }
 
 private fun LeakGroup.objectCountText(): String =
@@ -482,7 +594,8 @@ private const val MILLIS_PER_SECOND = 1000L
 /** Shown while the pass over every object of the heap dump is still running. */
 private const val LOOKING_FOR_LEAKS = "Going through the heap dump…"
 
-private const val NOTHING_LEAKING = "Nothing in this heap dump is leaking."
+/** No full stop, since what is on their way out is said after it on the same line. */
+private const val NOTHING_LEAKING = "Nothing in this heap dump is leaking"
 private const val NONE_FOUND = "none"
 
 private const val LEAK = "leak"
@@ -508,7 +621,8 @@ internal const val NAME_HINT =
     "LeakCanary calls the leak, and the last is the one that points straight at what leaked, which is " +
     "where to look on the chain to see it. They are one reference for most leaks. Everything above the " +
     "first is the app working as intended and everything below the last is what the leak is holding, so " +
-    "neither is part of what makes this leak this leak."
+    "neither is part of what makes this leak this leak. For an object on its way out it is the one " +
+    "reference the collector hasn't cleared yet, which is the whole of why the object is still here."
 
 internal const val LEAK_FINGERPRINT_HINT =
   "A hash of how this leak is held, which is the same for the same leak in the next heap dump of this app " +

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeaksScreenTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/LeaksScreenTest.kt
@@ -55,16 +55,37 @@ class LeaksScreenTest {
   /** The heap dump the window is opened on, and the objects of it these tests ask about. */
   private lateinit var heapDump: LeakyHeapDump
 
-  @Test fun `the leaks of a heap dump are listed in three parts`() {
+  @Test fun `the leaks to do something about are the list, and the rest are one folded heading`() {
     explorerUiTest {
       openLeaks()
 
-      // All three, however few of them were found: an empty part says that kind of leak was looked for.
-      LeakKind.values().forEach { kind ->
+      // Both parts, however few leaks were found: an empty part says that kind of leak was looked for.
+      leakKinds(onTheWayOut = false).forEach { kind ->
         onNodeWithText("${kind.title} ·", substring = true).assertIsDisplayed()
       }
       onNodeWithText(PRESENTER_LEAK_NAME, substring = true).assertIsDisplayed()
       onNodeWithText(ACTIVITY_LEAK_NAME, substring = true).assertIsDisplayed()
+      // And nothing of the sections nobody has to act on but the heading over them, since a screen that
+      // draws five more parts says a dump with two leaks in it has seven kinds of problem.
+      onNodeWithText(LeakKind.ON_THE_WAY_OUT_TITLE, substring = true).assertIsDisplayed()
+      leakKinds(onTheWayOut = true).forEach { kind ->
+        onNodeWithText("${kind.title} ·", substring = true).assertDoesNotExist()
+      }
+    }
+  }
+
+  @Test fun `pressing the heading over what is on its way out shows those parts`() {
+    explorerUiTest {
+      openLeaks()
+
+      onNodeWithText(LeakKind.ON_THE_WAY_OUT_TITLE, substring = true).performClick()
+
+      // One press for the lot, and what it opens with is what being on the way out means, which is the thing
+      // nobody had asked for while it was folded. How many of the parts under it are on screen is a matter of
+      // how tall the window is, so that there are five of them is `HeapLeaksTest`'s to say.
+      onNodeWithText(LeakKind.ON_THE_WAY_OUT_EXPLANATION).assertIsDisplayed()
+      onNodeWithText("${leakKinds(onTheWayOut = true).first().title} ·", substring = true)
+        .assertIsDisplayed()
     }
   }
 
@@ -271,6 +292,10 @@ class LeaksScreenTest {
   private fun ComposeUiTest.openTheRest() {
     onNodeWithText(LEAKING_THE_SAME_WAY, substring = true).performClick()
   }
+
+  /** The parts of the list on one side or the other of the fold. See [LeakKind.isOnTheWayOut]. */
+  private fun leakKinds(onTheWayOut: Boolean) =
+    LeakKind.values().filter { it.isOnTheWayOut == onTheWayOut }
 
   /** Everything on screen naming [objectId], which is how a list of objects says which ones they are. */
   private fun ComposeUiTest.nodesNaming(objectId: Long) =

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -825,7 +825,24 @@ class HeapDominatorTreemap internal constructor(
 
   private fun computeLeaks(): HeapLeaks {
     val startNanos = System.nanoTime()
-    val candidateIds = leakingCandidateIds
+    val candidateIds = leakingCandidateIds.filter { objectId ->
+      // A leak is an object the app is still holding. One whose strongest path is a soft, weak, finalizer
+      // or phantom reference is on its way out whatever the app does, so it belongs on the map, where it
+      // says which bytes haven't come back yet, and not on a list of things to go and fix. LeakCanary
+      // leaves the same objects out, one step later: its analysis follows none of those referents, so an
+      // object reachable no other way has no path from a GC root and never reaches a report.
+      val strength = strengthOf(objectId)
+      // Except an unreachable one, which is no more of a leak and is listed all the same, a section of
+      // gone objects being how a heap dump whose leaks were all collected says so.
+      strength.onlyTheAppCanRelease || strength == ReachabilityStrength.UNREACHABLE
+    }
+    val heldTooWeaklyCount = leakingCandidateIds.size - candidateIds.size
+    if (heldTooWeaklyCount > 0) {
+      SharkLog.d {
+        "$heldTooWeaklyCount of the ${leakingCandidateIds.size} objects that shouldn't be here are held " +
+          "no more firmly than the collector clears on its own, so they are not listed as leaks"
+      }
+    }
     // Largest first, and capped: the walk up to the GC roots per object is what this costs, and a heap
     // dump with thousands of leaking objects has a handful of leaks with thousands of instances each.
     val found = candidateIds

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -878,10 +878,10 @@ class HeapDominatorTreemap internal constructor(
     // Which section it goes in, when that is decided by how firmly it is held rather than by what holds
     // it: everything the collector clears on its own, from a soft reference down to nothing at all.
     val goingKind = LeakKind.ofOrNull(strength)
-    // Nothing holds an unreachable object, so there is no chain to it to read. Everything else has one,
-    // and it is read even for the sections a strength names, whose groups are not named after it: what a
-    // chain is for there is which other leak holds this object, which is what keeps one leaked screen's
-    // worth of objects to one row rather than to nine.
+    // Nothing holds an unreachable object, so there is no chain to it to read. Everything else has one, and
+    // every section needs it: it says which reference a leak is named after, and which other leak holds
+    // this object, the second being what keeps one leaked screen's worth of objects to one row rather than
+    // to nine.
     val pathObjectIds = if (strength == ReachabilityStrength.UNREACHABLE) {
       emptyList()
     } else {
@@ -910,10 +910,9 @@ class HeapDominatorTreemap internal constructor(
     // Everything the chain runs through on the way down to it, which is what says whether it is a leak of
     // its own or one more thing another leak is holding. See [foldedIntoWhatHoldsThem].
     val heldThrough = pathObjectIds.dropLast(1)
-    // A section a strength names, or an object nothing reaches: either way what it has in common with the
-    // rest of its section is how firmly it is held, so its class is what tells two of them apart. Which is
-    // also what keeps the chain out of the name — a phantom reachable view named after the static pool of
-    // canvases forty `Cleaner.prev` links above it is a leak named after none of its own doing.
+    // A section a strength names, or an object nothing reaches: either way there is nothing to fix for these
+    // to go, so what LeakCanary would call the leak — the reference that shouldn't be holding any more — is
+    // not what tells two of them apart. What does is the reference that hasn't let go yet.
     if (goingKind != null || steps.isEmpty()) {
       // A reachable object with no chain means the roots this walk started from aren't the roots the tree
       // was built from, which is the mismatch `gcRootLabelOf` logs. Listed as unreachable, since that is
@@ -924,15 +923,31 @@ class HeapDominatorTreemap internal constructor(
             "($strength), so it is listed as unreachable"
         }
       }
+      // The first reference of the chain holding no more firmly than the object itself, which is the one the
+      // collector hasn't got to yet: everything below it is in memory because that one reference still is,
+      // so the collection that clears it takes the lot. So it is what a group of these is, the way a
+      // suspect stretch of references is what an app's own leak is — one `Cleaner` that still has its
+      // referent, holding a screen's worth of views.
+      //
+      // Null when nothing holds the object at all, which is what leaves an unreachable leak named after its
+      // class: there is no reference left to name it after.
+      val weakenedBy = steps.firstOrNull { it.strength >= strength }?.reference?.genericLabel()
+      if (weakenedBy == null && steps.isNotEmpty()) {
+        SharkLog.d {
+          "Nothing on the chain to ${hexObjectId(objectId)} holds it as weakly as $strength does, so it is " +
+            "listed under its class rather than under the reference that hasn't let go"
+        }
+      }
       return FoundLeak(
         kind = kind,
-        // Its class and how firmly it is held, since there is no chain to hash and nothing else tells two
-        // of these apart — and the same class in two of these sections is two leaks, not one. LeakCanary
-        // has no leak fingerprint to match here: it reports what a GC root reaches, and as far as it is
-        // concerned none of these is reached.
-        leakFingerprint = "${leakingObject.className} ${kind.name}".sha1Hex(),
-        title = simpleClassName,
-        suspectPath = emptyList(),
+        // And how firmly, since the same reference in two of these sections is two leaks, not one.
+        // LeakCanary has no leak fingerprint to match here: it reports what a GC root reaches, and as far
+        // as it is concerned none of these is reached.
+        leakFingerprint = "${weakenedBy ?: leakingObject.className} ${kind.name}".sha1Hex(),
+        title = weakenedBy ?: simpleClassName,
+        suspectPath = listOfNotNull(weakenedBy),
+        // Which is only ever the one section whose groups are named after a class, since a class name says
+        // nothing about why the object is still in memory and a reference says all of it.
         subtitle = kind.subtitle,
         heldThrough = heldThrough,
         leakingObject = leakingObject

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -825,24 +825,7 @@ class HeapDominatorTreemap internal constructor(
 
   private fun computeLeaks(): HeapLeaks {
     val startNanos = System.nanoTime()
-    val candidateIds = leakingCandidateIds.filter { objectId ->
-      // A leak is an object the app is still holding. One whose strongest path is a soft, weak, finalizer
-      // or phantom reference is on its way out whatever the app does, so it belongs on the map, where it
-      // says which bytes haven't come back yet, and not on a list of things to go and fix. LeakCanary
-      // leaves the same objects out, one step later: its analysis follows none of those referents, so an
-      // object reachable no other way has no path from a GC root and never reaches a report.
-      val strength = strengthOf(objectId)
-      // Except an unreachable one, which is no more of a leak and is listed all the same, a section of
-      // gone objects being how a heap dump whose leaks were all collected says so.
-      strength.onlyTheAppCanRelease || strength == ReachabilityStrength.UNREACHABLE
-    }
-    val heldTooWeaklyCount = leakingCandidateIds.size - candidateIds.size
-    if (heldTooWeaklyCount > 0) {
-      SharkLog.d {
-        "$heldTooWeaklyCount of the ${leakingCandidateIds.size} objects that shouldn't be here are held " +
-          "no more firmly than the collector clears on its own, so they are not listed as leaks"
-      }
-    }
+    val candidateIds = leakingCandidateIds
     // Largest first, and capped: the walk up to the GC roots per object is what this costs, and a heap
     // dump with thousands of leaking objects has a handful of leaks with thousands of instances each.
     val found = candidateIds
@@ -892,8 +875,13 @@ class HeapDominatorTreemap internal constructor(
     watcher: WatchedObject?
   ): FoundLeak {
     val strength = strengthOf(objectId)
-    // Nothing holds it, so there is no chain to read and nothing to group by but its class: it is a leak
-    // that has already been collected, or that the collection before the dump was written got to.
+    // Which section it goes in, when that is decided by how firmly it is held rather than by what holds
+    // it: everything the collector clears on its own, from a soft reference down to nothing at all.
+    val goingKind = LeakKind.ofOrNull(strength)
+    // Nothing holds an unreachable object, so there is no chain to it to read. Everything else has one,
+    // and it is read even for the sections a strength names, whose groups are not named after it: what a
+    // chain is for there is which other leak holds this object, which is what keeps one leaked screen's
+    // worth of objects to one row rather than to nine.
     val pathObjectIds = if (strength == ReachabilityStrength.UNREACHABLE) {
       emptyList()
     } else {
@@ -922,16 +910,30 @@ class HeapDominatorTreemap internal constructor(
     // Everything the chain runs through on the way down to it, which is what says whether it is a leak of
     // its own or one more thing another leak is holding. See [foldedIntoWhatHoldsThem].
     val heldThrough = pathObjectIds.dropLast(1)
-    if (steps.isEmpty()) {
+    // A section a strength names, or an object nothing reaches: either way what it has in common with the
+    // rest of its section is how firmly it is held, so its class is what tells two of them apart. Which is
+    // also what keeps the chain out of the name — a phantom reachable view named after the static pool of
+    // canvases forty `Cleaner.prev` links above it is a leak named after none of its own doing.
+    if (goingKind != null || steps.isEmpty()) {
+      // A reachable object with no chain means the roots this walk started from aren't the roots the tree
+      // was built from, which is the mismatch `gcRootLabelOf` logs. Listed as unreachable, since that is
+      // what having no path from a GC root reads as, and said out loud rather than quietly.
+      val kind = goingKind ?: LeakKind.UNREACHABLE.also {
+        SharkLog.d {
+          "No chain from a GC root to ${hexObjectId(objectId)}, though the object is reachable " +
+            "($strength), so it is listed as unreachable"
+        }
+      }
       return FoundLeak(
-        kind = LeakKind.UNREACHABLE,
-        // Its class, since there is no chain to hash and nothing else to tell two of these apart. LeakCanary
-        // has no leak fingerprint to match here: it reports what a GC root reaches, and this is what none
-        // does.
-        leakFingerprint = leakingObject.className.sha1Hex(),
+        kind = kind,
+        // Its class and how firmly it is held, since there is no chain to hash and nothing else tells two
+        // of these apart — and the same class in two of these sections is two leaks, not one. LeakCanary
+        // has no leak fingerprint to match here: it reports what a GC root reaches, and as far as it is
+        // concerned none of these is reached.
+        leakFingerprint = "${leakingObject.className} ${kind.name}".sha1Hex(),
         title = simpleClassName,
         suspectPath = emptyList(),
-        subtitle = UNREACHABLE_LEAK_SUBTITLE,
+        subtitle = kind.subtitle,
         heldThrough = heldThrough,
         leakingObject = leakingObject
       )
@@ -1646,10 +1648,6 @@ class HeapDominatorTreemap internal constructor(
      * the way the chain spells it, and that is a string, not a module's API.
      */
     private const val LOCAL_VARIABLE = "<local variable>"
-
-    /** What the unreachable section says instead of a reason, since being gone is the whole of it. */
-    private const val UNREACHABLE_LEAK_SUBTITLE =
-      "Nothing reaches these any more: the next garbage collection would take them."
 
     /**
      * How many ways of holding an object [independentPathsBetween] spells out. Six chains is already more

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
@@ -61,8 +61,9 @@ enum class LeakKind(
    */
   val strength: ReachabilityStrength? = null,
   /**
-   * What a group of these says instead of a chain of references, since being on the way out is the whole
-   * of what they have in common. Null for the two sections whose groups say it with references.
+   * What a group of these says when there is no reference to name it after, which is [UNREACHABLE] and
+   * nothing else: every other section's groups are a reference, and a reference says what a sentence
+   * would have.
    */
   val subtitle: String? = null
 ) {
@@ -84,26 +85,21 @@ enum class LeakKind(
     "Softly reachable",
     "Objects a soft reference is the last thing holding, which the virtual machine clears when it wants " +
       "the memory back. So they stay until memory runs short, and then go without the app doing anything.",
-    strength = ReachabilityStrength.SOFT,
-    subtitle = "A soft reference is the only thing left holding these: the next collection that needs the " +
-      "room takes them."
+    strength = ReachabilityStrength.SOFT
   ),
 
   WEAK(
     "Weakly reachable",
     "Objects a weak reference is the last thing holding. The next garbage collection clears it and takes " +
       "them, whether or not memory is short.",
-    strength = ReachabilityStrength.WEAK,
-    subtitle = "A weak reference is the only thing left holding these: the next collection takes them."
+    strength = ReachabilityStrength.WEAK
   ),
 
   FINALIZER(
     "Waiting to be finalized",
     "Objects whose class has a `finalize()` method, reachable only from the queue of objects waiting for " +
       "it to run. They survive one more collection at least, and longer if finalization is backed up.",
-    strength = ReachabilityStrength.FINALIZER,
-    subtitle = "Only the finalizer queue still holds these: they go once `finalize()` has run, and " +
-      "finalizing one can make it reachable again."
+    strength = ReachabilityStrength.FINALIZER
   ),
 
   PHANTOM(
@@ -111,9 +107,7 @@ enum class LeakKind(
     "Objects already finalized and out of the app's reach, held only so that a `Cleaner` or a phantom " +
       "reference gets to run. On Android that is nearly always a `Cleaner` freeing native memory, which " +
       "the runtime drains on its own.",
-    strength = ReachabilityStrength.PHANTOM,
-    subtitle = "Nothing in the app can reach these any more: they are held until a `Cleaner` or a phantom " +
-      "reference has had its turn."
+    strength = ReachabilityStrength.PHANTOM
   ),
 
   UNREACHABLE(
@@ -153,6 +147,10 @@ data class LeakSection(
  * rather than as fifty: the app's own leaks by the references between what still holds the object and the
  * object itself, which is the part of the chain the leak is in, and the library ones by the known
  * reference they were recognized by.
+ *
+ * The sections whose objects are on their way out are grouped by the one reference the collector hasn't
+ * cleared yet, for the same reason: one `Cleaner` that still has its referent is one row and a screen's
+ * worth of views under it, rather than a row per view saying nothing about what they have in common.
  */
 data class LeakGroup(
   /**
@@ -167,11 +165,15 @@ data class LeakGroup(
    * `LeakFingerprint.kt`.
    */
   val leakFingerprint: String,
-  /** What the leak is: the class of the objects leaking, or the reference a library leak is known by. */
+  /**
+   * What the leak is: the reference it is, the pattern a library leak is known by, or the class of the
+   * objects leaking for the one section that has no reference to name a group after.
+   */
   val title: String,
   /**
    * The references the leak *is*, as `Foo.bar` each: from the one that shouldn't be holding any more down
-   * to the one that points straight at what leaked.
+   * to the one that points straight at what leaked. A single reference for a leak on its way out, that one
+   * being what still holds it rather than what shouldn't.
    *
    * The stretch of the chain [leakFingerprint] hashes, which is what makes these objects one leak, and
    * the same for every object in the group. Both ends are worth reading — the first says what to stop

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
@@ -19,6 +19,15 @@ data class HeapLeaks(
   /** How many leaking objects there are, which is what the button leading here says. */
   val objectCount: Int get() = sections.sumOf { it.objectCount }
 
+  /** The sections that are leaks to do something about, which is the half of the screen that leads it. */
+  val leakSections: List<LeakSection> get() = sections.filter { !it.kind.isOnTheWayOut }
+
+  /** And the ones nobody has to do anything about. See [LeakKind.isOnTheWayOut]. */
+  val onTheWayOutSections: List<LeakSection> get() = sections.filter { it.kind.isOnTheWayOut }
+
+  /** How many objects are leaks to do something about, which is what the screen leads with. */
+  val leakingObjectCount: Int get() = leakSections.sumOf { it.objectCount }
+
   /** Every leaking object by id, which is what the treemap shades leaks from. */
   val leakingObjectIds: Set<Long>
     get() = sections.flatMapTo(mutableSetOf()) { section ->
@@ -119,6 +128,13 @@ enum class LeakKind(
     subtitle = "Nothing reaches these any more: the next garbage collection would take them."
   );
 
+  /**
+   * Whether it is one of the sections nobody has to do anything about, which is the second half of the
+   * screen and is drawn folded under one heading. True of exactly the sections a [strength] names: those
+   * are the objects the collector takes on its own.
+   */
+  val isOnTheWayOut: Boolean get() = strength != null
+
   companion object {
     /**
      * The section an object held this firmly belongs in, for the strengths that have one: everything from
@@ -127,6 +143,18 @@ enum class LeakKind(
      */
     fun ofOrNull(strength: ReachabilityStrength): LeakKind? =
       values().firstOrNull { it.strength == strength }
+
+    /**
+     * The one heading over every section that [isOnTheWayOut], since between them they are one answer: this
+     * object shouldn't be in memory, and nothing you do will get rid of it any sooner.
+     */
+    const val ON_THE_WAY_OUT_TITLE = "On their way out"
+
+    const val ON_THE_WAY_OUT_EXPLANATION =
+      "Objects that shouldn't be in memory and are already leaving it, a section per way out. None of " +
+        "these is a leak to fix — the garbage collector clears every one of them on its own, which is why " +
+        "LeakCanary reports none of them. They are here so that a destroyed object still on the map has an " +
+        "answer for why it is still there."
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapLeaks.kt
@@ -12,7 +12,7 @@ import java.security.MessageDigest
  * is a list of objects to open and the explorer does the rest.
  */
 data class HeapLeaks(
-  /** In [LeakKind] order, all three of them, empty ones included: an empty section is an answer. */
+  /** In [LeakKind] order, all of them, empty ones included: an empty section is an answer. */
   val sections: List<LeakSection>
 ) {
 
@@ -32,16 +32,39 @@ data class HeapLeaks(
 }
 
 /**
- * Which of the three kinds of thing a leak is, which is what splits the screen into three.
+ * Which kind of thing a leak is, which is what splits the screen into sections.
  *
- * The split is what makes the list actionable: the app's own leaks are the ones to go and fix, the library
- * ones are somebody else's and are mostly there so they don't get mistaken for the app's, and the
- * unreachable objects are already gone and are here because their absence would read as nothing found.
+ * The split is what makes the list actionable, and it is a split in two halves. The first two are leaks to
+ * do something about: the app's own are the ones to go and fix, the library ones are somebody else's and
+ * are mostly there so they don't get mistaken for the app's. The rest are objects that shouldn't be in
+ * memory and are on their way out of it anyway, a section per way — the garbage collector clears every one
+ * of these strengths on its own, so nothing in the app has to change for the bytes to come back.
+ *
+ * LeakCanary reports none of that second half and can't tell one from another: its analysis follows no
+ * soft, weak or phantom referent, so everything below the rule here is an object no GC root reaches as far
+ * as it is concerned, and it drops the lot without saying so. Which is the reason to spell them out rather
+ * than leave them off — an object that was meant to be gone and is on its way is an answer, and it is a
+ * different answer from each of the others.
+ *
+ * **Declared in [ReachabilityStrength] order** after the first two, weakest last, which is the order the
+ * sections are drawn in.
  */
 enum class LeakKind(
   val title: String,
-  /** What being in this section means, since none of the three titles says it on its own. */
-  val explanation: String
+  /** What being in this section means, since not one of the titles says it on its own. */
+  val explanation: String,
+  /**
+   * How firmly the objects of this section are held, for the sections that are about that. Null for
+   * [APPLICATION] and [LIBRARY], which are about the reference that holds an object rather than how
+   * firmly: those two hold everything the app itself has to let go of, whether that is an ordinary
+   * reference, a cache, a thread's storage or a stack frame.
+   */
+  val strength: ReachabilityStrength? = null,
+  /**
+   * What a group of these says instead of a chain of references, since being on the way out is the whole
+   * of what they have in common. Null for the two sections whose groups say it with references.
+   */
+  val subtitle: String? = null
 ) {
 
   APPLICATION(
@@ -57,15 +80,63 @@ enum class LeakKind(
       "nothing to do about them but wait for a fix upstream."
   ),
 
+  SOFT(
+    "Softly reachable",
+    "Objects a soft reference is the last thing holding, which the virtual machine clears when it wants " +
+      "the memory back. So they stay until memory runs short, and then go without the app doing anything.",
+    strength = ReachabilityStrength.SOFT,
+    subtitle = "A soft reference is the only thing left holding these: the next collection that needs the " +
+      "room takes them."
+  ),
+
+  WEAK(
+    "Weakly reachable",
+    "Objects a weak reference is the last thing holding. The next garbage collection clears it and takes " +
+      "them, whether or not memory is short.",
+    strength = ReachabilityStrength.WEAK,
+    subtitle = "A weak reference is the only thing left holding these: the next collection takes them."
+  ),
+
+  FINALIZER(
+    "Waiting to be finalized",
+    "Objects whose class has a `finalize()` method, reachable only from the queue of objects waiting for " +
+      "it to run. They survive one more collection at least, and longer if finalization is backed up.",
+    strength = ReachabilityStrength.FINALIZER,
+    subtitle = "Only the finalizer queue still holds these: they go once `finalize()` has run, and " +
+      "finalizing one can make it reachable again."
+  ),
+
+  PHANTOM(
+    "Phantom reachable",
+    "Objects already finalized and out of the app's reach, held only so that a `Cleaner` or a phantom " +
+      "reference gets to run. On Android that is nearly always a `Cleaner` freeing native memory, which " +
+      "the runtime drains on its own.",
+    strength = ReachabilityStrength.PHANTOM,
+    subtitle = "Nothing in the app can reach these any more: they are held until a `Cleaner` or a phantom " +
+      "reference has had its turn."
+  ),
+
   UNREACHABLE(
     "Unreachable",
     "Objects that were meant to be gone and are: nothing reaches them any more, and the next garbage " +
       "collection would take them. Listed so that a heap dump whose leaks have all been collected doesn't " +
-      "read as a heap dump nothing looked at."
-  )
+      "read as a heap dump nothing looked at.",
+    strength = ReachabilityStrength.UNREACHABLE,
+    subtitle = "Nothing reaches these any more: the next garbage collection would take them."
+  );
+
+  companion object {
+    /**
+     * The section an object held this firmly belongs in, for the strengths that have one: everything from
+     * [ReachabilityStrength.SOFT] down, which is everything the garbage collector clears without the app
+     * doing anything. Null for the rest, whose objects are leaks and are named after what holds them.
+     */
+    fun ofOrNull(strength: ReachabilityStrength): LeakKind? =
+      values().firstOrNull { it.strength == strength }
+  }
 }
 
-/** One of the three parts of the leaks screen. See [LeakKind]. */
+/** One part of the leaks screen. See [LeakKind]. */
 data class LeakSection(
   val kind: LeakKind,
   /** Largest first, by what the objects in them retain together. */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/Place.kt
@@ -73,6 +73,10 @@ sealed interface Place {
     /**
      * Which leaks have been unfolded to show the objects in them, by [LeakGroup.leakFingerprint] and which
      * section the group is in: a leak of one class held two ways is two groups with one title.
+     *
+     * Plus [ON_THE_WAY_OUT] when the sections nobody has to act on have been unfolded, which is the one
+     * thing on the screen that starts folded. In the same set because it is the same kind of thing — what
+     * the reader has asked to see — so it is kept in a note and carried by a link like the rest of it.
      */
     val expandedGroups: Set<String> = emptySet()
   ) : Place {
@@ -80,6 +84,14 @@ sealed interface Place {
     override val title: String get() = LEAKS_LABEL
 
     override val viewRootObjectId: Long? get() = null
+
+    companion object {
+      /**
+       * Its key in [expandedGroups]. No group's is a single word, every one of those being a section and a
+       * hash, so this can't be mistaken for one.
+       */
+      const val ON_THE_WAY_OUT = "ON_THE_WAY_OUT"
+    }
   }
 
   /** The objects starred so far, kept so that two of them can be compared. */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReachabilityStrength.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReachabilityStrength.kt
@@ -88,5 +88,19 @@ enum class ReachabilityStrength {
    * never queues anything into it — nothing reaches an unreachable object by definition. What's
    * unreachable is what the walk didn't reach.
    */
-  UNREACHABLE
+  UNREACHABLE;
+
+  /**
+   * Whether an object held no more firmly than this stays in memory until the app lets go of it, which
+   * is what makes it something to fix rather than something on its way out.
+   *
+   * True for [STRONG] and the three below it: a cache, a thread's storage and a stack frame are ordinary
+   * strong references as far as the garbage collector is concerned, so nothing but the app releases what
+   * they hold. False from [SOFT] down, where the collector clears the reference itself and the bytes come
+   * back with nothing in the app changing — which is why LeakCanary's analysis follows no soft, weak or
+   * phantom referent and so never reports an object those are the only way to.
+   *
+   * False for [UNREACHABLE] too, which is one step further along the same road: nothing holds it at all.
+   */
+  val onlyTheAppCanRelease: Boolean get() = this < SOFT
 }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReachabilityStrength.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReachabilityStrength.kt
@@ -88,19 +88,5 @@ enum class ReachabilityStrength {
    * never queues anything into it — nothing reaches an unreachable object by definition. What's
    * unreachable is what the walk didn't reach.
    */
-  UNREACHABLE;
-
-  /**
-   * Whether an object held no more firmly than this stays in memory until the app lets go of it, which
-   * is what makes it something to fix rather than something on its way out.
-   *
-   * True for [STRONG] and the three below it: a cache, a thread's storage and a stack frame are ordinary
-   * strong references as far as the garbage collector is concerned, so nothing but the app releases what
-   * they hold. False from [SOFT] down, where the collector clears the reference itself and the bytes come
-   * back with nothing in the app changing — which is why LeakCanary's analysis follows no soft, weak or
-   * phantom referent and so never reports an object those are the only way to.
-   *
-   * False for [UNREACHABLE] too, which is one step further along the same road: nothing holds it at all.
-   */
-  val onlyTheAppCanRelease: Boolean get() = this < SOFT
+  UNREACHABLE
 }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
@@ -141,28 +141,41 @@ class HeapLeaksTest {
     }
   }
 
-  @Test fun `a leak on its way out is named after its class rather than after a cleaner list`() {
+  @Test fun `a leak on its way out is named after the reference that hasn't let go`() {
     HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
       val group = explorer.tree.findLeaks().sectionOf(PHANTOM).groups.single()
 
-      // What holds it is a Cleaner on a static list, which is where it lives rather than why it is still
-      // here, so there is no chain to name it after and the section says what being in it means.
-      assertThat(group.title).isEqualTo(ACTIVITY_CLASS_NAME.substringAfterLast('.'))
-      assertThat(group.suspectPath).isEmpty()
-      assertThat(group.subtitle).isEqualTo(PHANTOM.subtitle)
+      // Which is the whole of why the object is still in memory: clear that one reference and it goes. Not
+      // the class of what leaked, which says nothing about why it is here, and not the static list the
+      // `Cleaner` is on, which is where the `Cleaner` lives rather than what it is holding.
+      assertThat(group.title).isEqualTo("Cleaner.referent")
+      assertThat(group.suspectPath).containsExactly("Cleaner.referent")
+      // Nothing for a sentence to add to that, unlike the one section named after a class.
+      assertThat(group.subtitle).isNull()
     }
   }
 
-  @Test fun `the same class in two of the sections on their way out is two leaks`() {
+  @Test fun `objects each waiting on a cleaner of their own are one leak`() {
+    HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump(activityCount = 3)).use { explorer ->
+      val section = explorer.tree.findLeaks().sectionOf(PHANTOM)
+
+      // Three `Cleaner`s, so three chains and no object holding another — and one row, because what these
+      // have in common is the kind of reference still holding them and not which instance of it.
+      assertThat(section.groups).hasSize(1)
+      assertThat(section.objectCount).isEqualTo(3)
+    }
+  }
+
+  @Test fun `an object on its way out and one already collected are two leaks`() {
     HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
       val phantom = explorer.tree.findLeaks().sectionOf(PHANTOM).groups.single()
 
-      // The fingerprint is what tells one leak from another, and a class name alone would make a phantom
-      // reachable activity and an unreachable one the same leak found twice.
+      // The same class of object, meant to be gone in both dumps, and two different answers to why it is
+      // still here — so two leaks, which is the section being part of the fingerprint.
       HeapExplorer.open(testFolder.collectedActivityHeapDump()).use { collected ->
         val unreachable = collected.tree.findLeaks().sectionOf(UNREACHABLE).groups.single()
 
-        assertThat(phantom.title).isEqualTo(unreachable.title)
+        assertThat(phantom.objects.single().className).isEqualTo(unreachable.objects.single().className)
         assertThat(phantom.leakFingerprint).isNotEqualTo(unreachable.leakFingerprint)
       }
     }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
@@ -5,8 +5,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import shark.explorer.LeakKind.APPLICATION
+import shark.explorer.LeakKind.FINALIZER
 import shark.explorer.LeakKind.LIBRARY
+import shark.explorer.LeakKind.PHANTOM
+import shark.explorer.LeakKind.SOFT
 import shark.explorer.LeakKind.UNREACHABLE
+import shark.explorer.LeakKind.WEAK
 
 class HeapLeaksTest {
 
@@ -124,28 +128,55 @@ class HeapLeaksTest {
     }
   }
 
-  @Test fun `an object held only by a cleaner is on its way out rather than leaking`() {
+  @Test fun `an object held only by a cleaner is listed as phantom reachable`() {
     HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
       val leaks = explorer.tree.findLeaks()
 
-      // Destroyed, so the inspectors say it shouldn't be here, and phantom reachable, so the runtime is
-      // already seeing to it and there is nothing for the app to fix. LeakCanary reports no leak in a
-      // dump like this one either.
-      assertThat(leaks.objectCount).isZero()
+      // Destroyed, so the inspectors say it shouldn't be here, and phantom reachable, so it is on its way
+      // out and none of the app's business. Which is a section of its own rather than an app leak.
+      val leaking = leaks.objectsOf(PHANTOM).single()
+      assertThat(leaking.className).isEqualTo(ACTIVITY_CLASS_NAME)
+      assertThat(leaking.strength).isEqualTo(ReachabilityStrength.PHANTOM)
+      assertThat(leaks.objectsOf(APPLICATION)).isEmpty()
     }
   }
 
-  @Test fun `an object too weakly held to be a leak is still on the map`() {
+  @Test fun `a leak on its way out is named after its class rather than after a cleaner list`() {
+    HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
+      val group = explorer.tree.findLeaks().sectionOf(PHANTOM).groups.single()
+
+      // What holds it is a Cleaner on a static list, which is where it lives rather than why it is still
+      // here, so there is no chain to name it after and the section says what being in it means.
+      assertThat(group.title).isEqualTo(ACTIVITY_CLASS_NAME.substringAfterLast('.'))
+      assertThat(group.suspectPath).isEmpty()
+      assertThat(group.subtitle).isEqualTo(PHANTOM.subtitle)
+    }
+  }
+
+  @Test fun `the same class in two of the sections on their way out is two leaks`() {
+    HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
+      val phantom = explorer.tree.findLeaks().sectionOf(PHANTOM).groups.single()
+
+      // The fingerprint is what tells one leak from another, and a class name alone would make a phantom
+      // reachable activity and an unreachable one the same leak found twice.
+      HeapExplorer.open(testFolder.collectedActivityHeapDump()).use { collected ->
+        val unreachable = collected.tree.findLeaks().sectionOf(UNREACHABLE).groups.single()
+
+        assertThat(phantom.title).isEqualTo(unreachable.title)
+        assertThat(phantom.leakFingerprint).isNotEqualTo(unreachable.leakFingerprint)
+      }
+    }
+  }
+
+  @Test fun `an object on its way out is still on the map`() {
     HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
       val tree = explorer.tree
       val activity = tree.findByLabel(ACTIVITY_CLASS_NAME.substringAfterLast('.')).objectId
 
-      // Left where it was: which bytes haven't come back yet is what the map is for, and the leaks screen
-      // leaving an object out is not the tree losing it.
+      // Left where it was: which bytes haven't come back yet is what the map is for, and which section of
+      // the list an object is in says nothing about where the tree hangs it.
       assertThat(tree.strengthOf(activity)).isEqualTo(ReachabilityStrength.PHANTOM)
       assertThat(tree.dominatorOf(activity)!!.label).isEqualTo("Cleaner")
-      assertThat(tree.findLeaks().leakingObjectIds).doesNotContain(activity)
-      assertThat(tree.isBelowLeakingObject(activity)).isFalse()
     }
   }
 
@@ -256,12 +287,14 @@ class HeapLeaksTest {
     }
   }
 
-  @Test fun `a heap dump with nothing wrong in it has all three sections and no leak`() {
+  @Test fun `a heap dump with nothing wrong in it has every section and no leak`() {
     testFolder.openTestHeapDump().use { explorer ->
       val leaks = explorer.tree.findLeaks()
 
-      // All three of them, so that the screen says which kinds of leak were looked for and not found.
-      assertThat(leaks.sections.map { it.kind }).containsExactly(APPLICATION, LIBRARY, UNREACHABLE)
+      // Every one of them, so that the screen says which kinds of leak were looked for and not found: the
+      // two to do something about first, then the ways of being on the way out, weakest last.
+      assertThat(leaks.sections.map { it.kind })
+        .containsExactly(APPLICATION, LIBRARY, SOFT, WEAK, FINALIZER, PHANTOM, UNREACHABLE)
       assertThat(leaks.objectCount).isZero()
       assertThat(leaks.leakingObjectIds).isEmpty()
     }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeaksTest.kt
@@ -124,6 +124,31 @@ class HeapLeaksTest {
     }
   }
 
+  @Test fun `an object held only by a cleaner is on its way out rather than leaking`() {
+    HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
+      val leaks = explorer.tree.findLeaks()
+
+      // Destroyed, so the inspectors say it shouldn't be here, and phantom reachable, so the runtime is
+      // already seeing to it and there is nothing for the app to fix. LeakCanary reports no leak in a
+      // dump like this one either.
+      assertThat(leaks.objectCount).isZero()
+    }
+  }
+
+  @Test fun `an object too weakly held to be a leak is still on the map`() {
+    HeapExplorer.open(testFolder.cleanerHeldActivityHeapDump()).use { explorer ->
+      val tree = explorer.tree
+      val activity = tree.findByLabel(ACTIVITY_CLASS_NAME.substringAfterLast('.')).objectId
+
+      // Left where it was: which bytes haven't come back yet is what the map is for, and the leaks screen
+      // leaving an object out is not the tree losing it.
+      assertThat(tree.strengthOf(activity)).isEqualTo(ReachabilityStrength.PHANTOM)
+      assertThat(tree.dominatorOf(activity)!!.label).isEqualTo("Cleaner")
+      assertThat(tree.findLeaks().leakingObjectIds).doesNotContain(activity)
+      assertThat(tree.isBelowLeakingObject(activity)).isFalse()
+    }
+  }
+
   @Test fun `a leak held by a reference Shark knows is somebody else's`() {
     HeapExplorer.open(testFolder.libraryLeakHeapDump()).use { explorer ->
       val leaks = explorer.tree.findLeaks()

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
@@ -7,6 +7,7 @@ import shark.GcRoot.JniGlobal
 import shark.GcRoot.StickyClass
 import shark.GcRoot.ThreadObject
 import shark.HprofWriterHelper
+import shark.ValueHolder
 import shark.ValueHolder.BooleanHolder
 import shark.ValueHolder.IntHolder
 import shark.ValueHolder.ReferenceHolder
@@ -341,26 +342,35 @@ internal fun TemporaryFolder.collectedActivityHeapDump(): File {
 }
 
 /**
- * A heap dump where the only destroyed activity is one a `sun.misc.Cleaner` is the last holder of, which
- * is what an activity looks like between the moment it stops being used and the moment the runtime gets
- * to it: reachable, and only through a reference the collector clears on its own.
+ * A heap dump where every destroyed activity is one a `sun.misc.Cleaner` of its own is the last holder of,
+ * which is what an activity looks like between the moment it stops being used and the moment the runtime
+ * gets to it: reachable, and only through a reference the collector clears on its own.
  *
  * Written the way the cleaner list really is, since being at the end of one is how a heap dump reaches
- * this state at all — see [cleanerClass] and `HeapReachabilityTest`.
+ * this state at all — see [cleanerClass] and `HeapReachabilityTest`. [activityCount] is how many entries
+ * of that list still have their referent, which is how many objects are waiting on a `Cleaner`.
  */
-internal fun TemporaryFolder.cleanerHeldActivityHeapDump(): File {
-  val file = newFile("cleaner-held-activity.hprof")
+internal fun TemporaryFolder.cleanerHeldActivityHeapDump(activityCount: Int = 1): File {
+  val file = newFile("cleaner-held-activity-$activityCount.hprof")
   file.dump {
     val firstId = reserveObjectId()
     val classes = referenceClasses()
     val cleanerClassId = cleanerClass(classes, firstCleaner = firstId)
-    val activity = instance(activityClass(), fields = listOf(BooleanHolder(true)))
-    val second = cleaner(cleanerClassId, referent = activity)
-    cleaner(cleanerClassId, next = second, objectId = firstId)
+    val activityClassId = activityClass()
+    // The list from its end back to its head, since each entry has to be written before the one pointing
+    // at it, and the head is the one the static reaches.
+    val listHead = (1..activityCount).fold(NULL) { next, _ ->
+      val activity = instance(activityClassId, fields = listOf(BooleanHolder(true)))
+      cleaner(cleanerClassId, referent = activity, next = next)
+    }
+    cleaner(cleanerClassId, next = listHead, objectId = firstId)
     gcRoot(StickyClass(id = cleanerClassId))
   }
   return file
 }
+
+/** No reference: the value a field of a heap dump holds when it points at nothing. */
+private val NULL = ReferenceHolder(ValueHolder.NULL_REFERENCE)
 
 /**
  * A heap dump where a destroyed activity is held by a reference Shark knows leaks in code an app doesn't

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
@@ -4,6 +4,7 @@ import java.io.File
 import org.junit.rules.TemporaryFolder
 import shark.GcRoot.JavaFrame
 import shark.GcRoot.JniGlobal
+import shark.GcRoot.StickyClass
 import shark.GcRoot.ThreadObject
 import shark.HprofWriterHelper
 import shark.ValueHolder.BooleanHolder
@@ -335,6 +336,28 @@ internal fun TemporaryFolder.collectedActivityHeapDump(): File {
     instance(activityClass(), fields = listOf(BooleanHolder(true)))
     val holder = "com.example.Holder" instance { }
     gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+  }
+  return file
+}
+
+/**
+ * A heap dump where the only destroyed activity is one a `sun.misc.Cleaner` is the last holder of, which
+ * is what an activity looks like between the moment it stops being used and the moment the runtime gets
+ * to it: reachable, and only through a reference the collector clears on its own.
+ *
+ * Written the way the cleaner list really is, since being at the end of one is how a heap dump reaches
+ * this state at all — see [cleanerClass] and `HeapReachabilityTest`.
+ */
+internal fun TemporaryFolder.cleanerHeldActivityHeapDump(): File {
+  val file = newFile("cleaner-held-activity.hprof")
+  file.dump {
+    val firstId = reserveObjectId()
+    val classes = referenceClasses()
+    val cleanerClassId = cleanerClass(classes, firstCleaner = firstId)
+    val activity = instance(activityClass(), fields = listOf(BooleanHolder(true)))
+    val second = cleaner(cleanerClassId, referent = activity)
+    cleaner(cleanerClassId, next = second, objectId = firstId)
+    gcRoot(StickyClass(id = cleanerClassId))
   }
   return file
 }


### PR DESCRIPTION
The leaks screen listed every object the inspectors said shouldn't be here, however weakly it was held, with an exception only for the unreachable ones. So a destroyed view whose last holder is a `Cleaner` — phantom reachable, already finalized, waiting for the runtime to run a thunk and let go — came out as an app leak to go and fix, named after whatever the walk up to the GC roots ran into:

```
DisplayListCanvas.sPool → Pools$SimplePool.mPool → Object[][x] → Canvas.mFinalizer
  → NativeAllocationRegistry$CleanerRunner.cleaner
  → Cleaner.prev ×41 → Cleaner.referent → RenderNode.mOwningView
```

Now each way out of memory is a section of its own: **softly reachable**, **weakly reachable**, **waiting to be finalized**, **phantom reachable**, and the **unreachable** one that was already there. App leaks and library leaks stay at the top, and they are still the two sections that mean "somebody has to do something".

LeakCanary can tell none of the five apart. Its analysis follows no soft, weak or phantom referent, so every one of them is an object no GC root reaches as far as it is concerned, and the whole lot ends up in the bucket this screen has been calling unreachable. Splitting that bucket is a thing this window can do that a leak trace can't.

## Named after the reference that hasn't let go

A group in one of the five is named after the reference the collector hasn't cleared yet: the first one on the chain holding no more firmly than the object itself. Everything below it is in memory because that one reference still is, so clearing it takes the lot — which is what it has in common with the objects beside it, the way a suspect stretch of references is what an app leak's objects have in common.

The class name said what the object is and nothing about why it is still here. And the chain it sits on can't be read whole either: what holds a phantom reachable view is a `Cleaner` forty links down a static list, so the first reference of that chain is a canvas pool that says nothing about the view.

On this dump that is `Cleaner.referent`, and the three views that were three rows are one:

```
Cleaner.referent →        3 objects
  DecorView 0x12d4a220
  ActionMenuPresenter$OverflowMenuButton 0x12d4e1d0
  ImageButton 0x12d4d0f0
```

Unreachable is the one section still named after a class: nothing holds those objects, so there is no reference to name them after. It is also the one whose groups still carry a sentence saying what being in the section means — everywhere else the reference says it.

The fingerprint follows the name and keeps the section in it, since `LeakGroup.leakFingerprint` promises two groups never share one.

The chain is still walked for every section, because which *other* leak holds an object is what folds one leaked screen's worth of objects into one row instead of nine. Dropping the walk cost exactly that, and the phantom section went from 3 rows to 8 before it was put back.

## Folded, because none of it is a leak to fix

The five say the same thing between them — this object shouldn't be in memory, and nothing you do will get rid of it any sooner — so they go under one heading, folded, quieter than a section heading and with no band or bar of their own. Folded it still says what is in it, so folding hides the rows and never the answer:

```
App leaks · 1 leak, 1 object
  AsyncTask.SERIAL_EXECUTOR →   1 object
    MainActivity 0x12d368b8
Library leaks · none
▸ On their way out · 3 phantom reachable, 2 unreachable
```

The paragraph about what being on the way out means waits until someone presses it. The count line above the list is split the same way: `1 leaking object · 5 on their way out`.

The heading's own folded state goes in the set of unfolded groups, so it is kept in a note and carried by a link like the rest of it.

## On `leak_asynctask_o.hprof`

| Section | Before | After |
| --- | --- | --- |
| App leaks | 4 leaks, 4 objects | **1 leak, 1 object** |
| Library leaks | 0 | 0 |
| Softly reachable | — | 0 |
| Weakly reachable | — | 0 |
| Waiting to be finalized | — | 0 |
| Phantom reachable | — | **1 leak, 3 objects** |
| Unreachable | 1 leak, 2 objects | 1 leak, 2 objects |

The app leak that remains is `AsyncTask.SERIAL_EXECUTOR` → `MainActivity`, leak fingerprint `6bf18730`, which is the leak and the fingerprint LeakCanary reports for the same dump. The two unreachable ones are `ViewRootImpl`s that nothing points at at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)