### PR TITLE
Draw the whole chain from a GC root, however long it is

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -62,10 +62,10 @@ stamped with a generation per walk rather than cleared at the end.
 
 **The pointer asks questions on that thread too**, because moving over a rectangle describes it. Which is
 why nothing is read until the pointer has been still for `HOVER_SETTLE_MILLIS`, and why what a hover asks
-for is capped and index-backed: a chain from a GC root is one walk over `ReferrerIndex` with at most 20
-steps read out, and the search for every way an object is held runs for the object clicked and no other.
-A new question the panels ask has to be measured before it goes in the hover path — `notes/decisions.md`
-has the numbers on the biggest dump in the repo.
+for is index-backed: a chain from a GC root is one walk over `ReferrerIndex` and a read per step of what it
+found, and the search for every way an object is held runs for the object clicked and no other. A new
+question the panels ask has to be measured before it goes in the hover path — `notes/decisions.md` has the
+numbers on the biggest dump in the repo, including how long a chain gets there.
 
 ## A heap dump can have `android.os.Build` and not the fields Shark reads off it
 

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -370,8 +370,23 @@ list of what the treemap already draws, in a shape that couldn't hold more, and 
 Instead the chain is drawn the way a leak trace is (`PathDrawing.kt`): the shortest way a GC root reaches
 the object, one row per object, with the steps that dominate it marked. Shortest in steps, so it's the
 plainest way the object is held; the marked steps are the rectangles it sits inside, which is what ties the
-chain to the picture. On the production dump the longest one is 34 steps, two of them views and the rest
-RxJava plumbing — which is why it is cut at 20 and cut at the root end.
+chain to the picture.
+
+**All of it, however long.** A chain cut short answers "what holds this?" with a count of the steps that
+would have said, which is the one thing the pane exists not to do. Chains get long: 34 steps on the
+production dump, and the dumps in the repo go further — 499 on `large-dump.hprof`, 1,518 on
+`compose_leak.hprof`, both of them walks down a linked structure. What that costs, measured:
+
+- **Reading one is a heap dump read per step**, 6 ms for the 499 and 12 ms for the 1,518, against a
+  hover's budget of a hundred. Cheap because the walk that finds the chain is over `ReferrerIndex` and
+  only the steps of the chain it found are read.
+- **Drawing one is why the pane is a `LazyColumn`.** A `Column` with `verticalScroll` composes every row,
+  and a chain of 1,500 rows at four lines each never finished drawing at all — 60 s and still nothing on
+  screen. Lazy, the pane composes the seven rows it has the height for, so 20 steps and 500 steps are the
+  same 200 ms from the click to the chain being there.
+- **The stretches that could have run otherwise are still asked per chain**, and a chain that long has
+  almost none: the deep ones are linked lists, where every step dominates the object and so is a step the
+  chain had no choice about. One detour and 18 ms for the 499, none at all for the 1,518.
 
 It sits **on the far side of the view from the details panel**: chain, view, details, left to right — where
 the object came from, where it is, what it is keeping alive. A chain and the details are both tall columns,
@@ -584,8 +599,8 @@ can't take that way at all, because **its phase 1 treats a leaking object as a l
 
 - The suspect stretch ran past the first leaking object, and kept array indices, and named a reference by
   the class declaring the field rather than the class of the object. Three ways of grouping too finely.
