### PR TITLE
Delta encode the referrer index instead of a linked list per object

### DIFF
--- a/shark/shark-explorer/AGENTS.md
+++ b/shark/shark-explorer/AGENTS.md
@@ -538,6 +538,8 @@ Design decisions and findings, kept current as the work proceeds:
 
 - `notes/decisions.md` — stack and structure decisions, with rationale
 - `notes/dominator-tree.md` — dominator algorithm findings, memory/perf numbers
+- `notes/referrer-index.md` — how the referrer index is encoded, what it holds, and why the order it hands
+  referrers back in is not free to change
 - `notes/treemap-rendering.md` — adaptive depth model, the two shapes, bugs in the existing Android
   treemap
 - `notes/bitmaps.md` — which Android versions put a bitmap's pixels in the heap dump, and the two ways

--- a/shark/shark-explorer/notes/decisions.md
+++ b/shark/shark-explorer/notes/decisions.md
@@ -568,16 +568,18 @@ three rounds before the leak fingerprints did, because two chains can be differe
 orders are unrelated. **LeakCanary walks down**, so when it dequeues the set it enqueues the entries in the
 order Shark's `HashSet` reader reads the table, and the first of them claims the provider: that is
 `ActivityDelegateNotifier`, third in the table. **The explorer walks up**, and `ReferrerIndex` yields the
-referrers of an object most recently indexed first, so of the two it reaches the one further down the heap
+referrers of an object highest object index first, so of the two it reaches the one further down the heap
 dump: `DemoRootWithGatekeepersWorkflowProvider`, object index 31516 against 31263. Everything else about the
 two ten-step chains is identical. Bucket order isn't stable across two dumps of one app either, so neither
 answer is the right one — but a walk up cannot see a walk down's order, and the only way to break it the
 same way is to walk down: one prioritized BFS from the GC roots at open time, filling a parent-per-object
 array that every chain is then read out of. Every tie would then break the way a leak trace breaks it, since
-it would be the same walk in the same direction; a chain becomes a pointer chase up the array rather than a
-search per hover; and it is one int per object, against `ReferrerIndex`'s two per reference. What it isn't
-is a tie-break: it is a second traversal at open time, reading objects in BFS order where building the index
-is a sequential scan of the dump, and `ReferrerIndex` still has to exist for "every way this is held".
+it would be the same walk in the same direction, and a chain becomes a pointer chase up the array rather
+than a search per hover. **It is no longer the cheaper of the two, though** — an int per object against the
+three to six bytes an object `ReferrerIndex` now holds (`referrer-index.md`), where the linked list it used
+to be was three times that. What it isn't is a tie-break: it is a second traversal at open time, reading
+objects in BFS order where building the index is a sequential scan of the dump, and `ReferrerIndex` still
+has to exist for "every way this is held".
 
 `unloaded_classes-stripped.hprof` — two leaks, the same count as LeakCanary, and two leak fingerprints
 that differ by their prefix. What is left is **an owner rule**:
@@ -612,7 +614,7 @@ can't take that way at all, because **its phase 1 treats a leaking object as a l
   is on a stack because a method is running, and there is nothing to fix. `RootPathSearch` now puts off a
   stack frame, a known library leak and the arrays ART hangs off a class exactly as
   `PrioritizingShortestPathFinder` does, read in the other direction, and `ReferrerIndex` carries
-  `Reference.isLowPriority` in the top bit of each edge to answer it.
+  `Reference.isLowPriority` in a bit beside each referrer to answer it.
 - **A reference into an object that shouldn't be in memory wasn't put off**, so a chain took it where there
   was a way round, and the object it led to hashed to the leak fingerprint of the leak on the way. That is
   the third tier in `RootPathSearch`'s queue, on the same two queues as a stack frame and for the same reason:

--- a/shark/shark-explorer/notes/dominator-tree.md
+++ b/shark/shark-explorer/notes/dominator-tree.md
@@ -505,10 +505,10 @@ Two caveats, which `WAYS_HINT` states in the UI rather than leaving to be discov
 
 **The search walks backwards, from the object towards what holds it**, which is the direction a heap dump
 can't answer in: it records a reference only in the direction it points. Hence `ReferrerIndex` — one pass
-over the dump, kept as a linked list per object (an int per object, two per reference, ~30 MB on a million
-object dump). That replaced a full pass per question plus a pass per fork level, which was 2.3 s per click
-on the 82 MB dump and 3.4 s when a holder was shared, with a walk in memory. The pass is paid once per
-session, lazily, on the first question about paths.
+over the dump, kept as a delta encoded byte slice per object, three to six bytes an object
+(`referrer-index.md`). That replaced a full pass per question plus a pass per fork level, which was 2.3 s
+per click on the 82 MB dump and 3.4 s when a holder was shared, with a walk in memory. The pass is paid
+once per session, lazily, on the first question about paths.
 
 **A path that loops back through the object isn't a way of holding it.** An `AppCompatImageView` has seven
 referrers, five of them helpers it created that point back at it. The walk never leaves the object it

