### PR TITLE
Say what holds an object once a verdict is set on the loop above it

### DIFF
--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -964,12 +964,21 @@ has established, is a screen that goes on listing an object they have already ex
 **Two statuses set by hand can contradict each other, and the contradiction is shown rather than settled.**
 The propagation rules are what make it possible: a leaking object above forces everything it holds to be
 leaking, and an object still needed below forces everything holding it to be needed. So two hand-set statuses
-disagree exactly when one of the objects reaches the other, which is `HeapDominatorTreemap.reaches` —
-one walk up `ReferrerIndex` per status already set, a question somebody asked rather than one the pointer
-asks. `leakStatusConflictsWith` answers it before anything is written, and the dialog then lists every one of
-them by name, with the reason it was given, because whoever is about to overrule it is the only person who
-can weigh the two.
+disagree when one of the objects is above the other, which is `HeapDominatorTreemap.reaches` asked **both ways
+round** — one walk up `ReferrerIndex` per status already set, a question somebody asked rather than one the
+pointer asks. `leakStatusConflictsWith` answers it before anything is written, and the dialog then lists every
+one of them by name, with the reason it was given, because whoever is about to overrule it is the only person
+who can weigh the two.
 
+- **Reaching each other is not being above each other**, and it is ordinary rather than exotic: the sample
+  app's `AsyncTask` leak is three objects on a loop — the task holds the thread running it through
+  `FutureTask.runner`, that thread's frame holds the runnable the executor wrapped the task in, and that
+  runnable holds the task. Asking `reaches` one way round there answers yes whichever pair and whichever
+  direction, so the first version reported the canonical case as a conflict and named the two objects the
+  wrong way round in it. Neither object on a loop is above the other — which one a chain shows first is
+  decided by where the chain enters the loop — so `isAbove` asks both directions and a loop is no conflict.
+  The chain still says so wherever it does put one above the other, which is a reason reading
+  `Conflicts with`.
 - **Flipping to the opposite status always resolves it**, which is why solving a conflict is one button.
   `NOT_LEAKING` propagates upwards only and `LEAKING` downwards only, so the pair that can disagree is
   always those two, and agreeing with the new status is the same as being flipped.

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -558,7 +558,7 @@ six.
 the retained-since-the-last-dump one — against this screen. `LeakFingerprintTest` is that check on
 synthetic dumps, one per difference that used to break it; the sweep over the ten real Android dumps in
 this repo is worth re-running by hand after touching any of this, and it stands at **8 of the 10 dumps
-agreeing exactly, 12 of the 15 leaks**. It is what found everything on this page: the counts alone matched
+agreeing exactly, 13 of the 15 leaks**. It is what found everything on this page: the counts alone matched
 three rounds before the leak fingerprints did, because two chains can be different and the same length.
 
 **Two dumps still differ, and neither is a tie-break nobody can explain.**
@@ -615,7 +615,7 @@ can't take that way at all, because **its phase 1 treats a leaking object as a l
   `Reference.isLowPriority` in the top bit of each edge to answer it.
 - **A reference into an object that shouldn't be in memory wasn't put off**, so a chain took it where there
   was a way round, and the object it led to hashed to the leak fingerprint of the leak on the way. That is
-  the third tier in `RootPathSearch`'s queue, on the same two queues as a stack frame and for the same reason:
+  a queue of its own in `RootPathSearch`, walked after the plain one for the same reason a stack frame is:
   a path through a dead object explains what holds an object about as well as a running method does. Where
   every way is a leak the chain still runs through one, which is what the fold above then drops. It reads as
   a different rule in LeakCanary — its phase 1 makes a leaking object a leaf, so the way round is the only
@@ -625,6 +625,30 @@ can't take that way at all, because **its phase 1 treats a leaking object as a l
   rather than when the Leaks screen is opened, which on the 38 MB dump is 296 ms once, paid by the first
   chain (963 ms against 627 ms) and by nothing after it. Two thousand chains take 1381 ms with the tier and
   1348 ms without, which is noise — the extra tier is one array read per referrer.