-- The fold looked at the twenty drawn steps of a chain rather than all of it, so a leak held by another one
-  far above it stayed on the list.
+- The fold looked at the steps a chain drew, then cut at twenty, rather than all of it, so a leak held by
+  another one far above it stayed on the list.
 - **Collections were read the way they are built.** `ArrayList.elementData → Object[] → [3]` where a leak
   trace says `ArrayList[x]`, and worse for a `HashMap`. `DataStructureReferenceReader` adds Shark's own
   readers for the dozen structures it knows, the way `ViewChildReferenceReader` adds a `ViewGroup`'s

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/PathDrawing.kt
@@ -317,10 +317,10 @@ internal fun PathCutRow(
 /**
  * How much a chain says about each of its objects.
  *
- * A chain from a GC root down to a bitmap of a real app runs through a dozen objects and can be cut at
- * twenty, and everything worth saying about each of them is four lines: that chain is taller than any
- * window. So a chain the reader is only glancing at says as little as still names the object, and the one
- * they stopped on says all of it.
+ * A chain from a GC root down to a bitmap of a real app runs through dozens of objects, and everything
+ * worth saying about each of them is four lines: that chain is taller than any window. So a chain the
+ * reader is only glancing at says as little as still names the object, and the one they stopped on says
+ * all of it.
  */
 internal enum class PathDetail(val rowSpacing: Dp) {
 

--- a/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/main/java/shark/explorer/app/RootPathPanel.kt
@@ -3,12 +3,16 @@ package shark.explorer.app
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -98,30 +102,39 @@ internal fun RootPathPanel(
   } else {
     null
   }
-  val scrollState = rememberScrollState()
+  val listState = rememberLazyListState()
   // The bottom of the chain is what a reader is looking at, so that is what the pane is scrolled to: opening
   // an object runs the chain down to it, and the last few steps are the ones that say how it is held. Every
   // time the chain grows, which is also the pointer moving from rectangle to rectangle.
   val bottomObjectId = (tail ?: cutTail)?.lastOrNull()?.step?.objectId ?: target
   LaunchedEffect(bottomObjectId) {
     if (bottomObjectId != null) {
-      snapshotFlow { scrollState.maxValue }.collect { scrollState.animateScrollTo(it) }
+      snapshotFlow { listState.layoutInfo.totalItemsCount }.collect { count ->
+        if (count > 0) {
+          listState.animateScrollToItem(count - 1)
+        }
+      }
     }
   }
   Surface(modifier, color = MaterialTheme.colorScheme.surface) {
-    Column(
-      Modifier.verticalScroll(scrollState).padding(12.dp),
-      verticalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-      // Where every chain starts, and the way back to the screen the window opens on.
-      PathRootRow(
-        nextStrength = drawn?.path?.steps?.firstOrNull()?.step?.strength
-          ?: cutTail?.firstOrNull()?.step?.strength,
-        onOpen = onOpen,
-        onCopyLink = onCopyLink
-      )
+    // A row per object, drawn only where the pane has the room for it: a chain is as long as the heap dump
+    // makes it, and the linked structures of a real one run to hundreds of steps — a pane that composed all
+    // of them would take a minute to draw a chain nobody has scrolled to yet.
+    LazyColumn(state = listState, contentPadding = PaddingValues(12.dp)) {
+      item {
+        // Where every chain starts, and the way back to the screen the window opens on.
+        Column {
+          PathRootRow(
+            nextStrength = drawn?.path?.steps?.firstOrNull()?.step?.strength
+              ?: cutTail?.firstOrNull()?.step?.strength,
+            onOpen = onOpen,
+            onCopyLink = onCopyLink
+          )
+          Spacer(Modifier.height(BLOCK_SPACING))
+        }
+      }
       if (drawn != null) {
-        RootPathTrace(
+        rootPathTrace(
           drawn = drawn,
           stronglyReachableByteCount = stronglyReachableByteCount,
           ways = ways,
@@ -132,18 +145,18 @@ internal fun RootPathPanel(
         )
       } else {
         noChainText(selection, summary, isWholeHeapDump, rootPath, hasTail = cutTail != null)?.let {
-          Text(it, style = MaterialTheme.typography.bodySmall)
+          item { Text(it, style = MaterialTheme.typography.bodySmall) }
         }
       }
       if (tail != null) {
-        HoveredTail(
+        hoveredTail(
           steps = tail,
           isCut = false,
           stronglyReachableByteCount = stronglyReachableByteCount
         )
       } else if (cutTail != null) {
         // Nothing above it on screen is what holds it, so the end of it is the object being described here.
-        HoveredTail(
+        hoveredTail(
           steps = cutTail,
           isCut = true,
           stronglyReachableByteCount = stronglyReachableByteCount
@@ -173,8 +186,7 @@ private fun noChainText(
 }
 
 /** The chain itself: the GC root at the top, the object the window is describing at the bottom. */
-@Composable
-private fun RootPathTrace(
+private fun LazyListScope.rootPathTrace(
   drawn: DrawnRootPath,
   stronglyReachableByteCount: Long,
   ways: Map<Int, List<RootPathWay>>,
@@ -184,32 +196,32 @@ private fun RootPathTrace(
   onCopyLink: (Long) -> Unit
 ) {
   val steps = drawn.path.steps
-  Column(Modifier.fillMaxWidth()) {
+  item {
     PathHeadRow(
-      label = drawn.path.headLabel(),
+      label = drawn.path.gcRootLabel.orEmpty(),
       reference = steps.first().step.reference,
       nextStrength = steps.first().step.strength,
       below = { WaysOfDetour(drawn, HEAD_INDEX, ways, chosenWays, onChooseWay) }
     )
-    steps.forEachIndexed { depth, step ->
-      val next = steps.getOrNull(depth + 1)
-      PathStepRow(
-        step = step.step,
-        // How this step points at the next one, which is what the next step was reached through.
-        reference = next?.step?.reference,
-        nextStrength = next?.step?.strength,
-        stronglyReachableByteCount = stronglyReachableByteCount,
-        onOpen = onOpen,
-        onCopyLink = onCopyLink,
-        role = when {
-          // The object the details panel is about, whatever the pointer has added below it.
-          next == null -> PathRole.TARGET
-          step.isDominator -> PathRole.DOMINATOR
-          else -> PathRole.STEP
-        },
-        below = { WaysOfDetour(drawn, depth, ways, chosenWays, onChooseWay) }
-      )
-    }
+  }
+  itemsIndexed(steps) { depth, step ->
+    val next = steps.getOrNull(depth + 1)
+    PathStepRow(
+      step = step.step,
+      // How this step points at the next one, which is what the next step was reached through.
+      reference = next?.step?.reference,
+      nextStrength = next?.step?.strength,
+      stronglyReachableByteCount = stronglyReachableByteCount,
+      onOpen = onOpen,
+      onCopyLink = onCopyLink,
+      role = when {
+        // The object the details panel is about, whatever the pointer has added below it.
+        next == null -> PathRole.TARGET
+        step.isDominator -> PathRole.DOMINATOR
+        else -> PathRole.STEP
+      },
+      below = { WaysOfDetour(drawn, depth, ways, chosenWays, onChooseWay) }
+    )
   }
 }
 
@@ -220,39 +232,41 @@ private fun RootPathTrace(
  * much each of those is worth, and everything else on a full row of the chain is four more lines of a pane
  * that is already the height of the window.
  */
-@Composable
-private fun HoveredTail(
+private fun LazyListScope.hoveredTail(
   steps: List<RootPathStep>,
   /** Whether it runs on from the chain above or starts somewhere else, which the dots say. */
   isCut: Boolean,
   stronglyReachableByteCount: Long
 ) {
-  Column(Modifier.fillMaxWidth()) {
-    if (isCut) {
-      // Not below the object shown, so the chain above isn't the way to this one: the dots are that said in
-      // the gutter, and the map itself is the rest of the answer.
-      PathCutRow(nextStrength = steps.first().step.strength)
+  item {
+    Column {
+      Spacer(Modifier.height(BLOCK_SPACING))
+      if (isCut) {
+        // Not below the object shown, so the chain above isn't the way to this one: the dots are that said
+        // in the gutter, and the map itself is the rest of the answer.
+        PathCutRow(nextStrength = steps.first().step.strength)
+      }
     }
-    steps.forEachIndexed { depth, step ->
-      val next = steps.getOrNull(depth + 1)
-      PathStepRow(
-        step = step.step,
-        reference = next?.step?.reference,
-        nextStrength = next?.step?.strength,
-        stronglyReachableByteCount = stronglyReachableByteCount,
-        // Nothing to click: the pointer is on the map, and it leaving the map is what takes this away.
-        onOpen = { _, _ -> },
-        onCopyLink = {},
-        role = when {
-          // The end of a cut tail is the only object being described here, since the chain above it isn't
-          // the way to it; the end of one that runs on is described by the card at the pointer instead.
-          next == null && isCut -> PathRole.TARGET
-          step.isDominator -> PathRole.DOMINATOR
-          else -> PathRole.STEP
-        },
-        detail = PathDetail.BRIEF
-      )
-    }
+  }
+  itemsIndexed(steps) { depth, step ->
+    val next = steps.getOrNull(depth + 1)
+    PathStepRow(
+      step = step.step,
+      reference = next?.step?.reference,
+      nextStrength = next?.step?.strength,
+      stronglyReachableByteCount = stronglyReachableByteCount,
+      // Nothing to click: the pointer is on the map, and it leaving the map is what takes this away.
+      onOpen = { _, _ -> },
+      onCopyLink = {},
+      role = when {
+        // The end of a cut tail is the only object being described here, since the chain above it isn't
+        // the way to it; the end of one that runs on is described by the card at the pointer instead.
+        next == null && isCut -> PathRole.TARGET
+        step.isDominator -> PathRole.DOMINATOR
+        else -> PathRole.STEP
+      },
+      detail = PathDetail.BRIEF
+    )
   }
 }
 
@@ -304,18 +318,6 @@ private fun WaysOfDetour(
   }
 }
 
-/**
- * Which GC root the chain starts at, and how many steps below it were left out.
- *
- * When steps were left out, the reference drawn under this row belongs to the last of the objects left out
- * rather than to the root, and the class it names is how the reader can tell.
- */
-private fun RootPath.headLabel(): String = if (hiddenStepCount == 0) {
-  gcRootLabel.orEmpty()
-} else {
-  "${gcRootLabel.orEmpty()}, then $ELLIPSIS $hiddenStepCount steps"
-}
-
 /** Shown until a rectangle has been clicked, which is what this pane draws a chain for. */
 internal const val NO_ROOT_PATH_YET = "Click a rectangle to see what holds it."
 
@@ -341,10 +343,11 @@ internal const val WAYS_FROM_HERE = "ways from here"
 internal const val PREVIOUS_WAY = "◂"
 internal const val NEXT_WAY = "▸"
 
-internal const val ELLIPSIS = "…"
-
 /** As wide as a class name plus what a step says about the object, and no wider: the map needs the room. */
 internal val ROOT_PATH_WIDTH = 300.dp
+
+/** Between the blocks of the pane — the whole heap dump, the chain, what the pointer added to it. */
+private val BLOCK_SPACING = 4.dp
 
 /** What the arrows for switching a stretch of the chain sit on, so they don't read as one of its objects. */
 private val WAYS_BACKGROUND = Color(0x14000000)

--- a/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
+++ b/shark/shark-explorer/shark-explorer-app/src/test/java/shark/explorer/app/ExplorerAppTest.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
@@ -324,7 +323,9 @@ class ExplorerAppTest {
       // The links are numbered from the payload out, so the last of them is the one just above it.
       waitUntilAtLeastOneExists(hasText("Link0 instance"), OPEN_TIMEOUT_MILLIS)
       onNodeWithText("Link0 instance").assertIsDisplayed()
-      onNodeWithText("Link${CHAIN_LINK_COUNT - 1} instance").assertIsNotDisplayed()
+      // Not merely off screen: the pane draws the rows it has the room for and no others, which is what
+      // lets it draw a chain of a thousand steps at all.
+      onNodeWithText("Link${CHAIN_LINK_COUNT - 1} instance").assertDoesNotExist()
     }
   }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DominatorPaths.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/DominatorPaths.kt
@@ -77,9 +77,7 @@ data class IndependentPath(
    */
   val gcRootLabel: String?,
   /** From the step below where the search started down to the object itself, which is the last step. */
-  val steps: List<PathStep>,
-  /** How many steps between where it started and [steps], left out to keep the chain readable. */
-  val hiddenStepCount: Int
+  val steps: List<PathStep>
 )
 
 /**

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -574,9 +574,9 @@ class HeapDominatorTreemap internal constructor(
    * both dominate [toObjectId] are only one of the ways the lower one is reached from the upper, and these
    * are the rest of them. See [RootPathDetour].
    *
-   * At most [MAX_INDEPENDENT_PATHS] of them, each at most [MAX_PATH_STEPS] steps long. The first call for
-   * a heap dump builds a [ReferrerIndex], which reads the whole dump; the paths themselves are then walks
-   * in memory, so the wait is once per dump rather than once per object.
+   * At most [MAX_INDEPENDENT_PATHS] of them, each spelled out whole. The first call for a heap dump builds
+   * a [ReferrerIndex], which reads the whole dump; the paths themselves are then walks in memory, so the
+   * wait is once per dump rather than once per object.
    */
   fun independentPathsBetween(
     fromObjectId: Long,
@@ -664,8 +664,8 @@ class HeapDominatorTreemap internal constructor(
    * those dominators, so they are always all on it.
    *
    * Cheap enough to ask as the pointer moves, once [indexReferrers] has been paid for: one breadth first
-   * walk over as much of the graph as it takes to reach a root, and only the steps that end up shown are
-   * read out of the heap dump. At most [MAX_ROOT_PATH_STEPS] of them.
+   * walk over as much of the graph as it takes to reach a root, then a read of the heap dump per step of
+   * the chain it found.
    */
   fun rootPathTo(objectId: Long): RootPath = rootPathAlong(rootPathObjectIdsTo(objectId))
 
@@ -703,38 +703,22 @@ class HeapDominatorTreemap internal constructor(
     return found.map { referrerIndex.objectIdAt(it) }
   }
 
-  /** The steps of [pathObjectIds] worth drawing, read out of the heap dump. See [rootPathTo]. */
+  /** The steps of [pathObjectIds], read out of the heap dump, with what dominates it marked. */
   private fun rootPathAlong(pathObjectIds: List<Long>): RootPath {
     if (pathObjectIds.isEmpty()) {
       return RootPath.NONE
     }
-    // Kept from the object up, like an independent path: what holds it directly is what a reader is
-    // after, and the plumbing between a GC root and an app's own objects rarely is.
-    val hiddenStepCount = (pathObjectIds.size - MAX_ROOT_PATH_STEPS).coerceAtLeast(0)
-    // One before the first shown step, when there is one: it names the field that step is held in.
-    val fromIndex = (hiddenStepCount - 1).coerceAtLeast(0)
-    val objectIds = pathObjectIds.subList(fromIndex, pathObjectIds.size)
     val dominatorIds = dominatorIdsOf(pathObjectIds.last())
-    val steps = objectIds.mapIndexedNotNull { index, stepObjectId ->
-      when {
-        index > 0 -> stepTo(stepObjectId, referrerId = objectIds[index - 1])
-        // The GC root's own object, which no field of the heap dump points at. Only when the whole chain
-        // is shown: otherwise this is the last of the objects left out, here to name that field.
-        hiddenStepCount == 0 -> step(stepObjectId, reference = null)
-        else -> null
-      }
-    }
     return RootPath(
       gcRootLabel = gcRootLabelOf(pathObjectIds.first()),
-      steps = steps.withLeakStatuses()
-        .map { RootPathStep(it, isDominator = it.objectId in dominatorIds) },
-      hiddenStepCount = hiddenStepCount
+      steps = stepsAlong(pathObjectIds)
+        .map { RootPathStep(it, isDominator = it.objectId in dominatorIds) }
     )
   }
 
   /**
-   * Every step of [pathObjectIds], read out of the heap dump, where [rootPathAlong] reads the last
-   * [MAX_ROOT_PATH_STEPS] of them. For the questions a leak asks of a chain, which are about all of it.
+   * Every step of [pathObjectIds], read out of the heap dump. What both a drawn chain and the questions a
+   * leak asks of one are built from, since both are about all of it.
    */
   private fun stepsAlong(pathObjectIds: List<Long>): List<PathStep> =
     pathObjectIds.mapIndexed { index, stepObjectId ->
@@ -1082,11 +1066,7 @@ class HeapDominatorTreemap internal constructor(
     }
     return IndependentPath(
       gcRootLabel = if (isBelowGroup) gcRootLabelOf(objectIds.first()) else null,
-      // Kept from the object up: what holds it directly is what a reader is looking for, and the
-      // plumbing between a GC root and an app's own objects rarely is. Cut before the statuses are
-      // worked out, so that a status is never explained by an object the chain doesn't show.
-      steps = steps.takeLast(MAX_PATH_STEPS).withLeakStatuses(),
-      hiddenStepCount = (steps.size - MAX_PATH_STEPS).coerceAtLeast(0)
+      steps = steps.withLeakStatuses()
     )
   }
 
@@ -1640,19 +1620,6 @@ class HeapDominatorTreemap internal constructor(
      * rather than by anything anyone would call an owner.
      */
     private const val MAX_INDEPENDENT_PATHS = 6
-
-    /** How many steps of one path are shown, counted from the object up. */
-    private const val MAX_PATH_STEPS = 15
-
-    /**
-     * And how many of a path from a GC root, counted the same way.
-     *
-     * Longer than an independent path's, because this one starts at a GC root rather than below the
-     * dominator, and shorter than the chains a real heap dump has: the way from a thread down to a list
-     * row is dozens of steps of framework plumbing, and each step shown is a read of the heap dump on the
-     * way to answering what the pointer is on.
-     */
-    private const val MAX_ROOT_PATH_STEPS = 20
 
     /** No object index, so it stands for an object one walk of [PathSearch] hasn't reached. */
     private const val NOT_REACHED = -1

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPath.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPath.kt
@@ -16,13 +16,11 @@ data class RootPath(
    */
   val gcRootLabel: String?,
   /** From the GC rooted object down to the object itself, which is the last step. */
-  val steps: List<RootPathStep>,
-  /** How many steps between the GC root and [steps] were left out to keep the chain readable. */
-  val hiddenStepCount: Int
+  val steps: List<RootPathStep>
 ) {
   companion object {
     /** No chain: nothing the tree was built from reaches the object. */
-    val NONE = RootPath(gcRootLabel = null, steps = emptyList(), hiddenStepCount = 0)
+    val NONE = RootPath(gcRootLabel = null, steps = emptyList())
   }
 }
 

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathDetour.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathDetour.kt
@@ -72,10 +72,9 @@ fun RootPath.waysOf(
   val ownSteps = steps.subList(detour.fromIndex, detour.toIndex + 1)
   val isHead = detour.fromObjectId == null
   val own = RootPathWay(
-    // Only a stretch off the top of the chain has a GC root above it to name, and only that one can have
-    // had steps left out: the rest start at an object the chain shows.
+    // Only a stretch off the top of the chain has a GC root above it to name: the rest start at an object
+    // the chain shows.
     gcRootLabel = if (isHead) gcRootLabel else null,
-    hiddenStepCount = if (isHead) hiddenStepCount else 0,
     steps = ownSteps
   )
   val ownObjectIds = ownSteps.map { it.step.objectId }
@@ -84,7 +83,6 @@ fun RootPath.waysOf(
     .map { path ->
       RootPathWay(
         gcRootLabel = path.gcRootLabel,
-        hiddenStepCount = path.hiddenStepCount,
         // Only the step this stretch arrives at can dominate the object: the rest are steps the chain
         // could have gone round, which is what made this a detour.
         steps = path.steps.mapIndexed { index, step ->
@@ -99,8 +97,6 @@ fun RootPath.waysOf(
 data class RootPathWay(
   /** Which GC root it starts at, for a stretch off the top of a chain. Null below an object. */
   val gcRootLabel: String?,
-  /** How many of its steps were left out to keep it readable, as on [RootPath.hiddenStepCount]. */
-  val hiddenStepCount: Int,
   val steps: List<RootPathStep>
 )
 
@@ -121,7 +117,6 @@ fun RootPath.drawnWith(
   val drawn = mutableListOf<RootPathStep>()
   val detourByRow = mutableMapOf<Int, RootPathDetour>()
   var gcRootLabel = this.gcRootLabel
-  var hiddenStepCount = this.hiddenStepCount
   var index = 0
   while (index < steps.size) {
     val detour = detourByFromIndex[index]
@@ -140,13 +135,12 @@ fun RootPath.drawnWith(
       drawn += way.steps
       if (detour.fromObjectId == null) {
         gcRootLabel = way.gcRootLabel
-        hiddenStepCount = way.hiddenStepCount
       }
     }
     index = detour.toIndex + 1
   }
   return DrawnRootPath(
-    path = RootPath(gcRootLabel = gcRootLabel, steps = drawn, hiddenStepCount = hiddenStepCount),
+    path = RootPath(gcRootLabel = gcRootLabel, steps = drawn),
     detourByRow = detourByRow
   )
 }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerDumps.kt
@@ -350,7 +350,7 @@ internal fun TemporaryFolder.onAStackAndInAFieldHeapDump(): File {
 
 /**
  * A heap dump where a payload is held at the end of a chain of [CHAIN_LINK_COUNT] objects, which is
- * longer than a chain is drawn.
+ * taller than the pane a chain is drawn in.
  */
 internal fun TemporaryFolder.longChainHeapDump(): File {
   val file = newFile("long-chain.hprof")
@@ -450,7 +450,7 @@ internal const val TILE_CLASS_NAME = "com.example.Tile"
 /** Past `MIN_CHILDREN_TO_GROUP_BY_CLASS` in [HeapDominatorTreemap], which is 200. */
 internal const val TILE_COUNT = 205
 
-/** Enough objects between a GC root and a payload that the chain to it has to be cut. */
+/** More objects between a GC root and a payload than a chain pane has the height to draw at once. */
 internal const val CHAIN_LINK_COUNT = 25
 
 /**

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapExplorerTest.kt
@@ -434,7 +434,6 @@ class HeapExplorerTest {
       assertThat(path.gcRootLabel).isEqualTo("GC root: JNI global reference")
       assertThat(path.stepLabels()).containsExactly("Holder", "payload → Object[]")
       assertThat(path.steps.map { it.isDominator }).containsExactly(true, false)
-      assertThat(path.hiddenStepCount).isZero()
     }
   }
 
@@ -454,19 +453,18 @@ class HeapExplorerTest {
     }
   }
 
-  @Test fun `a chain too long to read leaves out the steps nearest the gc root`() {
+  @Test fun `a chain longer than the pane it is drawn in is still the whole chain`() {
     HeapExplorer.open(testFolder.longChainHeapDump()).use { explorer ->
       val tree = explorer.tree
       val payload = tree.findByLabel("Object[]")
 
       val path = tree.rootPathTo(payload.objectId)
 
-      // What the reader is after is what holds the object, and the plumbing between a GC root and an app's
-      // own objects rarely is, so a chain past what fits is cut at the root end.
-      assertThat(path.hiddenStepCount).isEqualTo(CHAIN_LINK_COUNT + 1 - MAX_ROOT_PATH_STEPS_SHOWN)
-      assertThat(path.steps).hasSize(MAX_ROOT_PATH_STEPS_SHOWN)
-      // Named by the field it is held in even though the object holding it is one of the steps left out.
-      assertThat(path.stepLabels().first()).isEqualTo("next → Link18")
+      // Every object between the GC root and the payload, however many that is: a chain cut short is a
+      // reader asking what holds this and being handed a count of the steps that would have said.
+      assertThat(path.steps).hasSize(CHAIN_LINK_COUNT + 1)
+      // The GC rooted object itself, which no field of the heap dump points at, down to the payload.
+      assertThat(path.stepLabels().first()).isEqualTo("Link${CHAIN_LINK_COUNT - 1}")
       assertThat(path.stepLabels().last()).isEqualTo("next → Object[]")
     }
   }
@@ -670,9 +668,6 @@ class HeapExplorerTest {
 
     /** Matches `MAX_FIELDS` in [HeapDominatorTreemap], which isn't public. */
     private const val MAX_FIELDS_SHOWN = 500
-
-    /** Matches `MAX_ROOT_PATH_STEPS` in [HeapDominatorTreemap], which isn't public. */
-    private const val MAX_ROOT_PATH_STEPS_SHOWN = 20
 
     /** Object ids are 4 bytes in a dump built by the test DSL. */
     private const val PAYLOAD_BYTE_SIZE = PAYLOAD_ELEMENT_COUNT * 4L

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/PathChains.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/PathChains.kt
@@ -11,12 +11,10 @@ package shark.explorer
 /** A chain of objects by id, each of them either a dominator of the last one or only on the way to it. */
 internal fun chain(
   vararg steps: Pair<Long, Boolean>,
-  gcRootLabel: String? = A_GC_ROOT,
-  hiddenStepCount: Int = 0
+  gcRootLabel: String? = A_GC_ROOT
 ): RootPath = RootPath(
   gcRootLabel = gcRootLabel,
-  steps = steps.map { (objectId, isDominator) -> RootPathStep(pathStep(objectId), isDominator) },
-  hiddenStepCount = hiddenStepCount
+  steps = steps.map { (objectId, isDominator) -> RootPathStep(pathStep(objectId), isDominator) }
 )
 
 internal fun pathStep(objectId: Long): PathStep = PathStep(

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/RootPathDetourTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/RootPathDetourTest.kt
@@ -69,24 +69,22 @@ class RootPathDetourTest {
       .containsExactly(listOf(false, true), listOf(false, true))
   }
 
-  @Test fun `only a stretch off the top of a chain names a gc root and hides steps`() {
-    val path = chain(1L to ON_THE_WAY, 5L to DOMINATES, gcRootLabel = A_GC_ROOT, hiddenStepCount = 3)
+  @Test fun `only a stretch off the top of a chain names a gc root`() {
+    val path = chain(1L to ON_THE_WAY, 5L to DOMINATES, gcRootLabel = A_GC_ROOT)
     val detour = path.detours().single()
 
     val own = path.waysOf(detour, found = IndependentPaths.NONE).single()
 
     assertThat(own.gcRootLabel).isEqualTo(A_GC_ROOT)
-    assertThat(own.hiddenStepCount).isEqualTo(3)
   }
 
   @Test fun `a stretch below an object has no gc root of its own to name`() {
-    val path = chain(1L to DOMINATES, 3L to ON_THE_WAY, 5L to DOMINATES, hiddenStepCount = 3)
+    val path = chain(1L to DOMINATES, 3L to ON_THE_WAY, 5L to DOMINATES)
     val detour = path.detours().single()
 
     val own = path.waysOf(detour, found = IndependentPaths.NONE).single()
 
     assertThat(own.gcRootLabel).isNull()
-    assertThat(own.hiddenStepCount).isEqualTo(0)
   }
 
   @Test fun `a chain drawn with another way of a stretch is one chain of steps`() {
@@ -115,7 +113,6 @@ class RootPathDetourTest {
     val detour = path.detours().single()
     val other = RootPathWay(
       gcRootLabel = "GC root: thread object",
-      hiddenStepCount = 2,
       steps = listOf(RootPathStep(pathStep(2L), ON_THE_WAY), RootPathStep(pathStep(5L), DOMINATES))
     )
 
@@ -123,7 +120,6 @@ class RootPathDetourTest {
 
     assertThat(drawn.path.steps.objectIds()).containsExactly(2L, 5L)
     assertThat(drawn.path.gcRootLabel).isEqualTo("GC root: thread object")
-    assertThat(drawn.path.hiddenStepCount).isEqualTo(2)
   }
 
   @Test fun `a chain drawn with its own ways is the chain itself`() {
@@ -137,7 +133,6 @@ class RootPathDetourTest {
   /** One way the search found, as it hands them back: no GC root below an object, and nothing marked. */
   private fun foundPath(vararg objectIds: Long) = IndependentPath(
     gcRootLabel = null,
-    steps = objectIds.map { pathStep(it) },
-    hiddenStepCount = 0
+    steps = objectIds.map { pathStep(it) }
   )
 }


### PR DESCRIPTION
A chain past twenty steps was cut at the root end, and the head row said `GC root: …, then … 14 steps` instead of the objects. That answers "what holds this?" with a count of the objects that would have said, in the one pane that exists to answer it, and there is no way from the count back to them. Independent paths — the other ways a stretch of a chain could have run — were cut at fifteen for the same non-reason.

Chains get long: on the dumps in this repo the deepest are **499 steps** (`large-dump.hprof`) and **1,518** (`compose_leak.hprof`), both walks down a linked structure.

What the cut was protecting was the drawing, not the reading:

- **Reading is a heap dump read per step** — 6 ms for the 499-step chain, 12 ms for the 1,518-step one, against a hover's budget of a hundred.
- **Drawing was the real cost.** The pane was a `Column` in a `verticalScroll`, which composes every row, and a chain of 1,500 rows at four lines each never appeared at all — 60 s and nothing on screen. It is a `LazyColumn` now: the pane composes the seven rows it has the height for, and a chain of 500 steps takes the same ~200 ms from the click as one of 20.
- **The stretches that could have run otherwise are still asked per chain**, and a chain that long has almost none — the deep ones are linked lists, where every step dominates the object. One detour and 18 ms for the 499, none at all for the 1,518.

Numbers came from throwaway tests over `large-dump.hprof` and `compose_leak.hprof`, deleted before this landed; they're recorded in `notes/decisions.md`.

Tests: the core test that pinned the cut now pins the whole chain, and the UI test for a chain taller than its pane asserts the off-screen row *doesn't exist* rather than isn't displayed, which is what a lazy pane means. `shark-explorer-core:check` and `shark-explorer-app:check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)