--- a/shark/shark-explorer/notes/referrer-index.md
+++ b/shark/shark-explorer/notes/referrer-index.md
@@ -1,0 +1,146 @@
+# The referrer index
+
+`ReferrerIndex` answers "what points at this object", for every object of a heap dump, from memory. It is
+built once per open dump and held until the window closes, so **what it holds is what matters** — the peak
+while it is being built is a fraction of the dominator tree standing beside it.
+
+It used to be one linked list per object: an int per object for the head, and two ints per reference. It is
+now one delta encoded byte slice per object. Everything below was measured on the ten real Android heap
+dumps in this repo, with a copy of the linked list version alongside the new one in one JVM, checking that
+the two hand back the same referrers before timing either.
+
+## What it holds
+
+| dump | objects | references | linked | encoded | linked B/ref | encoded B/ref | smaller by |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `large-dump.hprof` | 387 971 | 514 515 | 5 668 004 | 1 932 355 | 11.02 | 3.76 | 2.93x |
+| `safe_iterable_map.hprof` | 333 566 | 564 595 | 5 851 024 | 1 839 201 | 10.36 | 3.26 | 3.18x |
+| `gcroot_unknown_object.hprof` | 424 418 | 531 264 | 5 947 784 | 2 085 570 | 11.20 | 3.93 | 2.85x |
+| `compose_leak.hprof` | 258 993 | 410 447 | 4 319 548 | 1 447 172 | 10.52 | 3.53 | 2.98x |
+| `unloaded_classes-stripped.hprof` | 332 905 | 861 174 | 8 221 012 | 2 014 588 | 9.55 | 2.34 | 4.08x |
+| `hashmap_api_25.hprof` | 149 742 | 118 402 | 1 546 184 | 569 903 | 13.06 | 4.81 | 2.71x |
+| `leak_asynctask_m.hprof` | 139 818 | 132 083 | 1 615 936 | 608 214 | 12.23 | 4.60 | 2.66x |
+| `gc_root_in_non_primary_heap.hprof` | 133 177 | 88 854 | 1 243 540 | 467 028 | 14.00 | 5.26 | 2.66x |
+| `leak_asynctask_o.hprof` | 129 757 | 94 145 | 1 272 188 | 473 415 | 13.51 | 5.03 | 2.69x |
+| `leak_asynctask_pre_m.hprof` | 45 385 | 57 337 | 640 236 | 220 773 | 11.17 | 3.85 | 2.90x |
+
+Array payload only, both sides, which is all either holds.
+
+**Bytes per reference is the wrong unit for these dumps, and it is worth knowing why.** The encoding
+`parttimenerd/hprof-analyzer` uses reaches 1.29 bytes an edge at 1.65 G edges; here the same encoding lands
+between 2.3 and 5.3. Nothing is wrong: **these dumps have between 0.67 and 2.59 references per object**, so
+the per-object cost dominates. Every object needs a byte saying how long its slice is even when it is empty,
+and 14% to 65% of the objects in these dumps have nothing pointing at them at all. Divide the same numbers by
+objects rather than references and the spread collapses to 3.5 to 6.1 bytes an object, against the 12 to 15
+the linked list held. So **the saving scales with objects, not with references**, and a dump with a denser
+graph gets closer to their figure — `unloaded_classes-stripped.hprof`, the densest here at 2.59 references
+an object, is the best of the ten at 2.34.
+
+## The smallest heap a session runs in
+
+A minimum-heap ladder over `large-dump.hprof` — open the dump the way a window does, find the leaks, then ask
+for the chain from a GC root to 4 000 objects, and take the smallest `-Xmx` the run still completes in:
+
+| | linked | encoded |
+| --- | --- | --- |
+| Building the index alone | 41 MB | 41 MB |
+| A session holding the tree and the index | 106 MB | 98 MB |
+
+Two things follow. **The build peak does not move**, which it shouldn't: the new form is compacted out of the
+same linked lists, so both runs peak on the same two `MutableIntList`s and the encoded bytes growing beside
+them are lost in the slack those lists already carry. **The session floor drops by 8 MB**, more than the
+3.7 MB of arrays, because a collector needs headroom in proportion to what is live.
+
+## Why the offsets are per four objects and not per sixteen
+
+A slice is self delimiting, so the index into `referrers` can be sampled rather than complete: one byte
+offset per block of objects, and a lookup steps over the slices of its block to reach its own. The block size
+trades bytes against those steps, and it is the one number here that had to be measured rather than reasoned
+about. Bytes are exact — the offsets are 4 × ⌈objects / block⌉ — and the time is 200 breadth first walks up
+the referrers on `large-dump.hprof`, reaching 1.93 M objects between them:
+
+| objects per block | encoded bytes | walks, linked | walks, encoded |
+| --- | --- | --- | --- |
+| 16 | 1 641 379 | 59–68 ms | 80–88 ms |
+| 8 | 1 738 371 | 51–56 ms | 51–57 ms |
+| **4** | **1 932 355** | **55–61 ms** | **46–47 ms** |
+| 2 | 2 320 327 | 52–56 ms | 36–39 ms |
+| 1 (an offset per object) | 3 096 267 | 60–64 ms | 32–39 ms |
+
+**Sixteen, which is what the Rust analyzer uses, makes a walk a third slower than the linked list it
+replaced.** Eight breaks even. Four is 20% *faster* than the linked list while holding a third of what it
+held, and that is where this stops — not because the curve stops there, but because it is the first rung
+where nothing has been given up. Two and one are faster still, and buying that would mean giving back 0.4 MB
+and 1.2 MB of the 3.7 MB this change is *for*, to save fractions of a millisecond per chain on a question
+whose budget is a hundred of them.
+
+Their sixteen is the right answer for their problem and not for this one: their offsets are gigabytes at
+514 M objects, and their walk is a one-off inside a batch analysis, where this one is what a pointer moving
+over a treemap asks for.
+
+The reason four is faster than a linked list at all is that a slice is a run of adjacent bytes where the
+linked list was a pointer chase through two int arrays the size of the whole dump — sequential reads against
+a cache miss per reference.
+
+Build time is unchanged, 610–646 ms against 611–634 ms on `large-dump.hprof` over four alternating rounds:
+the compaction is a sort of a handful of ints per object, and the pass over the dump that dominates it is the
+same pass.
+
+**A sweep of every object's referrers is still slower** — 5.6 ms against 3.9 ms sequentially, 11.7 against
+8.0 in a shuffled order — because a sweep asks about the third to two thirds of objects nothing points at,
+where the linked list reads one int and this steps over a block. Walks are what the app does; sweeps are not.
+
+## The order the referrers come back in did not change, and could not
+
+The linked list handed back **the highest object index first**, because it was built by prepending while
+`graph.objects` ran in index order. Sorted ascending is the natural thing to store, and it is what the Rust
+analyzer stores, so the first version of this stored it that way — a variable length int can only be read
+forwards, so what is stored is what a lookup hands back.
+
+**That reversal is not a cosmetic tie-break.** A breadth first walk up the referrers takes whichever of two
+equally distant referrers it sees first, and the search for every way an object is held is greedy — it blocks
+the middle of each path it finds so the next path has to go another way. On the heap dump
+`HeapExplorerTest.cachedPayloadHeapDump` builds, where a tile holds an image both through its view and
+through the request that loaded it, and a cache holds the same image through that request's wrapper:
+
+- highest index first: two chains, `Tile → view → image` and `Cache → wrapper → image`.
+- lowest index first: the first walk claims the wrapper, so the second cannot use it — two chains, both from
+  the tile, and **the cache never appears as a holder at all**.
+
+So the slices are stored counting **down** from the last object of the heap dump instead, which costs 0.7%
+more bytes than counting up (the one absolute value in a slice becomes the distance to the end of the dump
+rather than the distance from its start) and hands back exactly the old order. Verified per object rather
+than argued: over all ten dumps every object's referrers came back in the same order and with the same
+`isLowPriority` bits as the linked list gave, 68 515 of 68 515 multi-referrer objects on `large-dump.hprof`
+and every one of the others. The session ladder above is the same check end to end — both implementations
+report 2 leak groups, 4 000 chains and 8 664 steps on `large-dump.hprof`.
+
+Which is why there is no leak-fingerprint sweep to go with this change. The sweep over the ten dumps that
+`decisions.md` records at 8 of 10 dumps and 12 of 15 leaks is a function of which referrers the index hands
+back in which order, and that is byte for byte what it was.
+
+## Two places this deliberately differs from `parttimenerd/hprof-analyzer`
+
+Read `src/pass2/model.rs` (`encode_phase4` and the `INB_BLOCK` comment), `src/vbyte.rs` and
+`src/chunkvec.rs` for theirs. Besides the block size above:
+
+**A slice is prefixed with its byte length, where theirs is prefixed with the count of referrers.** A count
+makes stepping over a slice a walk of every byte of it, because only the continuation bits say where each
+value ends. Nearly every dump here has an object twenty thousand others point at — 23 871 on
+`unloaded_classes-stripped.hprof`, 20 533 on `safe_iterable_map.hprof` — and a lookup of anything sharing
+that object's block would have had 50 KB to read past. With a length it is a read and an add.
+
+**Nothing is freed as the compaction advances**, where their `chunkvec.rs` hands each 256 MB chunk of the
+source back to the allocator as the read cursor passes it. It cannot be done from a linked list: the
+references pointing at one object are spread over the whole of it, so the compaction reads the source in
+scattered order, not left to right. Making it consumable in order means a first pass over the heap dump to
+count what points at each object before anything can be stored — about a quarter added to the time it takes
+to open a dump, to lower a peak the ladder above shows is not the binding one. If the peak ever becomes the
+constraint, that is the change to make.
+
+**And referrers are not translated into another numbering.** Theirs are turned into dominator pre-order
+numbers, which is both what their algorithm needs and why their deltas are so small: pre-order puts a node's
+predecessors near each other. Here they stay `HeapObject.objectIndex`, which is the order the dump was
+written in, so the deltas are only as small as the dump's own locality makes them. Renumbering would mean a
+translation table the size of the dump and a second numbering for every caller to hold, which is a larger
+change than this one and worth measuring separately if the bytes ever matter more than they do now.

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferrerIndex.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferrerIndex.kt
@@ -1,11 +1,12 @@
 package shark.explorer
 