+
+- **The two put-off kinds shared one queue, so between them the shorter way won**, and the shorter way to
+  nearly anything is a stack frame. Measured on `leak_asynctask_o.hprof`, marking `SerialExecutor$1`
+  `Expected` and `AsyncTask$3` `Stuck` — the two verdicts that make the chain name the faulty reference —
+  turned `AsyncTask.SERIAL_EXECUTOR → SerialExecutor$1 → AsyncTask$3 → MainActivity$2 → MainActivity` into
+  `Thread → <local variable> → MainActivity$2 → MainActivity`, the frame being two steps from the activity
+  where the executor is six. That chain has no `Expected` step on it, so nothing crosses to `Stuck` and no
+  reference is marked: the verdicts that identify the leak were what hid it. So the two kinds are now two
+  queues, a leak above a low priority reference, because **a leak is an answer and a stack frame is not** —
+  an object marked `Stuck` is a reader saying this is the thing to fix, and a frame answers "what holds
+  this" with "a method is running".
+
+  Costs one more int array the size of the dump, five in `RootPathSearch` now, and a `maxOf` per referrer.
+  A/B on the 38 MB dump, same sample and same JVM settings minutes apart: the 2000 chains to its 2000
+  largest objects, 1,713,405 steps and identical before and after, in 14.8–15.2 s ranked against 15.0–15.8 s
+  unranked. Reading the steps out of the dump dominates that number — 857 steps a chain here — so read it as
+  "no measurable cost" rather than as a measurement of the walk. The sweep below was re-run either side of
+  it and gives the same leak fingerprints on all ten dumps.
+
+  **What made it hard to see from the window is that nothing else offered the executor route.** The ways a
+  detour could have run are node-disjoint paths (`independentPathsFromRoots`), and the executor route
+  reaches `MainActivity$2` through `AsyncTask$3`, which the frame route already took — so it is not
+  independent of one and never reported as an alternative. It was on screen only because the chain itself
+  ran through it.
 
 **Shark's library leak matchers are added to the reference reader the tree is built from**
 (`ReferenceStrengthReader`), filtered to `LibraryLeakReferenceMatcher` — the ignored ones beside them would

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -116,7 +116,7 @@ class HeapDominatorTreemap internal constructor(
   private val bitmaps = HeapBitmaps(graph)
 
   /**
-   * The walk up to the roots the tree was built from, kept between questions: it works over four arrays
+   * The walk up to the roots the tree was built from, kept between questions: it works over five arrays
    * the size of the heap dump, and the pointer moving across a treemap asks for one path per rectangle it
    * crosses. Built on first use, like the index it walks.
    *
@@ -132,7 +132,7 @@ class HeapDominatorTreemap internal constructor(
    * Which objects a chain is worth going round, by object index. See [RootPathSearch].
    *
    * The heap dump's own answer, with the statuses set by hand written over it, and edited in place rather
-   * than built again per read: [rootPathSearch] holds on to this array and four more the size of the heap
+   * than built again per read: [rootPathSearch] holds on to this array and five more the size of the heap
    * dump, so undoing a handful of ids costs nothing where building another walk costs the dump twice over.
    * Which is only sound because one thread reads the tree — see [rootPathSearchThrough].
    */

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/HeapDominatorTreemap.kt
@@ -762,9 +762,9 @@ class HeapDominatorTreemap internal constructor(
   /**
    * Whether [fromObjectId] holds [toObjectId], through any chain of the references this tree was built by.
    *
-   * What "above" and "below" mean when they are asked about two objects rather than about one chain: a
-   * status decides what the objects it holds are, so two statuses set by hand disagree exactly when one of
-   * the objects reaches the other. See [leakStatusConflictsWith].
+   * Half of what "above" and "below" mean when they are asked about two objects rather than about one chain:
+   * two objects of a heap dump often reach each other, and then neither is above the other, so a status set
+   * by hand is settled against another one by asking this both ways round. See `isAbove`.
    *
    * One walk up the referrers from [toObjectId], which on an object the whole heap dump holds is a walk over
    * everything above it — the same cost as asking every way an object is held. So this is for a question

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/LeakStatusOverrides.kt
@@ -88,7 +88,8 @@ class LeakStatusOverrides private constructor(private val byObjectId: Map<Long, 
  * question about how the two objects are held rather than about either of them: everything a leaking object
  * holds is leaking, and everything holding an object that is still needed is still needed. So a leaking
  * object above and an object that is not leaking below are two statuses that cannot both be read off the
- * chain running through them, whichever of them a hand set. See [leakStatusConflictsWith].
+ * chain running through them, whichever of them a hand set. Above and below in the sense of [isAbove], which
+ * is not every pair one of which reaches the other. See [leakStatusConflictsWith].
  */
 class LeakStatusConflict(
   /** The status already set by hand, which the new one disagrees with. */
@@ -115,9 +116,9 @@ class LeakStatusConflict(
  * new one and flip the others to agree, or leave the heap dump as it was. Nothing is decided here — this
  * only says what the disagreements are.
  *
- * A walk up the referrers per status already set, which is what asking whether one object holds another
- * costs: see [HeapDominatorTreemap.reaches]. There are a handful of statuses in a heap dump, so this is a
- * handful of walks, and it belongs on the heap dump's thread like every other read.
+ * A walk up the referrers per status already set, which is what asking whether one object is above another
+ * costs: see [isAbove]. There are a handful of statuses in a heap dump, so this is a handful of walks, and it
+ * belongs on the heap dump's thread like every other read.
  */
 fun HeapDominatorTreemap.leakStatusConflictsWith(
   override: LeakStatusOverride,
@@ -132,12 +133,12 @@ fun HeapDominatorTreemap.leakStatusConflictsWith(
     // down here.
     val holdsIt = existing.status == LeakStatus.LEAKING &&
       override.status != LeakStatus.LEAKING &&
-      reaches(existing.objectId, override.objectId)
+      isAbove(aboveObjectId = existing.objectId, belowObjectId = override.objectId)
     // And an object below that is still needed forces everything holding it to be needed too, so it
     // disagrees with anything else up here.
     val heldByIt = existing.status == LeakStatus.NOT_LEAKING &&
       override.status != LeakStatus.NOT_LEAKING &&
-      reaches(override.objectId, existing.objectId)
+      isAbove(aboveObjectId = override.objectId, belowObjectId = existing.objectId)
     if (!holdsIt && !heldByIt) {
       return@mapNotNull null
     }
@@ -157,6 +158,38 @@ fun HeapDominatorTreemap.leakStatusConflictsWith(
       "${conflicts.size} of the ${overrides.all.size} statuses set by hand"
   }
   return conflicts
+}
+
+/**
+ * Whether [aboveObjectId] is above [belowObjectId]: it holds it, and is not held by it in turn.
+ *
+ * **Both directions, because objects that hold each other are ordinary in a heap dump** rather than a corner
+ * case: an `AsyncTask` holds the thread running it, that thread's stack frame holds the runnable the executor
+ * wrapped the task in, and that runnable holds the task — three objects each of which reaches the other two.
+ * [HeapDominatorTreemap.reaches] on its own answers yes whichever way it is asked about any of those pairs, so
+ * a conflict worked out from one direction of it is a conflict reported with whichever direction was asked
+ * first, which reads back to whoever set the status as the two objects the wrong way round.
+ *
+ * Neither of two objects on a loop is above the other. Which of them a chain shows first is decided by where
+ * that chain enters the loop, so the graph doesn't order them and a conflict between them would be one of two
+ * answers with nothing to pick between them. Nothing is lost by not reporting it: a chain that does put one
+ * above the other still records the disagreement, which is a reason reading `Conflicts with`.
+ */
+private fun HeapDominatorTreemap.isAbove(
+  aboveObjectId: Long,
+  belowObjectId: Long
+): Boolean {
+  if (!reaches(aboveObjectId, belowObjectId)) {
+    return false
+  }
+  if (reaches(belowObjectId, aboveObjectId)) {
+    SharkLog.d {
+      "${hexObjectId(aboveObjectId)} and ${hexObjectId(belowObjectId)} hold each other, so neither of them " +
+        "is above the other"
+    }
+    return false
+  }
+  return true
 }
 
 /**

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathSearch.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/RootPathSearch.kt
@@ -4,34 +4,26 @@ import androidx.collection.IntSet
 
 /**
  * The walk from one object out to the nearest of [treeRootIndexes], which is the way a GC root reaches it
- * that is easiest to make sense of: breadth first over the referrers, putting off the references that are
- * hard to read a leak from until there is nothing else left to walk.
+ * that is easiest to make sense of: breadth first over the referrers, putting off the ways that are hard to
+ * read a leak from until there is nothing better left to walk.
  *
  * Which is `shark.PrioritizingShortestPathFinder`'s rule, read in the other direction — it walks down from
  * the GC roots and this walks up from the object — and the same rule for the same reason: a shortest path
- * is a truthful answer to "what holds this", not necessarily a useful one. The reference to put off is
- * whichever the reference reader marked [shark.Reference.isLowPriority], which is a running method's stack
- * frame, a reference known to leak in code an app doesn't control, and the arrays ART hangs off a class.
- * A path through a stack frame says an object was in use when the dump was taken, which is nothing to fix
- * and often one step from anywhere.
+ * is a truthful answer to "what holds this", not necessarily a useful one.
  *
- * **An object that shouldn't be in memory is put off for the same reason**, which is [leakingIndexes]: a
- * chain that runs through one says this object is held by a leak, and while there is another way to it
- * that isn't, that other way is what holds it once the leak is fixed. It is also what LeakCanary does,
- * where it reads as a different rule — its phase 1 stops at a leaking object rather than deprioritizing
- * one, so the way round is the only path it can find at all.
- *
- * So a path with none of those in it wins over a shorter one that has one, and once a walk is past one
- * there is no going back to the cheap kind: a chain is only as readable as its worst step. Among paths of
- * the same kind, the shortest. Which means a chain still runs through a leak when every way to the object
- * does — an object a leak dominates is held by that leak, and saying so is the whole answer.
+ * **Three kinds of way, walked best first**, one queue each: [PLAIN], then [THROUGH_A_LEAK], then
+ * [THROUGH_A_LOW_PRIORITY_REFERENCE]. So a way with nothing worth putting off on it wins over a shorter one
+ * that has something, and once a walk is past one there is no going back to a better kind: a chain is only
+ * as readable as its worst step. Among ways of the same kind, the shortest. Which means a chain still runs
+ * through a leak when every way to the object does — an object a leak dominates is held by that leak, and
+ * saying so is the whole answer.
  *
  * Object indexes rather than ids throughout, because that is what a [ReferrerIndex] walks in and what the
  * arrays here are indexed by. See [HeapDominatorTreemap.rootPathTo], which reads the objects out.
  *
  * One instance per tree rather than per question, because a treemap answers this for every rectangle the
  * pointer crosses and the arrays are the size of the heap dump. Which objects one walk has seen is
- * therefore stamped with the walk rather than cleared afterwards: clearing four arrays of a million ints
+ * therefore stamped with the walk rather than cleared afterwards: clearing five arrays of a million ints
  * per rectangle would cost more than the walk does.
  */
 internal class RootPathSearch(
@@ -49,17 +41,21 @@ internal class RootPathSearch(
   private val nextTowardsTarget = IntArray(referrerIndex.objectCount)
 
   /**
-   * Which walk each object was last seen by, [NO_WALK] for one no walk has reached yet, and negated for
-   * one queued in [lastQueue] — which is a bit rather than an array of its own, since the walk has to be
-   * able to tell that an object it put off is now reachable without putting anything off.
+   * Which walk each object was last seen by and through which kind of way, as [seenThrough] packs the two:
+   * the walk decides whether anything is known about the object at all, and the kind whether a way just
+   * found is worth queueing it again for.
    */
   private val seenByWalk = IntArray(referrerIndex.objectCount)
 
-  /** Breadth first, and an object is queued at most once per walk, so the dump's size is the bound. */
-  private val queue = IntArray(referrerIndex.objectCount)
+  /**
+   * One queue per kind of way, and an object is queued at most once per kind per walk, so the dump's size
+   * is the bound on each of them.
+   */
+  private val queues = Array(KIND_COUNT) { IntArray(referrerIndex.objectCount) }
 
-  /** The objects only a reference worth putting off has reached, walked once [queue] runs out. */
-  private val lastQueue = IntArray(referrerIndex.objectCount)
+  /** Where each of them is being read and written, which is what a walk resets rather than the queues. */
+  private val queueHeads = IntArray(KIND_COUNT)
+  private val queueTails = IntArray(KIND_COUNT)
 
   private var walkCount = NO_WALK
 
@@ -71,52 +67,62 @@ internal class RootPathSearch(
       return intArrayOf(targetIndex)
     }
     walkCount++
+    queueHeads.fill(0)
+    queueTails.fill(0)
     // Seen from the start, so that no path found goes round through the object it leads to, which would
     // report the object as holding itself.
-    seenByWalk[targetIndex] = walkCount
-    queue[0] = targetIndex
-    var head = 0
-    var tail = 1
-    var lastHead = 0
-    var lastTail = 0
-    // Everything the first pass reached without a reference worth putting off, then everything else. An
-    // object queued in the second pass stays in it, since a path through it is already the second kind.
-    var walkingLast = false
-    while (head < tail || lastHead < lastTail) {
-      val current = if (!walkingLast && head < tail) {
-        queue[head++]
-      } else {
-        walkingLast = true
-        lastQueue[lastHead++]
+    seenByWalk[targetIndex] = seenThrough(PLAIN)
+    queues[PLAIN][queueTails[PLAIN]++] = targetIndex
+    var kind = PLAIN
+    while (kind < KIND_COUNT) {
+      if (queueHeads[kind] == queueTails[kind]) {
+        // Nothing reachable this well is left, so the next kind down is now the best there is.
+        kind++
+        continue
       }
-      // Put off when it was queued and walked before this pass reached it, since something turned out to
-      // hold it plainly. It is on this queue too, and there is nothing to do about that but skip it.
-      if (walkingLast && seenByWalk[current] != -walkCount) {
+      val current = queues[kind][queueHeads[kind]++]
+      // Queued here and then found a better way, which put it on a queue this one comes after. It is on
+      // this queue too, and there is nothing to do about that but skip it.
+      if (seenByWalk[current] != seenThrough(kind)) {
         continue
       }
       if (current in treeRootIndexes) {
         return pathFrom(current, targetIndex)
       }
       referrerIndex.forEachReferrer(current) { referrer, isLowPriority ->
-        // A step onto an object that shouldn't be in memory is a step this path is worse for, the same as a
-        // low priority reference: every object above the target is a referrer of something on the way up.
-        val putOff = walkingLast || isLowPriority || leakingIndexes[referrer]
+        // A chain is as good as its worst step, so a way on through a referrer is the worse of the way
+        // here and of the step itself.
+        val referrerKind = maxOf(kind, kindOfStepTo(referrer, isLowPriority))
         val seen = seenByWalk[referrer]
-        // Not seen at all, or seen only through a reference worth putting off and this one isn't.
-        if (seen != walkCount && (seen != -walkCount || !putOff)) {
+        // Not seen by this walk at all, or seen only through a worse kind of way than this one.
+        if (seen < seenThrough(PLAIN) || seen > seenThrough(referrerKind)) {
           nextTowardsTarget[referrer] = current
-          if (putOff) {
-            seenByWalk[referrer] = -walkCount
-            lastQueue[lastTail++] = referrer
-          } else {
-            seenByWalk[referrer] = walkCount
-            queue[tail++] = referrer
-          }
+          seenByWalk[referrer] = seenThrough(referrerKind)
+          queues[referrerKind][queueTails[referrerKind]++] = referrer
         }
       }
     }
     return null
   }
+
+  /** Which kind a way is that steps onto [referrer], every object above the target being one. */
+  private fun kindOfStepTo(
+    referrer: Int,
+    isLowPriority: Boolean
+  ): Int = when {
+    isLowPriority -> THROUGH_A_LOW_PRIORITY_REFERENCE
+    leakingIndexes[referrer] -> THROUGH_A_LEAK
+    else -> PLAIN
+  }
+
+  /**
+   * The walk and the kind of way in one int, kinds ascending inside a walk, so that a smaller number is a
+   * better way and every number of one walk is below every number of the next.
+   *
+   * One array rather than two because it is read once per referrer of every object a walk reaches, and a
+   * walk is what the pointer moving over a rectangle asks for.
+   */
+  private fun seenThrough(kind: Int): Int = walkCount * KIND_COUNT + kind
 
   private fun pathFrom(
     sourceIndex: Int,
@@ -134,5 +140,36 @@ internal class RootPathSearch(
   companion object {
     /** No walk has this number: they start at 1, so a zeroed array has been seen by none of them. */
     private const val NO_WALK = 0
+
+    /** Nothing worth putting off on the way, which is the chain to draw whenever there is one. */
+    private const val PLAIN = 0
+
+    /**
+     * Through an object that shouldn't be in memory, which is [leakingIndexes]: a chain that runs through
+     * one says this object is held by a leak, and while there is another way to it that isn't, that other
+     * way is what holds it once the leak is fixed. It is also what LeakCanary does, where it reads as a
+     * different rule — its phase 1 stops at a leaking object rather than deprioritizing one, so the way
+     * round is the only path it can find at all.
+     */
+    private const val THROUGH_A_LEAK = 1
+
+    /**
+     * Through whichever reference the reference reader marked [shark.Reference.isLowPriority], which is a
+     * running method's stack frame, a reference known to leak in code an app doesn't control, and the
+     * arrays ART hangs off a class. A path through a stack frame says an object was in use when the dump
+     * was taken, which is nothing to fix and often one step from anywhere.
+     *
+     * **Below [THROUGH_A_LEAK], because a leak is an answer and a stack frame is not.** An object marked
+     * leaking is a reader saying this is the thing to fix, so a chain running through it names that thing;
+     * a chain that leaves it for a frame answers "what holds this" with "a method is running", which is
+     * the one answer nobody can act on. Measured on `leak_asynctask_o.hprof`, where the two verdicts that
+     * make the chain name the faulty reference used to send it onto the worker thread instead — the frame
+     * being two steps from the activity where the executor is six — and a chain with no verdict on it
+     * marks no reference. `notes/decisions.md` has the numbers.
+     */
+    private const val THROUGH_A_LOW_PRIORITY_REFERENCE = 2
+
+    /** How many kinds of way there are, which is how many queues a walk works through. */
+    private const val KIND_COUNT = 3
   }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
@@ -215,6 +215,93 @@ class HeapLeakStatusTest {
     }
   }
 
+  /**
+   * The loop of [taskHoldingItsOwnThreadHeapDump], which is what makes both of the next two questions
+   * questions: every pair of objects on it reaches the other, so reaching is not what says which is above.
+   */
+  @Test fun `objects that hold each other each reach the other`() {
+    val dump = testFolder.taskHoldingItsOwnThreadHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      assertThat(explorer.tree.reaches(dump.wrapperObjectId, dump.taskObjectId)).isTrue()
+      assertThat(explorer.tree.reaches(dump.taskObjectId, dump.wrapperObjectId)).isTrue()
+    }
+  }
+
+  /**
+   * Which is the shape of the sample app's `AsyncTask` leak, and so the one every reader of it reaches: the
+   * runnable the executor is running belongs in memory and the task it holds does not, said in that order,
+   * with the faulty reference between them the whole point of saying it.
+   */
+  @Test fun `two statuses on objects that hold each other do not conflict`() {
+    val dump = testFolder.taskHoldingItsOwnThreadHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.taskObjectId, LEAKING, "this task should have been cancelled"),
+        overrides = overrides(dump.wrapperObjectId, NOT_LEAKING, "the executor is running this")
+      )
+
+      assertThat(conflicts).isEmpty()
+    }
+  }
+
+  /** And set in the other order, since the walk is from whichever of the two is already there. */
+  @Test fun `nor do they the other way round`() {
+    val dump = testFolder.taskHoldingItsOwnThreadHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.wrapperObjectId, NOT_LEAKING, "the executor is running this"),
+        overrides = overrides(dump.taskObjectId, LEAKING, "this task should have been cancelled")
+      )
+
+      assertThat(conflicts).isEmpty()
+    }
+  }
+
+  /**
+   * The two of them read as a chain, which is why there was nothing to settle: the reference from the object
+   * that belongs in memory to the one that doesn't is the fault, and nothing else on the chain can be.
+   */
+  @Test fun `a status on each of them marks the reference between them instead`() {
+    val dump = testFolder.taskHoldingItsOwnThreadHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val path = explorer.tree.rootPathTo(
+        objectId = dump.activityObjectId,
+        overrides = LeakStatusOverrides.of(
+          listOf(
+            override(dump.wrapperObjectId, NOT_LEAKING, "the executor is running this"),
+            override(dump.taskObjectId, LEAKING, "this task should have been cancelled")
+          )
+        )
+      )
+
+      assertThat(path.faultyReferences())
+        .containsExactly("${WRAPPER_CLASS_NAME.substringAfterLast('.')}.val\$r")
+    }
+  }
+
+  /**
+   * A loop is not a heap dump where nothing conflicts: an object below one is held by every object of it, so
+   * a status on it is settled against them the way any other pair is.
+   */
+  @Test fun `a status below a loop still conflicts with one on it`() {
+    val dump = testFolder.taskHoldingItsOwnThreadHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val conflicts = explorer.tree.leakStatusConflictsWith(
+        override = override(dump.activityObjectId, NOT_LEAKING, "this screen is coming back"),
+        overrides = overrides(dump.taskObjectId, LEAKING, "this task should have been cancelled")
+      )
+
+      val conflict = conflicts.single()
+      assertThat(conflict.existing.objectId).isEqualTo(dump.taskObjectId)
+      assertThat(conflict.isAbove).isTrue()
+    }
+  }
+
   @Test fun `setting a status again on the same object disagrees with nothing`() {
     val dump = testFolder.nestedLeaksHeapDump()
 

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/HeapLeakStatusTest.kt
@@ -394,6 +394,28 @@ class HeapLeakStatusTest {
     }
   }
 
+  /**
+   * The way round a leak is only worth taking while it is a way anybody can read, and a running method's
+   * stack frame is not one: it says the object was in use when the dump was taken, which is nothing to fix.
+   * So a chain gives up going round rather than take a frame — see [RootPathSearch].
+   */
+  @Test fun `a chain runs through what shouldn't be in memory rather than through a stack frame`() {
+    val dump = testFolder.taskHoldingItsOwnThreadHeapDump()
+
+    HeapExplorer.open(dump.file).use { explorer ->
+      val path = explorer.tree.rootPathTo(
+        objectId = dump.activityObjectId,
+        overrides = overrides(dump.taskObjectId, LEAKING, "this task should have been cancelled")
+      )
+
+      // The frame holding the activity is two steps from the thread where the executor's field is four, and
+      // it is the four that says what holds this activity: the task somebody has just said shouldn't be
+      // running.
+      assertThat(path.steps.map { it.step.objectId }).contains(dump.taskObjectId)
+      assertThat(path.steps.map { it.step.className }).doesNotContain("java.lang.Thread")
+    }
+  }
+
   private fun override(
     objectId: Long,
     status: LeakStatus,

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
@@ -374,8 +374,10 @@ internal fun TemporaryFolder.leakOnAStackAndInAFieldHeapDump(): File {
  * that thread's stack frame holds the runnable back. Which is a loop, and the objects on it are neither above
  * nor below each other however far a walk up the referrers gets. See `isAbove`.
  *
- * The chains drawn through it all take the executor's field rather than the frame, since [RootPathSearch]
- * puts a frame off, so what a reader sees is the wrapper above the task with the activity under both.
+ * The chains drawn through it all take the executor's field rather than a frame, since [RootPathSearch] puts
+ * a frame off, so what a reader sees is the wrapper above the task with the activity under both. **A frame
+ * holds the activity too**, as the running thread's frames do in `leak_asynctask_o.hprof`, which is what
+ * makes it the shorter way in the moment a status set by hand puts the way through the task off as well.
  */
 internal fun TemporaryFolder.taskHoldingItsOwnThreadHeapDump(): TaskLoopHeapDump {
   val file = newFile("task-holding-its-own-thread.hprof")
@@ -403,6 +405,9 @@ internal fun TemporaryFolder.taskHoldingItsOwnThreadHeapDump(): TaskLoopHeapDump
     // The runnable the thread is inside of, which is how the loop closes: a local variable of a method
     // running on that thread is a Java frame GC root, read as a reference of the thread itself.
     gcRoot(JavaFrame(id = wrapper.value, threadSerialNumber = 42, frameNumber = 0))
+    // And the activity the method it is running has a hold of, two steps from the thread where the
+    // executor's field is four.
+    gcRoot(JavaFrame(id = activity.value, threadSerialNumber = 42, frameNumber = 1))
     val executor = instance(
       clazz(className = EXECUTOR_CLASS_NAME, fields = listOf("mActive" to ReferenceHolder::class)),
       fields = listOf(wrapper)

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/LeakHeapDumps.kt
@@ -366,6 +366,66 @@ internal fun TemporaryFolder.leakOnAStackAndInAFieldHeapDump(): File {
   return file
 }
 
+/**
+ * A heap dump shaped like the `AsyncTask` of the sample app, where three objects each hold the other two.
+ *
+ * What a real executor looks like while it is running something: the executor holds the runnable it wrapped
+ * the task in, that runnable holds the task, the task holds the thread running it — `FutureTask.runner` — and
+ * that thread's stack frame holds the runnable back. Which is a loop, and the objects on it are neither above
+ * nor below each other however far a walk up the referrers gets. See `isAbove`.
+ *
+ * The chains drawn through it all take the executor's field rather than the frame, since [RootPathSearch]
+ * puts a frame off, so what a reader sees is the wrapper above the task with the activity under both.
+ */
+internal fun TemporaryFolder.taskHoldingItsOwnThreadHeapDump(): TaskLoopHeapDump {
+  val file = newFile("task-holding-its-own-thread.hprof")
+  var wrapperObjectId = 0L
+  var taskObjectId = 0L
+  var activityObjectId = 0L
+  file.dump {
+    val thread = instance(
+      clazz(className = "java.lang.Thread", fields = listOf("name" to ReferenceHolder::class)),
+      fields = listOf(string(WORKER_THREAD_NAME))
+    )
+    gcRoot(ThreadObject(id = thread.value, threadSerialNumber = 42, stackTraceSerialNumber = 0))
+    val activity = instance(activityClass(), fields = listOf(BooleanHolder(true)))
+    val task = instance(
+      clazz(
+        className = TASK_CLASS_NAME,
+        fields = listOf("this$0" to ReferenceHolder::class, "runner" to ReferenceHolder::class)
+      ),
+      fields = listOf(activity, thread)
+    )
+    val wrapper = instance(
+      clazz(className = WRAPPER_CLASS_NAME, fields = listOf("val\$r" to ReferenceHolder::class)),
+      fields = listOf(task)
+    )
+    // The runnable the thread is inside of, which is how the loop closes: a local variable of a method
+    // running on that thread is a Java frame GC root, read as a reference of the thread itself.
+    gcRoot(JavaFrame(id = wrapper.value, threadSerialNumber = 42, frameNumber = 0))
+    val executor = instance(
+      clazz(className = EXECUTOR_CLASS_NAME, fields = listOf("mActive" to ReferenceHolder::class)),
+      fields = listOf(wrapper)
+    )
+    gcRoot(JniGlobal(id = executor.value, jniGlobalRefId = 0))
+    wrapperObjectId = wrapper.value
+    taskObjectId = task.value
+    activityObjectId = activity.value
+  }
+  return TaskLoopHeapDump(file, wrapperObjectId, taskObjectId, activityObjectId)
+}
+
+/** A [taskHoldingItsOwnThreadHeapDump] and the three objects of it a status gets set on. */
+internal class TaskLoopHeapDump(
+  val file: File,
+  /** The runnable the executor is running, which is on the loop and above the task on every chain. */
+  val wrapperObjectId: Long,
+  /** The task it wrapped, which is on the loop too and is what holds the activity. */
+  val taskObjectId: Long,
+  /** The destroyed activity under both of them, which is on no loop. */
+  val activityObjectId: Long
+)
+
 /** A heap dump where the only destroyed activity is one nothing points at any more. */
 internal fun TemporaryFolder.collectedActivityHeapDump(): File {
   val file = newFile("collected-activity.hprof")
@@ -480,6 +540,16 @@ internal const val WATCHED_CLASS_NAME = "com.example.LeakingPresenter"
 internal const val ACTIVITY_CLASS_NAME = "com.example.MainActivity"
 
 internal const val HOLDER_CLASS_NAME = "com.example.Holder"
+
+/** The three classes of [taskHoldingItsOwnThreadHeapDump], named the way the framework's own are. */
+internal const val EXECUTOR_CLASS_NAME = "android.os.AsyncTask\$SerialExecutor"
+
+internal const val WRAPPER_CLASS_NAME = "android.os.AsyncTask\$SerialExecutor\$1"
+
+internal const val TASK_CLASS_NAME = "android.os.AsyncTask\$3"
+
+/** And the thread it is running on, which a chain names when it walks through its stack. */
+private const val WORKER_THREAD_NAME = "AsyncTask #1"
 
 internal const val APPLICATION_CLASS_NAME = "com.example.ExampleApplication"
 


### PR DESCRIPTION
Two fixes to what setting verdicts by hand does on `leak_asynctask_o.hprof`, found one behind the other: the first stops a conflict dialog nobody could make sense of, the second is why the verdicts that dialog was about still showed nothing.

## A conflict reported the two objects the wrong way round

Marking `0x12d00c50` (`AsyncTask$SerialExecutor$1`) as `Expected` and then `0x12d00c30` (`AsyncTask$3`) as `Stuck` — the two verdicts that make the chain name the faulty reference, which is what setting them is for — showed a conflict, saying the runnable *is held by* the task. Every chain the window draws has it the other way round: `SerialExecutor.mActive` → the runnable → `val$r` → the task → the activity.

The conflict check asked `HeapDominatorTreemap.reaches` once, in the one direction the verdict pair implied, and read a yes as "this object is above that one". Those three objects are on a loop, so `reaches` answers yes whichever pair and whichever way round it is asked:

```
AsyncTask$SerialExecutor$1  --val$r-->              AsyncTask$3
AsyncTask$3                 --FutureTask.runner-->  Thread "AsyncTask #1"
Thread "AsyncTask #1"       --<Java Local>-->       AsyncTask$SerialExecutor$1
```

The last edge is the frame of the method the worker thread is inside of, which `JavaLocalReferenceReader` reports as a reference of the thread. `RootPathSearch` puts a frame off, which is why no chain on screen goes that way, and why the direction the dialog reported was the one nobody could see.

So `isAbove` asks `reaches` both ways: an object that is reached by the object it reaches is on a loop with it, and neither of the two is above the other — which of them a chain shows first is decided by where that chain enters the loop. A loop is no conflict, and a conflict that is reported has the direction the chains show. Nothing goes unsaid either: a chain that does put one of them above the other still records the disagreement, as a reason reading `Conflicts with`.

## And then the chain left the reference those verdicts had just identified

With the dialog gone, setting the same two verdicts changed the chain to `MainActivity` from

```
AsyncTask.SERIAL_EXECUTOR → SerialExecutor$1 → AsyncTask$3 → MainActivity$2 → MainActivity
```

to

```
Thread → <local variable> → MainActivity$2 → MainActivity
```

`RootPathSearch` puts two kinds of referrer off until there is nothing else left to walk — a reference the reader marked low priority, a running method's stack frame among them, and an object that shouldn't be in memory — and both went on one queue with nothing to pick between them. So between two put off ways the shorter one won, and here that is the frame: two steps from the activity where the executor is six. That chain has no `Expected` step on it, so nothing crosses to `Stuck` and no reference is marked. The two verdicts that identify the leak were what hid it.

Nothing offered the executor back either: the ways a detour could have run are node disjoint paths, and the executor's route reaches `MainActivity$2` through `AsyncTask$3`, which the frame's route already took.

The two kinds are two queues now, a leak above a low priority reference, because **a leak is an answer and a stack frame is not** — an object marked `Stuck` is a reader saying this is the thing to fix, while a frame answers "what holds this" with "a method is running".

Costs one more int array the size of the heap dump and a `maxOf` per referrer. A/B on the 38 MB dump: the 2000 chains to its largest 2000 objects, identical before and after at 1,713,405 steps, in 14.8–15.2 s ranked against 15.0–15.8 s unranked. The sweep of the explorer's leaks against LeakCanary's over the ten real dumps in this repo was re-run either side of the change and gives the same leak fingerprints on all ten.

## Tests

A heap dump shaped like that `AsyncTask` — three objects each holding the other two, the destroyed activity under them, and a frame of the worker thread holding that activity as the real dump's frames do — and six cases on it in `HeapLeakStatusTest`: that the loop's objects each reach the other, that two verdicts on it conflict neither way round, that a verdict on the activity *below* the loop still conflicts with one on it, so this isn't a check switched off, that a `Stuck` verdict sends the chain through the task rather than through the frame, and that setting both verdicts marks `AsyncTask$SerialExecutor$1.val$r` as the faulty reference. The two "do not conflict" cases fail without the first change, and the last two without the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