-import androidx.collection.IntList
 import androidx.collection.MutableIntList
+import java.util.Arrays
 import shark.HeapGraph
 import shark.HeapObject
 import shark.Reference
 import shark.ReferenceReader
+import shark.SharkLog
 
 /**
  * Which objects point at each object of a heap dump, held in memory.
@@ -15,27 +16,50 @@ import shark.ReferenceReader
  * the details panel wait; this reads the dump once and answers from memory afterwards, which is what turns
  * searching for the paths to an object into a graph walk rather than a pass over a file per step.
  *
- * Stored as one linked list per object: an int per object for the head of its list, and two ints per
- * reference. That's around 30 MB on a million object dump, where a map of lists per object would be
- * several hundred. Objects are named by [HeapObject.objectIndex] throughout for the same reason.
+ * Stored as one delta encoded byte slice per object, laid end to end in [referrers]: each slice is its own
+ * byte length and then the referring object indexes, sorted, as the gap from the one before it, seven bits
+ * of a gap to a byte. **Three to six bytes an object** on the dumps in this repo, against the twelve to
+ * fifteen a linked list of two ints per reference held, so a third of what it was and 2 MB rather than 5.7
+ * on the largest dump here — and a map of lists per object would be several hundred. `notes/referrer-index.md`
+ * has the numbers per dump. Objects are named by [HeapObject.objectIndex] throughout for the same reason.
+ *
+ * Being self delimiting is what makes an index into it unnecessary: a byte offset per object would be four
+ * bytes per object again, so only one per [OBJECTS_PER_BLOCK] objects is kept and a lookup steps over the
+ * few slices before the one it wants. Which is also why it is faster than the linked list rather than the
+ * price paid for holding less: a slice is a run of adjacent bytes where the list was a pointer chase
+ * through two int arrays the size of the whole heap dump.
  */
 internal class ReferrerIndex private constructor(
   private val graph: HeapGraph,
-  /** The last edge pointing at each object, by object index, or [NO_EDGE] when nothing points at it. */
-  private val lastEdgeByObjectIndex: IntArray,
+  val objectCount: Int,
   /**
-   * Which object each edge comes from, by object index, with [Reference.isLowPriority] in the top bit.
+   * Every object's referrers, in object index order, one slice each: the slice's own byte length as a
+   * variable length int, then one variable length int per referring object, counting down from the last
+   * object of the heap dump with [Reference.isLowPriority] in the low bit.
    *
-   * Packed rather than kept beside it because there are two ints per reference here and a large heap dump
-   * has millions of them, and an object index can't use that bit: they run from 0 to
-   * [HeapGraph.objectCount] - 1.
+   * The gap from the referrer before rather than the index itself because a byte then holds a step of up to
+   * 63 rather than an object index up to 63, and a heap dump's objects are numbered in the order they were
+   * written, so what points at one object tends to be written near it. Counting down rather than up because
+   * [forEachReferrer] has to hand back the highest index first and a variable length int can only be read
+   * forwards. The low bit rather than the top one because the top bit of a variable length int is what says
+   * whether the next byte belongs to it.
+   *
+   * Sorted, so a gap is never negative, and deduplicated, so a referrer appears once however many of its
+   * fields point at the object — with the bit set only when every one of those references had it, which
+   * falls out of sorting: the lowest of a run of packed values is the one whose bit is clear.
+   *
+   * The length rather than the count of referrers, which is what `parttimenerd/hprof-analyzer` prefixes a
+   * slice with, so that stepping over a slice is an add rather than a walk of it: an object 24 000 objects
+   * point at, and there is one on nearly every dump here, would otherwise be 50 KB to read past for every
+   * lookup of an object sharing its block.
    */
-  private val referrerByEdge: IntList,
-  /** The edge before each edge in the list of the object it points at, or [NO_EDGE]. */
-  private val previousEdgeByEdge: IntList
+  private val referrers: ByteArray,
+  /** Where the slice of object `block * OBJECTS_PER_BLOCK` starts in [referrers], by block. */
+  private val sliceStartByBlock: IntArray
 ) {
 
-  val objectCount: Int get() = lastEdgeByObjectIndex.size
+  /** How much memory this holds for as long as the heap dump is open, which is what the log line says. */
+  val bytesHeld: Long get() = referrers.size.toLong() + Int.SIZE_BYTES * sliceStartByBlock.size
 
   /** The object index of [objectId], or [NOT_AN_OBJECT] for an id the heap dump has no object for. */
   fun indexOf(objectId: Long): Int =
@@ -44,36 +68,65 @@ internal class ReferrerIndex private constructor(
   fun objectIdAt(objectIndex: Int): Long = graph.findObjectByIndex(objectIndex).objectId
 
   /**
-   * Calls [block] with the object index of everything pointing at the object at [objectIndex], most
-   * recently indexed first, once per referring object however many of its fields point at it, and with
+   * Calls [block] with the object index of everything pointing at the object at [objectIndex], **highest
+   * object index first**, once per referring object however many of its fields point at it, and with
    * whether every one of those references is a [Reference.isLowPriority] one.
+   *
+   * Highest first is not arbitrary and not free — it is what the linked list this replaced happened to hand
+   * back, and a breadth first walk up the referrers takes the first of two equally distant referrers, so
+   * the order decides which chain the window draws. Reversing it costs a path: the greedy search for every
+   * way an object is held claims the first walk's middle, so on the heap dump
+   * `HeapExplorerTest.cachedPayloadHeapDump` builds, lowest first finds two chains from the same holder
+   * and never reaches the cache. See `notes/referrer-index.md`.
    */
   fun forEachReferrer(
     objectIndex: Int,
     block: (Int, Boolean) -> Unit
   ) {
-    var edge = lastEdgeByObjectIndex[objectIndex]
-    var referrer = NOT_AN_OBJECT
-    var isLowPriority = false
-    while (edge != NO_EDGE) {
-      val packed = referrerByEdge[edge]
-      val edgeReferrer = packed and OBJECT_INDEX_MASK
-      // Two fields of the same object pointing at it is one referrer, not two, and the edges of one
-      // object are next to each other in the list because they were indexed in one go. It is only worth
-      // putting off if all of them are: one field holding it plainly is a way of holding it plainly.
-      if (edgeReferrer == referrer) {
-        isLowPriority = isLowPriority && packed < 0
-      } else {
-        if (referrer != NOT_AN_OBJECT) {
-          block(referrer, isLowPriority)
-        }
-        referrer = edgeReferrer
-        isLowPriority = packed < 0
-      }
-      edge = previousEdgeByEdge[edge]
+    var position = sliceStartByBlock[objectIndex / OBJECTS_PER_BLOCK]
+    // Stepping over the objects of this block that come before it. A slice starts with its own length, so
+    // one step is a read and an add however many referrers that object has — which matters because the
+    // objects a whole heap dump points at are in here beside the ones nothing points at.
+    var toStepOver = objectIndex % OBJECTS_PER_BLOCK
+    while (toStepOver > 0) {
+      val length = readVarInt(position)
+      position = positionAfter(length) + valueOf(length)
+      toStepOver--
     }
-    if (referrer != NOT_AN_OBJECT) {
-      block(referrer, isLowPriority)
+    val length = readVarInt(position)
+    position = positionAfter(length)
+    val end = position + valueOf(length)
+    var previousReferrer = objectCount - 1
+    while (position < end) {
+      val packed = readVarInt(position)
+      position = positionAfter(packed)
+      val gap = valueOf(packed)
+      val referrer = previousReferrer - (gap ushr 1)
+      block(referrer, gap and LOW_PRIORITY_BIT != 0)
+      // The next referrer is a lower index than this one, so the gap to it is stored one short.
+      previousReferrer = referrer - 1
+    }
+  }
+
+  /**
+   * The variable length int at [position] in [referrers], with the position after it in the high 32 bits:
+   * one read rather than a value and a length, since handing back two ints means allocating and this is
+   * read once per referrer of every object a walk reaches.
+   *
+   * Read [valueOf] and [positionAfter] out of what this returns.
+   */
+  private fun readVarInt(position: Int): Long {
+    var index = position
+    var value = 0
+    var shift = 0
+    while (true) {
+      val byte = referrers[index++].toInt()
+      value = value or ((byte and VAR_INT_MASK) shl shift)
+      // A byte whose top bit is set is negative, and the top bit is what says another byte follows.
+      if (byte >= 0) {
+        return (index.toLong() shl Int.SIZE_BITS) or (value.toLong() and INT_MASK)
+      }
+      shift += VAR_INT_BITS
     }
   }
 
@@ -83,10 +136,49 @@ internal class ReferrerIndex private constructor(
     /** No object has this index: they run from 0 to [HeapGraph.objectCount] - 1. */
     const val NOT_AN_OBJECT = -1
 
-    /** What is left of a packed edge once the low priority bit is taken off. See [referrerByEdge]. */
+    /**
+     * How many objects share one entry of [sliceStartByBlock]: the byte an offset per object would cost
+     * against the slices a lookup has to step over to reach the one it wants, one and a half of them on
+     * average at four.
+     *
+     * **Four rather than the sixteen `parttimenerd/hprof-analyzer` uses**, which was measured rather than
+     * reasoned about: sixteen makes a walk up the referrers a third slower than the linked list this
+     * replaced, eight breaks even, and four is 20% faster than it while still holding a third of what the
+     * linked list did. Two and one are faster still and give back a third and a half of the bytes this
+     * saves, which is the wrong way round. `notes/referrer-index.md` has the curve. Their sixteen is for a
+     * heap two orders of magnitude larger, where the offsets are gigabytes and the walk is a one-off rather
+     * than something a pointer moving over a treemap asks for.
+     */
+    private const val OBJECTS_PER_BLOCK = 4
+
+    /** Which bit of a packed gap holds [Reference.isLowPriority]. */
+    private const val LOW_PRIORITY_BIT = 1
+
+    private const val VAR_INT_BITS = 7
+    private const val VAR_INT_MASK = 0x7f
+    private const val VAR_INT_CONTINUES = 0x80
+    private const val INT_MASK = 0xffffffffL
+
+    /** What is left of a packed edge of the list being compacted once the low priority bit is taken off. */
     private const val OBJECT_INDEX_MASK = Int.MAX_VALUE
 
-    private const val LOW_PRIORITY_BIT = Int.MIN_VALUE
+    private const val EDGE_LOW_PRIORITY_BIT = Int.MIN_VALUE
+
+    /**
+     * The most objects a heap dump can have here, since an object index is packed with a bit beside it.
+     * A heap dump that large is tens of gigabytes of objects, which is far past what this app can open.
+     */
+    private const val MAX_OBJECT_COUNT = 1 shl 30
+
+    /** What [referrers] is grown to hold per reference before it is measured. See `notes/referrer-index.md`. */
+    private const val ESTIMATED_BYTES_PER_REFERENCE = 2
+
+    /** Enough for the referrers of nearly every object, and doubled for the few that hold more. */
+    private const val INITIAL_REFERRER_CAPACITY = 16
+
+    private fun valueOf(read: Long): Int = read.toInt()
+
+    private fun positionAfter(read: Long): Int = (read ushr Int.SIZE_BITS).toInt()
 
     /**
      * Reads every object of [graph] and indexes the references [referenceReader] reports, which has to be
@@ -97,16 +189,24 @@ internal class ReferrerIndex private constructor(
       graph: HeapGraph,
       referenceReader: ReferenceReader<HeapObject>
     ): ReferrerIndex {
-      val lastEdgeByObjectIndex = IntArray(graph.objectCount) { NO_EDGE }
-      val referrerByEdge = MutableIntList(graph.objectCount)
-      val previousEdgeByEdge = MutableIntList(graph.objectCount)
+      val objectCount = graph.objectCount
+      require(objectCount <= MAX_OBJECT_COUNT) {
+        "This heap dump has $objectCount objects, and a referrer index sorts an object index with a bit " +
+          "beside it, so it can only name $MAX_OBJECT_COUNT of them. Widening that means sorting longs."
+      }
+      // One linked list per object first, then compacted: the references pointing at one object are spread
+      // over the whole dump, so nothing can be encoded until the last object has been read, and a list to
+      // prepend to is the cheapest way to hold them until then. See [compact] for what that costs.
+      val lastEdgeByObjectIndex = IntArray(objectCount) { NO_EDGE }
+      val referrerByEdge = MutableIntList(objectCount)
+      val previousEdgeByEdge = MutableIntList(objectCount)
       graph.objects.forEach { source ->
         val referrerIndex = source.objectIndex
         referenceReader.read(source).forEach { reference ->
           val target = graph.findObjectByIdOrNull(reference.valueObjectId) ?: return@forEach
           val targetIndex = target.objectIndex
           referrerByEdge += if (reference.isLowPriority) {
-            referrerIndex or LOW_PRIORITY_BIT
+            referrerIndex or EDGE_LOW_PRIORITY_BIT
           } else {
             referrerIndex
           }
@@ -114,16 +214,130 @@ internal class ReferrerIndex private constructor(
           lastEdgeByObjectIndex[targetIndex] = referrerByEdge.size - 1
         }
       }
-      // The lists grow by doubling, so what they over-allocated is worth handing back on a heap dump with
-      // millions of references in it.
-      referrerByEdge.trim()
-      previousEdgeByEdge.trim()
-      return ReferrerIndex(
+      val referenceCount = referrerByEdge.size
+      return compact(
         graph = graph,
+        objectCount = objectCount,
         lastEdgeByObjectIndex = lastEdgeByObjectIndex,
         referrerByEdge = referrerByEdge,
         previousEdgeByEdge = previousEdgeByEdge
+      ).also { index ->
+        SharkLog.d {
+          "Indexed which objects point at which: ${formatObjectCount(objectCount)}, " +
+            "${formatObjectCount(referenceCount)} references, ${formatByteSize(index.bytesHeld)}, " +
+            "%.2f bytes a reference".format(index.bytesHeld.toDouble() / maxOf(referenceCount, 1))
+        }
+      }
+    }
+
+    /**
+     * The linked lists of [lastEdgeByObjectIndex] read out into the encoding [referrers] describes, one
+     * object at a time in object index order.
+     *
+     * The lists are held whole while this runs, so the build peaks on them rather than on what it writes,
+     * which is where it peaked before — measured, at the same 41 MB minimum heap either way. Freeing them
+     * as it goes, the way `parttimenerd/hprof-analyzer`'s `chunkvec.rs` does, can't be done from a linked
+     * list: the references pointing at one object are spread over the whole dump, so this reads them in
+     * scattered order rather than left to right. Making them consumable in order means a pass over the heap
+     * dump to count what points at each object before any of it can be stored, which is a quarter added to
+     * the time it takes to open a dump to lower a peak the ladder says is not the binding one.
+     */
+    private fun compact(
+      graph: HeapGraph,
+      objectCount: Int,
+      lastEdgeByObjectIndex: IntArray,
+      referrerByEdge: MutableIntList,
+      previousEdgeByEdge: MutableIntList
+    ): ReferrerIndex {
+      val sliceStartByBlock = IntArray((objectCount + OBJECTS_PER_BLOCK - 1) / OBJECTS_PER_BLOCK)
+      var encoded = ByteArray(objectCount + referrerByEdge.size * ESTIMATED_BYTES_PER_REFERENCE)
+      var encodedSize = 0
+      // The referrers of one object, packed as an object index with the low priority bit under it, so that
+      // sorting these sorts by referrer and puts the reference to take the bit from first.
+      var packedReferrers = IntArray(INITIAL_REFERRER_CAPACITY)
+      for (objectIndex in 0 until objectCount) {
+        if (objectIndex % OBJECTS_PER_BLOCK == 0) {
+          sliceStartByBlock[objectIndex / OBJECTS_PER_BLOCK] = encodedSize
+        }
+        var count = 0
+        var edge = lastEdgeByObjectIndex[objectIndex]
+        while (edge != NO_EDGE) {
+          if (count == packedReferrers.size) {
+            packedReferrers = packedReferrers.copyOf(count * 2)
+          }
+          val packed = referrerByEdge[edge]
+          packedReferrers[count++] = ((packed and OBJECT_INDEX_MASK) shl 1) or
+            (if (packed < 0) LOW_PRIORITY_BIT else 0)
+          edge = previousEdgeByEdge[edge]
+        }
+        // Nothing to sort or deduplicate below two, which is most objects of a heap dump: what holds one is
+        // usually the one field of the one object that made it.
+        var unique = count
+        if (count > 1) {
+          Arrays.sort(packedReferrers, 0, count)
+          unique = 1
+          for (i in 1 until count) {
+            // The same referrer again: another of its fields pointing at this object, which is not another
+            // way of holding it. Keeping the first of the run is what makes the bit the one every reference
+            // of that referrer had, since sorting puts the reference without it first.
+            if (packedReferrers[i] ushr 1 != packedReferrers[unique - 1] ushr 1) {
+              packedReferrers[unique++] = packedReferrers[i]
+            }
+          }
+        }
+        var sliceLength = 0
+        var previousReferrer = objectCount - 1
+        for (i in unique - 1 downTo 0) {
+          val referrer = packedReferrers[i] ushr 1
+          sliceLength += varIntSize(((previousReferrer - referrer) shl 1) or (packedReferrers[i] and 1))
+          previousReferrer = referrer - 1
+        }
+        val needed = encodedSize + varIntSize(sliceLength) + sliceLength
+        if (needed > encoded.size) {
+          encoded = encoded.copyOf(maxOf(needed, encoded.size * 2))
+        }
+        encodedSize = writeVarInt(encoded, encodedSize, sliceLength)
+        previousReferrer = objectCount - 1
+        for (i in unique - 1 downTo 0) {
+          val referrer = packedReferrers[i] ushr 1
+          val gap = ((previousReferrer - referrer) shl 1) or (packedReferrers[i] and 1)
+          encodedSize = writeVarInt(encoded, encodedSize, gap)
+          previousReferrer = referrer - 1
+        }
+      }
+      return ReferrerIndex(
+        graph = graph,
+        objectCount = objectCount,
+        // What growing by doubling over-allocated is worth handing back on a heap dump with millions of
+        // references in it, and this is held for as long as the heap dump is open.
+        referrers = if (encodedSize == encoded.size) encoded else encoded.copyOf(encodedSize),
+        sliceStartByBlock = sliceStartByBlock
       )
+    }
+
+    /** How many bytes [value] takes as a variable length int, read as unsigned. */
+    private fun varIntSize(value: Int): Int = when {
+      value ushr 7 == 0 -> 1
+      value ushr 14 == 0 -> 2
+      value ushr 21 == 0 -> 3
+      value ushr 28 == 0 -> 4
+      else -> 5
+    }
+
+    /** Writes [value] at [position] as a variable length int, read as unsigned, and returns the end of it. */
+    private fun writeVarInt(
+      into: ByteArray,
+      position: Int,
+      value: Int
+    ): Int {
+      var remaining = value
+      var index = position
+      while (remaining ushr VAR_INT_BITS != 0) {
+        into[index++] = ((remaining and VAR_INT_MASK) or VAR_INT_CONTINUES).toByte()
+        remaining = remaining ushr VAR_INT_BITS
+      }
+      into[index++] = remaining.toByte()
+      return index
     }
   }
 }

--- a/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferrerIndex.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/main/java/shark/explorer/ReferrerIndex.kt
@@ -2,6 +2,7 @@ package shark.explorer
 
 import androidx.collection.MutableIntList
 import java.util.Arrays
+import java.util.Locale
 import shark.HeapGraph
 import shark.HeapObject
 import shark.Reference
@@ -223,9 +224,11 @@ internal class ReferrerIndex private constructor(
         previousEdgeByEdge = previousEdgeByEdge
       ).also { index ->
         SharkLog.d {
+          val bytesPerReference = index.bytesHeld.toDouble() / maxOf(referenceCount, 1)
           "Indexed which objects point at which: ${formatObjectCount(objectCount)}, " +
-            "${formatObjectCount(referenceCount)} references, ${formatByteSize(index.bytesHeld)}, " +
-            "%.2f bytes a reference".format(index.bytesHeld.toDouble() / maxOf(referenceCount, 1))
+            String.format(Locale.US, "%,d references, ", referenceCount) +
+            "${formatByteSize(index.bytesHeld)}, " +
+            String.format(Locale.US, "%.2f bytes a reference", bytesPerReference)
         }
       }
     }

--- a/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ReferrerIndexTest.kt
+++ b/shark/shark-explorer/shark-explorer-core/src/test/java/shark/explorer/ReferrerIndexTest.kt
@@ -1,6 +1,7 @@
 package shark.explorer
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -9,6 +10,8 @@ import shark.GcRoot.JniGlobal
 import shark.HeapGraph
 import shark.HeapObject
 import shark.HprofHeapGraph.Companion.openHeapGraph
+import shark.LibraryLeakReferenceMatcher
+import shark.ReferencePattern.InstanceFieldPattern
 import shark.ValueHolder.ReferenceHolder
 import shark.dump
 
@@ -40,6 +43,86 @@ class ReferrerIndexTest {
   @Test fun `nothing points at a gc root's own object`() {
     openIndexed { graph, index ->
       assertThat(index.referrersOf(graph.findByClassName("com.example.Holder"))).isEmpty()
+    }
+  }
+
+  @Test fun `referrers come back highest object index first`() {
+    // Which is load bearing rather than incidental: a breadth first walk up the referrers takes the first
+    // of two equally distant ones, so this order decides which chain the window draws. See
+    // notes/referrer-index.md for what reversing it costs.
+    openIndexed { graph, index ->
+      val referrers = index.referrerIndexesOf(graph.findByClassName("com.example.Shared"))
+
+      assertThat(referrers).hasSize(3).isEqualTo(referrers.sortedDescending())
+    }
+  }
+
+  @Test fun `a referrer is a last resort only if every field it holds an object by is one`() {
+    val file = testFolder.newFile("library-leak.hprof")
+    file.dump {
+      val payload = "com.example.Payload" instance {}
+      val mixed = "com.example.Mixed" instance {
+        field["known"] = payload
+        field["plain"] = payload
+      }
+      val allKnown = "com.example.AllKnown" instance {
+        field["known"] = payload
+        field["alsoKnown"] = payload
+      }
+      val holder = "com.example.Holder" instance {
+        field["mixed"] = mixed
+        field["allKnown"] = allKnown
+      }
+      gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+    }
+    file.openHeapGraph().use { graph ->
+      val knownLeaks = listOf("Mixed" to "known", "AllKnown" to "known", "AllKnown" to "alsoKnown")
+        .map { (className, fieldName) ->
+          LibraryLeakReferenceMatcher(InstanceFieldPattern("com.example.$className", fieldName))
+        }
+      val index = ReferrerIndex.buildFor(
+        graph,
+        ActualMatchingReferenceReaderFactory(knownLeaks).createFor(graph)
+      )
+
+      val payload = index.indexOf(graph.findByClassName("com.example.Payload"))
+      val lastResortByReferrer = mutableMapOf<String, Boolean>()
+      index.forEachReferrer(payload) { referrer, isLowPriority ->
+        lastResortByReferrer[graph.findObjectByIndex(referrer).simpleClassName()] = isLowPriority
+      }
+
+      // A field known to hold on to things is a reason to leave a referrer until last, but only if it is the
+      // only way that referrer holds the object: the plain field holds it whatever the known one does.
+      assertThat(lastResortByReferrer).containsOnly(entry("Mixed", false), entry("AllKnown", true))
+    }
+  }
+
+  @Test fun `referrers written far apart in the heap dump are both found`() {
+    // A referrer is stored as the step down from the one before it, seven bits of a step to a byte, so a
+    // step spread over several bytes only comes up with thousands of objects between two referrers.
+    val file = testFolder.newFile("far-apart.hprof")
+    val fillerCount = 5_000
+    file.dump {
+      val payload = "com.example.Payload" instance {}
+      val first = "com.example.First" instance { field["payload"] = payload }
+      val fillerClassId = clazz("com.example.Filler")
+      repeat(fillerCount) { instance(fillerClassId) }
+      val last = "com.example.Last" instance { field["payload"] = payload }
+      val holder = "com.example.Holder" instance {
+        field["first"] = first
+        field["last"] = last
+      }
+      gcRoot(JniGlobal(id = holder.value, jniGlobalRefId = 0))
+    }
+    file.openHeapGraph().use { graph ->
+      val referenceReader = ActualMatchingReferenceReaderFactory(emptyList()).createFor(graph)
+      val index = ReferrerIndex.buildFor(graph, referenceReader)
+
+      val referrers = index.referrerIndexesOf(graph.findByClassName("com.example.Payload"))
+      assertThat(referrers.map { graph.findObjectByIndex(it).simpleClassName() })
+        .containsExactly("Last", "First")
+      // What the filler is for: the two referrers really are too far apart to name in a single byte.
+      assertThat(referrers.first() - referrers.last()).isGreaterThan(fillerCount)
     }
   }
 
@@ -76,9 +159,12 @@ class ReferrerIndexTest {
     }
   }
 
-  private fun ReferrerIndex.referrersOf(objectId: Long): List<Long> {
-    val referrers = mutableListOf<Long>()
-    forEachReferrer(indexOf(objectId)) { referrer, _ -> referrers += objectIdAt(referrer) }
+  private fun ReferrerIndex.referrersOf(objectId: Long): List<Long> =
+    referrerIndexesOf(objectId).map { objectIdAt(it) }
+
+  private fun ReferrerIndex.referrerIndexesOf(objectId: Long): List<Int> {
+    val referrers = mutableListOf<Int>()
+    forEachReferrer(indexOf(objectId)) { referrer, _ -> referrers += referrer }
     return referrers
   }
 


### PR DESCRIPTION
`ReferrerIndex` answers "what points at this object" for every object of an open heap dump, and it held that as one linked list per object: an int per object plus two ints per reference. 5.7 MB on the largest dump in the repo, the second largest thing an open window holds after the dominator tree itself.

It is now one delta encoded byte slice per object, modelled on the inbound-referrer CSR in [`parttimenerd/hprof-analyzer`](https://github.com/parttimenerd/hprof-analyzer): the referrers of an object sorted, deduplicated, and written as the gap from the one before it, seven bits of a gap to a byte, with `Reference.isLowPriority` in the low bit. Each slice carries its own byte length in front of it, so an offset into the bytes is only kept once per four objects and a lookup steps over the few slices before the one it wants.

## What it buys

| dump | linked | encoded | |
| --- | --- | --- | --- |
| `large-dump.hprof` | 5 668 004 | 1 932 355 | 2.93x |
| `safe_iterable_map.hprof` | 5 851 024 | 1 839 201 | 3.18x |
| `unloaded_classes-stripped.hprof` | 8 221 012 | 2 014 588 | 4.08x |
| `gc_root_in_non_primary_heap.hprof` | 1 243 540 | 467 028 | 2.66x |

Ten dumps in `notes/referrer-index.md`, all of them between 2.7x and 4.1x. Three to six bytes an object against the twelve to fifteen the linked list held — the saving scales with objects rather than references, because these dumps have between 0.67 and 2.59 references an object and a third to two thirds of their objects have nothing pointing at them at all.

A minimum-heap ladder over `large-dump.hprof`, opening it the way a window does and then asking for the chain from a GC root to 4 000 objects, drops from **106 MB to 98 MB**. The build peak doesn't move, and shouldn't: the encoded form is compacted out of the same linked lists, so both runs peak on those.

And it is **20% faster** at the walk up the referrers a chain is found by — 46–47 ms against 55–61 ms for 200 walks reaching 1.93 M objects — because a slice is a run of adjacent bytes where the list was a pointer chase through two int arrays the size of the whole dump. Build time is unchanged. A sweep of every object is slower, and that's in the notes; walks are what the app does.

## Nothing observable changes

The slices count **down** from the last object of the dump rather than up from the first. That costs 0.7% more bytes and hands back exactly the order the linked list did, which turned out to be load bearing rather than incidental: a breadth first walk takes the first of two equally distant referrers, and the greedy search for every way an object is held blocks the middle of each path it finds. Stored ascending, on the dump `HeapExplorerTest` builds for it, the first walk claims the shared wrapper and **the cache stops appearing as a holder at all** — two chains from the same tile instead of one from each.

Checked per object rather than argued: with a copy of the linked list version alongside the new one in one JVM, every object of all ten dumps came back with the same referrers in the same order and with the same low priority bits, 68 515 of 68 515 multi-referrer objects on `large-dump.hprof`. Which is also why there's no leak-fingerprint sweep here — the recorded 8 of 10 dumps and 12 of 15 leaks is a function of exactly that, and it is byte for byte what it was.

`notes/referrer-index.md` has the per-dump numbers, the block size curve behind choosing four objects per offset where the Rust analyzer uses sixteen (sixteen is a third *slower* than the linked list), and the three places this deliberately differs from it.