### PR TITLE
Make Shark Dive say less, and say it once

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,12 @@ every diff. Refactors, internal cleanups and test-only changes usually don't nee
   the documentation site". Explain *why* in the body when it isn't obvious.
 - Don't leave test-only or unused code in the committed tree. If scaffolding was needed to get
   somewhere, remove it before the PR lands.
+- **The prose conventions in this repo are for the repo, not for the screen.** The guides, the KDoc and
+  the `notes/` files are written at length on purpose — the reader is someone about to change the code,
+  and the cost of a paragraph there is nothing. What a *user interface* says is governed by the opposite
+  rule: a label is one or two words, and the paragraph explaining it lives somewhere the reader goes
+  looking for it. `shark/shark-dive/AGENTS.md` has that rule and the mechanism, and Shark Dive is the
+  only substantial UI in this repo, so it is the only place it applies.
 - Test heap dumps are built with the `dump { }` DSL from `shark-hprof-test` (see `docs/dev-env.md`)
   rather than committed as binary fixtures. Never hand-assemble hprof bytes. For a large realistic
   dump, drive a real JVM via `HotSpotDiagnosticMXBean.dumpHeap`.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -111,3 +111,8 @@ uses, without the one for a newly recognized library leak:
   Now every one of them says `Strong`, `Cache`, `Thread local`, `Local`, `Soft`, `Weak`, `Finalizer`,
   `Phantom` or `Unreachable`, one or two words each, and what one *means* is the one page behind the `?` on
   the legend and on each of those sections.
+* 🔀 **One noun for a rectangle that stands for many objects.** There were three — `300 smaller objects` for
+  the children a rectangle had no room to draw, `400 objects of one class` for every instance of one class,
+  and `Unreachable` for the garbage — where the line under each already said which was which: the rectangle
+  they were left out of, the class name, and the strength. All three now say how many, and nothing else. The
+  panel also stops repeating that count as an `Objects` row under it.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -96,3 +96,11 @@ uses, without the one for a newly recognized library leak:
   other page of it is listed under the one being read. The app ships the text rather than opening a browser,
   so a release explains itself with the pages it was built with, and the sentence under the `?` is the page's
   own first sentence. The `?` never fades and is the same for everybody, however many heap dumps in.
+* 🔀 **A library leak is a leak to do something about**, and the screen now says so. It used to say there was
+  "usually nothing to do about them but wait for a fix upstream", which is wrong twice: a leak in a library is
+  an issue to file and often a small fix to send, and a leak in the framework has a workaround to look for and
+  a report to make. The `?` on that section leads to the page saying which to do, including
+  `AndroidLeakFixes`, the ten framework workarounds `plumber-android` already applies for you. And **the
+  description Shark carries for the leak is drawn in full, with its links live** — 51 of the 85 of them end in
+  the AOSP change that introduced the leak or the file it is in, which is where the way round it usually is,
+  and three ellipsized lines of plain text was throwing exactly that away.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -91,3 +91,8 @@ uses, without the one for a newly recognized library leak:
   `Leak solved` line above **What holds it** names that reference where the eye starts, rather than leaving
   it to be found tens of steps down a chain, and an agent reading the chain is answered with the same name.
   See [The verdict](shark-dive.md#the-verdict).
+* ✨ **A `?` beside the labels that take more than a label to know.** Hovering it says what the label means in
+  one sentence; clicking it opens the [reference](shark-dive-reference.md) as a tab of the window, and every
+  other page of it is listed under the one being read. The app ships the text rather than opening a browser,
+  so a release explains itself with the pages it was built with, and the sentence under the `?` is the page's
+  own first sentence. The `?` never fades and is the same for everybody, however many heap dumps in.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -116,3 +116,18 @@ uses, without the one for a newly recognized library leak:
   and `Unreachable` for the garbage — where the line under each already said which was which: the rectangle
   they were left out of, the class name, and the strength. All three now say how many, and nothing else. The
   panel also stops repeating that count as an `Objects` row under it.
+* ✨ **The objects you star are kept between runs**, in `~/.shark-dive/starred` — one file per heap dump, one
+  address per line, so a working set can be read, mailed or checked in without this app, and hand editing it
+  costs at worst the line that was mistyped. They come back in the order they were starred.
+* 🔀 **Starred is a list of objects, drawn as every other list of objects is.** It used to be a screen of its
+  own, keeping a copy of each object's sizes from the moment it was starred — which went stale as soon as a
+  verdict you set changed what something retains — and labelling them in words nothing else used. Now it and
+  the object list are one table with two contents, sharing a row and a set of column headings, and what a
+  starred object is, is read out of the heap dump like everything else.
+* 🔀 **One word for each of an object's two sizes.** The same two numbers were `Retained` and `Shallow` in the
+  details panel, `Retains 1.2 MB in 57 objects` and `88 B of its own` on the card at the pointer, and
+  `Retaining …` again on a chain — three vocabularies to reconcile before two of them could be compared. Now
+  everything says `Retained` and `Shallow`, with how many objects that is on the `Retained` line rather than
+  in a row of its own. The count of objects a rectangle *immediately* holds is gone from the panel and the
+  card: that number is the rectangles drawn inside it, which is what you are looking at. `Dominates` now
+  means one thing, on the chain.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -137,3 +137,6 @@ uses, without the one for a newly recognized library leak:
   in a row of its own. The count of objects a rectangle *immediately* holds is gone from the panel and the
   card: that number is the rectangles drawn inside it, which is what you are looking at. `Dominates` now
   means one thing, on the chain.
+* 🔀 The line above the map saying no object is held only through a `java.lang.ref.Reference` now says
+  `Nothing here is held only weakly.`, in the words of the `Soft`, `Weak`, `Phantom` and `Finalizer` rows it
+  sits under. Which class those four have in common is the page behind the `?` beside it.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -104,3 +104,10 @@ uses, without the one for a newly recognized library leak:
   description Shark carries for the leak is drawn in full, with its links live** — 51 of the 85 of them end in
   the AOSP change that introduced the leak or the file it is in, which is where the way round it usually is,
   and three ellipsized lines of plain text was throwing exactly that away.
+* 🔀 **One name for how firmly an object is held**, everywhere the app says it. The details panel used to
+  spell out a sentence per strength — "Reachable without going through a `java.lang.ref.Reference`" — where
+  the legend above the map said "Strong" and the leaks screen said "Softly reachable" for the same nine
+  things, so a colour on the map, a checkbox above it and a section of the list read as three vocabularies.
+  Now every one of them says `Strong`, `Cache`, `Thread local`, `Local`, `Soft`, `Weak`, `Finalizer`,
+  `Phantom` or `Unreachable`, one or two words each, and what one *means* is the one page behind the `?` on
+  the legend and on each of those sections.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -124,6 +124,12 @@ uses, without the one for a newly recognized library leak:
   verdict you set changed what something retains — and labelling them in words nothing else used. Now it and
   the object list are one table with two contents, sharing a row and a set of column headings, and what a
   starred object is, is read out of the heap dump like everything else.
+* 🔀 **One way to name an object, on every surface that names one.** A step of a chain, the card at the
+  pointer and the bar above the map said the class, the package under it and the address; a row of the object
+  list said the package, the class and the kind on one line and no address at all; a leaking object on the
+  **Leaks** screen said the class, the kind and the address and no package. Now all six are the same three
+  lines — so the object list and the starred list show an address, which is what a `shark://` link, a note
+  and an agent's answer all name an object by, and the leaks screen shows which `Handler` it is.
 * 🔀 **One word for each of an object's two sizes.** The same two numbers were `Retained` and `Shallow` in the
   details panel, `Retains 1.2 MB in 57 objects` and `88 B of its own` on the card at the pointer, and
   `Retaining …` again on a chain — three vocabularies to reconcile before two of them could be compared. Now

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -140,3 +140,17 @@ uses, without the one for a newly recognized library leak:
 * 🔀 The line above the map saying no object is held only through a `java.lang.ref.Reference` now says
   `Nothing here is held only weakly.`, in the words of the `Soft`, `Weak`, `Phantom` and `Finalizer` rows it
   sits under. Which class those four have in common is the page behind the `?` beside it.
+* 🔀 **An empty list says what fills it, and stops there.** `Nothing starred` used to name the panel the star
+  is in, the empty **Agent logs** screen explained what an agent is and how to point one at the window, and
+  the window with its last tab closed reassured you that the heap dump was still read. Each of those is now
+  the one line that is news — `Nothing starred. ☆ puts an object here.` — and what an agent *is* stays in
+  [the documentation](shark-dive.md), which is where somebody who doesn't know goes looking.
+* 🔀 **The dialogs say what a step costs, not how it works.** Taking a heap dump off a device, and fetching
+  the bitmap pixels a device too old for `am dumpheap -b png` leaves out of one, each used to spend a
+  paragraph on the mechanism above the list of devices: which Android version put the pixels in native
+  memory, what a debugger does to a process while it reads them, what `ro.debuggable` is. What is left is
+  what changes the click — `Freezes the app briefly. Tens of megabytes over adb.`,
+  `API 30: from a debugger, which suspends the app.` — and the mechanism moved to
+  [Open a heap dump](shark-dive.md#open-a-heap-dump), where somebody who wants it goes looking. Same for the
+  question a `shark://` link asks when this machine has two heap dumps of that name or none: the title
+  already names the file, so the question is now the count and where to look.

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -140,6 +140,13 @@ uses, without the one for a newly recognized library leak:
 * 🔀 The line above the map saying no object is held only through a `java.lang.ref.Reference` now says
   `Nothing here is held only weakly.`, in the words of the `Soft`, `Weak`, `Phantom` and `Finalizer` rows it
   sits under. Which class those four have in common is the page behind the `?` beside it.
+* 🔀 **Setting a verdict belongs to the tab it was started in**, so the bar and the tab strip still work
+  while one is open, and switching tabs leaves it half set rather than throwing it away. Which is what the
+  step listing the verdicts a new one contradicts needed: each of those is an object, and the reason somebody
+  typed for it is the case for the other reading — so each is now a link, and going to look at it opens a tab
+  and leaves your verdict where it was. Why two verdicts can disagree at all came out of a paragraph drawn
+  above that list every time and went behind the `?`, as
+  [Verdicts that disagree](shark-dive-reference.md). Closing the tab is what abandons a verdict half set.
 * 🔀 **An empty list says what fills it, and stops there.** `Nothing starred` used to name the panel the star
   is in, the empty **Agent logs** screen explained what an agent is and how to point one at the window, and
   the window with its last tab closed reassured you that the heap dump was still read. Each of those is now

--- a/docs/shark-dive-reference.md
+++ b/docs/shark-dive-reference.md
@@ -15,6 +15,8 @@ sentence below.
 
 --8<-- "docs/shark-dive-reference/library-leaks.md"
 
+--8<-- "docs/shark-dive-reference/reachability-strength.md"
+
 --8<-- "docs/shark-dive-reference/stuck-shading.md"
 
 --8<-- "docs/shark-dive-reference/weaker-references.md"

--- a/docs/shark-dive-reference.md
+++ b/docs/shark-dive-reference.md
@@ -1,0 +1,20 @@
+# Shark Dive reference
+
+What the labels in [Shark Dive](shark-dive.md) mean, one section each.
+
+Every `?` in the app leads to one of these sections, and the app ships this text rather than opening a
+browser: a build shows the reference it was built with, so an older release never reads a page written
+about a newer one. This page and that window include the same files, so there is one copy of every
+sentence below.
+
+--8<-- "docs/shark-dive-reference/leak-name.md"
+
+--8<-- "docs/shark-dive-reference/faulty-reference.md"
+
+--8<-- "docs/shark-dive-reference/leak-fingerprint.md"
+
+--8<-- "docs/shark-dive-reference/stuck-shading.md"
+
+--8<-- "docs/shark-dive-reference/weaker-references.md"
+
+--8<-- "docs/shark-dive-reference/other-ways.md"

--- a/docs/shark-dive-reference.md
+++ b/docs/shark-dive-reference.md
@@ -19,6 +19,8 @@ sentence below.
 
 --8<-- "docs/shark-dive-reference/stuck-shading.md"
 
+--8<-- "docs/shark-dive-reference/conflicting-verdicts.md"
+
 --8<-- "docs/shark-dive-reference/weaker-references.md"
 
 --8<-- "docs/shark-dive-reference/other-ways.md"

--- a/docs/shark-dive-reference.md
+++ b/docs/shark-dive-reference.md
@@ -13,6 +13,8 @@ sentence below.
 
 --8<-- "docs/shark-dive-reference/leak-fingerprint.md"
 
+--8<-- "docs/shark-dive-reference/library-leaks.md"
+
 --8<-- "docs/shark-dive-reference/stuck-shading.md"
 
 --8<-- "docs/shark-dive-reference/weaker-references.md"

--- a/docs/shark-dive-reference/conflicting-verdicts.md
+++ b/docs/shark-dive-reference/conflicting-verdicts.md
@@ -1,0 +1,21 @@
+## Verdicts that disagree
+
+Everything a stuck object holds is stuck too, so a verdict set by hand can contradict one set earlier.
+
+It runs both ways. Anything a stuck object dominates is only still in memory because that object is, so it
+is stuck as well; and anything holding an object that belongs in memory belongs there too, since something
+has to be keeping it. `Stuck` above and `Expected` below is a pair of verdicts that cannot both be right,
+so before writing anything Shark Dive walks the references and works out which of the verdicts already set
+by hand the new one runs into.
+
+**Every one of them is listed rather than counted**, with the reason it was given, because that reason is
+the case for the other reading. Whoever is about to overrule it is the only person who can weigh the two,
+and they can only do that if they can read what they are overruling. Each is a link to the object it is
+about, and going to look at it opens a tab of its own: the verdict you were setting stays where it was,
+half set, in the tab you left.
+
+Keeping this one flips the verdicts that disagreed to the opposite verdict, with what they said kept as
+part of the new reason — flipped rather than deleted, so the sentence somebody wrote is still in the file
+after somebody else has disagreed with it.
+
+Undoing writes nothing at all: nothing reaches the disk until the last question is answered.

--- a/docs/shark-dive-reference/faulty-reference.md
+++ b/docs/shark-dive-reference/faulty-reference.md
@@ -1,0 +1,14 @@
+## The faulty reference
+
+The one reference that should have been cleared: everything under it is still in memory only because of
+it.
+
+What it is read on is expected to be in memory. What it points at should have been gone. So this is the
+one reference to clear, and clearing it is what would let everything under it go.
+
+That is what makes it the leak rather than a symptom of one. Every object below it on the chain is
+retained by it, so a fix here is a fix for all of them — and a fix anywhere below it is a fix for none.
+
+Shark Dive marks it on the chain where it sits, and names it above the chain as well, in the same words
+the leaks screen names the leak with. A real chain is tens of steps and the pane is scrolled to the
+bottom of it, so the answer is said where the eye starts too.

--- a/docs/shark-dive-reference/leak-fingerprint.md
+++ b/docs/shark-dive-reference/leak-fingerprint.md
@@ -1,0 +1,12 @@
+## The leak fingerprint
+
+A hash of how a leak is held, the same for the same leak in the next heap dump of this app.
+
+Unlike the addresses under it, which are of this dump and of nothing else: two dumps of one app taken a
+minute apart name the same leaking screen by two different addresses. The fingerprint does not move.
+
+So it is what to write in a bug report, and what to compare two dumps by. A leak that is still there
+after a fix has the same fingerprint; a leak that is gone takes its fingerprint with it.
+
+It is also the leak fingerprint LeakCanary prints under a leak when it reports one, so a report and this
+list can be lined up hash by hash.

--- a/docs/shark-dive-reference/leak-name.md
+++ b/docs/shark-dive-reference/leak-name.md
@@ -1,0 +1,26 @@
+## What names a leak
+
+The references a leak *is*: the first should have been cleared, and the last points straight at what is
+stuck.
+
+They are one reference for most leaks, and the row on the leaks screen is that reference's name.
+
+**The first is the faulty reference** — the one that should have been cleared, and what LeakCanary calls
+the leak. Everything above it on the chain is the app working as intended: a screen held by the thing
+that is supposed to hold it is not a leak, however much it retains.
+
+**The last points at what is stuck**, which is where to look on the chain to see it. Everything below it
+is what the leak is *holding*, and none of that is part of what makes this leak this leak — it is what
+the leak costs.
+
+So a name of two references is a leak whose faulty reference is not the one pointing at the stuck object.
+There are steps in between, and every one of them is stuck because the first was not cleared.
+
+For an object on its way out, the name is the one reference the collector has not cleared yet, which is
+the whole of why it is still here.
+
+Where a leak is a single reference, the chain drawn for an object under it marks that step, so the row
+and the step are one thing said twice.
+
+See also [How LeakCanary works](https://square.github.io/leakcanary/fundamentals-how-leakcanary-works/)
+and [Fixing a memory leak](https://square.github.io/leakcanary/fundamentals-fixing-a-memory-leak/).

--- a/docs/shark-dive-reference/library-leaks.md
+++ b/docs/shark-dive-reference/library-leaks.md
@@ -1,0 +1,40 @@
+## Library leaks
+
+A leak in code the app doesn't own, which Shark recognizes by the reference holding it.
+
+That is the only thing separating these from the app's own leaks. It is not a judgement about whether they
+matter: a library leak retains the same bytes an app leak does, and the fact that somebody else wrote the
+line is no comfort to the device it is running on.
+
+**So there is something to do about every one of them.** What, depends on whose code it is.
+
+### If it's a library
+
+File an issue with the fingerprint from this screen and the chain the window drew — that is enough for a
+maintainer to find it without your heap dump. Better still, send the fix; a leak recognized here is usually
+a field that outlives what it points at, and the change is small. Then push for a release, and **update
+once it lands** — an entry that stays on this screen after the fix shipped is a dependency nobody bumped.
+
+### If it's the Android framework
+
+You can't fix it, so look for the way round it. Read the description on the row: many of them link to the
+AOSP change that introduced the leak or to the file it is in, which is where the workaround usually shows
+itself — a field to null out, a listener to unregister, a singleton to pre-warm with the application
+context instead of an activity.
+
+**Some of them already have a workaround written.** `AndroidLeakFixes` in `plumber-android` applies ten of
+them at process start, and LeakCanary installs plumber for you, so a framework leak on this screen is
+sometimes one nobody has added a fix for yet rather than one nobody can. Its source is the reference for
+what a workaround for this kind of leak looks like:
+[AndroidLeakFixes.kt](https://github.com/square/leakcanary/blob/main/plumber/plumber-android-core/src/main/java/leakcanary/AndroidLeakFixes.kt).
+
+And report it upstream anyway — to the [Android issue tracker](https://issuetracker.google.com/issues), or
+to the manufacturer when it is one of theirs. A framework leak that nobody reports is a framework leak that
+ships in the next version too.
+
+### If it's neither
+
+A pattern can match a reference it wasn't written for, and then the row is telling you about the wrong
+thing. Shark's own list of patterns is
+[AndroidReferenceMatchers](https://github.com/square/leakcanary/blob/main/shark/shark-android/src/main/java/shark/AndroidReferenceMatchers.kt);
+a pattern that matches too much is worth an issue on LeakCanary.

--- a/docs/shark-dive-reference/other-ways.md
+++ b/docs/shark-dive-reference/other-ways.md
@@ -1,0 +1,13 @@
+## Other ways down
+
+The steps between two objects that both hold this one are a stretch the chain did not have to take.
+
+If it had had to take them, those steps would hold the object too and be marked as dominators. They are
+not, so something else reaches the object below without going through them — and these arrows walk
+through the ways there are.
+
+They share no object in between, which graph theory calls independent. They are found greedily, so there
+can be more of them than are counted here: the count is how many were found, not how many exist.
+
+Which of them is drawn changes nothing about the object being described. It changes what the chain says
+about how that object came to be held, which is the part a fix has to act on.

--- a/docs/shark-dive-reference/reachability-strength.md
+++ b/docs/shark-dive-reference/reachability-strength.md
@@ -1,0 +1,38 @@
+## How firmly an object is held
+
+Every object has one strength, the strongest way anything holds it, and the map is coloured by it.
+
+Strongest first, which is also the order the legend above the map lists them in:
+
+- **Strong** — reachable without going through a `java.lang.ref.Reference`. Never reclaimed while it stays
+  that way, so this is most of a heap dump.
+- **Cache** — reachable only from a cache that gives its entries up on its own: an LRU that evicts as it
+  fills, and empties itself when Android says memory is short. The garbage collector sees an ordinary strong
+  reference here; what makes it weaker is the cache's own contract, which no heap dump records, so this comes
+  from a list of the caches Shark Dive recognizes.
+- **Thread local** — reachable only from a thread's own storage, which is given up when the thread dies.
+- **Local** — reachable only from a running method: a local variable, a JNI local reference, a native stack
+  frame, or a monitor a thread holds. The most transient holder there is, and the least informative — a local
+  variable is what a thread is doing right now rather than what keeps anything in memory.
+- **Soft** — reclaimed when the virtual machine decides it wants the memory back, which is what makes a
+  `SoftReference` a cache rather than a leak.
+- **Weak** — reclaimed at the next collection, whether or not memory is short.
+- **Finalizer** — reachable only from the queue of objects whose `finalize()` hasn't run yet, so it survives
+  at least one more collection, and longer if finalization is backed up. Finalizing it can even make it
+  reachable again.
+- **Phantom** — already finalized and out of the program's reach, held only so that a `PhantomReference` or a
+  `Cleaner` gets enqueued once it is gone.
+- **Unreachable** — no path from any GC root reaches it: garbage that hadn't been collected when the dump was
+  written, and that the next collection would take.
+
+**A path is only as strong as its weakest reference**, and an object's strength is the strongest path there
+is to it. So strong → weak → strong leaves its target weakly reachable, and an object a weak and a strong
+reference both point at is strongly reachable.
+
+Three of these are not the garbage collector's — Cache, Thread local and Local are strong references as far
+as it is concerned. They are here because "what holds this?" is a question about the app rather than about
+the collector: an image the view showing it also holds is the view's, and the cache is only why the dominator
+tree couldn't say so.
+
+Every object is in exactly one of the nine, so the bytes down the legend add up to the whole heap dump. Why
+the weakest few usually read 0 B is its own topic, *Reachable only through a reference*.

--- a/docs/shark-dive-reference/stuck-shading.md
+++ b/docs/shark-dive-reference/stuck-shading.md
@@ -1,0 +1,14 @@
+## Shading what is stuck
+
+Shades the objects that are stuck in memory and everything they hold with them, greying the rest of the
+map.
+
+Anything a stuck object dominates is only still there because it is, so shading the stuck objects without
+what they retain would colour the smallest part of the problem.
+
+**There is no colour for the objects that are expected.** A treemap draws what retains what, and most of a
+heap dump is objects nothing knows either way about — a colour for the expected ones would be a colour
+claiming a verdict nobody has given. The chain beside the map says which is which, object by object.
+
+Ticking this is also what sends Shark Dive looking for the leaks, which is a pass over the whole heap
+dump, so the row says so while that runs.

--- a/docs/shark-dive-reference/weaker-references.md
+++ b/docs/shark-dive-reference/weaker-references.md
@@ -1,0 +1,15 @@
+## Reachable only through a reference
+
+A referent nothing else holds is usually collected before a heap dump is written, so nothing softly,
+weakly or phantom reachable is normal.
+
+The garbage collection that runs before a dump clears the references whose referent nothing else was
+holding, which is most of them. That is why those rows of the legend read 0 B in most heap dumps, and it
+is not a bug.
+
+It is not a given either. A referent a thread got out of a reference and has since let go of is weakly
+reachable again until the next collection, and a soft reference is only cleared under memory pressure. So
+zero is common rather than certain, and a dump with something at those strengths is not odd.
+
+**Unreachable is a different thing again**: objects nothing points at at all, which that collection did
+not get to. They are in the dump because a heap dump is what was in memory, not what was live.

--- a/docs/shark-dive.md
+++ b/docs/shark-dive.md
@@ -69,7 +69,7 @@ a few seconds.
 * Bitmaps are drawn as their own pictures where the dump has the pixels. Android keeps them outside the
   Java heap from API 26 to 34, and for those the app offers to fetch them off the device the dump came from.
 * **Object list** is the whole dump as a searchable list, and **Starred** keeps the objects you want to
-  come back to.
+  come back to — kept between runs in `~/.shark-dive/starred`, one address per line, one file per heap dump.
 * **The verdict on the object a tab is on is the first thing "What it is" says** — `Stuck`, `Expected` or
   `Unknown` — and you can overrule it, see [The verdict](#the-verdict).
 * Every location takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).

--- a/docs/shark-dive.md
+++ b/docs/shark-dive.md
@@ -73,6 +73,8 @@ a few seconds.
 * **The verdict on the object a tab is on is the first thing "What it is" says** — `Stuck`, `Expected` or
   `Unknown` — and you can overrule it, see [The verdict](#the-verdict).
 * Every location takes a **note**, in markdown, kept between runs — see [Take notes](#take-notes).
+* **A `?` follows the labels that take more than a label to know.** Hover it for one sentence, click it to
+  read the rest as a tab of the window — it's the [reference](shark-dive-reference.md), shipped with the app.
 
 ## Link to a tab
 

--- a/docs/shark-dive.md
+++ b/docs/shark-dive.md
@@ -40,6 +40,15 @@ through the `adb` of your Android SDK: pick a device, then a process. Only an ap
 dumped, unless the device's whole build is debuggable (`ro.debuggable=1`, which is what a `userdebug`
 emulator image is), where every process on it can be.
 
+Dumping a heap freezes the app for a moment and pulls tens of megabytes over `adb`.
+
+**A bitmap keeps its pixels outside the Java heap from API 26**, so a heap dump carries them only when it
+was taken with `am dumpheap -b png`, which needs Android 15. On an older device the app offers to fetch
+them instead: that attaches a debugger and has the app compress every bitmap, suspended throughout —
+seconds of fixed cost, plus a fraction of a second per bitmap. It's the same offer as **Bitmaps from the
+live process**, which fetches them for a heap dump already open, as long as the process that wrote it is
+still running.
+
 Each heap dump opens in a window of its own, so two of them stay on screen side by side. Opening one takes
 a few seconds.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,13 @@ remote_branch: gh-pages
 
 copyright: 'Copyright &copy; 2015 Square, Inc.'
 
+# The sections of shark-dive-reference.md, each of which that page includes with a snippet: pages of
+# their own as well would be every one of them published twice, at a URL nothing links to. They live under
+# docs/ rather than beside the module because they are documentation, and Shark Dive ships a copy of this
+# directory on its classpath — see the copyReference task in shark-dive-core.
+exclude_docs: |
+  shark-dive-reference/
+
 theme:
   name: 'material'
   custom_dir: 'docs/theme'
@@ -96,6 +103,7 @@ nav:
     - 'Shark API': api/shark/index.md
   - 'Shark Dive':
     - 'Overview': shark-dive.md
+    - 'Reference': shark-dive-reference.md
     - 'Change Log': shark-dive-changelog.md
   - 'LeakCanary API': api/index.md
   - 'Change Log': changelog.md

--- a/shark/shark-dive/AGENTS.md
+++ b/shark/shark-dive/AGENTS.md
@@ -115,6 +115,7 @@ this way, each of which was several before:
 
 | Concept | The one place |
 | --- | --- |
+| Which object this is | `ObjectIdentity` — class, package, address, on every surface that names one |
 | How firmly an object is held | `ReachabilityStrength.label`, nine names, plus the one page behind the `?` |
 | An object's two sizes | `RETAINED`, `SHALLOW` and `retainedText` in `DetailsPanel.kt` |
 | A rectangle that isn't one object | `formatObjectCount` — a count, whichever kind of pile it is |
@@ -124,7 +125,10 @@ this way, each of which was several before:
 
 **So grep for the concept before writing a label.** A new string that names something the window already
 names is the one kind of change that passes review, passes the tests, and leaves the app harder to read
-than it was. The tests catch drift only from the other side: `onNodeWithText` failing with "found 2 nodes"
+than it was. **A composable is a second spelling as much as a string is**, and the harder one to spot: which
+object this is was drawn three ways at once — `ObjectIdentity`, and two hand-rolled `buildAnnotatedString`s
+that each read as consistent beside the list they were written next to, one of them dropping the address and
+the other the package. Reach for the entry in the table, not for text that comes out looking like it. The tests catch drift only from the other side: `onNodeWithText` failing with "found 2 nodes"
 after a rename usually means the rename worked and the assertion was pinned on a name that was never
 unique — see the testing conventions below.
 

--- a/shark/shark-dive/AGENTS.md
+++ b/shark/shark-dive/AGENTS.md
@@ -98,6 +98,18 @@ Each of the following is a change already made to this app, not a preference:
   see the bugs everybody else is hitting, and the hint that was in the way on day one is the one they go
   looking for on day thirty and can't find. So don't propose progressive onboarding here — the `?` is
   what that job was given to.
+- **A dialog over the whole window is a claim that nothing outside it will be needed.** The `?` is the
+  rule above and it opens a *tab*, so on a surface with a window wide scrim the only way to explain
+  something is to print the paragraph on it. Setting a verdict was a material3 `AlertDialog` and its
+  conflicts step broke on exactly that, twice over: the `?` had nowhere to go, and each verdict being
+  overruled is an object worth going to look at, which meant dismissing the dialog and losing the half
+  typed reason. `LeakStatusSetter` is the same dialog drawn by hand — same card, same scrim — inside the
+  `Box` holding the tab's panes, so the bar and the tab strip above it stay clickable, with its state kept
+  per tab id by `HeapDumpDive` rather than `remember`ed, so switching tabs and coming back finds it as it
+  was. **So don't reach for `AlertDialog` for a step of reading a heap dump.** The three that stay one —
+  `Take heap dump…`, `Bitmaps from the live process`, and the question a `shark://` link asks — are all
+  about *getting* a heap dump rather than reading one, which is why nothing behind them is worth
+  reaching.
 - **Prose belongs in the KDoc, `notes/decisions.md`, or a reference page.** Those are the three places
   something long enough to be worth writing goes. `notes/agent-surface.md` measures the same idea on the
   agent surface — ~80 tokens of name and description at rest, the ~2 k-token body only for a session that

--- a/shark/shark-dive/AGENTS.md
+++ b/shark/shark-dive/AGENTS.md
@@ -572,6 +572,10 @@ numbers belong in `notes/bitmaps.md`.
   default keeps notes in `~/.shark-dive/notes`, so a test taking it writes into the notes of whoever is
   running it. A window that never opens one only lists that directory to see which tabs to mark, which is
   why the tests that don't touch notes need no directory of their own.
+- **And a UI test that stars an object must pass a `DiveStars` over a temporary directory**, for the same
+  reason: the default keeps them in `~/.shark-dive/starred`, so a test that stars puts an address into the
+  working set of whoever is running it. Reading is harmless — a test window reads the file for its own dump
+  and finds nothing — so only the tests that click a star need one.
 - **A UI test that opens the *Agent logs* screen must pass its own `agentSessions`.** The default reads
   `~/.shark-dive/agents/sessions`, so a test taking it draws whatever the person running it last handed
   to an agent — and asserts on rows it didn't write. `AgentLogsScreenTest` builds the sessions it expects.

--- a/shark/shark-dive/AGENTS.md
+++ b/shark/shark-dive/AGENTS.md
@@ -69,6 +69,69 @@ found, and the search for every way an object is held runs for the object clicke
 question the panels ask has to be measured before it goes in the hover path — `notes/decisions.md` has the
 numbers on the biggest dump in the repo, including how long a chain gets there.
 
+## On-screen words are the scarcest thing here
+
+Everything else in this repo rewards prose — this file, the KDoc, `notes/`, `docs/`. **The window does
+not.** Whoever is reading a heap dump in it is holding a twenty-step chain in their head, and a sentence on
+screen is read at the cost of the thing they were working out. The failure mode is specific and it is one an
+agent is unusually prone to: having reasoned its way to why a label means what it means, it writes the
+reasoning into the label, and the screen fills with text addressed to its author rather than to its reader.
+
+Each of the following is a change already made to this app, not a preference:
+
+- **A label names, it doesn't explain**, and a value is one or two words: `Stuck`, `Expected`, `Retained`,
+  `Shallow`, `Strong`, `Cache`, `Unreachable`. Not `Shouldn't be here`, not `Reachable without going
+  through a java.lang.ref.Reference`, not `Retains 1.2 MB in 57 objects` where `Retained` and the number
+  would do. A button says what pressing it does — `List the instances` — and stops there.
+- **Delete, don't shorten, anything the picture already says.** A rectangle drawn inside another says it is
+  dominated by it; the count on a pile says how many; the colour with a legend above it says the strength.
+  A row that repeats one of those is ink spent on a question the reader has already had answered — which is
+  why the details panel has no `Dominates` row and no `Objects` row.
+- **The paragraph goes behind a `?`, and the `?` is always there.** `Explain(topic, onExplain) { … }` puts
+  one beside a label; `Topic` and `ReferencePage` are the pages, one markdown file each under
+  `docs/shark-dive-reference/`, whose **opening sentence is the tooltip** so that the short answer can't
+  drift from the long one. The pages ship with the app rather than linking out, so a release explains
+  itself with the text it was built with, and the same files are the website's via `pymdownx.snippets`.
+- **Nothing fades and nothing decays.** No first-run tour, no hint that stops appearing once the app
+  decides you look experienced. Two reasons, and they are the reasons this was asked for rather than a
+  taste: a window that shows its owner less than it shows everybody else is a window in which they can't
+  see the bugs everybody else is hitting, and the hint that was in the way on day one is the one they go
+  looking for on day thirty and can't find. So don't propose progressive onboarding here — the `?` is
+  what that job was given to.
+- **Prose belongs in the KDoc, `notes/decisions.md`, or a reference page.** Those are the three places
+  something long enough to be worth writing goes. `notes/agent-surface.md` measures the same idea on the
+  agent surface — ~80 tokens of name and description at rest, the ~2 k-token body only for a session that
+  asked — and the window is the same trade against a smaller budget.
+
+## One concept, one name, one place
+
+The map, the card at the pointer, the details panel, a row of a list, a step of a chain, the tab strip, the
+log line and the JSON an agent is answered with all say the same things about the same heap dump. **They
+have one reader**, who is either the person at the machine or the agent working beside them, and two
+spellings of one concept are two concepts to that reader — or two grep results, which is worse.
+
+So a concept gets **one name**, and **one declaration that name comes from**. What is already collapsed
+this way, each of which was several before:
+
+| Concept | The one place |
+| --- | --- |
+| How firmly an object is held | `ReachabilityStrength.label`, nine names, plus the one page behind the `?` |
+| An object's two sizes | `RETAINED`, `SHALLOW` and `retainedText` in `DetailsPanel.kt` |
+| A rectangle that isn't one object | `formatObjectCount` — a count, whichever kind of pile it is |
+| Which reference a leak is | `PathReference.leakLabel()`, and `RootPath.faultyReference()` |
+| Whether an object is meant to be in memory | `LeakStatus`: `STUCK`, `EXPECTED`, `UNKNOWN`, nothing else |
+| What a place is called | `Place.title` |
+
+**So grep for the concept before writing a label.** A new string that names something the window already
+names is the one kind of change that passes review, passes the tests, and leaves the app harder to read
+than it was. The tests catch drift only from the other side: `onNodeWithText` failing with "found 2 nodes"
+after a rename usually means the rename worked and the assertion was pinned on a name that was never
+unique — see the testing conventions below.
+
+And it is one *place*, not one *copy*. A second spelling is obvious; a second **definition** of the same
+sentence — the enum's KDoc and the reference page both saying what `SOFT` means — reads as fine and goes
+stale silently, which is why `LeakKind.explanation` is null for the five kinds named after a strength.
+
 ## A verdict set by hand is an argument to every read, never state of the tree
 
 **`STUCK`, `EXPECTED` and `UNKNOWN` are the only words for this, everywhere** — the enum, the window, the

--- a/shark/shark-dive/notes/decisions.md
+++ b/shark/shark-dive/notes/decisions.md
@@ -335,8 +335,14 @@ the pointer ends up inside takes the hover off the map — which would close the
 also the gap, and hence nothing in the card being clickable.
 
 **A rectangle that isn't one object gets the card too**, and needs it most. A pile is named on the map by a
-count and a simple class name — `400 × Sibling`, `300 smaller objects` — which is all a rectangle has room
+count and a simple class name — `400 × Sibling`, `300 objects` — which is all a rectangle has room
 for, so the qualified class name, or which rectangle a leftover pile was left out of, fits nowhere but here.
+
+**And a pile is a count, whichever kind of pile it is.** The three used to have a noun each — `300 smaller
+objects`, `400 objects of one class`, `Unreachable` — where the line under the count already said which:
+the class name, the rectangle they were left out of, or the strength. The one bit a reader can act on is
+whether a click goes *into* the pile or roots the map at what it was left out of, and that is said by the
+click rather than by a third noun.
 The card used to be drawn for `Selection.Object` alone, which meant pointing at the one kind of cell whose
 name is incomplete answered nothing at all.
 

--- a/shark/shark-dive/notes/decisions.md
+++ b/shark/shark-dive/notes/decisions.md
@@ -346,6 +346,17 @@ click rather than by a third noun.
 The card used to be drawn for `Selection.Object` alone, which meant pointing at the one kind of cell whose
 name is incomplete answered nothing at all.
 
+**And an object's sizes are `Retained` and `Shallow`, in those two words, everywhere they are given.** The
+card used to say `Retains 1.2 MB in 57 objects` and `88 B of its own, dominates 12 objects` where the panel
+behind it said `Retained`, `Retained objects`, `Shallow` and `Dominates` as four rows, and a chain step said
+`Retaining …` — three vocabularies for the same two numbers, which a reader has to reconcile before they can
+compare a card with the panel it is covering. `RETAINED`, `SHALLOW` and `retainedText` are the one answer.
+How many objects that is rides on the `Retained` line rather than getting a row, since it is the same fact
+counted the other way; how many an object *immediately* dominates is gone from the window entirely, being the
+count of rectangles drawn inside this one. `Dominates` therefore means one thing now, on the chain, where it
+says which step the map draws the rest inside. An agent still gets `dominatedObjects`, because an agent has
+no picture to read it off.
+
 Both are kept, as two sets of details from the same code: one for what the map is on, one for what the
 pointer is on. Nothing is read when the pointer leaves, and nothing beside the map is blanked as the
 next cell is read, so a sweep across the map doesn't flicker.
@@ -692,11 +703,17 @@ once per heap dump, behind a screen someone asked for, and is capped at the larg
 
 ## Which object it is, said the same way everywhere
 
-Four surfaces name an object: a step of a chain, the card at the pointer, the bar above the map, a row of the
-starred list. All four use `ObjectIdentity` — the class, then the class in full greyed under it, then its
-address — because they are all answering the same question, and a reader who has learnt to skip the grey
-lines on one should not have to learn where they are again on the next. The package on its own line is also
-what keeps a row from wrapping in a pane 300 dp wide.
+Three surfaces name an object in full: a step of a chain, the card at the pointer, the bar above the map. All
+three use `ObjectIdentity` — the class, then the class in full greyed under it, then its address — because
+they are all answering the same question, and a reader who has learnt to skip the grey lines on one should
+not have to learn where they are again on the next. The package on its own line is also what keeps a row from
+wrapping in a pane 300 dp wide.
+
+**A list of objects names one on one line instead**, `ObjectRow`, because a list is read down a column and
+three lines a row would make ten objects a screenful. It is the same order — package greyed, class, kind —
+laid sideways, and it carries no address: what tells one row from the next is the headline under it, and the
+address is a right click away and on the tab a row opens. Both lists that are lists of objects are built from
+it, so the object list and the starred objects are one table with two contents.
 
 **Which object it is lives above the map, not in the details panel.** It is a different question from the
 rest of that panel — which object, as against what that object holds — and it is what the tab strip and the
@@ -852,6 +869,24 @@ directory it was in, since two runs of one app produce two `heap.hprof`s and the
 inside it, a file per `noteKey` rather than one document with a section per place, so that a save touches only
 the note that was typed into, nothing has to be parsed back out of a document that also holds somebody's own
 headings, and the listing is the index.
+
+## Starred is a working set, kept as addresses and nothing else
+
+Starring is how a handful of objects are held side by side while being compared, since a treemap has no room
+to keep the last rectangle on screen while you look at the next. So it is kept the way the notes and the
+verdicts are: one file per heap dump under `~/.shark-dive/starred`, `StarredFile`, shared by every window on
+that dump, and read once per run before anything is drawn from it.
+
+**Addresses and nothing else.** The first version kept a copy of each object's class, sizes and dominator from
+the moment it was starred, which made the screen a comparison of snapshots — and made a row go stale the
+moment a verdict set by hand changed what something retains, with nothing on screen saying which of the two
+numbers was current. Reading them out of the heap dump again is one small read, the same read every other list
+of objects is, and it is the only way the starred rows and the map can't disagree.
+
+**In the order they were starred**, not sorted: the list somebody built while comparing is the list they
+expect to come back to. And one address per line with a comment at the top, because a working set is
+something to keep, mail or check in — a line that can't be read is skipped with a line in the log rather
+than costing the rest of the file, exactly as `leak-statuses` does.
 
 ## A link names the heap dump and nothing else
 

--- a/shark/shark-dive/notes/decisions.md
+++ b/shark/shark-dive/notes/decisions.md
@@ -703,17 +703,26 @@ once per heap dump, behind a screen someone asked for, and is capped at the larg
 
 ## Which object it is, said the same way everywhere
 
-Three surfaces name an object in full: a step of a chain, the card at the pointer, the bar above the map. All
-three use `ObjectIdentity` — the class, then the class in full greyed under it, then its address — because
-they are all answering the same question, and a reader who has learnt to skip the grey lines on one should
-not have to learn where they are again on the next. The package on its own line is also what keeps a row from
-wrapping in a pane 300 dp wide.
+Every surface that names an object uses `ObjectIdentity` — the class, then the class in full greyed under it,
+then its address — because they are all answering the same question, and a reader who has learnt to skip the
+grey lines on one should not have to learn where they are again on the next. A step of a chain, the card at
+the pointer, the bar above the map, a row of the object list, a row of the starred list, a leaking object on
+the leaks screen. The package on its own line is also what keeps a row from wrapping in a pane 300 dp wide.
 
-**A list of objects names one on one line instead**, `ObjectRow`, because a list is read down a column and
-three lines a row would make ten objects a screenful. It is the same order — package greyed, class, kind —
-laid sideways, and it carries no address: what tells one row from the next is the headline under it, and the
-address is a right click away and on the tab a row opens. Both lists that are lists of objects are built from
-it, so the object list and the starred objects are one table with two contents.
+**The rows were the ones that got this wrong, twice, and it is worth saying how.** A list row was written as
+one line of its own — package greyed, class, kind, no address — and the leaks screen's row as another —
+class, kind, address, no package. Neither was a decision; each was written next to the list it was for, and
+each looked consistent from where it was: the two lists of objects agreed with each other, and the leaks row
+agreed with what a leak's address is copied for. What that produced was three spellings of one question,
+which is exactly what "consistency between screens" gets you when the thing to be consistent about is the
+concept. **So the rule is that a naming of an object is a call to `ObjectIdentity`, not a `buildAnnotatedString`
+that looks like one.** `nameStyle` is the only thing a surface picks — the leaks row draws smaller, being
+indented inside the leak it is an instance of.
+
+A list row is that block with the headline under it and the sizes beside it, `ObjectRow`, which both lists of
+objects are built from — so the object list and the starred objects are one table with two contents. Three
+lines a row rather than one costs a screenful about half the objects it used to hold, which is the price of
+an address being readable where a link, a note or an agent's answer put one.
 
 **Which object it is lives above the map, not in the details panel.** It is a different question from the
 rest of that panel — which object, as against what that object holds — and it is what the tab strip and the

--- a/shark/shark-dive/notes/decisions.md
+++ b/shark/shark-dive/notes/decisions.md
@@ -1115,6 +1115,26 @@ who can weigh the two.
   leave a heap dump whose statuses contradict each other, which is the one state this step exists to
   prevent. It runs `NonCancellable` because the dialog closes as soon as it has.
 
+**It is a dialog of the tab, not of the window.** It was a material3 `AlertDialog`, which draws over the
+whole window, and the conflicts step is what that got wrong. Two things a reader wants there are behind the
+scrim. Why two verdicts can disagree at all is a paragraph — it was 265 characters drawn above the list,
+every time, for somebody who had read it once — and every other label in this window answers that shape with
+a `?` that opens the reference **in a tab**, which behind a window wide scrim is a tab nobody can reach. And
+each verdict being overruled is an *object*: the reason somebody typed for it is the case for the other
+reading, so weighing it against yours is sometimes going and looking, which a modal can only offer by being
+dismissed — and dismissing it throws away the half typed reason it was holding.
+
+So the dialog is drawn by hand instead: the same centred card over the same 32% scrim, inside the `Box` that
+holds the tab's panes rather than over the window, so the screen bar and the tab strip above it still take a
+click. And `SettingVerdict` is state `HeapDumpDive` keeps per tab id rather than `remember`ed inside the
+composable, so switching tabs leaves it where it is and coming back finds the reason half typed. Tab ids are
+never reused (see `Tab.id`), so an entry can only ever be about the tab it was made for, and closing a tab
+drops it. Two smaller differences from `AlertDialog` fall out: a click on the scrim is swallowed rather than
+taken as a dismissal, for the same reason as above, and the scrim is its own childless `Box` because
+`Modifier.clickable` merges the semantics of everything under it, which would have made the whole dialog one
+node to a test. The other three dialogs stay `AlertDialog`s: they are about acquiring a heap dump rather than
+reading one, so there is nothing behind them to go and look at.
+
 **One tab separated file per heap dump, in `~/.shark-dive/leak-statuses`.** Named after the dump the way
 its notes are, and beside them rather than next to the dump, for the same reason: dumps come from device
 pulls, temporary files and read only mounts. A file rather than a directory of files, which is the opposite

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentJson.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentJson.kt
@@ -270,7 +270,9 @@ internal object AgentJson {
         addJsonObject {
           put("kind", section.kind.name)
           put("title", section.kind.title)
-          put("explanation", section.kind.explanation)
+          // Absent for the five sections a reachability strength names, whose title is the whole of what
+          // they are. See LeakKind.explanation.
+          section.kind.explanation?.let { put("explanation", it) }
           // Whether this is a leak to fix or an object the collector will take on its own, which is the
           // split that makes the list actionable. See LeakKind.isOnTheWayOut.
           put("isOnTheWayOut", section.kind.isOnTheWayOut)

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentPlace.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentPlace.kt
@@ -36,8 +36,13 @@ internal fun AgentArguments.place(): Place {
 /**
  * The same place written back, and null for one an agent has no way of naming.
  *
- * The one that can't be is the pile of objects a rectangle had no room for: which objects are in it follows
- * from how wide the window is, so there is nothing here that would name it again on a screen of another size.
+ * One of the two can't be: the pile of objects a rectangle had no room for, because which objects are in it
+ * follows from how wide the window is, so there is nothing here that would name it again on a screen of
+ * another size.
+ *
+ * The other, a page of the reference, has no name here on purpose. It is what a *person* reads to find out
+ * what a label on screen means; the method is what an agent is handed for the same thing, twice, and
+ * sending it to read the human's copy would be the same prose a third time. See `AgentMethod`.
  */
 internal fun placeText(place: Place): String? = when (place) {
   is Place.Object -> exactHexObjectId(place.objectId)
@@ -52,6 +57,7 @@ internal fun placeText(place: Place): String? = when (place) {
   is Place.AgentLogs -> PLACE_AGENT_LOGS
   is Place.AgentLog -> "$PLACE_AGENT_LOGS$PLACE_SEPARATOR${place.sessionId}"
   is Place.SmallerObjects -> null
+  is Place.Reference -> null
 }
 
 /** What every tool taking one says, so that a place is described the one way. */

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
@@ -513,13 +513,15 @@ private val UNFOLDED_INSET = 20.dp
 /** And over the sessions of a client that connected and read nothing, which no window can be about. */
 private const val NO_HEAP_DUMP_READ = "No heap dump"
 
-private const val NO_SESSIONS =
-  "No agent has worked on this heap dump. Hand it to one by pointing its MCP client at Shark Dive, and " +
-    "everything it does lands here."
+/**
+ * Over a heap dump nothing has been handed to yet.
+ *
+ * What it is and how to point an MCP client at this window is [docs/shark-dive.md], not a paragraph on a
+ * screen somebody reached by pressing *Agent logs*: they know what an agent is by the time they are here.
+ */
+private const val NO_SESSIONS = "No agent has worked on this heap dump."
 
-private const val NOTHING_ASKED =
-  "This agent connected and asked nothing before it went away."
+private const val NOTHING_ASKED = "Connected and asked nothing."
 
-private const val NO_SUCH_SESSION =
-  "There is no session with that name. A link to one leads to the file it was written to, which is kept " +
-    "until a hundred newer sessions have pushed it out."
+/** And after a link to a session the newer ones have pushed out, which is the likeliest way to be here. */
+private const val NO_SUCH_SESSION = "No session by that name. The newest hundred are kept."

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/BitmapsFromDeviceDialog.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/BitmapsFromDeviceDialog.kt
@@ -91,10 +91,7 @@ internal fun BitmapsFromDeviceDialog(
         verticalArrangement = Arrangement.spacedBy(8.dp)
       ) {
         Text(counts.summary(), style = MaterialTheme.typography.bodyMedium)
-        Text(
-          "This heap dump was written by ${origin.description}.",
-          style = MaterialTheme.typography.bodySmall
-        )
+        Text("Written by ${origin.description}.", style = MaterialTheme.typography.bodySmall)
         HorizontalDivider()
         when (val currentStep = step) {
           FetchStep.Listing -> Waiting(LISTING_DEVICES)
@@ -205,7 +202,7 @@ private fun DeviceHeapDumps.candidatesFor(origin: HeapDumpOrigin): List<DeviceCa
 private val DeviceMatch.explanation: String
   get() = when (this) {
     DeviceMatch.SAME_BUILD -> "Same build as the heap dump."
-    DeviceMatch.SAME_MODEL -> "Same model and API level as the heap dump, but a different build."
+    DeviceMatch.SAME_MODEL -> "Same model and API level, different build."
     DeviceMatch.OTHER -> "Not the device the heap dump came from."
   }
 
@@ -216,19 +213,24 @@ private val DeviceMatch.explanation: String
  */
 private val AndroidDevice.fetchExplanation: String
   get() = if (canDumpBitmaps) {
-    "Its bitmaps come from dumping the process again, which costs it nothing."
+    "From a second heap dump, which costs it nothing."
   } else {
-    "API $sdkInt can't put bitmaps in a heap dump, so they come from attaching a debugger to the " +
-      "process, which suspends the app while they are read."
+    "API $sdkInt: from a debugger, which suspends the app."
   }
 
+/**
+ * How many bitmaps the dump has and how many it has the pixels of, which is why this dialog exists.
+ *
+ * Why the pixels are missing — native memory from API 26, carried only by a dump taken with
+ * `am dumpheap -b png`, which needs Android 15 — is `docs/shark-dive.md` for whoever wants it and
+ * `notes/bitmaps.md` for whoever is changing this, rather than four lines above a list of devices. What
+ * belongs here is the count and the one fact that makes fetching worth doing: the process still has them.
+ */
 private fun BitmapCounts.summary(): String = when {
-  count == 0 -> "This heap dump has no bitmaps in it."
-  withoutImageCount == 0 -> "This heap dump has the pixels of all ${bitmapCountText(count)} in it."
-  else -> "This heap dump has ${bitmapCountText(count)} in it, and the pixels of $withImageCount. " +
-    "From API 26 a bitmap keeps its pixels in native memory, which a heap dump only carries when it " +
-    "was taken with `am dumpheap -b png` — and that needs Android 15. The process that wrote this dump " +
-    "still has them, whichever version it runs."
+  count == 0 -> "No bitmaps in this heap dump."
+  withoutImageCount == 0 -> "Pixels of all ${bitmapCountText(count)}."
+  else -> "${bitmapCountText(count)}, the pixels of $withImageCount. The process that wrote this dump " +
+    "still has the rest."
 }
 
 private fun BitmapCounts.fetchedSummary(): String {
@@ -236,11 +238,9 @@ private fun BitmapCounts.fetchedSummary(): String {
   return if (mismatchedCount == 0) {
     fetched
   } else {
-    "$fetched $mismatchedCount were sent an image of the wrong size, which is a bitmap that has been " +
-      "recycled since the dump and whose address now belongs to another one."
+    "$fetched $mismatchedCount came back the wrong size, which is a bitmap recycled since the dump."
   }
 }
 
 internal const val FETCH_BITMAPS_TITLE = "Bitmaps from the live process"
-internal const val NO_MATCHING_PROCESS =
-  "No process of that app is running on this device, so its bitmaps are gone."
+internal const val NO_MATCHING_PROCESS = "That app isn't running here."

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/CellColors.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/CellColors.kt
@@ -325,34 +325,6 @@ private fun shaded(
   )
 }
 
-/** How the UI names a strength, e.g. next to its checkbox. */
-internal val ReachabilityStrength.displayName: String
-  get() = when (this) {
-    STRONG -> "Strong"
-    CACHE -> "Cache"
-    THREAD_LOCAL -> "Thread local"
-    LOCAL -> "Local"
-    SOFT -> "Soft"
-    WEAK -> "Weak"
-    FINALIZER -> "Finalizer"
-    PHANTOM -> "Phantom"
-    UNREACHABLE -> "Unreachable"
-  }
-
-/** How the details panel says an object is reachable. */
-internal val ReachabilityStrength.reachabilityText: String
-  get() = when (this) {
-    STRONG -> "Strongly reachable"
-    CACHE -> "Held only by a cache that evicts"
-    THREAD_LOCAL -> "Held only by a thread's own storage"
-    LOCAL -> "Held only by a running method"
-    SOFT -> "Softly reachable"
-    WEAK -> "Weakly reachable"
-    FINALIZER -> "Reachable only from the finalizer queue"
-    PHANTOM -> "Phantom reachable"
-    UNREACHABLE -> "Unreachable: uncollected garbage"
-  }
-
 private val ReachabilityStrength.hue: Float
   get() = when (this) {
     STRONG -> 210f

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
@@ -243,21 +243,33 @@ private fun BitmapPreview(bitmap: ImageBitmap?) {
   )
 }
 
-/** Whatever it wraps, with [text] shown while the pointer rests on it. */
+/**
+ * Whatever it wraps, with [text] shown while the pointer rests on it.
+ *
+ * [footer] is a line under it in the colour of a link, for a hint that leads somewhere: what a hint says
+ * about clicking has to be said in the hint, because the tooltip itself cannot be clicked — its [Surface]
+ * swallows pointer events, which is the same thing that keeps [PointerCard] out from under the pointer. See
+ * [Explain], which is the one thing that passes one.
+ */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun Hint(
   text: String,
+  footer: String? = null,
   content: @Composable () -> Unit
 ) {
   TooltipArea(
     tooltip = {
       Surface(shadowElevation = 4.dp, color = MaterialTheme.colorScheme.surface) {
-        Text(
-          text,
+        Column(
           Modifier.width(HINT_WIDTH).padding(8.dp),
-          style = MaterialTheme.typography.bodySmall
-        )
+          verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+          Text(text, style = MaterialTheme.typography.bodySmall)
+          footer?.let {
+            Text(it, style = MaterialTheme.typography.labelSmall, color = LINK_COLOR)
+          }
+        }
       }
     },
     content = content

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
@@ -28,11 +28,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import shark.dive.CellSubject
-import shark.dive.HeapDominatorTreemap
 import shark.dive.HeapObjectKind
 import shark.dive.HeapObjectSummary
 import shark.dive.ObjectGroupKind
 import shark.dive.ObjectGroupSummary
+import shark.dive.ReachabilityStrength
+import shark.dive.Topic
 import shark.dive.formatByteSize
 import shark.dive.formatByteSizeOfTotal
 import shark.dive.formatObjectCount
@@ -71,6 +72,8 @@ internal fun DetailsPanel(
   onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
   onToggleStar: () -> Unit,
+  /** Where the `?` beside how firmly an object is held goes. See [Explain]. */
+  onExplain: (Topic) -> Unit,
   modifier: Modifier = Modifier
 ) {
   Surface(modifier, color = MaterialTheme.colorScheme.surfaceVariant) {
@@ -89,7 +92,7 @@ internal fun DetailsPanel(
           Detail("Retained", formatByteSizeOfTotal(selection.byteCount, stronglyReachableByteCount))
         }
         is Selection.ObjectGroup ->
-          ObjectGroupDetails(selection.summary, stronglyReachableByteCount)
+          ObjectGroupDetails(selection.summary, stronglyReachableByteCount, onExplain)
         is Selection.Object -> ObjectDetails(
           summary = selection.summary,
           stronglyReachableByteCount = stronglyReachableByteCount,
@@ -102,7 +105,8 @@ internal fun DetailsPanel(
           onOpen = onOpen,
           onCopyLink = onCopyLink,
           onListInstances = onListInstances,
-          onToggleStar = onToggleStar
+          onToggleStar = onToggleStar,
+          onExplain = onExplain
         )
       }
     }
@@ -135,25 +139,44 @@ internal sealed interface Selection {
 @Composable
 private fun ObjectGroupDetails(
   summary: ObjectGroupSummary,
-  stronglyReachableByteCount: Long
+  stronglyReachableByteCount: Long,
+  onExplain: (Topic) -> Unit
 ) {
   Text(summary.title(), style = MaterialTheme.typography.titleMedium)
   summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
-  Row(
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
-    verticalAlignment = Alignment.CenterVertically
-  ) {
-    Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(summary.strength)))
-    Text(summary.strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
-  }
+  StrengthRow(summary.strength, onExplain)
   Detail("Retained together", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
   Detail("Objects", formatObjectCount(summary.objectCount))
 }
 
 /** What a pile of objects is called wherever it is described: here, and on the card at the pointer. */
 internal fun ObjectGroupSummary.title(): String = when (kind) {
-  ObjectGroupKind.UNREACHABLE -> HeapDominatorTreemap.UNREACHABLE_LABEL
+  ObjectGroupKind.UNREACHABLE -> ReachabilityStrength.UNREACHABLE.label
   ObjectGroupKind.CLASS -> "${formatObjectCount(objectCount)} of one class"
+}
+
+/**
+ * How firmly the thing being described is held: the colour the map draws it in, and the one name that colour
+ * has. See [ReachabilityStrength.label].
+ *
+ * One composable rather than the same row written out per panel, because the swatch beside the word is the
+ * whole of what ties the panel to the map — a panel that draws the swatch a pixel differently from another
+ * is a panel a reader has to check against the legend again.
+ */
+@Composable
+private fun StrengthRow(
+  strength: ReachabilityStrength,
+  onExplain: (Topic) -> Unit
+) {
+  Explain(Topic.REACHABILITY_STRENGTH, onExplain) {
+    Row(
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(strength)))
+      Text(strength.label, style = MaterialTheme.typography.bodySmall)
+    }
+  }
 }
 
 @Composable
@@ -169,7 +192,8 @@ private fun ObjectDetails(
   onOpen: (Long, OpenIn) -> Unit,
   onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
-  onToggleStar: () -> Unit
+  onToggleStar: () -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   Hint(if (isStarred) UNSTAR_HINT else STAR_HINT) {
     Text(
@@ -195,13 +219,7 @@ private fun ObjectDetails(
   // Under the headline, which for a bitmap is its size and its format: the picture is what the bitmap is,
   // and the sentence describing it stops just short of saying it.
   BitmapPreview(bitmap)
-  Row(
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
-    verticalAlignment = Alignment.CenterVertically
-  ) {
-    Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(summary.strength)))
-    Text(summary.strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
-  }
+  StrengthRow(summary.strength, onExplain)
   Detail("Retained", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
   Detail("Retained objects", summary.retainedCount.toString())
   // No share of the total on the shallow size: what one object is made of on its own is never a

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import shark.dive.CellSubject
 import shark.dive.HeapObjectKind
 import shark.dive.HeapObjectSummary
-import shark.dive.ObjectGroupKind
 import shark.dive.ObjectGroupSummary
 import shark.dive.ReachabilityStrength
 import shark.dive.Topic
@@ -85,7 +84,7 @@ internal fun DetailsPanel(
         null -> Text(NO_SELECTION, style = MaterialTheme.typography.bodyMedium)
         is Selection.Group -> {
           Text(
-            "${selection.nodeCount} smaller objects",
+            formatObjectCount(selection.nodeCount),
             style = MaterialTheme.typography.titleMedium
           )
           Text("Held by ${selection.parentLabel}", style = MaterialTheme.typography.bodySmall)
@@ -146,14 +145,16 @@ private fun ObjectGroupDetails(
   summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
   StrengthRow(summary.strength, onExplain)
   Detail("Retained together", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
-  Detail("Objects", formatObjectCount(summary.objectCount))
 }
 
-/** What a pile of objects is called wherever it is described: here, and on the card at the pointer. */
-internal fun ObjectGroupSummary.title(): String = when (kind) {
-  ObjectGroupKind.UNREACHABLE -> ReachabilityStrength.UNREACHABLE.label
-  ObjectGroupKind.CLASS -> "${formatObjectCount(objectCount)} of one class"
-}
+/**
+ * What a pile of objects is called wherever it is described: here, and on the card at the pointer.
+ *
+ * **A count, and the same count whichever kind of pile it is.** Which kind it is is the line under it — the
+ * class name for a pile of one class, and the strength for the uncollected garbage — so a second word for it
+ * here would be that line said twice, in a different vocabulary each time.
+ */
+internal fun ObjectGroupSummary.title(): String = formatObjectCount(objectCount)
 
 /**
  * How firmly the thing being described is held: the colour the map draws it in, and the one name that colour

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
@@ -85,10 +85,7 @@ internal fun DetailsPanel(
             "${selection.nodeCount} smaller objects",
             style = MaterialTheme.typography.titleMedium
           )
-          Text(
-            "Held by ${selection.parentLabel}. $GROUP_EXPLANATION",
-            style = MaterialTheme.typography.bodySmall
-          )
+          Text("Held by ${selection.parentLabel}", style = MaterialTheme.typography.bodySmall)
           Detail("Retained", formatByteSizeOfTotal(selection.byteCount, stronglyReachableByteCount))
         }
         is Selection.ObjectGroup ->
@@ -130,8 +127,10 @@ internal sealed interface Selection {
 
 /**
  * A cell standing for many objects: half of the heap dump, or every instance of one class under the
- * root. Says so in as many words, because a rectangle that isn't an object looks exactly like one that
- * is until something says otherwise.
+ * root. Its title is a count, which is what says it is not one object.
+ *
+ * The same rows an object gets, in the same order, so that a pile and an object read as two of a kind
+ * rather than as two panels: how firmly it is held, then what it costs.
  */
 @Composable
 private fun ObjectGroupDetails(
@@ -145,7 +144,7 @@ private fun ObjectGroupDetails(
     verticalAlignment = Alignment.CenterVertically
   ) {
     Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(summary.strength)))
-    Text(summary.explanation(), style = MaterialTheme.typography.bodySmall)
+    Text(summary.strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
   }
   Detail("Retained together", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
   Detail("Objects", formatObjectCount(summary.objectCount))
@@ -155,11 +154,6 @@ private fun ObjectGroupDetails(
 internal fun ObjectGroupSummary.title(): String = when (kind) {
   ObjectGroupKind.UNREACHABLE -> HeapDominatorTreemap.UNREACHABLE_LABEL
   ObjectGroupKind.CLASS -> "${formatObjectCount(objectCount)} of one class"
-}
-
-private fun ObjectGroupSummary.explanation(): String = when (kind) {
-  ObjectGroupKind.UNREACHABLE -> UNREACHABLE_EXPLANATION
-  ObjectGroupKind.CLASS -> CLASS_GROUP_EXPLANATION
 }
 
 @Composable
@@ -342,18 +336,6 @@ private const val STARRED = "Starred"
 private const val NOT_STARRED = "Star this object"
 private const val STAR_HINT = "Star this object, to compare it with others later."
 private const val UNSTAR_HINT = "Remove this object from the starred list."
-
-internal const val UNREACHABLE_EXPLANATION =
-  "Not one object: everything no GC root reaches, so garbage that hadn't been collected when the heap " +
-    "dump was written. The next collection would take all of it."
-
-internal const val CLASS_GROUP_EXPLANATION =
-  "Not one object: these are all the instances of this class that nothing owns on its own, gathered " +
-    "so the root's children can be read. Click it to see them one by one."
-
-private const val GROUP_EXPLANATION =
-  "Too small or too many to draw one by one in the rectangle they belong to. Clicking them roots the " +
-    "map at what holds them, which gives it the whole view to draw them in."
 
 /** What the pixels of the selected bitmap are, to anything that can't look at them. */
 internal const val BITMAP_DESCRIPTION = "The pixels of the selected bitmap."

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DetailsPanel.kt
@@ -144,7 +144,10 @@ private fun ObjectGroupDetails(
   Text(summary.title(), style = MaterialTheme.typography.titleMedium)
   summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
   StrengthRow(summary.strength, onExplain)
-  Detail("Retained together", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
+  // How many objects is the title, so this row is the bytes and nothing else. The same word an object gets,
+  // rather than "Retained together": that a pile of objects retains something together is what makes it a
+  // pile, and it is already headed by a count.
+  Detail(RETAINED, formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
 }
 
 /**
@@ -221,13 +224,11 @@ private fun ObjectDetails(
   // and the sentence describing it stops just short of saying it.
   BitmapPreview(bitmap)
   StrengthRow(summary.strength, onExplain)
-  Detail("Retained", formatByteSizeOfTotal(summary.retainedSize, stronglyReachableByteCount))
-  Detail("Retained objects", summary.retainedCount.toString())
+  Detail(RETAINED, retainedText(summary.retainedSize, summary.retainedCount, stronglyReachableByteCount))
   // No share of the total on the shallow size: what one object is made of on its own is never a
   // meaningful fraction of a heap dump, and a second percentage in the column would only dilute the
   // one that says something.
-  Detail("Shallow", formatByteSize(summary.shallowSize))
-  Detail("Dominates", "${summary.dominatedObjectCount} objects")
+  Detail(SHALLOW, formatByteSize(summary.shallowSize))
   summary.inspectorLabels.forEach { label ->
     Text(label, style = MaterialTheme.typography.bodySmall)
   }
@@ -350,6 +351,28 @@ internal fun Detail(
     Text(value, style = MaterialTheme.typography.bodyMedium)
   }
 }
+
+/**
+ * What an object's two sizes are called wherever they are given: the rows of this panel, the lines of the
+ * card at the pointer, and the columns of every list of objects. See [ObjectRow].
+ *
+ * **One word each.** These were three vocabularies for two numbers — `Retained` here, `Retains … in N
+ * objects` on the card, `Retained` again over a column — and a reader comparing a card against the panel
+ * behind it had to work out that they were the same numbers before they could compare them.
+ *
+ * How many objects that is goes on the [RETAINED] line rather than in a row of its own, because it is the
+ * same fact counted the other way. And how many the object *immediately* dominates is gone from both: that
+ * is the number of rectangles drawn inside this one, which is what the picture beside them is.
+ */
+internal const val RETAINED = "Retained"
+internal const val SHALLOW = "Shallow"
+
+internal fun retainedText(
+  retainedSize: Long,
+  retainedCount: Int,
+  stronglyReachableByteCount: Long
+): String = "${formatByteSizeOfTotal(retainedSize, stronglyReachableByteCount)} · " +
+  formatObjectCount(retainedCount)
 
 /**
  * Shown by the details panel until something has been clicked, which is what it describes: pointing at a

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DiveStars.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DiveStars.kt
@@ -1,0 +1,125 @@
+package shark.dive.app
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import shark.SharkLog
+import shark.dive.StarredFile
+import shark.dive.hexObjectId
+
+/**
+ * The objects starred in every heap dump this run has open.
+ *
+ * Per run rather than per window, for the reason [DiveNotes] and [DiveLeakStatuses] are: the same heap dump is
+ * often open in two windows, and two of these over one file would mean each window saving over the other's.
+ *
+ * Plain state rather than a composable's, so that it can be handed to a window and to a test.
+ */
+internal class DiveStars(private val root: File = STARRED_DIRECTORY) {
+
+  private val byFile = mutableMapOf<String, HeapDumpStars>()
+
+  /** What is starred in [heapDumpFile], the same ones every time they are asked for. */
+  fun of(heapDumpFile: File): HeapDumpStars = synchronized(byFile) {
+    val file = StarredFile(root, heapDumpFile)
+    byFile.getOrPut(file.file.path) { HeapDumpStars(file) }
+  }
+
+  companion object {
+    /** Beside the notes, the leak statuses and the logs, which is everything else this app keeps. */
+    private val STARRED_DIRECTORY = File(SHARK_DIVE_DIRECTORY, "starred")
+  }
+}
+
+/**
+ * What is starred in one heap dump: the addresses, and how to star or unstar one.
+ *
+ * **Nothing is starred that wasn't written**, for the reason [HeapDumpLeakStatuses] applies to a status: until
+ * the file has been read, [objectIds] is empty because nothing was read rather than because nothing is
+ * starred, and saving over that would take the star off everything to say the disk was slow.
+ */
+@Stable
+internal class HeapDumpStars(private val starredFile: StarredFile) {
+
+  /** Where these are kept, so a working set can be found without this app. */
+  val file: File get() = starredFile.file
+
+  /** The starred objects, in the order they were starred, which is the order the screen lists them in. */
+  var objectIds: List<Long> by mutableStateOf(emptyList())
+    private set
+
+  /** Whether the file has been read, which is what makes writing safe. */
+  var isRead by mutableStateOf(false)
+    private set
+
+  /** What went wrong reading or writing the file. Null while nothing has. */
+  var problem: String? by mutableStateOf(null)
+    private set
+
+  fun isStarred(objectId: Long): Boolean = objectId in objectIds
+
+  /** Reads the file, once per run of the app. */
+  suspend fun read() {
+    if (isRead) {
+      return
+    }
+    val read = try {
+      withContext(Dispatchers.IO) { starredFile.read() }
+    } catch (throwable: Throwable) {
+      SharkLog.d(throwable) { "Could not read the starred objects in $file" }
+      problem = "Could not read $file: $throwable"
+      return
+    }
+    isRead = true
+    problem = null
+    objectIds = read
+  }
+
+  /**
+   * Stars [objectId], or takes the star off it, and puts the lot on disk.
+   *
+   * One at a time, because the whole list is written every time: two stars set faster than a disk writes
+   * would both work out what to write from the list before either of them, and the second would save over
+   * the first. [NonCancellable] for the same reason from the other side — a star is set by a click that
+   * leaves nothing on screen waiting for it, so a save given up on half way would leave a file that
+   * disagrees with the screen above it.
+   */
+  suspend fun toggle(objectId: Long) {
+    saving.withLock {
+      if (!isRead) {
+        SharkLog.d { "Not starring ${hexObjectId(objectId)}: $file has not been read yet" }
+        return
+      }
+      val wasStarred = objectId in objectIds
+      // Appended rather than sorted in: the order is the order they were starred. See [StarredFile].
+      val next = if (wasStarred) objectIds - objectId else objectIds + objectId
+      val written = withContext(Dispatchers.IO + NonCancellable) {
+        try {
+          starredFile.write(next)
+          true
+        } catch (throwable: Throwable) {
+          SharkLog.d(throwable) { "Could not save the starred objects to $file" }
+          problem = "Could not save $file: $throwable"
+          false
+        }
+      }
+      if (!written) {
+        return
+      }
+      SharkLog.d {
+        "${if (wasStarred) "Unstarred" else "Starred"} ${hexObjectId(objectId)} in $file"
+      }
+      objectIds = next
+      problem = null
+    }
+  }
+
+  private val saving = Mutex()
+}

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DiveWindow.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/DiveWindow.kt
@@ -352,9 +352,11 @@ internal class DiveWindows(
       choices: List<File>,
       areOpen: Boolean
     ): String = if (areOpen) {
-      "${choices.size} heap dumps called ${link.heapDumpName} are open."
+      // The title asks which ${link.heapDumpName}, and the rows are the directories, so this says the one
+      // thing neither of them does: whether the choice is between windows or between files on disk.
+      "${choices.size} open."
     } else {
-      "${choices.size} heap dumps called ${link.heapDumpName} have been opened here, and none is open now."
+      "${choices.size} opened here before, none open now."
     }
 
     /**
@@ -369,13 +371,12 @@ internal class DiveWindows(
       link: DeepLink,
       gone: List<File>
     ): String = if (gone.isEmpty()) {
-      "No heap dump called ${link.heapDumpName} is open here, and this machine has no record of opening one " +
-        "by that name. Choose the file, or say where it is in the link: " +
+      // The title is `Where is <name>?`, so this is where it isn't, and the second way to answer it — the
+      // one the file picker under it can't offer, for a link about to be sent to somebody else.
+      "Nothing here has opened it. Choose the file, or say where it is in the link: " +
         "&${DeepLink.DUMP_PARAMETER}=/path/to/${link.heapDumpName}"
     } else {
-      "${link.heapDumpName} is not open, and there is no file at ${gone.joinToString(" or ")} any more. A " +
-        "link outlives the window it was copied from, but not the heap dump it is about. Choose the file if " +
-        "it has moved."
+      "Not at ${gone.joinToString(" or ")} any more."
     }
   }
 }

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/Explain.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/Explain.kt
@@ -1,0 +1,76 @@
+package shark.dive.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import shark.dive.ReferencePage
+import shark.dive.Topic
+
+/**
+ * Whatever it wraps, with a `?` after it: one sentence on hover, and the page it opens with that sentence
+ * when clicked.
+ *
+ * **The same `?` for everyone, forever.** It doesn't fade, it isn't a first-run tour, and it says the same
+ * thing on the thousandth heap dump as on the first — a hint that decays is a hint whoever built this stops
+ * seeing, so the day it starts saying the wrong thing nobody here notices. It is also there to be found
+ * later, which is the moment a hint is wanted: not while getting something done, but afterwards, wondering
+ * what that column was.
+ *
+ * Which is what puts the whole explanation in the page rather than in the tooltip. The tooltip is one
+ * sentence because it is read while deciding whether to look further, and it is the page's own first
+ * sentence, so the two cannot disagree. See [Topic].
+ *
+ * The `?` and not the tooltip is what takes the click: a tooltip's surface swallows pointer events in
+ * Compose Desktop, so the footer names the `?` rather than saying "click here".
+ */
+@Composable
+internal fun Explain(
+  topic: Topic,
+  /** Where a click goes, which is a tab on [shark.dive.Place.Reference]. See [HeapDumpDive]. */
+  onExplain: (Topic) -> Unit,
+  /** In [RowScope] so that a label that has to ellipsize can take the width the `?` leaves. */
+  content: @Composable RowScope.() -> Unit
+) {
+  val page = ReferencePage.of(topic)
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(4.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    content()
+    Hint(page.hint, footer = LEARN_MORE) {
+      Text(
+        EXPLAIN_GLYPH,
+        // Named after the page rather than after the label it follows, because that is where it goes and
+        // because a screen has several of these: one `?` is not findable, and this is also how a test
+        // clicks the right one.
+        Modifier.semantics { contentDescription = "$MORE_ABOUT ${page.title}" }
+          .clickableRow { onExplain(topic) }
+          // So that the character is not the whole of what a click has to land on.
+          .padding(horizontal = 2.dp),
+        style = MaterialTheme.typography.bodySmall,
+        color = MUTED_TEXT
+      )
+    }
+  }
+}
+
+/** What a click on it does, said in the hint because the hint itself cannot be clicked. See [Hint]. */
+private const val LEARN_MORE = "Click ? to read more"
+
+/**
+ * A question mark, in the muted grey of everything on screen that is about the window rather than about the
+ * heap dump. An icon would be a glyph in a circle at this size, and a circle around a `?` is a `?`.
+ */
+private const val EXPLAIN_GLYPH = "?"
+
+/** What the `?` is called to anything that can't see where it sits: a screen reader, or a test. */
+internal const val MORE_ABOUT = "More about"

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -234,8 +235,17 @@ internal fun HeapDumpDive(
   val starring = rememberCoroutineScope()
   /** Which objects of this heap dump have a status someone set, which is what every chain is read with. */
   val overrides = leakStatuses.overrides
-  /** Whether the dialog that sets one is open, for the object the tab is on. */
-  var setsLeakStatus by remember { mutableStateOf(false) }
+  /**
+   * The verdict being set in each tab, by tab id, and empty in a window where nobody is setting one.
+   *
+   * Per tab rather than per window, because setting a verdict is not a dialog: it is drawn inside the tab
+   * it was started from, so the reader can open the reference, go and look at a verdict this one disagrees
+   * with, or read the chain, and come back to the reason half typed. Tab ids are never reused, so an entry
+   * here can only ever be about the tab it was made for. See [SettingVerdict] and [LeakStatusSetter].
+   */
+  val settingVerdicts = remember { mutableStateMapOf<Int, SettingVerdict>() }
+  /** And the one in the tab on screen, which is the only one drawn. */
+  val settingVerdict = tabs.selectedId?.let { settingVerdicts[it] }
 
   // Nothing is under the pointer while a list is showing: the view isn't there, so the rectangle it was on
   // last is neither where the pointer is now nor what the tab is about.
@@ -419,9 +429,6 @@ internal fun HeapDumpDive(
   // And on the statuses set by hand, because they are half of what a chain says: setting one is asking the
   // window to read the heap dump through it, which is this read again.
   LaunchedEffect(session, place, overrides) {
-    // Whatever was being decided was being decided about the object this is leaving, and a dialog that
-    // outlived the tab it was opened from would set a status on an object nobody is looking at.
-    setsLeakStatus = false
     if (place == null || place.viewRootObjectId == null) {
       details = null
       return@LaunchedEffect
@@ -741,22 +748,6 @@ internal fun HeapDumpDive(
     )
   }
 
-  if (setsLeakStatus && describedLeakStatus != null) {
-    LeakStatusDialog(
-      status = describedLeakStatus,
-      // A walk up the references per status already set, which is a read of the heap dump like any other —
-      // and one asked for, so it is not on the path the pointer takes. See [leakStatusConflictsWith].
-      onFindConflicts = { override ->
-        session.read("what setting ${hexObjectId(override.objectId)} to ${override.status} disagrees with") {
-          it.tree.leakStatusConflictsWith(override, overrides)
-        }
-      },
-      onSet = { override, solved -> leakStatuses.set(override, solved) },
-      onClear = { leakStatuses.clear(describedLeakStatus.objectId) },
-      onDismiss = { setsLeakStatus = false }
-    )
-  }
-
   Column(modifier) {
     ScreenBar(
       starredCount = stars.objectIds.size,
@@ -770,7 +761,12 @@ internal fun HeapDumpDive(
       titleOf = { it.title ?: placeTitles[it] ?: NAMING_TAB },
       hasNote = { notes.hasNote(it) },
       onSelect = { id -> tabs = tabs.select(id) },
-      onClose = { id -> tabs = tabs.close(id) },
+      onClose = { id ->
+        tabs = tabs.close(id)
+        // A verdict being set belongs to its tab, so closing the tab is abandoning it — and leaving the
+        // entry behind would hand it to whichever tab took that id, if ids were ever reused.
+        settingVerdicts.remove(id)
+      },
       onCopyLink = copyLink
     )
     // Two things in one row, and a rule between them: how the tab got here, then what it is on. The height is
@@ -884,7 +880,12 @@ internal fun HeapDumpDive(
             leakStatus = describedLeakStatus,
             isLeakStatusRead = leakStatuses.isRead,
             leakStatusProblem = leakStatuses.problem,
-            onChangeLeakStatus = { setsLeakStatus = true },
+            onChangeLeakStatus = {
+              val tabId = tabs.selectedId
+              if (tabId != null && describedLeakStatus != null) {
+                settingVerdicts[tabId] = SettingVerdict(describedLeakStatus)
+              }
+            },
             onOpen = openObject,
             onCopyLink = copyObjectLink,
             onListInstances = { className ->
@@ -917,6 +918,32 @@ internal fun HeapDumpDive(
             Spacer(Modifier.weight(1f))
           }
         }
+      }
+      // Over the tab and no further: the scrim stops where this box does, so the screen bar and the tab
+      // strip above it still take a click while a verdict is being set. Which is what the `?` inside it
+      // needs — it opens the reference in a tab — and what going to look at a verdict this one contradicts
+      // needs. See [LeakStatusSetter].
+      settingVerdict?.let { setting ->
+        LeakStatusSetter(
+          setting = setting,
+          // A walk up the references per status already set, which is a read of the heap dump like any
+          // other — and one asked for, so it is not on the path the pointer takes. See
+          // [leakStatusConflictsWith].
+          onFindConflicts = { override ->
+            session.read(
+              "what setting ${hexObjectId(override.objectId)} to ${override.status} disagrees with"
+            ) {
+              it.tree.leakStatusConflictsWith(override, overrides)
+            }
+          },
+          onSet = { override, solved -> leakStatuses.set(override, solved) },
+          onClear = { leakStatuses.clear(setting.status.objectId) },
+          // In a tab of its own and in front, the way a `?` opens a page: going to look at a verdict this
+          // one disagrees with is reading, and the tab it was left in keeps what was typed into it.
+          onOpenObject = { objectId -> openInNewTab(Place.Object(objectId)) },
+          onExplain = explain,
+          onDone = { tabs.selectedId?.let { settingVerdicts.remove(it) } }
+        )
       }
     }
   }

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
@@ -69,11 +69,13 @@ import shark.dive.Place
 import shark.dive.PresentedCell
 import shark.dive.RadialLayout
 import shark.dive.RadialPresentation
+import shark.dive.ReferencePage
 import shark.dive.RootPath
 import shark.dive.RootPathWay
 import shark.dive.StackLayout
 import shark.dive.StackPresentation
 import shark.dive.Tabs
+import shark.dive.Topic
 import shark.dive.TreemapLayout
 import shark.dive.TreemapPresentation
 import shark.dive.TreemapRect
@@ -630,6 +632,14 @@ internal fun HeapDumpDive(
   }
   /** And for the buttons on the bar, which always open a tab of their own, in front. */
   val openInNewTab: (Place) -> Unit = { destination -> tabs = tabs.open(destination) }
+  /**
+   * Where a `?` goes: the page of the reference about that label, in a tab in front of what is being read.
+   *
+   * A tab rather than a browser, and in front rather than behind: clicking a `?` is asking to read the page,
+   * unlike ⌘ clicking a rectangle, which is parking somewhere to come back to. What was being read is a tab
+   * away, and the back arrow comes back from it. See [Explain] and [ReferenceScreen].
+   */
+  val explain: (Topic) -> Unit = { topic -> openInNewTab(Place.Reference(topic)) }
   /** Where a click on the view goes, which is wherever was clicked. Every rectangle is a move. */
   val onClickCell: (LayoutCell<Long>, OpenIn) -> Unit = { cell, openIn ->
     open(Place.of(cell), openIn)
@@ -789,6 +799,8 @@ internal fun HeapDumpDive(
           onCopyPlaceLink = copyLink,
           onReplacePlace = { tabs = tabs.replacingCurrent(it) },
           onRemoveStar = { objectId -> favourites = favourites.filterNot { it.objectId == objectId } },
+          onFollowLink = followNoteLink,
+          onExplain = explain,
           modifier = Modifier.fillMaxSize()
         )
         else -> Row(Modifier.fillMaxSize()) {
@@ -804,7 +816,8 @@ internal fun HeapDumpDive(
             chosenWays = chosenWays,
             onChooseWay = { detour, way -> chosenWays = chosenWays + (detour to way) },
             onOpen = openObject,
-            onCopyLink = copyObjectLink
+            onCopyLink = copyObjectLink,
+            onExplain = explain
           )
           ViewPane(
             panes = panes,
@@ -828,7 +841,8 @@ internal fun HeapDumpDive(
             onClick = onClickCell,
             onOpenHovered = openHovered,
             onCopyHoveredLink = copyHoveredLink,
-            onMeasured = { viewportSize = it }
+            onMeasured = { viewportSize = it },
+            onExplain = explain
           )
           DetailsPane(
             panes = panes,
@@ -936,7 +950,8 @@ private fun RowScope.ChainPane(
   chosenWays: Map<Int, Int>,
   onChooseWay: (Int, Int) -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
-  onCopyLink: (Long) -> Unit
+  onCopyLink: (Long) -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   if (panes.isFolded(Pane.CHAIN)) {
     FoldedPane(Pane.CHAIN) { panes.toggleFold(Pane.CHAIN) }
@@ -957,6 +972,7 @@ private fun RowScope.ChainPane(
       onChooseWay = onChooseWay,
       onOpen = onOpen,
       onCopyLink = onCopyLink,
+      onExplain = onExplain,
       modifier = Modifier.weight(1f).fillMaxWidth()
     )
   }
@@ -991,7 +1007,8 @@ private fun RowScope.ViewPane(
   onOpenHovered: (OpenIn) -> Unit,
   /** And what that menu copies a link to, which is the same rectangle. */
   onCopyHoveredLink: () -> Unit,
-  onMeasured: (IntSize) -> Unit
+  onMeasured: (IntSize) -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   if (panes.isFolded(Pane.VIEW)) {
     FoldedPane(Pane.VIEW) { panes.toggleFold(Pane.VIEW) }
@@ -1010,6 +1027,7 @@ private fun RowScope.ViewPane(
       isFindingLeaks = isFindingLeaks,
       onColoringChange = onColoringChange,
       onShapeChange = onShapeChange,
+      onExplain = onExplain,
       modifier = Modifier.fillMaxWidth()
     )
     Box(Modifier.weight(1f).fillMaxWidth()) {
@@ -1137,6 +1155,10 @@ private fun ListPlace(
   onCopyPlaceLink: (Place) -> Unit,
   onReplacePlace: (Place) -> Unit,
   onRemoveStar: (Long) -> Unit,
+  /** And where a link written in prose goes: a browser, this heap dump, or another window. */
+  onFollowLink: (NoteLink) -> Unit,
+  /** And where a `?` goes, which is the page of the reference on that label. See [Explain]. */
+  onExplain: (Topic) -> Unit,
   modifier: Modifier = Modifier
 ) {
   when (place) {
@@ -1167,6 +1189,7 @@ private fun ListPlace(
       },
       onOpen = onOpen,
       onCopyLink = onCopyLink,
+      onExplain = onExplain,
       modifier = modifier
     )
     is Place.Starred -> StarredScreen(
@@ -1175,6 +1198,13 @@ private fun ListPlace(
       onOpen = onOpen,
       onCopyLink = onCopyLink,
       onRemove = onRemoveStar,
+      modifier = modifier
+    )
+    is Place.Reference -> ReferenceScreen(
+      page = ReferencePage.of(place.topic),
+      onOpenTopic = { topic, openIn -> onOpenPlace(Place.Reference(topic), openIn) },
+      onCopyTopicLink = { topic -> onCopyPlaceLink(Place.Reference(topic)) },
+      onLink = onFollowLink,
       modifier = modifier
     )
     is Place.AgentLogs -> AgentLogsScreen(
@@ -1277,6 +1307,9 @@ private fun ScreenBar(
     // been looked at, by whoever was looking. An agent works in this window rather than in one of its own,
     // so what it did belongs on this bar and not in a file somebody has to be told about.
     ScreenButton(Place.AgentLogs, Place.AGENT_LOGS_LABEL, onOpen, onCopyLink)
+    // Last, and here at all so that the pages every `?` leads to can be found without one: a reader who
+    // wondered about a label an hour ago and has moved on has nothing left to hover. See [Explain].
+    ScreenButton(Place.Reference(Topic.values().first()), Place.REFERENCE_LABEL, onOpen, onCopyLink)
     // Only when there are bitmaps the dump has no pixels for, because that's the only thing a device can
     // add: pixels the dump carries are already on the map by the time this bar is read.
     if (bitmapCounts.withoutImageCount > 0) {

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
@@ -69,6 +69,7 @@ import shark.dive.Place
 import shark.dive.PresentedCell
 import shark.dive.RadialLayout
 import shark.dive.RadialPresentation
+import shark.dive.ReachabilityStrength
 import shark.dive.ReferencePage
 import shark.dive.RootPath
 import shark.dive.RootPathWay
@@ -886,7 +887,8 @@ internal fun HeapDumpDive(
                   favourites + Favourite.of(summary, details?.dominator)
                 }
               }
-            }
+            },
+            onExplain = explain
           )
           // Every pane folded away leaves three strips and a window of nothing, which still has to be
           // laid out: without this the strips would be stretched across it instead.
@@ -1077,7 +1079,8 @@ private fun RowScope.DetailsPane(
   onOpen: (Long, OpenIn) -> Unit,
   onCopyLink: (Long) -> Unit,
   onListInstances: (String) -> Unit,
-  onToggleStar: () -> Unit
+  onToggleStar: () -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   if (panes.isFolded(Pane.DETAILS)) {
     FoldedPane(Pane.DETAILS) { panes.toggleFold(Pane.DETAILS) }
@@ -1101,6 +1104,7 @@ private fun RowScope.DetailsPane(
       onCopyLink = onCopyLink,
       onListInstances = onListInstances,
       onToggleStar = onToggleStar,
+      onExplain = onExplain,
       modifier = Modifier.weight(1f).fillMaxWidth()
     )
   }
@@ -1258,7 +1262,7 @@ private fun DescribedObject(selection: Selection?) {
       )
     }
     is Selection.ObjectGroup -> Text(
-      selection.summary.className ?: HeapDominatorTreemap.UNREACHABLE_LABEL,
+      selection.summary.className ?: ReachabilityStrength.UNREACHABLE.label,
       style = titleStyle,
       fontWeight = FontWeight.Bold
     )

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
@@ -1190,6 +1190,7 @@ private fun ListPlace(
       onOpen = onOpen,
       onCopyLink = onCopyLink,
       onExplain = onExplain,
+      onFollowLink = onFollowLink,
       modifier = modifier
     )
     is Place.Starred -> StarredScreen(

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
@@ -1267,7 +1267,7 @@ private fun DescribedObject(selection: Selection?) {
       fontWeight = FontWeight.Bold
     )
     is Selection.Group -> Text(
-      "${selection.nodeCount} smaller objects",
+      formatObjectCount(selection.nodeCount),
       style = titleStyle,
       fontWeight = FontWeight.Bold
     )

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/HeapDumpDive.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -48,6 +49,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import shark.SharkLog
 import shark.dive.BitmapCounts
@@ -62,8 +64,8 @@ import shark.dive.LeakStatusOverrides
 import shark.dive.NativeBitmapPixels
 import shark.dive.Note
 import shark.dive.NoteLink
-import shark.dive.ObjectDominator
 import shark.dive.ObjectList
+import shark.dive.ObjectListEntry
 import shark.dive.ObjectListFilter
 import shark.dive.Place
 import shark.dive.PresentedCell
@@ -126,6 +128,8 @@ internal fun HeapDumpDive(
   notes: HeapDumpNotes,
   /** And what has been decided about its objects by hand, shared the same way. See [LeakStatusDetail]. */
   leakStatuses: HeapDumpLeakStatuses,
+  /** And which of its objects are starred, shared the same way. See [HeapDumpStars]. */
+  stars: HeapDumpStars,
   /** Places a link has asked for, opened as tabs. See [DiveWindow.linkedPlaces]. */
   linkedPlaces: List<Place> = emptyList(),
   onLinkedPlaceOpened: (Place) -> Unit = {},
@@ -198,8 +202,8 @@ internal fun HeapDumpDive(
   /** Bumped when pixels arrive from the device, which is what makes the bitmaps be asked for again. */
   var bitmapRevision by remember { mutableStateOf(0) }
   var showsBitmapsFromDevice by remember { mutableStateOf(false) }
-  /** The objects starred so far, with everything the list shows about them read once. */
-  var favourites by remember { mutableStateOf(emptyList<Favourite>()) }
+  /** The objects starred so far, as the rows that draw them. Read from the addresses in [stars]. */
+  var starredObjects by remember { mutableStateOf(emptyList<ObjectListEntry>()) }
   /** What the agents that have worked through this app did, while a screen showing them is open. */
   var sessions by remember { mutableStateOf(emptyList<AgentSession>()) }
   /** What each tab is called, by the place it is on. Only grows: a place is named once and stays named. */
@@ -220,6 +224,14 @@ internal fun HeapDumpDive(
       subject = current.title ?: placeTitles[current] ?: NAMING_TAB
     )
   }
+  /**
+   * Where saving a star runs, which is the composition rather than an effect.
+   *
+   * A `LaunchedEffect` keyed on what was clicked is how the leak status dialog does it, and it can't be that
+   * here: two stars set in a row would key the effect twice, and the second would cancel the first between
+   * its write landing and the list on screen being told about it. See [HeapDumpStars.toggle].
+   */
+  val starring = rememberCoroutineScope()
   /** Which objects of this heap dump have a status someone set, which is what every chain is read with. */
   val overrides = leakStatuses.overrides
   /** Whether the dialog that sets one is open, for the object the tab is on. */
@@ -567,6 +579,24 @@ internal fun HeapDumpDive(
   // answer where someone has already recorded another. See [HeapDumpLeakStatuses].
   LaunchedEffect(leakStatuses) { leakStatuses.read() }
 
+  // And which of its objects are starred, the same way and for the same reason: a star is drawn beside every
+  // object the panel describes, so a window that hasn't read the file yet would say every one of them isn't.
+  LaunchedEffect(stars) { stars.read() }
+
+  // What those addresses stand for, which is a read of the heap dump like every other list of objects. Not
+  // gated on the starred screen being open: it is a handful of objects rather than a pass over the dump, and
+  // one that has left the tree is a row that quietly isn't there, which is worth being in the log early.
+  LaunchedEffect(session, stars.objectIds) {
+    val starredIds = stars.objectIds
+    if (starredIds.isEmpty()) {
+      starredObjects = emptyList()
+      return@LaunchedEffect
+    }
+    starredObjects = session.read("the ${starredIds.size} starred objects") { dive ->
+      dive.tree.listObjects(starredIds)
+    }
+  }
+
   // And what the note about this one says, once per run of the app. Here rather than in the section that draws
   // it, because a place nobody has written about has no section at all until the read says it has none.
   LaunchedEffect(tabNote?.notes) { tabNote?.notes?.read() }
@@ -729,7 +759,7 @@ internal fun HeapDumpDive(
 
   Column(modifier) {
     ScreenBar(
-      starredCount = favourites.size,
+      starredCount = stars.objectIds.size,
       bitmapCounts = bitmapCounts,
       onOpen = openInNewTab,
       onCopyLink = copyLink,
@@ -787,7 +817,7 @@ internal fun HeapDumpDive(
           isListing = isListing,
           leaks = leaks,
           isFindingLeaks = isFindingLeaks,
-          favourites = favourites,
+          starredObjects = starredObjects,
           sessions = sessions,
           heapDumpFile = session.heapDumpFile,
           agentPlaceTitles = agentPlaceTitles,
@@ -799,7 +829,7 @@ internal fun HeapDumpDive(
           onOpenPlace = open,
           onCopyPlaceLink = copyLink,
           onReplacePlace = { tabs = tabs.replacingCurrent(it) },
-          onRemoveStar = { objectId -> favourites = favourites.filterNot { it.objectId == objectId } },
+          onRemoveStar = { objectId -> starring.launch { stars.toggle(objectId) } },
           onFollowLink = followNoteLink,
           onExplain = explain,
           modifier = Modifier.fillMaxSize()
@@ -850,7 +880,7 @@ internal fun HeapDumpDive(
             selection = details?.selection,
             sizes = sizes,
             bitmap = describedBitmap,
-            isStarred = favourites.any { it.objectId == describedSummary?.objectId },
+            isStarred = describedSummary?.let { stars.isStarred(it.objectId) } == true,
             leakStatus = describedLeakStatus,
             isLeakStatusRead = leakStatuses.isRead,
             leakStatusProblem = leakStatuses.problem,
@@ -876,16 +906,7 @@ internal fun HeapDumpDive(
                 // selection disagreeing rather than a click on nothing.
                 SharkLog.d { "Nothing to star: no object is selected" }
               } else {
-                val wasStarred = favourites.any { it.objectId == summary.objectId }
-                SharkLog.d {
-                  "${if (wasStarred) "Unstarred" else "Starred"} ${hexObjectId(summary.objectId)}"
-                }
-                favourites = if (wasStarred) {
-                  favourites.filterNot { it.objectId == summary.objectId }
-                } else {
-                  // Described, since a summary to star came from the same read as the dominator beside it.
-                  favourites + Favourite.of(summary, details?.dominator)
-                }
+                starring.launch { stars.toggle(summary.objectId) }
               }
             },
             onExplain = explain
@@ -1140,7 +1161,7 @@ private fun ListPlace(
   isListing: Boolean,
   leaks: HeapLeaks?,
   isFindingLeaks: Boolean,
-  favourites: List<Favourite>,
+  starredObjects: List<ObjectListEntry>,
   /** What the agents that have worked through this app did, for the screens that draw them. */
   sessions: List<AgentSession>,
   /** Which heap dump this window has open, which is what decides where an agent's row leads. */
@@ -1198,7 +1219,7 @@ private fun ListPlace(
       modifier = modifier
     )
     is Place.Starred -> StarredScreen(
-      favourites = favourites,
+      entries = starredObjects,
       stronglyReachableByteCount = sizes.stronglyReachableByteCount,
       onOpen = onOpen,
       onCopyLink = onCopyLink,
@@ -1643,7 +1664,6 @@ private class PlaceDetails(
   /** Which place these are of, so that a pane can tell them from the ones it is waiting to replace. */
   val place: Place,
   val selection: Selection?,
-  val dominator: ObjectDominator?,
   /** Null until the walk up to the GC roots comes back. */
   val rootPath: RootPath?
 )
@@ -1686,13 +1706,9 @@ private suspend fun HeapDumpSession.describing(
       // A list has no one object to describe, so nothing asks this about one.
       else -> null
     }
-    // The tree already knows what dominates what, so this is a read of one label rather than a search,
-    // and it belongs in the same read: two of them means the panel showing a dominator a beat late.
-    val objectId = (selection as? Selection.Object)?.summary?.objectId
     PlaceDetails(
       place = place,
       selection = selection,
-      dominator = objectId?.let { tree.dominatorOf(it) },
       rootPath = null
     )
   }
@@ -1705,7 +1721,6 @@ private suspend fun HeapDumpSession.describing(
     PlaceDetails(
       place = place,
       selection = placeDetails.selection,
-      dominator = placeDetails.dominator,
       rootPath = rootPath
     )
   )

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeakStatusSection.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeakStatusSection.kt
@@ -2,20 +2,25 @@ package shark.dive.app
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -34,6 +39,7 @@ import shark.SharkLog
 import shark.dive.LeakStatus
 import shark.dive.LeakStatusConflict
 import shark.dive.LeakStatusOverride
+import shark.dive.Topic
 import shark.dive.statusText
 
 /**
@@ -123,141 +129,216 @@ internal fun LeakStatusDetail(
 }
 
 /**
+ * A verdict being set by hand: what has been picked, why, and how far the flow has got.
+ *
+ * Held by [HeapDumpDive] against the tab it was started in rather than `remember`ed by the composable that
+ * draws it, which is half of what makes this a dialog of the tab rather than of the window: switching tabs
+ * leaves it where it is, and coming back finds the reason half typed exactly as it was left. The other half
+ * is where [LeakStatusSetter] draws — inside the tab's panes, so the scrim stops at them.
+ */
+internal class SettingVerdict(
+  /**
+   * The object it is about, as it was when the pencil was pressed.
+   *
+   * Kept rather than read off the tab each time, because the tab is free to move while this is open: going
+   * to look at a verdict this one disagrees with is the whole point, and what is being set has to stay the
+   * thing that was asked about.
+   */
+  val status: ObjectLeakStatus
+) {
+  var chosen: LeakStatus by mutableStateOf(status.setByHand?.status ?: status.status)
+  var reason: String by mutableStateOf(status.setByHand?.reason.orEmpty())
+  var step: SetStep by mutableStateOf(SetStep.Choosing)
+
+  /** What has been asked for, and null while nothing has: the ask is what the reading below follows. */
+  var requested: LeakStatusOverride? by mutableStateOf(null)
+}
+
+/**
  * Sets the leaking status of one object by hand, and settles what that disagrees with.
  *
  * Two steps, and the second one only when it has to be: a status, with the reason that makes it worth
  * keeping, and then whatever else was set by hand that it cannot be true alongside. The reader decides which
  * of the two readings to keep — nothing is flipped without being shown, and nothing is written until it is.
  *
+ * **A dialog of the tab rather than of the window**, which is the whole of what it is doing by hand what an
+ * `AlertDialog` would have done for it: the scrim covers the panes and stops at them, so the screen bar and
+ * the tab strip above are still there to click. That is what the `?` on why two verdicts disagree needs —
+ * every `?` in this window opens the reference in a tab, and a tab opened behind a window wide scrim is a tab
+ * nobody can reach. Each verdict this one contradicts opens the object it is about for the same reason.
+ * Switching tabs leaves this where it is, because [SettingVerdict] belongs to the tab and not to this
+ * composable, so coming back finds the reason half typed exactly as it was left.
+ *
  * Finding the disagreements is a walk up the heap dump's references, so it happens on the heap dump's thread
  * like everything else here and this waits for it. See [shark.dive.leakStatusConflictsWith].
  */
 @Composable
-internal fun LeakStatusDialog(
-  status: ObjectLeakStatus,
+internal fun LeakStatusSetter(
+  setting: SettingVerdict,
   /** What the new status would disagree with, read off the heap dump. See [HeapDumpDive]. */
   onFindConflicts: suspend (LeakStatusOverride) -> List<LeakStatusConflict>,
   /** Sets it, along with whatever had to change for it to be true. */
   onSet: suspend (LeakStatusOverride, List<LeakStatusOverride>) -> Unit,
   /** Takes the status off the object, so that the heap dump says what it says about it again. */
   onClear: suspend () -> Unit,
-  onDismiss: () -> Unit
+  /** Where a verdict this one disagrees with leads: the object it is about, in a tab of its own. */
+  onOpenObject: (Long) -> Unit,
+  /** Where the `?` on what a disagreement is goes. See [Explain]. */
+  onExplain: (Topic) -> Unit,
+  /** Answered or abandoned, which is the same thing to whoever is holding this. */
+  onDone: () -> Unit,
+  modifier: Modifier = Modifier
 ) {
-  var chosen: LeakStatus by remember { mutableStateOf(status.setByHand?.status ?: status.status) }
-  var reason by remember { mutableStateOf(status.setByHand?.reason.orEmpty()) }
-  var step: SetStep by remember { mutableStateOf(SetStep.Choosing) }
-  /** What has been asked for, and null while nothing has: the ask is what the reading below follows. */
-  var requested: LeakStatusOverride? by remember { mutableStateOf(null) }
+  val status = setting.status
 
-  LaunchedEffect(requested) {
-    val override = requested ?: return@LaunchedEffect
-    step = SetStep.Checking
+  LaunchedEffect(setting, setting.requested) {
+    val override = setting.requested ?: return@LaunchedEffect
+    setting.step = SetStep.Checking
     val conflicts = onFindConflicts(override)
-    step = if (conflicts.isEmpty()) {
+    setting.step = if (conflicts.isEmpty()) {
       // Nothing to settle, so the status someone typed is the whole of what they were asked for.
       SetStep.Writing(Decision.Set(override, emptyList()))
     } else {
       SetStep.Conflicts(override, conflicts)
     }
-    requested = null
+    setting.requested = null
   }
 
-  // Every write goes through here, and closing the dialog is the last thing it does: a save started from a
-  // button and a dialog that goes away in the same breath is a save whose result nothing is left to keep.
-  val writing = (step as? SetStep.Writing)?.decision
-  LaunchedEffect(writing) {
+  // Every write goes through here, and closing this is the last thing it does: a save started from a button
+  // and a dialog that goes away in the same breath is a save whose result nothing is left to keep.
+  val writing = (setting.step as? SetStep.Writing)?.decision
+  LaunchedEffect(setting, writing) {
     when (val decision = writing ?: return@LaunchedEffect) {
       is Decision.Set -> onSet(decision.override, decision.solved)
       Decision.Clear -> onClear()
     }
-    onDismiss()
+    onDone()
   }
 
-  AlertDialog(
-    onDismissRequest = onDismiss,
-    title = { Text(statusDialogTitle(status.objectName)) },
-    text = {
+  Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    // Its own box with nothing in it, so that the click it swallows is a click and not the semantics of
+    // everything below merged into one node. It swallows rather than dismisses, which is the one way this
+    // differs from an `AlertDialog`: a click landing outside is a click that missed, and treating it as an
+    // answer would throw away a reason somebody was half way through typing.
+    Box(
+      Modifier.fillMaxSize()
+        .background(MaterialTheme.colorScheme.scrim.copy(alpha = SCRIM_ALPHA))
+        .clickable(
+          interactionSource = remember { MutableInteractionSource() },
+          indication = null
+        ) {}
+    )
+    Surface(
+      Modifier.padding(16.dp).widthIn(min = DIALOG_MIN_WIDTH, max = DIALOG_WIDTH),
+      shape = AlertDialogDefaults.shape,
+      color = AlertDialogDefaults.containerColor,
+      tonalElevation = AlertDialogDefaults.TonalElevation,
+      shadowElevation = DIALOG_SHADOW
+    ) {
       Column(
-        Modifier.heightIn(max = DIALOG_MAX_HEIGHT).verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        Modifier.padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
       ) {
-        when (val currentStep = step) {
-          SetStep.Choosing -> ChoosingStatus(
-            status = status,
-            chosen = chosen,
-            reason = reason,
-            onChoose = { chosen = it },
-            onReason = { reason = it }
-          )
-          SetStep.Checking -> Waiting(CHECKING_CONFLICTS)
-          is SetStep.Conflicts -> Conflicts(currentStep.requested, currentStep.conflicts)
-          is SetStep.Writing -> Waiting(WRITING_STATUS)
-        }
-      }
-    },
-    confirmButton = {
-      when (val currentStep = step) {
-        SetStep.Choosing -> TextButton(
-          onClick = {
-            requested = LeakStatusOverride(
-              objectId = status.objectId,
-              status = chosen,
-              reason = reason.trim()
-            )
-          },
-          // A status set by hand overrules the heap dump, so it is worth nothing to whoever reads it next
-          // without the why — which is why this waits for one rather than filling one in.
-          enabled = reason.isNotBlank()
+        Text(settingVerdictTitle(status.objectName), style = MaterialTheme.typography.headlineSmall)
+        Column(
+          Modifier.heightIn(max = DIALOG_MAX_HEIGHT).verticalScroll(rememberScrollState()),
+          verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-          Text(SAVE_STATUS)
-        }
-        is SetStep.Conflicts -> TextButton(
-          onClick = {
-            SharkLog.d {
-              "Keeping ${currentStep.requested.status} for ${status.objectName} and flipping the " +
-                "${currentStep.conflicts.size} statuses set by hand that disagreed with it"
-            }
-            step = SetStep.Writing(
-              Decision.Set(currentStep.requested, currentStep.conflicts.map { it.solved })
+          when (val currentStep = setting.step) {
+            SetStep.Choosing -> ChoosingStatus(
+              status = status,
+              chosen = setting.chosen,
+              reason = setting.reason,
+              onChoose = { setting.chosen = it },
+              onReason = { setting.reason = it }
             )
+            SetStep.Checking -> Waiting(CHECKING_CONFLICTS)
+            is SetStep.Conflicts -> Conflicts(
+              requested = currentStep.requested,
+              conflicts = currentStep.conflicts,
+              onOpenObject = onOpenObject,
+              onExplain = onExplain
+            )
+            is SetStep.Writing -> Waiting(WRITING_STATUS)
           }
+        }
+        Row(
+          Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End)
         ) {
-          Text(SOLVE_CONFLICTS)
-        }
-        // Nothing to confirm while the heap dump is being read or written: both of them are already the
-        // answer to a button someone pressed.
-        SetStep.Checking, is SetStep.Writing -> Unit
-      }
-    },
-    dismissButton = {
-      Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        // Only for a status a hand set: there is nothing to take off an object the inspectors alone spoke
-        // about, and a button that says there is would read as a way to silence them.
-        if (step == SetStep.Choosing && status.setByHand != null) {
-          TextButton(onClick = { step = SetStep.Writing(Decision.Clear) }) {
-            Text(CLEAR_STATUS)
-          }
-        }
-        if (step !is SetStep.Writing) {
-          TextButton(
-            onClick = {
-              if (step is SetStep.Conflicts) {
-                // Which is a reader who read what they were about to overrule and decided not to, and is
-                // worth as much in the log as the other choice.
-                SharkLog.d {
-                  "Left the statuses of this heap dump as they were rather than setting " +
-                    "${status.objectName} to $chosen"
-                }
-              }
-              onDismiss()
-            }
-          ) {
-            Text(if (step is SetStep.Conflicts) UNDO_STATUS else CANCEL_STATUS)
-          }
+          SetterButtons(setting, onDone)
         }
       }
     }
-  )
+  }
+}
+
+/**
+ * What there is to press, in the order a dialog puts them: what leaves things as they were on the left,
+ * what changes them on the right, and neither while a file is being written.
+ */
+@Composable
+private fun SetterButtons(
+  setting: SettingVerdict,
+  onDone: () -> Unit
+) {
+  val status = setting.status
+  // Only for a status a hand set: there is nothing to take off an object the inspectors alone spoke about,
+  // and a button that says there is would read as a way to silence them.
+  if (setting.step == SetStep.Choosing && status.setByHand != null) {
+    TextButton(onClick = { setting.step = SetStep.Writing(Decision.Clear) }) {
+      Text(CLEAR_STATUS)
+    }
+  }
+  if (setting.step !is SetStep.Writing) {
+    TextButton(
+      onClick = {
+        if (setting.step is SetStep.Conflicts) {
+          // Which is a reader who read what they were about to overrule and decided not to, and is worth as
+          // much in the log as the other choice.
+          SharkLog.d {
+            "Left the statuses of this heap dump as they were rather than setting " +
+              "${status.objectName} to ${setting.chosen}"
+          }
+        }
+        onDone()
+      }
+    ) {
+      Text(if (setting.step is SetStep.Conflicts) UNDO_STATUS else CANCEL_STATUS)
+    }
+  }
+  when (val currentStep = setting.step) {
+    SetStep.Choosing -> TextButton(
+      onClick = {
+        setting.requested = LeakStatusOverride(
+          objectId = status.objectId,
+          status = setting.chosen,
+          reason = setting.reason.trim()
+        )
+      },
+      // A status set by hand overrules the heap dump, so it is worth nothing to whoever reads it next
+      // without the why — which is why this waits for one rather than filling one in.
+      enabled = setting.reason.isNotBlank()
+    ) {
+      Text(SAVE_STATUS)
+    }
+    is SetStep.Conflicts -> TextButton(
+      onClick = {
+        SharkLog.d {
+          "Keeping ${currentStep.requested.status} for ${status.objectName} and flipping the " +
+            "${currentStep.conflicts.size} statuses set by hand that disagreed with it"
+        }
+        setting.step = SetStep.Writing(
+          Decision.Set(currentStep.requested, currentStep.conflicts.map { it.solved })
+        )
+      }
+    ) {
+      Text(SOLVE_CONFLICTS)
+    }
+    // Nothing to confirm while the heap dump is being read or written: both of them are already the answer
+    // to a button someone pressed.
+    SetStep.Checking, is SetStep.Writing -> Unit
+  }
 }
 
 /** What the object is now, the three statuses it could be, and the reason that has to come with a change. */
@@ -310,25 +391,39 @@ private fun ChoosingStatus(
  * Every one of them rather than a count, with the reason each was given, because that reason is the case for
  * the other reading: whoever is about to overrule it is the one person who can weigh the two, and they can
  * only do that if they can read what they are overruling.
+ *
+ * Which is also why each one leads to the object it is about. A reason somebody typed is what they knew and
+ * not what the heap dump says, so weighing it against this one is sometimes going and looking — and the
+ * dialog belonging to its tab rather than to the window is what lets that happen without throwing away the
+ * verdict half set. *Why* two verdicts can disagree at all is the `?`, for the same reason it is a `?`
+ * everywhere else: it is one paragraph, read once, above something read every time.
  */
 @Composable
 private fun Conflicts(
   requested: LeakStatusOverride,
-  conflicts: List<LeakStatusConflict>
+  conflicts: List<LeakStatusConflict>,
+  onOpenObject: (Long) -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
-  Text(
-    "${conflicts.size} ${if (conflicts.size == 1) CONFLICT_ONE else CONFLICT_MANY} " +
-      "\"${requested.status.statusText}\".",
-    style = MaterialTheme.typography.bodyMedium,
-    fontWeight = FontWeight.Bold
-  )
-  Text(CONFLICT_EXPLANATION, style = MaterialTheme.typography.bodySmall)
+  Explain(Topic.CONFLICTING_VERDICTS, onExplain) {
+    Text(
+      "${conflicts.size} ${if (conflicts.size == 1) CONFLICT_ONE else CONFLICT_MANY} " +
+        "\"${requested.status.statusText}\".",
+      style = MaterialTheme.typography.bodyMedium,
+      fontWeight = FontWeight.Bold
+    )
+  }
   conflicts.forEach { conflict ->
-    Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+    Column(
+      Modifier.fillMaxWidth()
+        .clickableRow { onOpenObject(conflict.existing.objectId) }
+        .padding(vertical = 4.dp)
+    ) {
       Text(
         "${conflict.objectName} ${if (conflict.isAbove) CONFLICT_ABOVE else CONFLICT_BELOW}",
         style = MaterialTheme.typography.bodyMedium,
-        fontWeight = FontWeight.Bold
+        fontWeight = FontWeight.Bold,
+        color = LINK_COLOR
       )
       Text(
         "${conflict.existing.status.statusText}: ${conflict.existing.reason}",
@@ -350,7 +445,7 @@ private fun Conflicts(
  * Nothing has been written in any of the three. What is on disk changes once, when the last of them is
  * answered.
  */
-private sealed interface SetStep {
+internal sealed interface SetStep {
 
   object Choosing : SetStep
 
@@ -367,7 +462,7 @@ private sealed interface SetStep {
 }
 
 /** What was decided, which is the whole of what a dialog full of choices comes down to. */
-private sealed interface Decision {
+internal sealed interface Decision {
 
   class Set(
     val override: LeakStatusOverride,
@@ -412,9 +507,10 @@ private val LeakStatus.glyph: String
  */
 internal const val STATUS_LABEL = "Verdict"
 
-internal fun statusDialogTitle(objectName: String) = "Verdict on $objectName"
+/** What the dialog setting one is titled, which is the one thing on it that names what is being changed. */
+internal fun settingVerdictTitle(objectName: String) = "Verdict on $objectName"
 
-/** What opens the dialog, set or not: the same mark the app writes a note with. */
+/** What opens the dialog that sets one, set or not: the same mark the app writes a note with. */
 internal const val EDIT_STATUS_GLYPH = "✎"
 
 internal const val SAVE_STATUS = "Set the verdict"
@@ -450,11 +546,6 @@ internal const val REASON_DESCRIPTION = "Why this object is being given that ver
 private const val CONFLICT_ONE = "verdict set by hand cannot be true alongside"
 private const val CONFLICT_MANY = "verdicts set by hand cannot be true alongside"
 
-private const val CONFLICT_EXPLANATION =
-  "Everything a stuck object holds is stuck too, and everything holding an expected one is expected too — " +
-    "so these and the verdict being set contradict each other. Keeping this one flips them to the opposite " +
-    "verdict, with what they said kept as part of the new reason."
-
 private const val CONFLICT_ABOVE = "holds it"
 private const val CONFLICT_BELOW = "is held by it"
 
@@ -462,3 +553,9 @@ private const val CONFLICT_BECOMES = "Would become:"
 
 /** Enough for the sentence someone is expected to type, and no more: the panes below keep the window. */
 private val REASON_HEIGHT = 90.dp
+
+/** What Material gives a dialog, since this is one drawn by hand: 280dp to 560dp wide, over a 32% scrim. */
+private val DIALOG_MIN_WIDTH = 280.dp
+private val DIALOG_WIDTH = 560.dp
+private val DIALOG_SHADOW = 6.dp
+private const val SCRIM_ALPHA = 0.32f

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
@@ -37,6 +37,8 @@ import shark.dive.LeakGroup
 import shark.dive.LeakKind
 import shark.dive.LeakSection
 import shark.dive.LeakingObject
+import shark.dive.Note
+import shark.dive.NoteLink
 import shark.dive.Place
 import shark.dive.Topic
 import shark.dive.WatchedObject
@@ -64,6 +66,8 @@ internal fun LeaksScreen(
   onCopyLink: (Long) -> Unit,
   /** Where the `?` beside what a leak is called goes. See [Explain]. */
   onExplain: (Topic) -> Unit,
+  /** And where a link written into a library leak's description goes, which is out to a browser. */
+  onFollowLink: (NoteLink) -> Unit,
   modifier: Modifier = Modifier
 ) {
   Surface(modifier, color = MaterialTheme.colorScheme.surface) {
@@ -91,7 +95,8 @@ internal fun LeaksScreen(
               onToggleGroup,
               onOpen,
               onCopyLink,
-              onExplain
+              onExplain,
+              onFollowLink
             )
         }
         val onTheWayOut = leaks.onTheWayOutSections
@@ -115,7 +120,8 @@ internal fun LeaksScreen(
               onToggleGroup,
               onOpen,
               onCopyLink,
-              onExplain
+              onExplain,
+              onFollowLink
             )
           }
         }
@@ -133,18 +139,19 @@ private fun LazyListScope.leakSection(
   onToggleGroup: (String) -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
   onCopyLink: (Long) -> Unit,
-  onExplain: (Topic) -> Unit
+  onExplain: (Topic) -> Unit,
+  onFollowLink: (NoteLink) -> Unit
 ) {
   // Pinned while its own leaks scroll under it, which is what says they are its: a heading that scrolls away
   // leaves a list of rows with nothing above them saying which part they are.
   stickyHeader(key = section.kind.name) {
-    SectionHeader(section, isFirst = isFirst)
+    SectionHeader(section, isFirst = isFirst, onExplain = onExplain)
   }
   section.groups.forEach { group ->
     val groupKey = section.kind.groupKey(group)
     val isExpanded = groupKey in expandedGroups
     val hasMore = group.objects.size > 1
-    item(key = groupKey) { GroupRow(group, onExplain) }
+    item(key = groupKey) { GroupRow(group, onExplain, onFollowLink) }
     // The first object always: a leak is a reference, and a reference with nothing under it says
     // what shouldn't be holding without ever saying what it is holding.
     item(key = "$groupKey ${group.objects.first().objectId}") {
@@ -192,7 +199,8 @@ private fun LazyListScope.leakSection(
 private fun SectionHeader(
   section: LeakSection,
   /** Whether it opens what it is under, where there is nothing above to be told apart from. */
-  isFirst: Boolean
+  isFirst: Boolean,
+  onExplain: (Topic) -> Unit
 ) {
   Column(
     Modifier.fillMaxWidth()
@@ -209,13 +217,29 @@ private fun SectionHeader(
         "${section.kind.title} · ${section.summary()}",
         style = MaterialTheme.typography.titleSmall
       )
-      Text(
-        section.kind.explanation,
-        style = MaterialTheme.typography.bodySmall,
-        color = MUTED_TEXT
-      )
+      // What to do about a library leak is a page rather than a line, and it is the one section where what
+      // to do isn't obvious from what the section is. See [LeakKind.topic].
+      val topic = section.kind.topic
+      if (topic == null) {
+        SectionExplanation(section.kind.explanation, Modifier)
+      } else {
+        Explain(topic, onExplain) {
+          // The weight leaves the `?` its room: a paragraph in a row takes the whole width otherwise, and
+          // the `?` is pushed off the end of it.
+          SectionExplanation(section.kind.explanation, Modifier.weight(1f, fill = false))
+        }
+      }
     }
   }
+}
+
+/** What being in a section means, which not one of the titles says on its own. See [LeakKind]. */
+@Composable
+private fun SectionExplanation(
+  explanation: String,
+  modifier: Modifier
+) {
+  Text(explanation, modifier, style = MaterialTheme.typography.bodySmall, color = MUTED_TEXT)
 }
 
 /**
@@ -283,7 +307,8 @@ private fun OnTheWayOutHeader(
 @Composable
 private fun GroupRow(
   group: LeakGroup,
-  onExplain: (Topic) -> Unit
+  onExplain: (Topic) -> Unit,
+  onFollowLink: (NoteLink) -> Unit
 ) {
   Row(Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
     SectionBar()
@@ -304,13 +329,13 @@ private fun GroupRow(
           )
         }
         group.subtitle?.let { subtitle ->
-          Text(
-            subtitle,
-            style = MaterialTheme.typography.bodySmall,
-            color = MUTED_TEXT,
-            maxLines = MAX_SUBTITLE_LINES,
-            overflow = TextOverflow.Ellipsis
-          )
+          // In full, and with the links live. What Shark knows about a library leak is written into the
+          // pattern that recognizes it, and half of those descriptions end in the AOSP change that
+          // introduced the leak or the file it is in — which is where the way round it is, and which three
+          // lines of ellipsized plain text was throwing away. See [Note.ofDocument].
+          Note.ofDocument(subtitle).blocks.forEach { block ->
+            NoteBlockView(block, onFollowLink, MaterialTheme.typography.bodySmall, MUTED_TEXT)
+          }
         }
         // What makes a leak something to write down: the addresses in this list are of one heap dump, and
         // this is the same for the same leak in the next one. See [LeakGroup.leakFingerprint].

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
@@ -213,27 +213,40 @@ private fun SectionHeader(
         .background(MaterialTheme.colorScheme.secondaryContainer)
         .padding(horizontal = 12.dp, vertical = 6.dp)
     ) {
-      Text(
-        "${section.kind.title} · ${section.summary()}",
-        style = MaterialTheme.typography.titleSmall
-      )
-      // What to do about a library leak is a page rather than a line, and it is the one section where what
-      // to do isn't obvious from what the section is. See [LeakKind.topic].
+      // Beside the title rather than beside the explanation, so that the `?` of a section that has one and
+      // of a section that doesn't are in the same place. See [LeakKind.topic].
       val topic = section.kind.topic
       if (topic == null) {
-        SectionExplanation(section.kind.explanation, Modifier)
+        SectionTitle(section, Modifier)
       } else {
         Explain(topic, onExplain) {
-          // The weight leaves the `?` its room: a paragraph in a row takes the whole width otherwise, and
-          // the `?` is pushed off the end of it.
-          SectionExplanation(section.kind.explanation, Modifier.weight(1f, fill = false))
+          // The weight leaves the `?` its room: text in a row takes the whole width otherwise, and the `?`
+          // is pushed off the end of it.
+          SectionTitle(section, Modifier.weight(1f, fill = false))
         }
+      }
+      val explanation = section.kind.explanation
+      if (explanation != null) {
+        SectionExplanation(explanation, Modifier)
       }
     }
   }
 }
 
-/** What being in a section means, which not one of the titles says on its own. See [LeakKind]. */
+/** What the section is, and how much of the heap dump is in it. */
+@Composable
+private fun SectionTitle(
+  section: LeakSection,
+  modifier: Modifier
+) {
+  Text(
+    "${section.kind.title} · ${section.summary()}",
+    modifier,
+    style = MaterialTheme.typography.titleSmall
+  )
+}
+
+/** What being in a section means, for the sections whose title doesn't. See [LeakKind.explanation]. */
 @Composable
 private fun SectionExplanation(
   explanation: String,

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
@@ -25,12 +25,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import shark.dive.HeapLeaks
 import shark.dive.LeakGroup
@@ -43,7 +40,6 @@ import shark.dive.Place
 import shark.dive.Topic
 import shark.dive.WatchedObject
 import shark.dive.formatByteSize
-import shark.dive.hexObjectId
 
 /**
  * Every leaking object of the heap dump, in two halves: the leaks to do something about, which is the app's
@@ -464,11 +460,13 @@ private fun LeakingObjectRow(
         ) {
           Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(leakingObject.strength)))
           Column(Modifier.weight(1f)) {
-            Text(
-              leakingObject.identityText(),
-              style = MaterialTheme.typography.bodySmall,
-              maxLines = 1,
-              overflow = TextOverflow.Ellipsis
+            // Named the way every other surface names an object. Smaller, because a leaking object is
+            // drawn inside the leak it is an instance of, and that indent is what the size says too.
+            ObjectIdentity(
+              className = leakingObject.className,
+              typeName = leakingObject.kind.typeName,
+              objectId = leakingObject.objectId,
+              nameStyle = MaterialTheme.typography.bodySmall
             )
             leakingObject.headline?.let { headline ->
               Text(
@@ -629,14 +627,6 @@ private fun LeakGroup.nameText(): String = when (suspectPath.size) {
 /** How many objects the leak has past the one on the row above, which is what opening it shows. */
 private fun moreObjectsText(count: Int): String =
   "$count $MORE ${if (count == 1) OBJECT else OBJECTS} $LEAKING_THE_SAME_WAY"
-
-/** The class in full, then the address: the same two things every list of objects here shows. */
-private fun LeakingObject.identityText() = buildAnnotatedString {
-  withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(className.substringAfterLast('.')) }
-  withStyle(SpanStyle(color = MUTED_TEXT)) {
-    append(" ${kind.typeName} · ${hexObjectId(objectId)}")
-  }
-}
 
 /**
  * What the watcher knew: the key it logged the object under, how long before the dump it was handed over,

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/LeaksScreen.kt
@@ -38,6 +38,7 @@ import shark.dive.LeakKind
 import shark.dive.LeakSection
 import shark.dive.LeakingObject
 import shark.dive.Place
+import shark.dive.Topic
 import shark.dive.WatchedObject
 import shark.dive.formatByteSize
 import shark.dive.hexObjectId
@@ -61,6 +62,8 @@ internal fun LeaksScreen(
   onOpen: (Long, OpenIn) -> Unit,
   /** Puts a link to a row's object on the clipboard, beside opening it. See [OpenTarget]. */
   onCopyLink: (Long) -> Unit,
+  /** Where the `?` beside what a leak is called goes. See [Explain]. */
+  onExplain: (Topic) -> Unit,
   modifier: Modifier = Modifier
 ) {
   Surface(modifier, color = MaterialTheme.colorScheme.surface) {
@@ -81,7 +84,15 @@ internal fun LeaksScreen(
       HorizontalDivider()
       LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
         leaks.leakSections.forEachIndexed { sectionIndex, section ->
-          leakSection(section, sectionIndex == 0, expandedGroups, onToggleGroup, onOpen, onCopyLink)
+          leakSection(
+              section,
+              sectionIndex == 0,
+              expandedGroups,
+              onToggleGroup,
+              onOpen,
+              onCopyLink,
+              onExplain
+            )
         }
         val onTheWayOut = leaks.onTheWayOutSections
         val isOnTheWayOutExpanded = Place.Leaks.ON_THE_WAY_OUT in expandedGroups
@@ -97,7 +108,15 @@ internal fun LeaksScreen(
         }
         if (isOnTheWayOutExpanded) {
           onTheWayOut.forEachIndexed { sectionIndex, section ->
-            leakSection(section, sectionIndex == 0, expandedGroups, onToggleGroup, onOpen, onCopyLink)
+            leakSection(
+              section,
+              sectionIndex == 0,
+              expandedGroups,
+              onToggleGroup,
+              onOpen,
+              onCopyLink,
+              onExplain
+            )
           }
         }
       }
@@ -113,7 +132,8 @@ private fun LazyListScope.leakSection(
   expandedGroups: Set<String>,
   onToggleGroup: (String) -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
-  onCopyLink: (Long) -> Unit
+  onCopyLink: (Long) -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   // Pinned while its own leaks scroll under it, which is what says they are its: a heading that scrolls away
   // leaves a list of rows with nothing above them saying which part they are.
@@ -124,7 +144,7 @@ private fun LazyListScope.leakSection(
     val groupKey = section.kind.groupKey(group)
     val isExpanded = groupKey in expandedGroups
     val hasMore = group.objects.size > 1
-    item(key = groupKey) { GroupRow(group) }
+    item(key = groupKey) { GroupRow(group, onExplain) }
     // The first object always: a leak is a reference, and a reference with nothing under it says
     // what shouldn't be holding without ever saying what it is holding.
     item(key = "$groupKey ${group.objects.first().objectId}") {
@@ -261,7 +281,10 @@ private fun OnTheWayOutHeader(
  * this one whether the leak has one or fifty. See [MoreObjectsRow] for the rest.
  */
 @Composable
-private fun GroupRow(group: LeakGroup) {
+private fun GroupRow(
+  group: LeakGroup,
+  onExplain: (Topic) -> Unit
+) {
   Row(Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
     SectionBar()
     Row(
@@ -270,9 +293,10 @@ private fun GroupRow(group: LeakGroup) {
       verticalAlignment = Alignment.CenterVertically
     ) {
       Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Hint(NAME_HINT) {
+        Explain(Topic.LEAK_NAME, onExplain) {
           Text(
             group.nameText(),
+            Modifier.weight(1f, fill = false),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
@@ -290,9 +314,10 @@ private fun GroupRow(group: LeakGroup) {
         }
         // What makes a leak something to write down: the addresses in this list are of one heap dump, and
         // this is the same for the same leak in the next one. See [LeakGroup.leakFingerprint].
-        Hint(LEAK_FINGERPRINT_HINT) {
+        Explain(Topic.LEAK_FINGERPRINT, onExplain) {
           Text(
             "$LEAK_FINGERPRINT ${group.leakFingerprint}",
+            Modifier.weight(1f, fill = false),
             style = MaterialTheme.typography.bodySmall,
             color = MUTED_TEXT,
             maxLines = 1,
@@ -548,7 +573,7 @@ private fun LeakGroup.objectCountText(): String =
  * One line rather than two, because the ends are the same reference for most leaks and a second line that
  * repeats the first says the row has two names. Which end is which is worth knowing — the first is what to
  * stop holding, the last is where the object that leaked hangs off — and a row of a list is read left to
- * right, so it is the same order the chain is in. See [LeakGroup.suspectPath] and [NAME_HINT].
+ * right, so it is the same order the chain is in. See [LeakGroup.suspectPath] and the `leak-name` page of the reference.
  *
  * It ends on an arrow, because what the last reference points at is the row underneath: the references are
  * the leak and the objects below them are what it left behind, which is the whole shape of this list.
@@ -615,22 +640,6 @@ private const val WATCHED_GLYPH = "◉"
 
 /** What the hash of a leak is called on the row, since a bare 40 characters of hex names nothing. */
 internal const val LEAK_FINGERPRINT = "Leak fingerprint:"
-
-internal const val NAME_HINT =
-  "The references this leak is: the first is the faulty reference, the one that should have been cleared " +
-    "and what LeakCanary calls the leak, and the last is the one that points straight at what is stuck, " +
-    "which is where to look on the chain to see it. They are one reference for most leaks. Everything " +
-    "above the first is the app working as intended and everything below the last is what the leak is " +
-    "holding, so neither is part of what makes this leak this leak. For an object on its way out it is " +
-    "the one reference the collector hasn't cleared yet, which is the whole of why it is still here. Where " +
-    "a leak is a single reference, the chain drawn for an object under this row marks it, so the row and " +
-    "the step are one thing said twice."
-
-internal const val LEAK_FINGERPRINT_HINT =
-  "A hash of how this leak is held, which is the same for the same leak in the next heap dump of this app " +
-    "— unlike the addresses under it, which are of this one. So it is what to write in a bug report, and " +
-    "what to compare two dumps by. It is also the leak fingerprint LeakCanary prints under this leak when " +
-    "it reports it, so a report and this list can be lined up hash by hash."
 
 /** Between the two ends of a leak, pointing the way the chain runs: down, away from the GC roots. */
 internal const val STRETCH_ARROW = "→"

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/Main.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/Main.kt
@@ -168,6 +168,8 @@ private fun diveApplication(
   // And one set of statuses set by hand per heap dump, for the same reason: a status is a conclusion about
   // the dump rather than about a window, so both windows on one dump read the heap through the same ones.
   val leakStatuses = remember { DiveLeakStatuses() }
+  // And one set of starred objects per heap dump, for the same reason again.
+  val stars = remember { DiveStars() }
   // Once per run, not once per window, and off the UI thread: this is a network request, and a window that
   // waits for GitHub to answer before it draws is a window that hangs when GitHub is unreachable.
   LaunchedEffect(updateNotice) {
@@ -210,6 +212,7 @@ private fun diveApplication(
             updateNotice = updateNotice,
             notes = notes,
             leakStatuses = leakStatuses,
+            stars = stars,
             // What this window has open, for the agent surface: a socket thread has to be able to find it,
             // and it is a composable's state. See [DiveWindow.openHeapDump].
             onHeapDumpOpen = { open ->
@@ -271,6 +274,8 @@ internal fun DiveApp(
    * default for the same reason: a test that took whoever is running it would rewrite their conclusions.
    */
   leakStatuses: DiveLeakStatuses = remember { DiveLeakStatuses() },
+  /** And the starred objects of each of them, shared and defaulted the same way. See [DiveStars]. */
+  stars: DiveStars = remember { DiveStars() },
   /**
    * Where what this window has open is published, for everything that isn't drawing it — which today is an
    * agent reaching in from outside the app. Called with the heap dump as it opens and with null as it
@@ -437,6 +442,7 @@ internal fun DiveApp(
         fetchedBitmapPixels = currentState.bitmapPixels,
         notes = notes.of(currentState.session.heapDumpFile),
         leakStatuses = leakStatuses.of(currentState.session.heapDumpFile),
+        stars = stars.of(currentState.session.heapDumpFile),
         agentSessions = agentSessions,
         linkedPlaces = linkedPlaces,
         onLinkedPlaceOpened = onLinkedPlaceOpened,

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/Main.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/Main.kt
@@ -568,7 +568,7 @@ private fun HeapDumpState.statusLine(): String = when (this) {
 private fun HeapSizes.strengthsText(): String = ReachabilityStrength.values()
   .filter { byteCountByStrength.getValue(it) > 0L }
   .joinToString(", ") { strength ->
-    "${formatByteSize(byteCountByStrength.getValue(strength))} ${strength.displayName.lowercase()}"
+    "${formatByteSize(byteCountByStrength.getValue(strength))} ${strength.label.lowercase()}"
   }
 
 private fun HeapDumpState.centerMessage(): String = when (this) {

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/NoteSection.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/NoteSection.kt
@@ -261,27 +261,31 @@ private fun Modifier.noteHeight(
   layout(placeable.width, placeable.height) { placeable.place(0, 0) }
 }
 
-/** One block of markdown, whether it was typed as a note or shipped as a page. See [ReferenceScreen]. */
+/**
+ * One block of markdown, whether it was typed as a note, shipped as a page, or written into the library leak
+ * pattern that recognized a leak. See [ReferenceScreen] and [LeaksScreen].
+ *
+ * [style] and [color] are what the surrounding text is set in, since the third of those is a subtitle in a
+ * list rather than a document of its own. A heading keeps its own sizes either way — see [headingStyle] —
+ * because what makes a heading a heading is being bigger than the line under it.
+ */
 @Composable
 internal fun NoteBlockView(
   block: NoteBlock,
-  onLink: (NoteLink) -> Unit
+  onLink: (NoteLink) -> Unit,
+  style: TextStyle = MaterialTheme.typography.bodyMedium,
+  color: Color = Color.Unspecified
 ) {
   when (block) {
-    is NoteBlock.Paragraph -> NoteText(block.spans, MaterialTheme.typography.bodyMedium, onLink)
-    is NoteBlock.Heading -> NoteText(block.spans, headingStyle(block.level), onLink)
+    is NoteBlock.Paragraph -> NoteText(block.spans, style, onLink, color)
+    is NoteBlock.Heading -> NoteText(block.spans, headingStyle(block.level), onLink, color)
     is NoteBlock.Item -> Row(Modifier.padding(start = INDENT_WIDTH * block.depth)) {
-      Text(
-        block.marker,
-        Modifier.width(MARKER_WIDTH),
-        style = MaterialTheme.typography.bodyMedium,
-        color = MUTED_TEXT
-      )
-      NoteText(block.spans, MaterialTheme.typography.bodyMedium, onLink)
+      Text(block.marker, Modifier.width(MARKER_WIDTH), style = style, color = MUTED_TEXT)
+      NoteText(block.spans, style, onLink, color)
     }
     is NoteBlock.Quote -> Row {
-      Text(QUOTE_BAR, style = MaterialTheme.typography.bodyMedium, color = MUTED_TEXT)
-      NoteText(block.spans, MaterialTheme.typography.bodyMedium, onLink, color = MUTED_TEXT)
+      Text(QUOTE_BAR, style = style, color = MUTED_TEXT)
+      NoteText(block.spans, style, onLink, color = MUTED_TEXT)
     }
     is NoteBlock.Code -> Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
       Text(

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/NoteSection.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/NoteSection.kt
@@ -261,8 +261,9 @@ private fun Modifier.noteHeight(
   layout(placeable.width, placeable.height) { placeable.place(0, 0) }
 }
 
+/** One block of markdown, whether it was typed as a note or shipped as a page. See [ReferenceScreen]. */
 @Composable
-private fun NoteBlockView(
+internal fun NoteBlockView(
   block: NoteBlock,
   onLink: (NoteLink) -> Unit
 ) {

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ObjectRows.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ObjectRows.kt
@@ -1,0 +1,164 @@
+package shark.dive.app
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import shark.dive.ObjectListEntry
+import shark.dive.formatByteSize
+import shark.dive.formatPercentOfTotal
+
+/**
+ * One object as a row of a list, and the header over a column of them.
+ *
+ * **The same row on every screen that lists objects**, so that a list of what matched a search and a list of
+ * what somebody starred are one table with two contents rather than two tables. Which colour it is drawn in,
+ * where the sizes sit, what a click does and what the right button offers are all answers a reader learns
+ * once.
+ *
+ * The lists that are *not* built from this are the ones whose rows aren't objects: the leaks screen groups
+ * objects under the leak they are instances of, and its rows carry why each one is leaking.
+ */
+@Composable
+internal fun ObjectRowHeader(
+  /** Whether a row of this list ends in something of its own, which is a column to leave room for. */
+  hasTrailing: Boolean = false
+) {
+  Row(
+    Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    HeaderCell(CLASS_COLUMN, Modifier.weight(1f))
+    HeaderCell(SHALLOW, Modifier.width(SIZE_COLUMN_WIDTH), TextAlign.End)
+    HeaderCell(RETAINED, Modifier.width(SIZE_COLUMN_WIDTH), TextAlign.End)
+    if (hasTrailing) {
+      Box(Modifier.width(TRAILING_COLUMN_WIDTH))
+    }
+  }
+}
+
+@Composable
+private fun HeaderCell(
+  text: String,
+  modifier: Modifier = Modifier,
+  textAlign: TextAlign = TextAlign.Start
+) {
+  Text(text, modifier, style = MaterialTheme.typography.labelSmall, textAlign = textAlign)
+}
+
+/** One object: what it is, what tells it apart from the next of its class, and what it holds. */
+@Composable
+internal fun ObjectRow(
+  entry: ObjectListEntry,
+  /** What a retained size here is a share of. See [shark.dive.HeapSizes.stronglyReachableByteCount]. */
+  stronglyReachableByteCount: Long,
+  onOpen: (Long, OpenIn) -> Unit,
+  /** Puts a link to the row's object on the clipboard, beside opening it. See [OpenTarget]. */
+  onCopyLink: (Long) -> Unit,
+  /** What this list has to offer about a row that the others don't, at the end of it. */
+  trailing: (@Composable () -> Unit)? = null
+) {
+  val open: (OpenIn) -> Unit = { openIn -> onOpen(entry.objectId, openIn) }
+  OpenTarget(open, { onCopyLink(entry.objectId) }) {
+    Row(
+      Modifier.fillMaxWidth()
+        .openable(open)
+        .padding(horizontal = 12.dp, vertical = 4.dp),
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(entry.strength)))
+      Column(Modifier.weight(1f)) {
+        Text(
+          entry.classNameText(),
+          style = MaterialTheme.typography.bodyMedium,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis
+        )
+        entry.headline?.let { headline ->
+          Text(
+            headline,
+            style = MaterialTheme.typography.bodySmall,
+            color = MUTED_TEXT,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+          )
+        }
+      }
+      Text(
+        formatByteSize(entry.shallowSize),
+        Modifier.width(SIZE_COLUMN_WIDTH),
+        style = MaterialTheme.typography.bodySmall,
+        textAlign = TextAlign.End
+      )
+      // The share under the size rather than beside it: the column is as wide as a size and no wider,
+      // and a table's numbers only line up while every cell in the column is the same shape.
+      Column(Modifier.width(SIZE_COLUMN_WIDTH)) {
+        Text(
+          formatByteSize(entry.retainedSize),
+          Modifier.fillMaxWidth(),
+          style = MaterialTheme.typography.bodyMedium,
+          textAlign = TextAlign.End
+        )
+        Text(
+          formatPercentOfTotal(entry.retainedSize, stronglyReachableByteCount),
+          Modifier.fillMaxWidth(),
+          style = MaterialTheme.typography.labelSmall,
+          color = MUTED_TEXT,
+          textAlign = TextAlign.End
+        )
+      }
+      if (trailing != null) {
+        Box(Modifier.width(TRAILING_COLUMN_WIDTH), contentAlignment = Alignment.CenterEnd) {
+          trailing()
+        }
+      }
+    }
+  }
+}
+
+/** What a list of objects says when it has none, in the same place a row would be. */
+@Composable
+internal fun NoObjectRows(text: String) {
+  Text(
+    text,
+    Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+    style = MaterialTheme.typography.bodySmall,
+    color = MUTED_TEXT
+  )
+}
+
+/** The package greyed out, the class name in full, and which kind of thing it is. */
+private fun ObjectListEntry.classNameText() = buildAnnotatedString {
+  val packageName = className.substringBeforeLast('.', missingDelimiterValue = "")
+  if (packageName.isNotEmpty()) {
+    withStyle(SpanStyle(color = MUTED_TEXT)) { append("$packageName.") }
+  }
+  withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(className.substringAfterLast('.')) }
+  withStyle(SpanStyle(color = MUTED_TEXT)) { append(" ${kind.typeName}") }
+}
+
+private const val CLASS_COLUMN = "Class"
+
+/** Wide enough for a size in gigabytes, so that the numbers line up down the column. */
+private val SIZE_COLUMN_WIDTH = 72.dp
+
+/** Wide enough for one glyph to be pressed, which is all any list has put here. */
+private val TRAILING_COLUMN_WIDTH = 32.dp

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ObjectRows.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ObjectRows.kt
@@ -14,12 +14,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import shark.dive.ObjectListEntry
 import shark.dive.formatByteSize
@@ -86,11 +82,13 @@ internal fun ObjectRow(
     ) {
       Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(entry.strength)))
       Column(Modifier.weight(1f)) {
-        Text(
-          entry.classNameText(),
-          style = MaterialTheme.typography.bodyMedium,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis
+        // The same lines the chain, the card at the pointer and the bar above the map name an object
+        // with, address included: a row of a list is asking the same question as any of those, and a
+        // reader who has an address in a note or a link has to be able to find it in a list.
+        ObjectIdentity(
+          className = entry.className,
+          typeName = entry.kind.typeName,
+          objectId = entry.objectId
         )
         entry.headline?.let { headline ->
           Text(
@@ -143,16 +141,6 @@ internal fun NoObjectRows(text: String) {
     style = MaterialTheme.typography.bodySmall,
     color = MUTED_TEXT
   )
-}
-
-/** The package greyed out, the class name in full, and which kind of thing it is. */
-private fun ObjectListEntry.classNameText() = buildAnnotatedString {
-  val packageName = className.substringBeforeLast('.', missingDelimiterValue = "")
-  if (packageName.isNotEmpty()) {
-    withStyle(SpanStyle(color = MUTED_TEXT)) { append("$packageName.") }
-  }
-  withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(className.substringAfterLast('.')) }
-  withStyle(SpanStyle(color = MUTED_TEXT)) { append(" ${kind.typeName}") }
 }
 
 private const val CLASS_COLUMN = "Class"

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ObjectsScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ObjectsScreen.kt
@@ -1,8 +1,6 @@
 package shark.dive.app
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -11,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.toggleable
@@ -26,21 +23,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import java.util.Locale
 import shark.dive.HeapObjectKind
 import shark.dive.ObjectList
-import shark.dive.ObjectListEntry
 import shark.dive.ObjectListFilter
-import shark.dive.formatByteSize
 import shark.dive.formatObjectCount
-import shark.dive.formatPercentOfTotal
 
 /**
  * Every object of the heap dump as a list, largest first, filtered by class name and kind.
@@ -167,112 +155,12 @@ private fun ObjectList.countText(isListing: Boolean): String = when {
 private fun ObjectList.matchesOfTotal() =
   "${String.format(Locale.US, "%,d", matchCount)} of ${formatObjectCount(totalCount)} match"
 
-@Composable
-private fun ObjectRowHeader() {
-  Row(
-    Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp),
-    verticalAlignment = Alignment.CenterVertically
-  ) {
-    HeaderCell(CLASS_COLUMN, Modifier.weight(1f))
-    HeaderCell(SHALLOW_COLUMN, Modifier.width(SIZE_COLUMN_WIDTH), TextAlign.End)
-    HeaderCell(RETAINED_COLUMN, Modifier.width(SIZE_COLUMN_WIDTH), TextAlign.End)
-  }
-}
-
-@Composable
-private fun HeaderCell(
-  text: String,
-  modifier: Modifier = Modifier,
-  textAlign: TextAlign = TextAlign.Start
-) {
-  Text(text, modifier, style = MaterialTheme.typography.labelSmall, textAlign = textAlign)
-}
-
-/** One object: what it is, what tells it apart from the next of its class, and what it holds. */
-@Composable
-private fun ObjectRow(
-  entry: ObjectListEntry,
-  stronglyReachableByteCount: Long,
-  onOpen: (Long, OpenIn) -> Unit,
-  onCopyLink: (Long) -> Unit
-) {
-  val open: (OpenIn) -> Unit = { openIn -> onOpen(entry.objectId, openIn) }
-  OpenTarget(open, { onCopyLink(entry.objectId) }) {
-    Row(
-      Modifier.fillMaxWidth()
-        .openable(open)
-        .padding(horizontal = 12.dp, vertical = 4.dp),
-      horizontalArrangement = Arrangement.spacedBy(8.dp),
-      verticalAlignment = Alignment.CenterVertically
-    ) {
-      Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(entry.strength)))
-      Column(Modifier.weight(1f)) {
-        Text(
-          entry.classNameText(),
-          style = MaterialTheme.typography.bodyMedium,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis
-        )
-        entry.headline?.let { headline ->
-          Text(
-            headline,
-            style = MaterialTheme.typography.bodySmall,
-            color = MUTED_TEXT,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-          )
-        }
-      }
-      Text(
-        formatByteSize(entry.shallowSize),
-        Modifier.width(SIZE_COLUMN_WIDTH),
-        style = MaterialTheme.typography.bodySmall,
-        textAlign = TextAlign.End
-      )
-      // The share under the size rather than beside it: the column is as wide as a size and no wider,
-      // and a table's numbers only line up while every cell in the column is the same shape.
-      Column(Modifier.width(SIZE_COLUMN_WIDTH)) {
-        Text(
-          formatByteSize(entry.retainedSize),
-          Modifier.fillMaxWidth(),
-          style = MaterialTheme.typography.bodyMedium,
-          textAlign = TextAlign.End
-        )
-        Text(
-          formatPercentOfTotal(entry.retainedSize, stronglyReachableByteCount),
-          Modifier.fillMaxWidth(),
-          style = MaterialTheme.typography.labelSmall,
-          color = MUTED_TEXT,
-          textAlign = TextAlign.End
-        )
-      }
-    }
-  }
-}
-
-/** The package greyed out, the class name in full, and which kind of thing it is. */
-private fun ObjectListEntry.classNameText() = buildAnnotatedString {
-  val packageName = className.substringBeforeLast('.', missingDelimiterValue = "")
-  if (packageName.isNotEmpty()) {
-    withStyle(SpanStyle(color = MUTED_TEXT)) { append("$packageName.") }
-  }
-  withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(className.substringAfterLast('.')) }
-  withStyle(SpanStyle(color = MUTED_TEXT)) { append(" ${kind.typeName}") }
-}
-
 private const val SEARCH_LABEL = "Class name"
 
 internal const val EXACT_MATCH = "Exact match"
 
 /** Shown while the pass over every object of the heap dump is still running. */
 private const val LISTING = "Going through the heap dump…"
-
-private const val CLASS_COLUMN = "Class"
-private const val SHALLOW_COLUMN = "Shallow"
-private const val RETAINED_COLUMN = "Retained"
-
-/** Wide enough for a size in gigabytes, so that the numbers line up down the column. */
-private val SIZE_COLUMN_WIDTH = 72.dp
 
 private val SPINNER_SIZE = 12.dp
 private val SPINNER_STROKE = 2.dp

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PathDrawing.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PathDrawing.kt
@@ -193,7 +193,7 @@ internal fun PathStepRow(
     }
     if (step.strength != ReachabilityStrength.STRONG) {
       Text(
-        step.strength.reachabilityText,
+        step.strength.label,
         style = MaterialTheme.typography.bodySmall,
         color = objectStrengthColor(step.strength)
       )

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PathDrawing.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PathDrawing.kt
@@ -44,6 +44,8 @@ import shark.dive.LeakStatus
 import shark.dive.PathReference
 import shark.dive.PathStep
 import shark.dive.ReachabilityStrength
+import shark.dive.ReferencePage
+import shark.dive.Topic
 import shark.dive.formatByteSizeOfTotal
 import shark.dive.formatObjectCount
 import shark.dive.hexObjectId
@@ -472,16 +474,17 @@ private fun ReferenceLine(reference: PathReference) {
       style = MaterialTheme.typography.bodySmall
     )
   }
-  // Why this reference and not another, and what is known about a leak somebody else's code holds: both are
-  // paragraphs, so both belong on hover rather than in the chain.
+  // Why this reference and not another, and what is known about a leak somebody else's code holds. One
+  // sentence for the first of those, because the `?` above the chain leads to the rest of it: a step of a
+  // chain is one row of a column of rows, and a paragraph per row is a pane nobody reads twice.
   val explanation = listOfNotNull(
-    FAULTY_REFERENCE_HINT.takeIf { reference.isFaulty },
+    ReferencePage.of(Topic.FAULTY_REFERENCE).hint.takeIf { reference.isFaulty },
     reference.libraryLeak?.description?.takeIf { it.isNotEmpty() }
   )
   if (explanation.isEmpty()) {
     line()
   } else {
-    Hint(explanation.joinToString("\n\n"), line)
+    Hint(explanation.joinToString("\n\n"), content = line)
   }
 }
 
@@ -645,12 +648,6 @@ internal const val LIBRARY_LEAK = "· known library leak"
  * of names, and this is the line to stop on.
  */
 internal const val FAULTY_REFERENCE = "· faulty reference"
-
-/** Why this reference of the chain and not another, which is a paragraph and so sits on hover. */
-internal const val FAULTY_REFERENCE_HINT =
-  "The leak itself: what this reference is read on is expected to be in memory, what it points at should " +
-    "have been gone, so this is the one reference that should have been cleared. Everything under it is " +
-    "only still here because of it, and clearing this one is what would let all of it go."
 
 /** Wide enough for the line, its arrow head and a ring to sit clear of the text beside it. */
 private val GUTTER_WIDTH = 26.dp

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PathDrawing.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PathDrawing.kt
@@ -47,7 +47,6 @@ import shark.dive.ReachabilityStrength
 import shark.dive.ReferencePage
 import shark.dive.Topic
 import shark.dive.formatByteSizeOfTotal
-import shark.dive.formatObjectCount
 import shark.dive.hexObjectId
 import shark.dive.statusText
 
@@ -184,9 +183,10 @@ internal fun PathStepRow(
     if (detail == PathDetail.FULL) {
       step.headline?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
       if (step.retainedCount > 0) {
+        // The same word and the same numbers the details panel and the card at the pointer give an object,
+        // since a step of the chain is one of those objects. See [RETAINED].
         Text(
-          "Retaining ${formatByteSizeOfTotal(step.retainedSize, stronglyReachableByteCount)} in " +
-            formatObjectCount(step.retainedCount),
+          "$RETAINED ${retainedText(step.retainedSize, step.retainedCount, stronglyReachableByteCount)}",
           style = MaterialTheme.typography.bodySmall
         )
       }

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
@@ -96,6 +96,8 @@ private fun ObjectLines(
  *
  * The fully qualified class name is the line the map can't draw: a rectangle has room for `42 × Bitmap`
  * and no more, and which `Bitmap` that is, is the whole question a pile of them raises.
+ *
+ * A pile of one class is a node of the tree, so clicking it goes into it and the objects are there.
  */
 @Composable
 private fun ObjectGroupLines(
@@ -106,10 +108,15 @@ private fun ObjectGroupLines(
   summary.className?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
   StrengthLine(summary.strength)
   Text(summary.retainedText(stronglyReachableByteCount), style = MaterialTheme.typography.bodySmall)
-  Text(PILE_OF_OBJECTS, style = MaterialTheme.typography.bodySmall)
 }
 
-/** The children of a rectangle that its subdivision had no room for. See [shark.dive.CellSubject.Group]. */
+/**
+ * The children of a rectangle that its subdivision had no room for. See [shark.dive.CellSubject.Group].
+ *
+ * The other kind of pile, and no node of the tree, so there is nothing to go into. What a click does
+ * instead is root the map at the rectangle they were left out of, which is where there is the room to draw
+ * them one by one. See `TreemapLayout.maxRootChildren`.
+ */
 @Composable
 private fun GroupLines(
   selection: Selection.Group,
@@ -127,7 +134,6 @@ private fun GroupLines(
     "Retains ${formatByteSizeOfTotal(selection.byteCount, stronglyReachableByteCount)}",
     style = MaterialTheme.typography.bodySmall
   )
-  Text(LEFTOVER_OBJECTS, style = MaterialTheme.typography.bodySmall)
 }
 
 /** How firmly what the pointer is on is held, beside the colour the map drew it in. */
@@ -152,24 +158,6 @@ private fun HeapObjectSummary.shallowText(): String =
 private fun ObjectGroupSummary.retainedText(stronglyReachableByteCount: Long): String =
   "Retains ${formatByteSizeOfTotal(retainedSize, stronglyReachableByteCount)} in " +
     formatObjectCount(objectCount)
-
-/**
- * What a pile of objects has to say for itself in one line, because a rectangle full of them looks exactly
- * like one object until something says otherwise. The details panel spells out which kind of pile it is.
- *
- * A pile of one class is a node of the tree, so clicking it goes into it and the objects are there. See
- * [LEFTOVER_OBJECTS] for the pile that isn't.
- */
-internal const val PILE_OF_OBJECTS = "Not one object. Click it to reach the objects it stands for."
-
-/**
- * The other kind of pile: what a rectangle's subdivision had no room for. It is no node of the tree, so
- * there is nothing to go into and the promise [PILE_OF_OBJECTS] makes would be a lie here. What a click
- * does instead is root the map at the rectangle they were left out of, which is where there is the room
- * to draw them one by one. See `TreemapLayout.maxRootChildren`.
- */
-internal const val LEFTOVER_OBJECTS =
-  "Not one object. Click it for what holds them, where there is room to draw them one by one."
 
 /**
  * Where a card of [cardSize] goes for a pointer at [pointer] in a view of [viewSize]: below and to the right

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
@@ -123,7 +123,7 @@ private fun GroupLines(
   stronglyReachableByteCount: Long
 ) {
   Text(
-    "${selection.nodeCount} smaller objects",
+    formatObjectCount(selection.nodeCount),
     style = MaterialTheme.typography.bodyMedium,
     fontWeight = FontWeight.Bold
   )

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
@@ -144,7 +144,7 @@ private fun StrengthLine(strength: ReachabilityStrength) {
     verticalAlignment = Alignment.CenterVertically
   ) {
     Box(Modifier.size(SWATCH_SIZE).background(objectStrengthColor(strength)))
-    Text(strength.reachabilityText, style = MaterialTheme.typography.bodySmall)
+    Text(strength.label, style = MaterialTheme.typography.bodySmall)
   }
 }
 

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/PointerCard.kt
@@ -131,7 +131,7 @@ private fun GroupLines(
   // go to if any of them is worth finding.
   Text("Held by ${selection.parentLabel}", style = MaterialTheme.typography.bodySmall)
   Text(
-    "Retains ${formatByteSizeOfTotal(selection.byteCount, stronglyReachableByteCount)}",
+    "$RETAINED ${formatByteSizeOfTotal(selection.byteCount, stronglyReachableByteCount)}",
     style = MaterialTheme.typography.bodySmall
   )
 }
@@ -148,16 +148,16 @@ private fun StrengthLine(strength: ReachabilityStrength) {
   }
 }
 
+// The same two words the details panel labels these numbers with, and the same numbers under them: a card
+// read at a glance and a panel read at leisure are one vocabulary. See [RETAINED].
 private fun HeapObjectSummary.retainedText(stronglyReachableByteCount: Long): String =
-  "Retains ${formatByteSizeOfTotal(retainedSize, stronglyReachableByteCount)} in " +
-    formatObjectCount(retainedCount)
+  "$RETAINED ${retainedText(retainedSize, retainedCount, stronglyReachableByteCount)}"
 
-private fun HeapObjectSummary.shallowText(): String =
-  "${formatByteSize(shallowSize)} of its own, dominates ${formatObjectCount(dominatedObjectCount)}"
+private fun HeapObjectSummary.shallowText(): String = "$SHALLOW ${formatByteSize(shallowSize)}"
 
+// How many objects is the bold line above this one, so it isn't said again here.
 private fun ObjectGroupSummary.retainedText(stronglyReachableByteCount: Long): String =
-  "Retains ${formatByteSizeOfTotal(retainedSize, stronglyReachableByteCount)} in " +
-    formatObjectCount(objectCount)
+  "$RETAINED ${formatByteSizeOfTotal(retainedSize, stronglyReachableByteCount)}"
 
 /**
  * Where a card of [cardSize] goes for a pointer at [pointer] in a view of [viewSize]: below and to the right

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ReferenceScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ReferenceScreen.kt
@@ -1,0 +1,81 @@
+package shark.dive.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import shark.dive.NoteLink
+import shark.dive.ReferencePage
+import shark.dive.Topic
+
+/**
+ * One page of the reference, and the way to every other one under it.
+ *
+ * In a tab rather than in a browser, so that reading up on a label is a move like any other: the back arrow
+ * comes back from it, a link to it can be pasted to somebody, and the window it is read in is the window
+ * with the heap dump in it. And the text is the text this build ships — see [shark.dive.Topic].
+ *
+ * The other pages are listed at the foot of every page rather than down the side, which is what makes one `?`
+ * the way in to all of them: a reader who wanted to know what one column meant is a reader who may want the
+ * next one, and a `?` is not something to have to go and find twice.
+ */
+@Composable
+internal fun ReferenceScreen(
+  page: ReferencePage,
+  onOpenTopic: (Topic, OpenIn) -> Unit,
+  onCopyTopicLink: (Topic) -> Unit,
+  /** Where a link written in the reference goes: out to a browser, or into this heap dump. */
+  onLink: (NoteLink) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Surface(modifier, color = MaterialTheme.colorScheme.surface) {
+    Column(
+      Modifier.verticalScroll(rememberScrollState()).padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+      Column(
+        // A measure, not the width of the window: prose set across a maximised window is prose nobody
+        // finds the start of the next line in.
+        Modifier.widthIn(max = PAGE_WIDTH),
+        verticalArrangement = Arrangement.spacedBy(BLOCK_SPACING)
+      ) {
+        Text(page.title, style = MaterialTheme.typography.titleLarge)
+        page.blocks.forEach { block ->
+          NoteBlockView(block, onLink)
+        }
+      }
+      HorizontalDivider(Modifier.fillMaxWidth().padding(top = 8.dp))
+      Text(MORE_TOPICS, style = MaterialTheme.typography.labelSmall, color = MUTED_TEXT)
+      ReferencePage.all.filter { it.topic != page.topic }.forEach { other ->
+        // A row per page rather than its title alone, so that the list says what each one answers: a
+        // reader picking between six titles is guessing, and the sentence is already written.
+        val open: (OpenIn) -> Unit = { openIn -> onOpenTopic(other.topic, openIn) }
+        OpenTarget(open, { onCopyTopicLink(other.topic) }) {
+          Column(Modifier.widthIn(max = PAGE_WIDTH).openable(open).padding(vertical = 2.dp)) {
+            Text(other.title, style = MaterialTheme.typography.bodyMedium, color = LINK_COLOR)
+            Text(other.hint, style = MaterialTheme.typography.bodySmall, color = MUTED_TEXT)
+          }
+        }
+      }
+    }
+  }
+}
+
+/** What the list under a page is called: the pages, minus the one being read. */
+private const val MORE_TOPICS = "More topics"
+
+/** Long enough for the sentences these pages are written in, short enough to read across. */
+private val PAGE_WIDTH = 720.dp
+
+/** The same space between two blocks that a note leaves. See [NoteSection]. */
+private val BLOCK_SPACING = 4.dp

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/RootPathPanel.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/RootPathPanel.kt
@@ -33,6 +33,7 @@ import shark.dive.PathReference
 import shark.dive.RootPath
 import shark.dive.RootPathStep
 import shark.dive.RootPathWay
+import shark.dive.Topic
 import shark.dive.detours
 import shark.dive.drawnWith
 import shark.dive.faultyReference
@@ -82,6 +83,8 @@ internal fun RootPathPanel(
   onOpen: (Long, OpenIn) -> Unit,
   /** Puts a link to a step's object on the clipboard, beside opening it. See [OpenTarget]. */
   onCopyLink: (Long) -> Unit,
+  /** Where the `?` beside what the chain says about itself goes. See [Explain]. */
+  onExplain: (Topic) -> Unit,
   modifier: Modifier = Modifier
 ) {
   val summary = (selection as? Selection.Object)?.summary
@@ -123,7 +126,7 @@ internal fun RootPathPanel(
   }
   Surface(modifier, color = MaterialTheme.colorScheme.surface) {
     Column {
-      drawn?.path?.faultyReference()?.let { SolvedLeak(it) }
+      drawn?.path?.faultyReference()?.let { SolvedLeak(it, onExplain) }
       // A row per object, drawn only where the pane has the room for it: a chain is as long as the heap dump
       // makes it, and the linked structures of a real one run to hundreds of steps — a pane that composed all
       // of them would take a minute to draw a chain nobody has scrolled to yet.
@@ -148,7 +151,8 @@ internal fun RootPathPanel(
             chosenWays = chosenWays,
             onChooseWay = onChooseWay,
             onOpen = onOpen,
-            onCopyLink = onCopyLink
+            onCopyLink = onCopyLink,
+            onExplain = onExplain
           )
         } else {
           noChainText(selection, summary, isWholeHeapDump, rootPath, hasTail = cutTail != null)?.let {
@@ -186,17 +190,20 @@ internal fun RootPathPanel(
  * pointer moves: a row at the top of it is a row that scrolls away.
  */
 @Composable
-private fun SolvedLeak(faultyReference: PathReference) {
-  Hint(FAULTY_REFERENCE_HINT) {
-    Column(Modifier.padding(start = 12.dp, top = 12.dp, end = 12.dp)) {
+private fun SolvedLeak(
+  faultyReference: PathReference,
+  onExplain: (Topic) -> Unit
+) {
+  Column(Modifier.padding(start = 12.dp, top = 12.dp, end = 12.dp)) {
+    Explain(Topic.FAULTY_REFERENCE, onExplain) {
       Text(LEAK_SOLVED, style = MaterialTheme.typography.labelSmall, color = MUTED_TEXT)
-      Text(
-        faultyReference.leakLabel(),
-        style = MaterialTheme.typography.bodyMedium,
-        color = LeakStatus.STUCK.textColor
-      )
-      HorizontalDivider(Modifier.padding(top = 8.dp))
     }
+    Text(
+      faultyReference.leakLabel(),
+      style = MaterialTheme.typography.bodyMedium,
+      color = LeakStatus.STUCK.textColor
+    )
+    HorizontalDivider(Modifier.padding(top = 8.dp))
   }
 }
 
@@ -227,7 +234,8 @@ private fun LazyListScope.rootPathTrace(
   chosenWays: Map<Int, Int>,
   onChooseWay: (Int, Int) -> Unit,
   onOpen: (Long, OpenIn) -> Unit,
-  onCopyLink: (Long) -> Unit
+  onCopyLink: (Long) -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   val steps = drawn.path.steps
   item {
@@ -235,7 +243,7 @@ private fun LazyListScope.rootPathTrace(
       label = drawn.path.gcRootLabel.orEmpty(),
       reference = steps.first().step.reference,
       nextStrength = steps.first().step.strength,
-      below = { WaysOfDetour(drawn, HEAD_INDEX, ways, chosenWays, onChooseWay) }
+      below = { WaysOfDetour(drawn, HEAD_INDEX, ways, chosenWays, onChooseWay, onExplain) }
     )
   }
   itemsIndexed(steps) { depth, step ->
@@ -254,7 +262,7 @@ private fun LazyListScope.rootPathTrace(
         step.isDominator -> PathRole.DOMINATOR
         else -> PathRole.STEP
       },
-      below = { WaysOfDetour(drawn, depth, ways, chosenWays, onChooseWay) }
+      below = { WaysOfDetour(drawn, depth, ways, chosenWays, onChooseWay, onExplain) }
     )
   }
 }
@@ -317,7 +325,8 @@ private fun WaysOfDetour(
   row: Int,
   ways: Map<Int, List<RootPathWay>>,
   chosenWays: Map<Int, Int>,
-  onChooseWay: (Int, Int) -> Unit
+  onChooseWay: (Int, Int) -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   val detour = drawn.detourByRow[row] ?: return
   val found = ways[detour.fromIndex] ?: return
@@ -337,7 +346,7 @@ private fun WaysOfDetour(
       Modifier.clickableRow { onChooseWay(detour.fromIndex, (chosen - 1 + found.size) % found.size) },
       style = MaterialTheme.typography.bodySmall
     )
-    Hint(WAYS_HINT) {
+    Explain(Topic.OTHER_WAYS, onExplain) {
       Text(
         "${chosen + 1} of ${found.size} $WAYS_FROM_HERE",
         style = MaterialTheme.typography.labelSmall,
@@ -370,14 +379,6 @@ internal const val NO_ROOT_PATH_FOR_A_PILE =
 internal const val SEARCHING_ROOT_PATH = "Working out what holds it…"
 
 internal const val NO_ROOT_PATH = "No chain from a GC root down to this object was found."
-
-/** What the arrows either side of a stretch of the chain do, which is worth spelling out once. */
-internal const val WAYS_HINT =
-  "The steps between two objects that both hold this one are a stretch the chain didn't have to take: if " +
-    "it had, those steps would hold it too and be marked as dominators. So there are other ways from the " +
-    "object above down to the one below, and these arrows walk through them. They share no object in " +
-    "between, which graph theory calls independent, and they are found greedily, so there can be more of " +
-    "them than are counted here."
 
 /** What the count between the arrows counts, after which of them is drawn: `2 of 3 ways from here`. */
 internal const val WAYS_FROM_HERE = "ways from here"

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/RootPathPanel.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/RootPathPanel.kt
@@ -372,13 +372,13 @@ internal const val LEAK_SOLVED = "Leak solved"
 /** Shown until a rectangle has been clicked, which is what this pane draws a chain for. */
 internal const val NO_ROOT_PATH_YET = "Click a rectangle to see what holds it."
 
-internal const val NO_ROOT_PATH_FOR_A_PILE =
-  "Not one object, so there is no one chain holding it. Click it to reach the objects it stands for."
+/** And for a rectangle standing for many objects, which is held as many ways as it has objects in it. */
+internal const val NO_ROOT_PATH_FOR_A_PILE = "Not one object. Click it for the objects it stands for."
 
 /** Shown while the walk up to the GC roots is still running. */
 internal const val SEARCHING_ROOT_PATH = "Working out what holds it…"
 
-internal const val NO_ROOT_PATH = "No chain from a GC root down to this object was found."
+internal const val NO_ROOT_PATH = "No chain from a GC root reaches it."
 
 /** What the count between the arrows counts, after which of them is drawn: `2 of 3 ways from here`. */
 internal const val WAYS_FROM_HERE = "ways from here"

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/StarredScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/StarredScreen.kt
@@ -56,6 +56,10 @@ internal fun StarredScreen(
   }
 }
 
-/** What the list says when it has none, which is also what says the star is what fills it. */
-internal const val NOTHING_STARRED =
-  "Nothing starred. $UNSTARRED_GLYPH in the details panel puts an object here."
+/**
+ * What the list says when it has none, which is also what says the star is what fills it.
+ *
+ * The glyph and nothing about where it is: naming the panel it sits in is a second thing to find, and one
+ * that goes stale the day the star moves.
+ */
+internal const val NOTHING_STARRED = "Nothing starred. $UNSTARRED_GLYPH puts an object here."

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/StarredScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/StarredScreen.kt
@@ -1,35 +1,33 @@
 package shark.dive.app
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import shark.dive.HeapObjectSummary
-import shark.dive.ObjectDominator
-import shark.dive.formatByteSize
-import shark.dive.formatByteSizeOfTotal
-import shark.dive.hexObjectId
+import shark.dive.ObjectListEntry
 
 /**
- * The objects starred so far, everything about them read when they were starred.
+ * The objects starred so far, as the same list of objects every other list on this window is.
  *
  * Comparing what two rectangles hold means looking at them one after the other, and a treemap has no room
  * to keep the first one on screen. Starring is how a handful of objects stay comparable.
+ *
+ * **Read out of the heap dump, not remembered from the moment they were starred.** The list used to keep a
+ * copy of each object's sizes, which made it a screen of its own with columns of its own, and made a row go
+ * stale the moment a status set by hand changed what an object retains. What is kept is the addresses, in
+ * `~/.shark-dive/starred` — see [shark.dive.StarredFile].
  */
 @Composable
 internal fun StarredScreen(
-  favourites: List<Favourite>,
+  entries: List<ObjectListEntry>,
   /** What a retained size here is a share of. See [shark.dive.HeapSizes.stronglyReachableByteCount]. */
   stronglyReachableByteCount: Long,
   onOpen: (Long, OpenIn) -> Unit,
@@ -39,31 +37,18 @@ internal fun StarredScreen(
   modifier: Modifier = Modifier
 ) {
   Surface(modifier, color = MaterialTheme.colorScheme.surface) {
-    Column(
-      Modifier.verticalScroll(rememberScrollState()).padding(16.dp),
-      verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-      Text("$STARRED_GLYPH Starred objects", style = MaterialTheme.typography.titleMedium)
-      if (favourites.isEmpty()) {
-        Text(NOTHING_STARRED, style = MaterialTheme.typography.bodyMedium)
+    Column(Modifier.fillMaxSize()) {
+      ObjectRowHeader(hasTrailing = true)
+      HorizontalDivider()
+      if (entries.isEmpty()) {
+        NoObjectRows(NOTHING_STARRED)
       }
-      favourites.forEach { favourite ->
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          Column(Modifier.weight(1f)) {
-            Inspectable(favourite.label, favourite.objectId, onOpen, onCopyLink)
-            Text(favourite.className, style = MaterialTheme.typography.bodySmall)
-            SelectionContainer {
-              Text(hexObjectId(favourite.objectId), style = MaterialTheme.typography.bodySmall)
+      LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
+        items(entries, key = { it.objectId }) { entry ->
+          ObjectRow(entry, stronglyReachableByteCount, onOpen, onCopyLink) {
+            TextButton(onClick = { onRemove(entry.objectId) }) {
+              Text(STARRED_GLYPH)
             }
-            Text(
-              "Retained ${formatByteSizeOfTotal(favourite.retainedSize, stronglyReachableByteCount)} · " +
-                "shallow ${formatByteSize(favourite.shallowSize)} · " +
-                "dominated by ${favourite.dominatorLabel}",
-              style = MaterialTheme.typography.bodySmall
-            )
-          }
-          TextButton(onClick = { onRemove(favourite.objectId) }) {
-            Text(STARRED_GLYPH)
           }
         }
       }
@@ -71,32 +56,6 @@ internal fun StarredScreen(
   }
 }
 
-/** One starred object, with what the list shows about it kept rather than read again. */
-internal data class Favourite(
-  val objectId: Long,
-  val label: String,
-  val className: String,
-  val shallowSize: Long,
-  val retainedSize: Long,
-  val dominatorLabel: String
-) {
-  companion object {
-    fun of(
-      summary: HeapObjectSummary,
-      dominator: ObjectDominator?
-    ) = Favourite(
-      objectId = summary.objectId,
-      label = summary.headline?.let { "${summary.label} · $it" } ?: summary.label,
-      className = summary.className,
-      shallowSize = summary.shallowSize,
-      retainedSize = summary.retainedSize,
-      dominatorLabel = dominator?.label ?: UNKNOWN_DOMINATOR
-    )
-  }
-}
-
-private const val NOTHING_STARRED =
-  "Nothing is starred. The star next to an object's name in the panel keeps it here, so that two of " +
-    "them can be compared without holding one in your head."
-
-private const val UNKNOWN_DOMINATOR = "not read yet"
+/** What the list says when it has none, which is also what says the star is what fills it. */
+internal const val NOTHING_STARRED =
+  "Nothing starred. $UNSTARRED_GLYPH in the details panel puts an object here."

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/TabStrip.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/TabStrip.kt
@@ -173,10 +173,10 @@ private fun TabView(
  * Shown where a tab would be once the last one has been closed.
  *
  * Says what to do rather than nothing at all, because a window that has gone blank reads as one that has
- * broken — and the heap dump behind it is still open, which is the thing worth not throwing away.
+ * broken. And no more than that: closing the last tab leaves the heap dump open, which is worth knowing
+ * once and is a sentence in the way of the buttons every time after.
  */
-internal const val NO_TAB_OPEN =
-  "No tab open. The buttons above open one, and the heap dump stays read while you decide."
+internal const val NO_TAB_OPEN = "No tab open. The buttons above open one."
 
 /** What closes a tab, on the tab: its own click target, so a test presses it rather than the tab. */
 internal const val CLOSE_TAB = "✕"

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/TakeHeapDumpDialog.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/TakeHeapDumpDialog.kt
@@ -376,26 +376,28 @@ private fun DeviceHeapDumps.readyDevices(): List<AndroidDevice> = connectedDevic
  */
 private val AndroidDevice.dumpableProcesses: String
   get() = when (isDebuggableBuild) {
-    true -> "This build is debuggable (ro.debuggable=1), so any of these can be dumped, the system's own included."
-    false -> "This build is not debuggable (ro.debuggable=0), so only an app built debuggable can be " +
-      "dumped: a release build and every app of the system will refuse."
-    null -> "An app built debuggable can be dumped, and so can anything at all on a device whose build " +
-      "is debuggable. This one didn't say which it is."
+    true -> "ro.debuggable=1 — anything here can be dumped."
+    false -> "ro.debuggable=0 — only an app built debuggable can be dumped."
+    null -> "This device didn't say whether its build is debuggable."
   }
 
-/** Why the fetch is on offer at all, which is the device's Android version, and what it costs. */
+/**
+ * Why the fetch is on offer at all, which is the device's Android version, and what it costs.
+ *
+ * What it costs is a debugger attached and the app compressing every bitmap while suspended — seconds of
+ * fixed cost plus a fraction of a second each — and "suspends the app" is the whole of that worth reading
+ * beside a checkbox: it is the part that is someone else's problem rather than a wait.
+ */
 private val AndroidDevice.fetchBitmapsExplanation: String
   get() {
-    val version = sdkInt?.let { "API $it" } ?: "This device's Android version"
-    return "$version can't put the pixels of a bitmap in a heap dump, so this one will have none. " +
-      "Fetching them attaches a debugger and has the app compress every bitmap, suspended throughout: " +
-      "seconds of fixed cost, plus a fraction of a second per bitmap."
+    val version = sdkInt?.let { "API $it" } ?: "This Android version"
+    return "$version keeps bitmap pixels out of the dump. Fetching suspends the app."
   }
 
 internal const val TAKE_HEAP_DUMP = "Take heap dump…"
 internal const val TAKE_HEAP_DUMP_TITLE = "Take a heap dump off a device"
-internal const val TAKE_HEAP_DUMP_EXPLANATION =
-  "Dumping a heap freezes the app for a moment and pulls tens of megabytes over adb."
+/** Under the title on every step of this, so it is the cost and not a sentence about the cost. */
+internal const val TAKE_HEAP_DUMP_EXPLANATION = "Freezes the app briefly. Tens of megabytes over adb."
 internal const val PICK_A_DEVICE = "Which device?"
 internal const val PICK_A_PROCESS = "Which process?"
 internal const val FETCH_BITMAPS_WITH_DUMP = "Fetch the pixels of its bitmaps too"

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ViewControls.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ViewControls.kt
@@ -151,11 +151,15 @@ private fun StrengthLegend(
     horizontalArrangement = Arrangement.spacedBy(4.dp),
     verticalArrangement = Arrangement.spacedBy(2.dp)
   ) {
-    Text(
-      "Colour",
-      style = MaterialTheme.typography.labelLarge,
-      modifier = Modifier.padding(end = 4.dp)
-    )
+    // One `?` for the nine rows after it rather than one each: what a strength is is one page, and nine
+    // question marks in a row is nine times the ink for the same answer.
+    Explain(Topic.REACHABILITY_STRENGTH, onExplain) {
+      Text(
+        "Colour",
+        style = MaterialTheme.typography.labelLarge,
+        modifier = Modifier.padding(end = 4.dp)
+      )
+    }
     ReachabilityStrength.values().forEach { strength ->
       val checked = strength in coloring.coloredStrengths
       LegendRow(
@@ -220,7 +224,7 @@ private fun LegendRow(
 private fun ReachabilityStrength.legendText(sizes: HeapSizes): String {
   val byteCount = formatByteSize(sizes.byteCountByStrength.getValue(this))
   val objectCount = formatObjectCount(sizes.objectCountByStrength.getValue(this))
-  return "$displayName $byteCount · $objectCount"
+  return "$label $byteCount · $objectCount"
 }
 
 /**

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ViewControls.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ViewControls.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import shark.dive.HeapSizes
 import shark.dive.ReachabilityStrength
+import shark.dive.Topic
 import shark.dive.formatByteSize
 import shark.dive.formatObjectCount
 
@@ -43,6 +44,8 @@ internal fun ViewControls(
   isFindingLeaks: Boolean,
   onColoringChange: (CellColoring) -> Unit,
   onShapeChange: (ViewShape) -> Unit,
+  /** Where the `?` on a row of the legend goes. See [Explain]. */
+  onExplain: (Topic) -> Unit,
   modifier: Modifier = Modifier
 ) {
   Surface(modifier, color = MaterialTheme.colorScheme.surfaceVariant) {
@@ -56,7 +59,8 @@ internal fun ViewControls(
         leakCount = leakCount,
         isFindingLeaks = isFindingLeaks,
         onColoredStrengthsChange = { onColoringChange(coloring.withStrengths(it)) },
-        onShowLeaksChange = { onColoringChange(coloring.withLeaks(it)) }
+        onShowLeaksChange = { onColoringChange(coloring.withLeaks(it)) },
+        onExplain = onExplain
       )
       Row(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -78,9 +82,9 @@ internal fun ViewControls(
         )
       }
       if (REFERENCE_STRENGTHS.none { sizes.byteCountByStrength.getValue(it) > 0L }) {
-        // The fact on one line, the paragraph saying why on hover: this sits above the map for as long as
-        // the heap dump is open, and the reader who has read it once is looking at the map underneath.
-        Hint(NOTHING_WEAKER_HINT) {
+        // The fact on one line, and why it is normal a `?` away: this sits above the map for as long as the
+        // heap dump is open, and the reader who has read it once is looking at the map underneath.
+        Explain(Topic.WEAKER_REFERENCES, onExplain) {
           Text(NOTHING_WEAKER, style = MaterialTheme.typography.bodySmall, color = MUTED_TEXT)
         }
       }
@@ -140,7 +144,8 @@ private fun StrengthLegend(
   leakCount: Int?,
   isFindingLeaks: Boolean,
   onColoredStrengthsChange: (Set<ReachabilityStrength>) -> Unit,
-  onShowLeaksChange: (Boolean) -> Unit
+  onShowLeaksChange: (Boolean) -> Unit,
+  onExplain: (Topic) -> Unit
 ) {
   FlowRow(
     horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -172,7 +177,7 @@ private fun StrengthLegend(
     // how the collector holds an object, and this is whether the object should be there at all. Ticking it
     // is what sends Shark Dive looking for the leaks, so the row says so while that runs — and it unticks
     // every strength, see [CellColoring.withLeaks].
-    Hint(LEAKING_HINT) {
+    Explain(Topic.STUCK_SHADING, onExplain) {
       LegendRow(
         isChecked = coloring.showsLeaks,
         onCheckedChange = onShowLeaksChange,
@@ -243,23 +248,9 @@ internal const val STUCK = "Stuck"
 /** And while the pass over the heap dump that finds them runs, which is what ticking it starts. */
 internal const val FINDING_LEAKS = "Stuck: looking…"
 
-internal const val LEAKING_HINT =
-  "Shade the objects that are stuck in memory, and everything they hold with them — anything a stuck " +
-    "object dominates is only still there because it is. Greys the rest of the map, so that the shade is " +
-    "the only colour on it. There is no colour for the objects that are expected: a treemap draws what " +
-    "retains what, and most of a heap dump is objects nothing knows either way about. The chain beside " +
-    "the map says which is which, object by object."
-
 /**
  * Shown when every object a `java.lang.ref.Reference` points at is also reachable some stronger way,
  * which is what the legend rows reading 0 B mean and would otherwise read as a bug.
  */
 internal const val NOTHING_WEAKER =
   "Nothing in this heap dump is reachable only through a java.lang.ref.Reference."
-
-/** Why that is normal, which is a paragraph, and a paragraph is more than the bar above a map can hold. */
-internal const val NOTHING_WEAKER_HINT =
-  "$NOTHING_WEAKER That's common, because the garbage collection before a dump clears the references " +
-    "whose referent nothing else was holding — but it isn't a given: a referent a thread got out of a " +
-    "reference and has since let go of is weakly reachable again until the next collection. Unreachable " +
-    "is a different thing again: objects nothing points at, which that collection didn't get to."

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ViewControls.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/ViewControls.kt
@@ -255,6 +255,10 @@ internal const val FINDING_LEAKS = "Stuck: looking…"
 /**
  * Shown when every object a `java.lang.ref.Reference` points at is also reachable some stronger way,
  * which is what the legend rows reading 0 B mean and would otherwise read as a bug.
+ *
+ * In the words the legend beside it uses rather than in `java.lang.ref.Reference`'s: this line sits under
+ * rows reading `Soft`, `Weak`, `Phantom` and `Finalizer`, and naming the class they have in common is one
+ * more vocabulary to hold for a reader who has the four names in front of them. Which class that is, and why
+ * having none of them is normal, is the page behind the `?`.
  */
-internal const val NOTHING_WEAKER =
-  "Nothing in this heap dump is reachable only through a java.lang.ref.Reference."
+internal const val NOTHING_WEAKER = "Nothing here is held only weakly."

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
@@ -53,6 +53,8 @@ import shark.dive.ReachabilityStrength.PHANTOM
 import shark.dive.ReachabilityStrength.STRONG
 import shark.dive.ReachabilityStrength.UNREACHABLE
 import shark.dive.ReachabilityStrength.WEAK
+import shark.dive.ReferencePage
+import shark.dive.Topic.WEAKER_REFERENCES
 import shark.dive.formatByteSize
 import shark.dive.hexObjectId
 
@@ -696,9 +698,31 @@ class DiveAppTest {
       // bug until something explains it.
       strengthToggle(PHANTOM).assertTextContains(formatByteSize(0L), substring = true)
       onNodeWithText(NOTHING_WEAKER).assertIsDisplayed()
-      // The paragraph saying why that is normal waits for the pointer: it is above the map for as long as
-      // the heap dump is open, and read once it is in the way of the thing it is about.
-      onNodeWithText(NOTHING_WEAKER_HINT).assertDoesNotExist()
+      // The `?` beside it is there for everyone, always. What it says waits for the pointer: it is above
+      // the map for as long as the heap dump is open, and read once it is in the way of what it is about.
+      val page = ReferencePage.of(WEAKER_REFERENCES)
+      onNodeWithContentDescription("$MORE_ABOUT ${page.title}").assertIsDisplayed()
+      onNodeWithText(page.hint).assertDoesNotExist()
+    }
+  }
+
+  @Test fun `a question mark opens the page it is about, and the way to the others`() {
+    diveUiTest {
+      openHeapDump()
+      val page = ReferencePage.of(WEAKER_REFERENCES)
+
+      onNodeWithContentDescription("$MORE_ABOUT ${page.title}").performClick()
+
+      // A tab of this window rather than a browser, opening with the very sentence the `?` shows, so that
+      // what was hovered and what is now being read are one text. See `ReferencePage`.
+      waitUntilAtLeastOneExists(hasText(page.hint), OPEN_TIMEOUT_MILLIS)
+      onNode(hasText(page.title) and isTab()).assertIsDisplayed()
+      // And every other page under it, each with its own opening sentence, which is what makes one `?` the
+      // way in to all of them.
+      ReferencePage.all.filter { it.topic != page.topic }.forEach { other ->
+        onNodeWithText(other.title).assertIsDisplayed()
+        onNodeWithText(other.hint).assertIsDisplayed()
+      }
     }
   }
 

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
@@ -511,6 +511,9 @@ class DiveAppTest {
       // keep the first on screen. So the one starred is a row of the same kind every other list has, read
       // out of the heap dump again rather than remembered from the moment it was starred.
       waitUntilAtLeastOneExists(hasText("$PAYLOAD_LENGTH elements"), OPEN_TIMEOUT_MILLIS)
+      // Named the way every surface of this window names an object, address included: a row of a list is
+      // where an address written in a note or handed back by an agent has to be findable again.
+      onNodeWithText(hexObjectId(payloadObjectId)).assertIsDisplayed()
     }
   }
 
@@ -1104,7 +1107,6 @@ class DiveAppTest {
 
     /** Big enough that the row of the object list naming it is the bitmap rather than its buffer. */
     private const val BITMAP_SIDE = 64
-    private const val BITMAP_ROW = "android.graphics.Bitmap instance"
     private const val BITMAP_DUMP_MODEL = "Pixel 9"
     private const val BITMAP_DUMP_SDK_INT = 36
 

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
@@ -581,8 +581,8 @@ class DiveAppTest {
 
       waitUntilAtLeastOneExists(hasText("of one class", substring = true), OPEN_TIMEOUT_MILLIS)
       assertThat(onAllNodesWithText(SIBLING_CLASS_NAME).fetchSemanticsNodes()).isNotEmpty()
-      // Says it in words as well as with the label, the slate fill and the dashed outline.
-      onNodeWithText(CLASS_GROUP_EXPLANATION).assertIsDisplayed()
+      // And gets the rows an object gets, so that a pile and an object read as two of a kind.
+      onNodeWithText(STRONG.reachabilityText).assertIsDisplayed()
       onNodeWithText("Retained together").assertIsDisplayed()
     }
   }
@@ -624,7 +624,7 @@ class DiveAppTest {
         hasText(HeapDominatorTreemap.UNREACHABLE_LABEL),
         OPEN_TIMEOUT_MILLIS
       )
-      onNodeWithText(UNREACHABLE_EXPLANATION).assertIsDisplayed()
+      onNodeWithText(UNREACHABLE.reachabilityText).assertIsDisplayed()
       strengthToggle(UNREACHABLE).assertTextContains(
         formatByteSize(GARBAGE_PAYLOAD_BYTE_SIZE),
         substring = true

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
@@ -55,6 +55,7 @@ import shark.dive.ReachabilityStrength.UNREACHABLE
 import shark.dive.ReachabilityStrength.WEAK
 import shark.dive.ReferencePage
 import shark.dive.Topic.WEAKER_REFERENCES
+import shark.dive.exactHexObjectId
 import shark.dive.formatByteSize
 import shark.dive.formatObjectCount
 import shark.dive.hexObjectId
@@ -170,7 +171,7 @@ class DiveAppTest {
       // The panel was already describing the whole heap dump the window opened on, so what a click does is
       // move it onto the object clicked: what it says has to be about that object and not about the tree.
       waitUntilAtLeastOneExists(hasText("$PAYLOAD_LENGTH elements"), OPEN_TIMEOUT_MILLIS)
-      onNodeWithText("Retained objects").assertIsDisplayed()
+      onNodeWithText(RETAINED).assertIsDisplayed()
       onNodeWithText(STRONG.label).assertIsDisplayed()
     }
   }
@@ -447,8 +448,9 @@ class DiveAppTest {
       onNodeWithText(hexObjectId(holderObjectId)).assertIsDisplayed()
       // Which field of the holder the array is reached through, the way a leak trace names it.
       onNodeWithText("$HOLDER_LABEL.payload").assertIsDisplayed()
-      // And what each of the two retains, which is the size the treemap draws its rectangle at.
-      assertThat(onAllNodesWithText("Retaining ", substring = true).fetchSemanticsNodes()).hasSize(2)
+      // And what each of the two retains, which is the size the treemap draws its rectangle at, in the
+      // words the details panel and the card at the pointer use for it. See [RETAINED].
+      assertThat(onAllNodesWithText("$RETAINED ", substring = true).fetchSemanticsNodes()).hasSize(2)
     }
   }
 
@@ -494,9 +496,11 @@ class DiveAppTest {
     diveUiTest {
       openHeapDump()
       clickView(TREEMAP_X, TREEMAP_Y)
-      waitUntilAtLeastOneExists(hasText("Retained objects"), OPEN_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText(RETAINED), OPEN_TIMEOUT_MILLIS)
 
       onNodeWithText(UNSTARRED_GLYPH, substring = true).performClick()
+      // Which is a file being written, so the count on the bar arrives a beat after the click.
+      waitUntilAtLeastOneExists(hasText("$STARRED_GLYPH 1 starred"), OPEN_TIMEOUT_MILLIS)
       // Moving on to the object that dominates it, which is what leaves the panel describing something else.
       onNodeWithText("com.example.Holder").performClick()
       waitUntilAtLeastOneExists(hasText("payload = Object[]"), OPEN_TIMEOUT_MILLIS)
@@ -504,10 +508,47 @@ class DiveAppTest {
       screenButton("$STARRED_GLYPH 1 starred").performClick()
 
       // Comparing two rectangles means looking at them one after the other, and a treemap has no room to
-      // keep the first on screen. So the list keeps everything the panel had read about it.
-      onNodeWithText("Starred objects", substring = true).assertIsDisplayed()
-      onNodeWithText(hexObjectId(payloadObjectId)).assertIsDisplayed()
-      onNodeWithText("dominated by $HOLDER_LABEL", substring = true).assertIsDisplayed()
+      // keep the first on screen. So the one starred is a row of the same kind every other list has, read
+      // out of the heap dump again rather than remembered from the moment it was starred.
+      waitUntilAtLeastOneExists(hasText("$PAYLOAD_LENGTH elements"), OPEN_TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `starring an object writes it down for the next run`() {
+    val starred = testFolder.newFolder()
+    diveUiTest {
+      openHeapDump(stars = DiveStars(starred))
+      clickView(TREEMAP_X, TREEMAP_Y)
+      waitUntilAtLeastOneExists(hasText(RETAINED), OPEN_TIMEOUT_MILLIS)
+
+      onNodeWithText(UNSTARRED_GLYPH, substring = true).performClick()
+
+      // A working set outlives the window that built it, and it is one address per line so that it can be
+      // read, grepped and fixed without this app. See [StarredFile].
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { starred.listFiles().orEmpty().isNotEmpty() }
+      assertThat(starred.listFiles().orEmpty().single().readText())
+        .contains(exactHexObjectId(payloadObjectId))
+    }
+  }
+
+  @Test fun `taking the star off the last object is the working set gone`() {
+    val starred = testFolder.newFolder()
+    diveUiTest {
+      openHeapDump(stars = DiveStars(starred))
+      clickView(TREEMAP_X, TREEMAP_Y)
+      waitUntilAtLeastOneExists(hasText(RETAINED), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText(UNSTARRED_GLYPH, substring = true).performClick()
+      waitUntilAtLeastOneExists(hasText("$STARRED_GLYPH 1 starred"), OPEN_TIMEOUT_MILLIS)
+      screenButton("$STARRED_GLYPH 1 starred").performClick()
+      waitUntilAtLeastOneExists(hasText("$PAYLOAD_LENGTH elements"), OPEN_TIMEOUT_MILLIS)
+
+      // The star on the row itself, which is the one thing this list offers that the object list doesn't.
+      onNode(hasText(STARRED_GLYPH) and isButton()).performClick()
+
+      // A heap dump whose last star has been taken off is one nobody has starred anything in, so there is
+      // no file left behind to read as a dump somebody worked on.
+      waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) { starred.listFiles().orEmpty().isEmpty() }
+      onNodeWithText(NOTHING_STARRED, substring = true).assertIsDisplayed()
     }
   }
 
@@ -586,7 +627,7 @@ class DiveAppTest {
       assertThat(onAllNodesWithText(SIBLING_CLASS_NAME).fetchSemanticsNodes()).isNotEmpty()
       // And gets the rows an object gets, so that a pile and an object read as two of a kind.
       onNodeWithText(STRONG.label).assertIsDisplayed()
-      onNodeWithText("Retained together").assertIsDisplayed()
+      onNodeWithText(RETAINED).assertIsDisplayed()
     }
   }
 
@@ -743,7 +784,7 @@ class DiveAppTest {
       // fills only the first three of them and the space past that belongs to no cell.
       clickView(RING_X, RING_Y)
 
-      waitUntilAtLeastOneExists(hasText("Retained objects"), OPEN_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText(RETAINED), OPEN_TIMEOUT_MILLIS)
     }
   }
 
@@ -759,7 +800,7 @@ class DiveAppTest {
       waitForTheTree(OPEN_TIMEOUT_MILLIS)
       clickAt(stackRow(STACK_ROW))
 
-      waitUntilAtLeastOneExists(hasText("Retained objects"), OPEN_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText(RETAINED), OPEN_TIMEOUT_MILLIS)
     }
   }
 
@@ -821,7 +862,10 @@ class DiveAppTest {
     copyToClipboard: (String) -> Unit = {},
     // An `adb` that is connected to nothing, rather than the one on this machine: a test that shells out
     // has whatever devices happen to be plugged in to answer for.
-    deviceHeapDumps: DeviceHeapDumps = DeviceHeapDumps(NO_DEVICE_ADB)
+    deviceHeapDumps: DeviceHeapDumps = DeviceHeapDumps(NO_DEVICE_ADB),
+    // And its own directory for whatever it stars, for the same reason: the default is the starred objects
+    // of whoever is running the tests, which a test that stars would be writing into.
+    stars: DiveStars = DiveStars(testFolder.newFolder())
   ) = setContent {
     MaterialTheme {
       var shown: File? by remember { mutableStateOf(heapDumpFile) }
@@ -832,7 +876,8 @@ class DiveAppTest {
         onHeapDumpChosen = { file, _ -> shown = file },
         copyToClipboard = copyToClipboard,
         chooseHeapDumpFile = chooseHeapDumpFile,
-        deviceHeapDumps = deviceHeapDumps
+        deviceHeapDumps = deviceHeapDumps,
+        stars = stars
       )
     }
   }
@@ -840,9 +885,10 @@ class DiveAppTest {
   /** Opens a heap dump and hands back the file, which is what a link to a place in it names. */
   private fun ComposeUiTest.openHeapDump(
     heapDumpFile: File = testHeapDump(),
-    copyToClipboard: (String) -> Unit = {}
+    copyToClipboard: (String) -> Unit = {},
+    stars: DiveStars = DiveStars(testFolder.newFolder())
   ): File {
-    setDiveContent(heapDumpFile, copyToClipboard = copyToClipboard)
+    setDiveContent(heapDumpFile, copyToClipboard = copyToClipboard, stars = stars)
     waitForTheTree(OPEN_TIMEOUT_MILLIS)
     return heapDumpFile
   }

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
@@ -170,7 +170,7 @@ class DiveAppTest {
       // move it onto the object clicked: what it says has to be about that object and not about the tree.
       waitUntilAtLeastOneExists(hasText("$PAYLOAD_LENGTH elements"), OPEN_TIMEOUT_MILLIS)
       onNodeWithText("Retained objects").assertIsDisplayed()
-      onNodeWithText(STRONG.reachabilityText).assertIsDisplayed()
+      onNodeWithText(STRONG.label).assertIsDisplayed()
     }
   }
 
@@ -584,7 +584,7 @@ class DiveAppTest {
       waitUntilAtLeastOneExists(hasText("of one class", substring = true), OPEN_TIMEOUT_MILLIS)
       assertThat(onAllNodesWithText(SIBLING_CLASS_NAME).fetchSemanticsNodes()).isNotEmpty()
       // And gets the rows an object gets, so that a pile and an object read as two of a kind.
-      onNodeWithText(STRONG.reachabilityText).assertIsDisplayed()
+      onNodeWithText(STRONG.label).assertIsDisplayed()
       onNodeWithText("Retained together").assertIsDisplayed()
     }
   }
@@ -610,7 +610,7 @@ class DiveAppTest {
 
       clickView(TREEMAP_X, TREEMAP_Y)
 
-      waitUntilAtLeastOneExists(hasText(WEAK.reachabilityText), OPEN_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText(WEAK.label), OPEN_TIMEOUT_MILLIS)
     }
   }
 
@@ -622,11 +622,12 @@ class DiveAppTest {
 
       clickContainerEdge(yFraction = 0.5f)
 
-      waitUntilAtLeastOneExists(
-        hasText(HeapDominatorTreemap.UNREACHABLE_LABEL),
-        OPEN_TIMEOUT_MILLIS
-      )
-      onNodeWithText(UNREACHABLE.reachabilityText).assertIsDisplayed()
+      // The cell, the tab it opens, the chain and the details panel all say the one word, because the pile
+      // is every object of that strength and the strength has one name. So this counts rather than finding
+      // one: how firmly an object is held reads off the details panel in the tests about a strength that
+      // isn't also a pile.
+      waitUntilAtLeastOneExists(hasText(UNREACHABLE.label), OPEN_TIMEOUT_MILLIS)
+      assertThat(onAllNodesWithText(UNREACHABLE.label).fetchSemanticsNodes()).isNotEmpty()
       strengthToggle(UNREACHABLE).assertTextContains(
         formatByteSize(GARBAGE_PAYLOAD_BYTE_SIZE),
         substring = true
@@ -642,7 +643,7 @@ class DiveAppTest {
 
       // No GC root reaches it, so there is no object to blame for it still being here: the chain starts at
       // that said in as many words, where every other chain names the kind of root it starts at.
-      waitUntilAtLeastOneExists(hasText(UNREACHABLE.reachabilityText), OPEN_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText(UNREACHABLE.label), OPEN_TIMEOUT_MILLIS)
       waitUntilAtLeastOneExists(hasText(UNCOLLECTED_GARBAGE_CHAIN), OPEN_TIMEOUT_MILLIS)
     }
   }
@@ -804,7 +805,7 @@ class DiveAppTest {
       waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
         onAllNodesWithText(ViewShape.RADIAL.displayName).fetchSemanticsNodes().isEmpty()
       }
-      assertThat(onAllNodesWithText(STRONG.displayName, substring = true).fetchSemanticsNodes())
+      assertThat(onAllNodesWithText(STRONG.label, substring = true).fetchSemanticsNodes())
         .isEmpty()
     }
   }
@@ -894,7 +895,7 @@ class DiveAppTest {
 
   /** The checkbox for [strength] above the view, which carries its name and how much it holds. */
   private fun ComposeUiTest.strengthToggle(strength: ReachabilityStrength): SemanticsNodeInteraction =
-    onNode(hasText(strength.displayName, substring = true) and isToggleable())
+    onNode(hasText(strength.label, substring = true) and isToggleable())
 
   /** The radio button for [scheme] above the view. */
   private fun ComposeUiTest.schemeOption(scheme: CellColorScheme): SemanticsNodeInteraction =

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveAppTest.kt
@@ -56,6 +56,7 @@ import shark.dive.ReachabilityStrength.WEAK
 import shark.dive.ReferencePage
 import shark.dive.Topic.WEAKER_REFERENCES
 import shark.dive.formatByteSize
+import shark.dive.formatObjectCount
 import shark.dive.hexObjectId
 
 @OptIn(ExperimentalTestApi::class)
@@ -568,7 +569,7 @@ class DiveAppTest {
 
       clickView(LEFTOVER_X, LEFTOVER_Y)
 
-      waitUntilAtLeastOneExists(hasText("smaller objects", substring = true), OPEN_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText("Held by Object[]", substring = true), OPEN_TIMEOUT_MILLIS)
       onNodeWithText("Held by Object[]", substring = true).assertIsDisplayed()
     }
   }
@@ -581,7 +582,7 @@ class DiveAppTest {
 
       clickContainerEdge(yFraction = 0.5f)
 
-      waitUntilAtLeastOneExists(hasText("of one class", substring = true), OPEN_TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText(formatObjectCount(SIBLING_COUNT)), OPEN_TIMEOUT_MILLIS)
       assertThat(onAllNodesWithText(SIBLING_CLASS_NAME).fetchSemanticsNodes()).isNotEmpty()
       // And gets the rows an object gets, so that a pile and an object read as two of a kind.
       onNodeWithText(STRONG.label).assertIsDisplayed()

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveBitmapsTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveBitmapsTest.kt
@@ -142,7 +142,7 @@ class DiveBitmapsTest {
     /** Opening a heap dump and rebuilding a tree both happen on another thread. */
     private const val OPEN_TIMEOUT_MILLIS = 10_000L
 
-    private const val BITMAP_ROW = "android.graphics.Bitmap instance"
+    private const val BITMAP_ROW = "Bitmap instance"
 
     /** What `adb devices` prints when nothing is plugged in, which is every command this test needs. */
     private val NO_DEVICE_ADB = Adb { AdbOutput(exitCode = 0, text = "List of devices attached\n") }

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveWindowTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/DiveWindowTest.kt
@@ -284,7 +284,7 @@ class DiveWindowTest {
     val asked = windows.last()
     assertThat(asked.deepLinkProblem)
       .contains(SECOND_DUMP.name)
-      .contains("no record of opening one by that name")
+      .contains("Nothing here has opened it")
       // And what to type instead, since a link from another machine can carry the path.
       .contains("&dump=/path/to/${SECOND_DUMP.name}")
     // The same sentence in the dialog that asks for the file, so the question and the reason for it are one.
@@ -307,7 +307,9 @@ class DiveWindowTest {
     val asked = windows.first().linkedHeapDump
     assertThat(windows).hasSize(2)
     assertThat(asked?.choices).containsExactly(pixel.absoluteFile, emulator.absoluteFile)
-    assertThat(asked?.question).contains("2 heap dumps called app.hprof are open")
+    // Which file is in the title and the directories are the rows, so the question is the count and
+    // whether the choice is between windows or between files on disk.
+    assertThat(asked?.question).contains("2 open")
     assertThat(windows.none { it.linkedPlaces.isNotEmpty() }).isTrue()
   }
 
@@ -325,7 +327,7 @@ class DiveWindowTest {
     val asked = windows.last()
     assertThat(asked.linkedHeapDump?.choices)
       .containsExactlyInAnyOrder(pixel.absoluteFile, emulator.absoluteFile)
-    assertThat(asked.deepLinkProblem).contains("have been opened here, and none is open now")
+    assertThat(asked.deepLinkProblem).contains("none open now")
   }
 
   @Test fun `the heap dump picked for a link is where the link goes`() {

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeakStatusSectionTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeakStatusSectionTest.kt
@@ -34,6 +34,8 @@ import shark.dive.LeakStatusFile
 import shark.dive.LeakStatusOverride
 import shark.dive.LeakStatusOverrides
 import shark.dive.Place
+import shark.dive.ReferencePage
+import shark.dive.Topic
 import shark.dive.hexObjectId
 import shark.dive.statusText
 
@@ -244,6 +246,60 @@ class LeakStatusSectionTest {
   }
 
   /**
+   * What the dialog belonging to its tab rather than to the window is for.
+   *
+   * The reason a verdict was given is the case for the other reading, and weighing it against yours is
+   * sometimes going and looking at the object — which a dialog over the window can only offer by being
+   * dismissed, and dismissing it throws away the reason that had been typed. Here it is a tab, and the tab
+   * it was started in is still half set when you come back to it. See [LeakStatusSetter].
+   */
+  @Test fun `going to look at a verdict this one disagrees with leaves it half set`() {
+    diveUiTest {
+      openHeapDump(setAlready = { holderIsLeaking() }) { it.activityObjectId }
+      changeStatus()
+      choose(LeakStatus.EXPECTED)
+      write(TYPED_REASON)
+      set()
+      waitUntilAtLeastOneExists(hasText("$HOLDER_NAME $CONFLICT_ABOVE"), SAVE_TIMEOUT_MILLIS)
+
+      onNodeWithText("$HOLDER_NAME $CONFLICT_ABOVE").performClick()
+
+      // In front, the way a `?` opens a page: clicking it is asking to read the object, and the tab it was
+      // opened from is where the question waits.
+      // By address, which is what a tab strip of several instances of one class is told apart by.
+      waitUntilAtLeastOneExists(tabOn(heapDump.holderObjectId), OPEN_TIMEOUT_MILLIS)
+      onNode(tabOn(heapDump.activityObjectId)).performClick()
+      onNodeWithText(settingVerdictTitle(ACTIVITY_NAME)).assertIsDisplayed()
+      onNodeWithText(SOLVE_CONFLICTS).assertIsDisplayed()
+      // Nothing written by any of that, which is what makes going to look free.
+      assertThat(statusFile().read().all.map { it.objectId }).containsExactly(heapDump.holderObjectId)
+    }
+  }
+
+  /**
+   * And why two verdicts can disagree at all, which is a paragraph read once above a list read every time.
+   *
+   * The `?` everywhere else in the window opens the reference in a tab, and that is exactly what a dialog
+   * over the window cannot do: the tab would open behind it, unreachable until it was dismissed.
+   */
+  @Test fun `why two verdicts disagree is behind the question mark, in a tab`() {
+    diveUiTest {
+      openHeapDump(setAlready = { holderIsLeaking() }) { it.activityObjectId }
+      changeStatus()
+      choose(LeakStatus.EXPECTED)
+      write(TYPED_REASON)
+      set()
+      waitUntilAtLeastOneExists(hasText(SOLVE_CONFLICTS), SAVE_TIMEOUT_MILLIS)
+      val page = ReferencePage.of(Topic.CONFLICTING_VERDICTS)
+
+      onNodeWithContentDescription("$MORE_ABOUT ${page.title}").performClick()
+
+      waitUntilAtLeastOneExists(hasText(page.hint), OPEN_TIMEOUT_MILLIS)
+      onNode(hasText(page.title) and isTab()).assertIsDisplayed()
+    }
+  }
+
+  /**
    * The other half of setting a status: the leaks are read through them, so the list changes rather than
    * only the colour of one object. See [shark.dive.HeapDominatorTreemap.findLeaks].
    */
@@ -300,7 +356,7 @@ class LeakStatusSectionTest {
   }
 
   /**
-   * Opens the dialog that sets a status.
+   * Opens the dialog that sets a status, which belongs to the tab the pencil was pressed in.
    *
    * Waits for the button to be enabled rather than pressing it as it is: it stays disabled until the file
    * has been read, which is what keeps a save from deleting statuses still on their way off the disk.
@@ -309,7 +365,7 @@ class LeakStatusSectionTest {
     val pencil = hasText(EDIT_STATUS_GLYPH) and hasClickAction()
     waitUntilAtLeastOneExists(pencil and isEnabled(), RENDER_TIMEOUT_MILLIS)
     onNode(pencil).performClick()
-    onNodeWithText(statusDialogTitle(ACTIVITY_NAME)).assertIsDisplayed()
+    onNodeWithText(settingVerdictTitle(ACTIVITY_NAME)).assertIsDisplayed()
   }
 
   /** Picks one of the three statuses, by the row it is on rather than by the mark beside it. */
@@ -370,6 +426,12 @@ class LeakStatusSectionTest {
 
   private fun isButton(): SemanticsMatcher =
     SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button)
+
+  private fun isTab(): SemanticsMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Tab)
+
+  /** A tab open on one object, which the strip names by class and address. See `HeapDominatorTreemap`. */
+  private fun tabOn(objectId: Long) = hasText(hexObjectId(objectId), substring = true) and isTab()
 
   companion object {
     /** Opening a heap dump and laying its tree out both happen on another thread. */

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
@@ -181,7 +181,9 @@ class LeaksScreenTest {
     diveUiTest {
       // Rendered from leaks rather than read off a heap dump: what is being pinned is how the two ends of a
       // leak are named, and a dump whose leaks have the shape to show it is a dump built for it.
-      setContent { MaterialTheme { LeaksScreen(TWO_ENDED_LEAKS, false, emptySet(), {}, { _, _ -> }, {}) } }
+      setContent {
+        MaterialTheme { LeaksScreen(TWO_ENDED_LEAKS, false, emptySet(), {}, { _, _ -> }, {}, {}) }
+      }
 
       // Both ends and a gap for what is between them, then the leak whose two ends are one reference. Each
       // ends on an arrow, because what it points at is the object on the row below.

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
@@ -231,6 +231,39 @@ class LeaksScreenTest {
     }
   }
 
+  /**
+   * And a section a strength names says the strength's own name and leads to the one page about the nine of
+   * them: a paragraph per section would be that page written out five more times, in five places that go
+   * stale one at a time.
+   */
+  @Test fun `a section named after a strength leads to the page about strengths`() {
+    diveUiTest {
+      var explained: Topic? = null
+      setContent {
+        MaterialTheme {
+          LeaksScreen(
+            WEAKLY_HELD,
+            false,
+            // Open, since the half of the screen nobody has to act on is folded away until it is asked for.
+            setOf(Place.Leaks.ON_THE_WAY_OUT),
+            {},
+            { _, _ -> },
+            {},
+            { explained = it },
+            {}
+          )
+        }
+      }
+
+      onNodeWithText(ReachabilityStrength.WEAK.label, substring = true).assertIsDisplayed()
+      onNodeWithContentDescription(
+        "$MORE_ABOUT ${ReferencePage.of(Topic.REACHABILITY_STRENGTH).title}"
+      ).performClick()
+
+      assertThat(explained).isEqualTo(Topic.REACHABILITY_STRENGTH)
+    }
+  }
+
   @Test fun `the map is shaded by what is leaking as soon as it is drawn`() {
     diveUiTest {
       openHeapDump()
@@ -362,7 +395,7 @@ class LeaksScreenTest {
 
   /** And one of the boxes beside it that colour the map by how firmly an object is held. */
   private fun ComposeUiTest.strengthToggle(): SemanticsNodeInteraction =
-    onNode(hasText(ReachabilityStrength.STRONG.displayName, substring = true) and isToggleable())
+    onNode(hasText(ReachabilityStrength.STRONG.label, substring = true) and isToggleable())
 
   companion object {
     /** The two destroyed activities and the watched object of [leakyHeapDump]. */
@@ -412,6 +445,16 @@ class LeaksScreenTest {
         LeakSection(
           kind = LeakKind.LIBRARY,
           groups = listOf(leakGroup(listOf("AmsTask.response"), subtitle = LIBRARY_DESCRIPTION))
+        )
+      )
+    )
+
+    /** One of the five sections a [ReachabilityStrength] names, which are the half nobody has to act on. */
+    private val WEAKLY_HELD = HeapLeaks(
+      listOf(
+        LeakSection(
+          kind = LeakKind.WEAK,
+          groups = listOf(leakGroup(listOf("Cache.entry")))
         )
       )
     )

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
@@ -35,6 +36,8 @@ import shark.dive.LeakSection
 import shark.dive.LeakingObject
 import shark.dive.Place
 import shark.dive.ReachabilityStrength
+import shark.dive.ReferencePage
+import shark.dive.Topic
 import shark.dive.hexObjectId
 import shark.dive.statusText
 
@@ -182,7 +185,7 @@ class LeaksScreenTest {
       // Rendered from leaks rather than read off a heap dump: what is being pinned is how the two ends of a
       // leak are named, and a dump whose leaks have the shape to show it is a dump built for it.
       setContent {
-        MaterialTheme { LeaksScreen(TWO_ENDED_LEAKS, false, emptySet(), {}, { _, _ -> }, {}, {}) }
+        MaterialTheme { LeaksScreen(TWO_ENDED_LEAKS, false, emptySet(), {}, { _, _ -> }, {}, {}, {}) }
       }
 
       // Both ends and a gap for what is between them, then the leak whose two ends are one reference. Each
@@ -190,6 +193,41 @@ class LeaksScreenTest {
       onNodeWithText("$FIRST_END $STRETCH_ARROW $STRETCH_GAP $STRETCH_ARROW $LAST_END $STRETCH_ARROW")
         .assertIsDisplayed()
       onNodeWithText("$ONE_REFERENCE $STRETCH_ARROW").assertIsDisplayed()
+    }
+  }
+
+  /**
+   * All of it, on one line's worth of paragraph, with the URL at the end of it live. Three ellipsized lines
+   * was throwing away the half of these descriptions that says where the workaround is.
+   */
+  @Test fun `a library leak's description is drawn in full`() {
+    diveUiTest {
+      setContent {
+        MaterialTheme { LeaksScreen(LIBRARY_LEAK, false, emptySet(), {}, { _, _ -> }, {}, {}, {}) }
+      }
+
+      onNodeWithText(
+        "AccountManager.AmsTask.Response is a stub, and as all stubs it's held in memory by a native ref " +
+          "until the calling side gets GCed, which can happen long after the stub is no longer of use. " +
+          "https://issuetracker.google.com/issues/318303120"
+      ).assertIsDisplayed()
+    }
+  }
+
+  /** And what to do about somebody else's leak is a page, since it is more than a section heading holds. */
+  @Test fun `the library leaks section leads to the page about them`() {
+    diveUiTest {
+      var explained: Topic? = null
+      setContent {
+        MaterialTheme {
+          LeaksScreen(LIBRARY_LEAK, false, emptySet(), {}, { _, _ -> }, {}, { explained = it }, {})
+        }
+      }
+
+      onNodeWithContentDescription("$MORE_ABOUT ${ReferencePage.of(Topic.LIBRARY_LEAKS).title}")
+        .performClick()
+
+      assertThat(explained).isEqualTo(Topic.LIBRARY_LEAKS)
     }
   }
 
@@ -358,6 +396,26 @@ class LeaksScreenTest {
     private const val ONE_REFERENCE = "Holder.activity"
 
     /** Two app leaks, one of each shape. See [LeakGroup.suspectPath]. */
+    /**
+     * Verbatim from `AndroidReferenceMatchers.ACCOUNT_MANAGER`, wrapping and all: what the leaks screen has
+     * to draw is a `"""` block out of Shark, and 51 of the 85 of them end in a URL.
+     */
+    private val LIBRARY_DESCRIPTION = """
+      AccountManager.AmsTask.Response is a stub, and as all stubs it's held in memory by a
+      native ref until the calling side gets GCed, which can happen long after the stub is no
+      longer of use.
+      https://issuetracker.google.com/issues/318303120
+    """.trimIndent()
+
+    private val LIBRARY_LEAK = HeapLeaks(
+      listOf(
+        LeakSection(
+          kind = LeakKind.LIBRARY,
+          groups = listOf(leakGroup(listOf("AmsTask.response"), subtitle = LIBRARY_DESCRIPTION))
+        )
+      )
+    )
+
     private val TWO_ENDED_LEAKS = HeapLeaks(
       listOf(
         LeakSection(
@@ -370,11 +428,14 @@ class LeaksScreenTest {
       )
     )
 
-    private fun leakGroup(suspectPath: List<String>) = LeakGroup(
+    private fun leakGroup(
+      suspectPath: List<String>,
+      subtitle: String? = null
+    ) = LeakGroup(
       leakFingerprint = suspectPath.first().sha1OfNothing(),
       title = suspectPath.first(),
       suspectPath = suspectPath,
-      subtitle = null,
+      subtitle = subtitle,
       objects = listOf(
         LeakingObject(
           objectId = suspectPath.first().hashCode().toLong(),

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LeaksScreenTest.kt
@@ -303,7 +303,7 @@ class LeaksScreenTest {
       // Filtered down to it rather than scrolled to it: the activities of this dump retain the least of
       // anything in it, so they are the last rows of a list that is longer than the window.
       onNode(hasSetTextAction()).performTextInput(LEAKING_ACTIVITY_CLASS_NAME.substringAfterLast('.'))
-      val listed = "$LEAKING_ACTIVITY_CLASS_NAME instance"
+      val listed = "${LEAKING_ACTIVITY_CLASS_NAME.substringAfterLast('.')} instance"
       waitUntilAtLeastOneExists(hasText(listed), OPEN_TIMEOUT_MILLIS)
 
       onAllNodesWithText(listed)[0].performClick()

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LinkedHeapDumpTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/LinkedHeapDumpTest.kt
@@ -31,7 +31,7 @@ class LinkedHeapDumpTest {
       setContentAsking(
         LinkedHeapDump(
           heapDumpName = HEAP_DUMP_NAME,
-          question = "2 heap dumps called $HEAP_DUMP_NAME are open.",
+          question = TWO_OPEN,
           choices = listOf(PIXEL_DUMP, EMULATOR_DUMP),
           place = Place.Starred
         )
@@ -50,7 +50,7 @@ class LinkedHeapDumpTest {
       setContentAsking(
         LinkedHeapDump(
           heapDumpName = HEAP_DUMP_NAME,
-          question = "No heap dump called $HEAP_DUMP_NAME is open here.",
+          question = NONE_OPEN,
           choices = emptyList(),
           place = Place.Starred
         ),
@@ -66,7 +66,7 @@ class LinkedHeapDumpTest {
   }
 
   @Test fun `why it is asking is said in the dialog and behind it`() {
-    val question = "No heap dump called $HEAP_DUMP_NAME is open here."
+    val question = NONE_OPEN
     runComposeUiTest {
       setContentAsking(
         LinkedHeapDump(
@@ -90,7 +90,7 @@ class LinkedHeapDumpTest {
       setContentAsking(
         LinkedHeapDump(
           heapDumpName = HEAP_DUMP_NAME,
-          question = "2 heap dumps called $HEAP_DUMP_NAME are open.",
+          question = TWO_OPEN,
           choices = listOf(PIXEL_DUMP, EMULATOR_DUMP),
           place = Place.Starred
         )
@@ -131,6 +131,15 @@ class LinkedHeapDumpTest {
 
     val PIXEL_DUMP = File("/dumps/pixel/$HEAP_DUMP_NAME")
     val EMULATOR_DUMP = File("/dumps/emulator/$HEAP_DUMP_NAME")
+
+    /**
+     * The two questions `DiveWindows` asks, copied rather than called: which one a link gets is
+     * `DiveWindowTest`'s, and what is being tested here is the dialog, which takes whatever it is handed.
+     * Copied from the real ones all the same, so that reading this file shows what one looks like.
+     */
+    const val TWO_OPEN = "2 open."
+    const val NONE_OPEN = "Nothing here has opened it. Choose the file, or say where it is in the " +
+      "link: &dump=/path/to/$HEAP_DUMP_NAME"
 
     /** Long enough for the dialog to be composed, and it draws nothing that has to be read off disk. */
     const val TIMEOUT_MILLIS = 5_000L

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/MapNamesTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/MapNamesTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasAnySibling
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -36,7 +37,7 @@ import shark.dive.hexObjectId
  * clicking one goes there, which is what makes a container reachable without hunting for the pixels of its
  * edge.
  *
- * The names that stand for a pile of objects rather than for one, `400 × Sibling` and `300 smaller objects`,
+ * The names that stand for a pile of objects rather than for one, `400 × Sibling` and `300 objects`,
  * are the other half of it: a rectangle has room for the count and a simple class name and no more, so which
  * pile it is has to be said at the pointer. [DiveAppTest] covers the rest of the window.
  */
@@ -94,7 +95,7 @@ class MapNamesTest {
       waitUntilAtLeastOneExists(hasText(SIBLING_CLASS_NAME), OPEN_TIMEOUT_MILLIS)
       // The count is also what says it is a pile at all, because a rectangle full of objects looks exactly
       // like one object.
-      onNodeWithText("${formatObjectCount(SIBLING_COUNT)} of one class").assertIsDisplayed()
+      onNodeWithText(formatObjectCount(SIBLING_COUNT)).assertIsDisplayed()
     }
   }
 
@@ -106,8 +107,11 @@ class MapNamesTest {
 
       // They have nothing in common but the rectangle they were left out of, so that is the whole of what
       // there is to say about them: how many, how much, and which rectangle to go to for any of them.
-      waitUntilAtLeastOneExists(hasText("smaller objects", substring = true), OPEN_TIMEOUT_MILLIS)
-      onNodeWithText("Held by Object[]").assertIsDisplayed()
+      waitUntilAtLeastOneExists(hasText("Held by Object[]"), OPEN_TIMEOUT_MILLIS)
+      // How many is the line above it, and a count is the whole of that line: how many is layout's to
+      // decide, so what the card is held to is that it counts them and says nothing else.
+      onNode(hasText(" objects", substring = true) and hasAnySibling(hasText("Held by Object[]")))
+        .assertIsDisplayed()
     }
   }
 

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/MapNamesTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/MapNamesTest.kt
@@ -92,9 +92,9 @@ class MapNamesTest {
       // The map has room for `400 × Sibling` and no more, and which Sibling that is, is the question a pile
       // of them raises. So the qualified name is what the pointer gets.
       waitUntilAtLeastOneExists(hasText(SIBLING_CLASS_NAME), OPEN_TIMEOUT_MILLIS)
+      // The count is also what says it is a pile at all, because a rectangle full of objects looks exactly
+      // like one object.
       onNodeWithText("${formatObjectCount(SIBLING_COUNT)} of one class").assertIsDisplayed()
-      // And that it is a pile at all, because a rectangle full of objects looks exactly like one object.
-      onNodeWithText(PILE_OF_OBJECTS).assertIsDisplayed()
     }
   }
 
@@ -108,7 +108,6 @@ class MapNamesTest {
       // there is to say about them: how many, how much, and which rectangle to go to for any of them.
       waitUntilAtLeastOneExists(hasText("smaller objects", substring = true), OPEN_TIMEOUT_MILLIS)
       onNodeWithText("Held by Object[]").assertIsDisplayed()
-      onNodeWithText(LEFTOVER_OBJECTS).assertIsDisplayed()
     }
   }
 

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/ObjectsScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/ObjectsScreenTest.kt
@@ -65,7 +65,7 @@ class ObjectsScreenTest {
       listObjects()
 
       // One line per object, whatever its size, with the retained size the treemap draws its rectangle from.
-      onNodeWithText("com.example.Holder instance").assertIsDisplayed()
+      onNodeWithText("Holder instance").assertIsDisplayed()
       onNodeWithText("$PAYLOAD_LENGTH elements").assertIsDisplayed()
       // How much of the heap dump is being looked at, which is what says a search found little of it.
       onNodeWithText("objects match", substring = true).assertIsDisplayed()
@@ -80,9 +80,9 @@ class ObjectsScreenTest {
       // Part of a name rather than all of it, which is how anyone types a class they half remember.
       searchBox().performTextInput("Hold")
 
-      waitUntilExactlyOneExists(hasText("com.example.Holder instance"), OPEN_TIMEOUT_MILLIS)
+      waitUntilExactlyOneExists(hasText("Holder instance"), OPEN_TIMEOUT_MILLIS)
       waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
-        onAllNodesWithText("java.lang.Object[] array").fetchSemanticsNodes().isEmpty()
+        onAllNodesWithText("Object[] array").fetchSemanticsNodes().isEmpty()
       }
     }
   }
@@ -92,7 +92,7 @@ class ObjectsScreenTest {
       openHeapDump()
       listObjects()
       // The class object itself, which the list has a line of its own for.
-      onNodeWithText("com.example.Holder class").performClick()
+      onNodeWithText("Holder class").performClick()
       waitUntilAtLeastOneExists(hasText(LIST_INSTANCES), OPEN_TIMEOUT_MILLIS)
 
       onNodeWithText(LIST_INSTANCES).performClick()
@@ -102,9 +102,9 @@ class ObjectsScreenTest {
       // itself going, since listing the objects again is a read of the heap dump and the list on screen is
       // the one from before it until it comes back.
       waitUntil(timeoutMillis = OPEN_TIMEOUT_MILLIS) {
-        onAllNodesWithText("com.example.Holder class").fetchSemanticsNodes().isEmpty()
+        onAllNodesWithText("Holder class").fetchSemanticsNodes().isEmpty()
       }
-      onNodeWithText("com.example.Holder instance").assertIsDisplayed()
+      onNodeWithText("Holder instance").assertIsDisplayed()
       onNode(hasText(EXACT_MATCH) and isToggleable()).assertIsOn()
       kindToggle(HeapObjectKind.INSTANCE).assertIsOn()
       kindToggle(HeapObjectKind.CLASS).assertIsOff()
@@ -116,7 +116,7 @@ class ObjectsScreenTest {
       openHeapDump()
       listObjects()
 
-      onNodeWithText("java.lang.Object[] array").performClick()
+      onNodeWithText("Object[] array").performClick()
 
       // The same place clicking its rectangle would have taken you, in the tab the list was read in: the
       // map rooted at it, and the panel describing it.
@@ -133,7 +133,7 @@ class ObjectsScreenTest {
       openHeapDump()
       listObjects()
 
-      onNodeWithText("java.lang.Object[] array").performMouseInput { rightClick() }
+      onNodeWithText("Object[] array").performMouseInput { rightClick() }
       onNodeWithText(OPEN_IN_NEW_TAB).performClick()
 
       // The gesture ⌘ clicking a row already had, spelled out in words: a row of a list is a way to an
@@ -151,7 +151,7 @@ class ObjectsScreenTest {
       val heapDumpFile = openHeapDump(copyToClipboard = { copied += it })
       listObjects()
 
-      onNodeWithText("java.lang.Object[] array").performMouseInput { rightClick() }
+      onNodeWithText("Object[] array").performMouseInput { rightClick() }
       onNodeWithText(COPY_LINK).performClick()
 
       // Beside "open in a new tab" wherever that is, this row included: the two are the same thought a
@@ -187,7 +187,7 @@ class ObjectsScreenTest {
   /** Opens a tab on the list and waits for the pass over the heap dump that fills it. */
   private fun ComposeUiTest.listObjects() {
     onNode(hasText(Place.OBJECTS_LABEL) and isButton()).performClick()
-    waitUntilAtLeastOneExists(hasText("java.lang.Object[] array"), OPEN_TIMEOUT_MILLIS)
+    waitUntilAtLeastOneExists(hasText("Object[] array"), OPEN_TIMEOUT_MILLIS)
   }
 
   /** A button of the screen bar, as against the tab of the same name that clicking it opens. */

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/RadialViewTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/RadialViewTest.kt
@@ -32,6 +32,7 @@ import shark.dive.RadialPresentation
 import shark.dive.ReachabilityStrength.STRONG
 import shark.dive.TreemapRect
 import shark.dive.TreemapTree
+import shark.dive.formatObjectCount
 
 /**
  * The same wiring [TreemapViewTest] covers, for the radial view: a click reports the sector under the
@@ -169,7 +170,7 @@ class RadialViewTest {
           is CellSubject.Node -> PresentedCell(cell, "node ${subject.node}", CellContent.Object(STRONG))
           is CellSubject.Group -> PresentedCell(
             cell,
-            "${subject.nodeCount} smaller objects",
+            formatObjectCount(subject.nodeCount),
             CellContent.Leftover(STRONG)
           )
           is CellSubject.Own -> PresentedCell(

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/StackViewTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/StackViewTest.kt
@@ -34,6 +34,7 @@ import shark.dive.StackLayout
 import shark.dive.StackPresentation
 import shark.dive.TreemapRect
 import shark.dive.TreemapTree
+import shark.dive.formatObjectCount
 
 /**
  * The same wiring [TreemapViewTest] covers, for the stack: a click reports the block under the pointer,
@@ -241,7 +242,7 @@ class StackViewTest {
           is CellSubject.Node -> PresentedCell(cell, "node ${subject.node}", CellContent.Object(STRONG))
           is CellSubject.Group -> PresentedCell(
             cell,
-            "${subject.nodeCount} smaller objects",
+            formatObjectCount(subject.nodeCount),
             CellContent.Leftover(STRONG)
           )
           is CellSubject.Own -> PresentedCell(

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/TakeHeapDumpTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/TakeHeapDumpTest.kt
@@ -67,11 +67,11 @@ class TakeHeapDumpTest {
       waitUntilAtLeastOneExists(hasText(OLD_DEVICE_DESCRIPTION), TIMEOUT_MILLIS)
       // Not on the device list, which says nothing about bitmaps: it is on the screen where the fetch
       // is offered, next to the checkbox it is the reason for.
-      assertThat(onAllNodesWithText("can't put", substring = true).fetchSemanticsNodes()).isEmpty()
+      assertThat(onAllNodesWithText(BITMAPS_MISSING, substring = true).fetchSemanticsNodes()).isEmpty()
       onNodeWithText(OLD_DEVICE_DESCRIPTION).performClick()
 
       // The dump is still worth taking, and it's the one thing about it worth knowing in advance.
-      waitUntilAtLeastOneExists(hasText("API 30 can't put", substring = true), TIMEOUT_MILLIS)
+      waitUntilAtLeastOneExists(hasText("API 30 $BITMAPS_MISSING", substring = true), TIMEOUT_MILLIS)
     }
   }
 
@@ -292,6 +292,12 @@ class TakeHeapDumpTest {
     /** Older than `am dumpheap -b png`, which is what makes a debugger the only way to the pixels. */
     private const val OLD_SDK_INT = 30
     private const val OLD_DEVICE_DESCRIPTION = "$MODEL · API $OLD_SDK_INT · $SERIAL"
+
+    /**
+     * What such a device says about its dumps, after the API level: matched here as a fragment rather
+     * than in full, because the sentence after it is about the fetch and not about the device.
+     */
+    private const val BITMAPS_MISSING = "keeps bitmap pixels out of the dump"
 
     /** What the debugger reads out of the process: one image, for the one bitmap of the dump. */
     private val FETCHED_PIXELS = NativeBitmapPixels(

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/TreemapViewTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/TreemapViewTest.kt
@@ -36,6 +36,7 @@ import shark.dive.TreemapLayout
 import shark.dive.TreemapPresentation
 import shark.dive.TreemapRect
 import shark.dive.TreemapTree
+import shark.dive.formatObjectCount
 
 /**
  * Covers the wiring between clicks on the canvas and the callbacks reporting what was clicked or pointed
@@ -319,7 +320,7 @@ class TreemapViewTest {
           is CellSubject.Node -> PresentedCell(cell, "node ${subject.node}", CellContent.Object(STRONG))
           is CellSubject.Group -> PresentedCell(
             cell,
-            "${subject.nodeCount} smaller objects",
+            formatObjectCount(subject.nodeCount),
             CellContent.Leftover(STRONG)
           )
           is CellSubject.Own -> PresentedCell(

--- a/shark/shark-dive/shark-dive-core/build.gradle.kts
+++ b/shark/shark-dive/shark-dive-core/build.gradle.kts
@@ -18,3 +18,29 @@ dependencies {
   testImplementation(libs.dagger.runtime)
   testImplementation(libs.metro.runtime)
 }
+
+/**
+ * Puts the reference on the classpath, which is where [shark.dive.ReferencePage] reads it.
+ *
+ * Copied rather than kept here, because the same files are the website's: `docs/shark-dive-reference.md`
+ * includes every one of them, so there is one copy of every sentence and no way for the page a `?` leads to
+ * and the page the site publishes to drift apart. See `exclude_docs` in `mkdocs.yml`.
+ *
+ * Shipped inside the build rather than opened in a browser so that a release shows the reference it was
+ * built with: a link to the site would have an old release explaining itself with a page written about a
+ * newer one. Same reasoning as `writeVersionResource` in shark-dive-app.
+ */
+val copyReference by tasks.registering(Sync::class) {
+  from(rootProject.layout.projectDirectory.dir("docs/shark-dive-reference"))
+  into(layout.buildDirectory.dir("generated/reference/shark-dive-reference"))
+}
+
+sourceSets.main {
+  resources.srcDir(copyReference.map { it.destinationDir.parentFile })
+}
+
+tasks.test {
+  // Where the page that publishes the reference is, so that `ReferenceTest` can hold it to including every
+  // topic. The only thing here that reads the repository rather than the classpath.
+  systemProperty("shark.dive.referencePage", rootProject.file("docs/shark-dive-reference.md").path)
+}

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/DeepLink.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/DeepLink.kt
@@ -129,6 +129,7 @@ data class DeepLink(
       )
       LEAKS_PATH -> Place.Leaks(parameters.all(EXPANDED_PARAMETER).toSet())
       STARRED_PATH -> Place.Starred
+      REFERENCE_PATH -> Place.Reference(parameters.topic(uri))
       AGENT_LOGS_PATH -> Place.AgentLogs
       AGENT_LOG_PATH -> Place.AgentLog(parameters.required(SESSION_PARAMETER, uri))
       else -> throw IllegalArgumentException("\"$path\" is no place of \"$uri\". ${usage()}")
@@ -196,6 +197,21 @@ data class DeepLink(
       }
     }
 
+    /**
+     * Which page of the reference, by its file name: `?topic=leak-fingerprint`.
+     *
+     * By name rather than by [Enum.name], so that a link written down today still opens the same page after
+     * the topics have been reordered or one has been renamed in Kotlin — and so that a link is readable.
+     */
+    private fun List<Pair<String, String>>.topic(uri: String): Topic {
+      val page = required(TOPIC_PARAMETER, uri)
+      return Topic.ofPage(page)
+        ?: throw IllegalArgumentException(
+          "\"$page\" is no page of the reference. Pages are " +
+            Topic.values().joinToString(", ") { it.page } + "."
+        )
+    }
+
     private fun String.toIntOrThrow(
       name: String,
       uri: String
@@ -231,6 +247,7 @@ data class DeepLink(
     internal const val OBJECTS_PATH = "objects"
     internal const val LEAKS_PATH = "leaks"
     internal const val STARRED_PATH = "starred"
+    internal const val REFERENCE_PATH = "reference"
     internal const val AGENT_LOGS_PATH = "agent-logs"
     internal const val AGENT_LOG_PATH = "agent-log"
 
@@ -240,6 +257,7 @@ data class DeepLink(
       OBJECTS_PATH,
       LEAKS_PATH,
       STARRED_PATH,
+      REFERENCE_PATH,
       AGENT_LOGS_PATH,
       AGENT_LOG_PATH
     )
@@ -261,6 +279,7 @@ data class DeepLink(
     internal const val EXACT_PARAMETER = "exact"
     internal const val KINDS_PARAMETER = "kinds"
     internal const val EXPANDED_PARAMETER = "expanded"
+    internal const val TOPIC_PARAMETER = "topic"
     internal const val SESSION_PARAMETER = "session"
 
     internal const val HEX_PREFIX = "0x"
@@ -275,6 +294,7 @@ private fun Place.linkPath(): String = when (this) {
   is Place.Objects -> DeepLink.OBJECTS_PATH
   is Place.Leaks -> DeepLink.LEAKS_PATH
   is Place.Starred -> DeepLink.STARRED_PATH
+  is Place.Reference -> DeepLink.REFERENCE_PATH
   is Place.AgentLogs -> DeepLink.AGENT_LOGS_PATH
   is Place.AgentLog -> DeepLink.AGENT_LOG_PATH
 }
@@ -307,6 +327,7 @@ private fun Place.linkParameters(): List<Pair<String, String>> = when (this) {
   }
   is Place.Leaks -> expandedGroups.sorted().map { DeepLink.EXPANDED_PARAMETER to it }
   is Place.Starred -> emptyList()
+  is Place.Reference -> listOf(DeepLink.TOPIC_PARAMETER to topic.page)
   is Place.AgentLogs -> emptyList()
   is Place.AgentLog -> listOf(DeepLink.SESSION_PARAMETER to sessionId)
 }

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapDominatorTreemap.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapDominatorTreemap.kt
@@ -1606,7 +1606,7 @@ class HeapDominatorTreemap internal constructor(
     } ?: presentedObject(subject.node)
     is CellSubject.Group -> PresentedCell(
       cell = this,
-      label = "${subject.nodeCount} smaller objects",
+      label = formatObjectCount(subject.nodeCount),
       content = CellContent.Leftover(strengthOf(subject.parent))
     )
     // An object's own bytes are that object, so this reads as the object and is where its name shows:

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapDominatorTreemap.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapDominatorTreemap.kt
@@ -411,7 +411,7 @@ class HeapDominatorTreemap internal constructor(
   }
 
   private fun NodeGroup.label(): String = when (kind) {
-    ObjectGroupKind.UNREACHABLE -> UNREACHABLE_LABEL
+    ObjectGroupKind.UNREACHABLE -> ReachabilityStrength.UNREACHABLE.label
     // "42 × Bitmap" rather than "Bitmap": a count and a multiplication sign say this cell is a pile
     // of objects and not one of them, on a rectangle with room for nothing else.
     ObjectGroupKind.CLASS -> "$objectCount $CLASS_GROUP_LABEL_SEPARATOR $simpleClassName"
@@ -1770,8 +1770,6 @@ class HeapDominatorTreemap internal constructor(
      * heap dump whose garbage was all collected before it was written.
      */
     const val UNREACHABLE_NODE_ID = FIRST_PILE_ID
-
-    const val UNREACHABLE_LABEL = "Unreachable"
 
     /** The ids after it are the class groups. See [GroupIds]. */
     private const val FIRST_CLASS_GROUP_ID = FIRST_PILE_ID + 1

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapDominatorTreemap.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapDominatorTreemap.kt
@@ -570,6 +570,23 @@ class HeapDominatorTreemap internal constructor(
     )
   }
 
+  /**
+   * The same rows for objects picked by hand, in the order given: what the starred screen draws.
+   *
+   * An id no node of this tree has is left out, with a line in the log saying so, because the objects
+   * starred in a heap dump are a file anybody can edit — see [StarredFile] — and one address that was
+   * mistyped must not be a screen that throws.
+   */
+  fun listObjects(objectIds: List<Long>): List<ObjectListEntry> = objectIds.mapNotNull { objectId ->
+    val node = nodes[objectId]
+    if (node == null) {
+      SharkLog.d { "No object ${hexObjectId(objectId)} in this heap dump, so there is no row for it" }
+      null
+    } else {
+      Match(objectId, node.retainedSize, node.shallowSize).entry()
+    }
+  }
+
   /** One object a filter matched, before the read that turns it into a row. */
   private class Match(
     val objectId: Long,

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapLeaks.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapLeaks.kt
@@ -74,7 +74,15 @@ enum class LeakKind(
    * nothing else: every other section's groups are a reference, and a reference says what a sentence
    * would have.
    */
-  val subtitle: String? = null
+  val subtitle: String? = null,
+  /**
+   * The page of the reference behind this section's `?`, for the sections where what to do about one is
+   * more than [explanation] can hold.
+   *
+   * Null for the rest, and the `?` is simply not drawn — a `?` leading to a page that says what the line
+   * above it already said is a `?` nobody clicks a second time.
+   */
+  val topic: Topic? = null
 ) {
 
   APPLICATION(
@@ -86,8 +94,9 @@ enum class LeakKind(
   LIBRARY(
     "Library leaks",
     "The same thing in code the app doesn't control: the Android framework or a library. Shark recognizes " +
-      "the reference that holds them, so they can be told apart from the app's own — there is usually " +
-      "nothing to do about them but wait for a fix upstream."
+      "the reference that holds them, so they can be told apart from the app's own — which is who fixes " +
+      "them, not whether they need fixing.",
+    topic = Topic.LIBRARY_LEAKS
   ),
 
   SOFT(

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapLeaks.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/HeapLeaks.kt
@@ -60,8 +60,14 @@ data class HeapLeaks(
  */
 enum class LeakKind(
   val title: String,
-  /** What being in this section means, since not one of the titles says it on its own. */
-  val explanation: String,
+  /**
+   * What being in this section means, for the sections whose title doesn't say it on its own.
+   *
+   * Null for the five named after a [ReachabilityStrength]: what being held that firmly means is
+   * [Topic.REACHABILITY_STRENGTH], one page for the nine of them, and a paragraph here saying it again is
+   * the copy that goes stale. Those sections are a title and a `?`.
+   */
+  val explanation: String? = null,
   /**
    * How firmly the objects of this section are held, for the sections that are about that. Null for
    * [APPLICATION] and [LIBRARY], which are about the reference that holds an object rather than how
@@ -76,11 +82,11 @@ enum class LeakKind(
    */
   val subtitle: String? = null,
   /**
-   * The page of the reference behind this section's `?`, for the sections where what to do about one is
-   * more than [explanation] can hold.
+   * The page of the reference behind this section's `?`: what to do about a library leak, and what being
+   * held this firmly means for the five sections that are a [strength].
    *
-   * Null for the rest, and the `?` is simply not drawn — a `?` leading to a page that says what the line
-   * above it already said is a `?` nobody clicks a second time.
+   * Null for [APPLICATION], whose [explanation] is the whole of it, and the `?` is simply not drawn — a `?`
+   * leading to a page that says what the line above it already said is a `?` nobody clicks a second time.
    */
   val topic: Topic? = null
 ) {
@@ -100,40 +106,33 @@ enum class LeakKind(
   ),
 
   SOFT(
-    "Softly reachable",
-    "Objects a soft reference is the last thing holding, which the virtual machine clears when it wants " +
-      "the memory back. So they stay until memory runs short, and then go without the app doing anything.",
-    strength = ReachabilityStrength.SOFT
+    ReachabilityStrength.SOFT.label,
+    strength = ReachabilityStrength.SOFT,
+    topic = Topic.REACHABILITY_STRENGTH
   ),
 
   WEAK(
-    "Weakly reachable",
-    "Objects a weak reference is the last thing holding. The next garbage collection clears it and takes " +
-      "them, whether or not memory is short.",
-    strength = ReachabilityStrength.WEAK
+    ReachabilityStrength.WEAK.label,
+    strength = ReachabilityStrength.WEAK,
+    topic = Topic.REACHABILITY_STRENGTH
   ),
 
   FINALIZER(
-    "Waiting to be finalized",
-    "Objects whose class has a `finalize()` method, reachable only from the queue of objects waiting for " +
-      "it to run. They survive one more collection at least, and longer if finalization is backed up.",
-    strength = ReachabilityStrength.FINALIZER
+    ReachabilityStrength.FINALIZER.label,
+    strength = ReachabilityStrength.FINALIZER,
+    topic = Topic.REACHABILITY_STRENGTH
   ),
 
   PHANTOM(
-    "Phantom reachable",
-    "Objects already finalized and out of the app's reach, held only so that a `Cleaner` or a phantom " +
-      "reference gets to run. On Android that is nearly always a `Cleaner` freeing native memory, which " +
-      "the runtime drains on its own.",
-    strength = ReachabilityStrength.PHANTOM
+    ReachabilityStrength.PHANTOM.label,
+    strength = ReachabilityStrength.PHANTOM,
+    topic = Topic.REACHABILITY_STRENGTH
   ),
 
   UNREACHABLE(
-    "Unreachable",
-    "Objects that were meant to be gone and are: nothing reaches them any more, and the next garbage " +
-      "collection would take them. Listed so that a heap dump whose leaks have all been collected doesn't " +
-      "read as a heap dump nothing looked at.",
+    ReachabilityStrength.UNREACHABLE.label,
     strength = ReachabilityStrength.UNREACHABLE,
+    topic = Topic.REACHABILITY_STRENGTH,
     subtitle = "Nothing reaches these any more: the next garbage collection would take them."
   );
 

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/Note.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/Note.kt
@@ -47,6 +47,17 @@ data class Note(val blocks: List<NoteBlock>) {
 
     /** Reads [text] as markdown, with its mentions left for the heap dump to answer. See [resolvedWith]. */
     fun of(text: String): Note = Note(noteBlocksOf(text))
+
+    /**
+     * The same, for prose that was wrapped to fit a column rather than typed into a box: a page of the
+     * reference, or the description a library leak pattern carries.
+     *
+     * The one difference is what a line break means. In a note it is a line break, by the one-line-one-block
+     * rule above. In wrapped prose it is nothing at all — the writer was fitting a diff — so a run of lines
+     * is one paragraph and a blank line is what ends it. Reading such a text with [of] breaks every sentence
+     * where the wrapping fell.
+     */
+    fun ofDocument(text: String): Note = Note(documentBlocksOf(text))
   }
 }
 

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/NoteFile.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/NoteFile.kt
@@ -74,6 +74,9 @@ fun Place.noteKey(): String = when (this) {
   is Place.Objects -> OBJECT_LIST_KEY
   is Place.Leaks -> LEAKS_KEY
   is Place.Starred -> STARRED_KEY
+  // Per page, because a page of the reference is a thing to have something to say about — usually what it
+  // meant for this heap dump, which is why the note belongs to this dump's notes and not to the page.
+  is Place.Reference -> "$REFERENCE_KEY_PREFIX${topic.page}"
   is Place.AgentLogs -> AGENT_LOGS_KEY
   // Per session, because a note about what one agent did is about that investigation and not about agents.
   is Place.AgentLog -> "$AGENT_LOG_KEY_PREFIX$sessionId"
@@ -103,6 +106,8 @@ fun placeOfNoteKeyOrNull(key: String): Place? = when {
   key == STARRED_KEY -> Place.Starred
   key == AGENT_LOGS_KEY -> Place.AgentLogs
   key.startsWith(AGENT_LOG_KEY_PREFIX) -> Place.AgentLog(key.removePrefix(AGENT_LOG_KEY_PREFIX))
+  key.startsWith(REFERENCE_KEY_PREFIX) ->
+    Topic.ofPage(key.removePrefix(REFERENCE_KEY_PREFIX))?.let { Place.Reference(it) }
   key.startsWith(OBJECT_KEY_PREFIX) ->
     objectIdOfHex(key.removePrefix(OBJECT_KEY_PREFIX))?.let { Place.Object(it) }
   // A pile of the objects one rectangle had no room for is drawn from the window's width, so how many
@@ -118,6 +123,7 @@ private const val SMALLER_OBJECTS_KEY_PREFIX = "smaller-objects-"
 private const val OBJECT_LIST_KEY = "object-list"
 private const val LEAKS_KEY = "leaks"
 private const val STARRED_KEY = "starred"
+private const val REFERENCE_KEY_PREFIX = "reference-"
 private const val AGENT_LOGS_KEY = "agent-logs"
 private const val AGENT_LOG_KEY_PREFIX = "agent-log-"
 

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/NoteMarkdown.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/NoteMarkdown.kt
@@ -44,6 +44,62 @@ internal fun noteBlocksOf(text: String): List<NoteBlock> {
   return blocks
 }
 
+/**
+ * Reading the markdown of a written document rather than of a note: a page of the reference, wrapped at the
+ * column the rest of this repository is wrapped at.
+ *
+ * The one difference from [noteBlocksOf] is what a line break means. In a note it means a line break, which
+ * is what anyone typing into a box expects and why nothing there has to be ended with two spaces. In a file
+ * somebody wrapped to fit a diff it means nothing at all, so a run of prose lines is one paragraph and the
+ * blank line between two runs is what separates them — plain markdown, and the same reading the website
+ * gives these files.
+ *
+ * Everything else is [noteBlocksOf]'s, headings and links and fences and all, so a page reads in the window
+ * the way a note does and there is one parser to be wrong.
+ */
+internal fun documentBlocksOf(text: String): List<NoteBlock> = noteBlocksOf(unwrapped(text))
+
+/**
+ * The same markdown with each paragraph on one line, which is the shape [noteBlocksOf] reads.
+ *
+ * Blank lines go with the wrapping they separated: they were the paragraph break, and once the paragraphs
+ * are one line each they would be empty paragraphs drawn as blank space on top of the spacing the window
+ * already puts between blocks. Inside a fence every line is left exactly as it is, blank ones included —
+ * code is the one place a line break is the content.
+ */
+private fun unwrapped(text: String): String {
+  val unwrapped = mutableListOf<String>()
+  var isCode = false
+  var isParagraph = false
+  text.split('\n').map { it.removeSuffix("\r") }.forEach { line ->
+    when {
+      line.trimStart().startsWith(CODE_FENCE) -> {
+        isCode = !isCode
+        isParagraph = false
+        unwrapped += line
+      }
+      isCode -> unwrapped += line
+      line.isBlank() -> isParagraph = false
+      // A heading, a bullet, a quote or a rule is a block of its own, so it neither continues the
+      // paragraph above it nor is continued by the line below.
+      !isProse(line) -> {
+        isParagraph = false
+        unwrapped += line
+      }
+      isParagraph -> unwrapped[unwrapped.lastIndex] = "${unwrapped.last()} ${line.trim()}"
+      else -> {
+        isParagraph = true
+        unwrapped += line.trim()
+      }
+    }
+  }
+  return unwrapped.joinToString("\n")
+}
+
+/** Whether this line is prose, rather than one of the shapes [blockOf] reads as a block in its own right. */
+private fun isProse(line: String): Boolean =
+  !RULE.matches(line) && !HEADING.matches(line) && !QUOTE.matches(line) && !ITEM.matches(line)
+
 private fun blockOf(line: String): NoteBlock {
   // Before the list, so that `---` is a rule rather than a bullet with nothing after it.
   if (RULE.matches(line)) {

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/Place.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/Place.kt
@@ -52,7 +52,7 @@ sealed interface Place {
     val byteCount: Long
   ) : Place {
 
-    override val title: String get() = "$nodeCount smaller objects"
+    override val title: String get() = formatObjectCount(nodeCount)
 
     override val viewRootObjectId: Long get() = parentObjectId
   }

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/Place.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/Place.kt
@@ -102,6 +102,20 @@ sealed interface Place {
     override val viewRootObjectId: Long? get() = null
   }
 
+  /**
+   * One page of the reference: what a label on screen means, at more length than a label has room for.
+   *
+   * A place rather than a browser window, so that reading up on what the map is saying is a tab beside the
+   * map — closeable, linkable, and somewhere the back arrow returns from. Which also means the text is the
+   * text this build ships: see [Topic].
+   */
+  data class Reference(val topic: Topic) : Place {
+
+    override val title: String get() = ReferencePage.of(topic).title
+
+    override val viewRootObjectId: Long? get() = null
+  }
+
   /** Every agent that has worked on a heap dump of this app, one row each. See `AgentSessionFile`. */
   data object AgentLogs : Place {
 
@@ -160,6 +174,9 @@ sealed interface Place {
 
     /** And to what the agents that have worked on a heap dump of this app did. */
     const val AGENT_LOGS_LABEL = "Agent logs"
+
+    /** And to the reference, which the button opens at its first page. Every page leads to the others. */
+    const val REFERENCE_LABEL = "Reference"
   }
 }
 
@@ -185,6 +202,7 @@ fun HeapDominatorTreemap.titleOf(place: Place): String = when (place) {
   is Place.Objects -> place.title
   is Place.Leaks -> place.title
   is Place.Starred -> place.title
+  is Place.Reference -> place.title
   is Place.AgentLogs -> place.title
   is Place.AgentLog -> place.title
 }

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReachabilityStrength.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReachabilityStrength.kt
@@ -13,11 +13,27 @@ package shark.dive
  *
  * Every object of a heap dump has one of these, [UNREACHABLE] included, so the strengths partition the
  * dump: the bytes and the object counts of [HeapSizes] add up to the whole thing.
+ *
+ * The KDoc below is for whoever is reading this file. What a strength means to whoever is reading a heap
+ * dump is `docs/shark-dive-reference/reachability-strength.md`, the page behind every `?` beside a [label],
+ * and a change to what one of these *means* is a change to both.
  */
-enum class ReachabilityStrength {
+enum class ReachabilityStrength(
+  /**
+   * What it is called wherever a person reads it: the checkbox above the map, the details panel, the card
+   * at the pointer, the heading of a section of the leaks screen, and the log line saying how a dump splits
+   * up.
+   *
+   * **One name each, and one or two words of it.** A strength called `Soft` on a checkbox and
+   * `Softly reachable` in the panel beside it is two things to whoever is reading, and the sentence saying
+   * what one means is [Topic.REACHABILITY_STRENGTH] rather than the label — a name that explains itself is a
+   * name too long to put in a row of nine.
+   */
+  val label: String
+) {
 
   /** Reachable without going through a `java.lang.ref.Reference`. Never reclaimed. */
-  STRONG,
+  STRONG("Strong"),
 
   /**
    * Reachable only from a cache that gives its entries up on its own: an LRU that evicts as it fills,
@@ -34,7 +50,7 @@ enum class ReachabilityStrength {
    * tree couldn't say so. Ranked above [SOFT] because a cache decides for itself when to let go, where
    * a soft reference is at the mercy of the next collection that needs room.
    */
-  CACHE,
+  CACHE("Cache"),
 
   /**
    * Reachable only from a thread's own storage, which is given up when the thread dies.
@@ -45,7 +61,7 @@ enum class ReachabilityStrength {
    * [CACHE] because a cache lets go when memory runs short and a thread local doesn't, and stronger than
    * [SOFT] because nothing collects it while the thread lives.
    */
-  THREAD_LOCAL,
+  THREAD_LOCAL("Thread local"),
 
   /**
    * Reachable only from a running method: a local variable, a JNI local reference, a native stack frame,
@@ -56,29 +72,29 @@ enum class ReachabilityStrength {
    * anything in memory. So an object a field also holds is the field's, and this is what's left for the
    * objects nothing else points at, which are usually the ones being built.
    */
-  LOCAL,
+  LOCAL("Local"),
 
   /**
    * Reclaimed when the VM decides it wants the memory back, which is what makes a `SoftReference` a
    * cache rather than a leak.
    */
-  SOFT,
+  SOFT("Soft"),
 
   /** Reclaimed at the next collection, whether or not memory is short. */
-  WEAK,
+  WEAK("Weak"),
 
   /**
    * Reachable only from the queue of objects whose `finalize()` hasn't run yet, so it survives at
    * least one more collection, and longer if finalization is backed up. Finalizing it can even make
    * it reachable again.
    */
-  FINALIZER,
+  FINALIZER("Finalizer"),
 
   /**
    * Already finalized and unreachable to the program, held only so that a `PhantomReference` or a
    * `Cleaner` gets enqueued once it's gone.
    */
-  PHANTOM,
+  PHANTOM("Phantom"),
 
   /**
    * No path from any GC root reaches it: garbage that hadn't been collected when the heap dump was
@@ -88,5 +104,5 @@ enum class ReachabilityStrength {
    * never queues anything into it — nothing reaches an unreachable object by definition. What's
    * unreachable is what the walk didn't reach.
    */
-  UNREACHABLE
+  UNREACHABLE("Unreachable")
 }

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
@@ -1,0 +1,105 @@
+package shark.dive
+
+/**
+ * Something the UI names that takes more than a label to know: the pages of the reference, and the one
+ * sentence each of them opens with.
+ *
+ * **The sentence on screen is the page's own first sentence.** Both are read out of one markdown file, so
+ * the hint under a `?` cannot say something the page it leads to has stopped saying — which is what a hint
+ * written in Kotlin beside a page written in markdown becomes after one of the two is edited.
+ *
+ * The files are `docs/shark-dive-reference/`, copied onto the classpath by the `copyReference` task in this
+ * module's build script and published as `docs/shark-dive-reference.md`, which includes the same files. So a
+ * build carries the reference it was built with: an older release shows what was true of it, rather than
+ * following a link to a page written about a newer one.
+ *
+ * See [Place.Reference], which is where a `?` leads, and `Explain`, which draws it.
+ */
+enum class Topic(
+  /** Its file under `docs/shark-dive-reference/`, and how [DeepLink] spells it. */
+  val page: String
+) {
+  LEAK_NAME("leak-name"),
+  FAULTY_REFERENCE("faulty-reference"),
+  LEAK_FINGERPRINT("leak-fingerprint"),
+  STUCK_SHADING("stuck-shading"),
+  WEAKER_REFERENCES("weaker-references"),
+  OTHER_WAYS("other-ways");
+
+  companion object {
+    /** Which topic a link names, or null for a page this build has never heard of. */
+    fun ofPage(page: String): Topic? = values().firstOrNull { it.page == page }
+  }
+}
+
+/**
+ * One page of the reference, as the window draws it.
+ *
+ * Named for the page rather than for the reference: `Reference` in this package would sit one letter away
+ * from `shark.Reference`, a reference of the heap graph, which a dozen files here import.
+ */
+class ReferencePage internal constructor(
+  val topic: Topic,
+  /** Its heading, which is also what a tab showing it is called. */
+  val title: String,
+  /**
+   * Its opening sentence, which is what the `?` says on hover.
+   *
+   * One sentence, because a tooltip is read while deciding whether to look further and a paragraph there is
+   * a paragraph in the way of the thing it is about. `ReferenceTest` is what holds it to that.
+   */
+  val hint: String,
+  /** The page itself, opening with the sentence [hint] is. */
+  val blocks: List<NoteBlock>
+) {
+
+  /** The pages, read once off the classpath. */
+  companion object {
+
+    /** In [Topic] order, which is the order `docs/shark-dive-reference.md` includes them in. */
+    val all: List<ReferencePage> by lazy { Topic.values().map { pageOf(it) } }
+
+    fun of(topic: Topic): ReferencePage = all[topic.ordinal]
+
+    private fun pageOf(topic: Topic): ReferencePage {
+      val path = "/$RESOURCE_DIRECTORY/${topic.page}$MARKDOWN_SUFFIX"
+      val blocks = documentBlocksOf(markdownOf(topic, path))
+      val heading = blocks.firstOrNull()
+      check(heading is NoteBlock.Heading) {
+        "\"$path\" has to start with its title as a \"## \" heading, which is what names the page here " +
+          "and what docs/shark-dive-reference.md draws under its own title, and it starts with $heading."
+      }
+      val body = blocks.drop(1)
+      val opening = body.firstOrNull()
+      check(opening is NoteBlock.Paragraph) {
+        "The paragraph under the title of \"$path\" is what the `?` leading to it says, and there is " +
+          "$opening under it instead."
+      }
+      return ReferencePage(
+        topic = topic,
+        title = heading.spans.plainText(),
+        hint = opening.spans.plainText(),
+        blocks = body
+      )
+    }
+
+    private fun markdownOf(topic: Topic, path: String): String =
+      checkNotNull(
+        ReferencePage::class.java.getResourceAsStream(path)?.use {
+          it.readBytes().toString(Charsets.UTF_8)
+        }
+      ) {
+        "There is no \"$path\" on the classpath, so ${topic.name} has no page to lead to. These are copied " +
+          "out of docs/shark-dive-reference by the copyReference task in shark-dive-core, so a topic added " +
+          "to Topic without a file of that name beside the others is what this is."
+      }
+
+    /** What the markdown says with the styling taken off, which is all a tooltip and a tab title need. */
+    private fun List<NoteSpan>.plainText(): String = joinToString("") { it.text }
+
+    /** Where `copyReference` puts them, under the resource root. */
+    private const val RESOURCE_DIRECTORY = "shark-dive-reference"
+
+    private const val MARKDOWN_SUFFIX = ".md"
+  }
+}

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
@@ -23,6 +23,7 @@ enum class Topic(
   FAULTY_REFERENCE("faulty-reference"),
   LEAK_FINGERPRINT("leak-fingerprint"),
   LIBRARY_LEAKS("library-leaks"),
+  REACHABILITY_STRENGTH("reachability-strength"),
   STUCK_SHADING("stuck-shading"),
   WEAKER_REFERENCES("weaker-references"),
   OTHER_WAYS("other-ways");

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
@@ -22,6 +22,7 @@ enum class Topic(
   LEAK_NAME("leak-name"),
   FAULTY_REFERENCE("faulty-reference"),
   LEAK_FINGERPRINT("leak-fingerprint"),
+  LIBRARY_LEAKS("library-leaks"),
   STUCK_SHADING("stuck-shading"),
   WEAKER_REFERENCES("weaker-references"),
   OTHER_WAYS("other-ways");
@@ -63,7 +64,7 @@ class ReferencePage internal constructor(
 
     private fun pageOf(topic: Topic): ReferencePage {
       val path = "/$RESOURCE_DIRECTORY/${topic.page}$MARKDOWN_SUFFIX"
-      val blocks = documentBlocksOf(markdownOf(topic, path))
+      val blocks = Note.ofDocument(markdownOf(topic, path)).blocks
       val heading = blocks.firstOrNull()
       check(heading is NoteBlock.Heading) {
         "\"$path\" has to start with its title as a \"## \" heading, which is what names the page here " +

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/ReferencePage.kt
@@ -25,6 +25,7 @@ enum class Topic(
   LIBRARY_LEAKS("library-leaks"),
   REACHABILITY_STRENGTH("reachability-strength"),
   STUCK_SHADING("stuck-shading"),
+  CONFLICTING_VERDICTS("conflicting-verdicts"),
   WEAKER_REFERENCES("weaker-references"),
   OTHER_WAYS("other-ways");
 

--- a/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/StarredFile.kt
+++ b/shark/shark-dive/shark-dive-core/src/main/java/shark/dive/StarredFile.kt
@@ -1,0 +1,73 @@
+package shark.dive
+
+import java.io.File
+import shark.SharkLog
+
+/**
+ * Which objects of one heap dump are starred, kept between runs: one file of this app's own, named after the
+ * dump the way its notes and its leak statuses are. See [heapDumpFileKey].
+ *
+ * **Addresses and nothing else.** What a starred object *is* — its class, what it retains, how firmly it is
+ * held — is read out of the heap dump when the screen opens, the same way every other list of objects reads
+ * it. Keeping a copy here would be a second source for numbers the dump already has, and the two would agree
+ * only until the reader set a status by hand and changed which objects are leaks.
+ *
+ * In the order they were starred rather than sorted, because that order is the reader's: starring is how a
+ * handful of objects are held side by side while being compared, and the list they built is the list they
+ * expect to come back to.
+ *
+ * One address per line, with a comment at the top, because this file is a working set someone can keep, mail
+ * or check in — a line that can't be read is skipped with a line in the log rather than losing the rest.
+ */
+class StarredFile(
+  /** This app's own directory, which the caller decides. */
+  root: File,
+  /** The heap dump these stars are about, which names the file and nothing more. */
+  heapDumpFile: File
+) {
+
+  /** The file itself, so that a working set can be found without this app. */
+  val file: File = File(root, "${heapDumpFileKey(heapDumpFile)}$STARRED_SUFFIX")
+
+  /** What is on disk, or nothing at all for a heap dump nobody has starred anything in. */
+  fun read(): List<Long> {
+    if (!file.isFile) {
+      return emptyList()
+    }
+    val objectIds = file.readLines().mapIndexedNotNull { index, line ->
+      when {
+        line.isBlank() || line.startsWith(COMMENT) -> null
+        else -> objectIdOfHex(line.trim()) ?: null.also {
+          SharkLog.d { "Skipping line ${index + 1} of $file: \"$line\" is no object address" }
+        }
+      }
+    }
+    SharkLog.d { "Read ${objectIds.size} starred objects from $file" }
+    return objectIds.distinct()
+  }
+
+  /** Puts [objectIds] on disk, all of them, replacing whatever was there. See [writeWholeFile]. */
+  fun write(objectIds: List<Long>) {
+    val text = if (objectIds.isEmpty()) {
+      // Which deletes the file: a heap dump whose last star has been taken off is one nobody has starred
+      // anything in, and an empty file left behind would be a heap dump that reads as worked on.
+      ""
+    } else {
+      objectIds.joinToString(separator = "\n", prefix = "$HEADER\n", postfix = "\n") {
+        exactHexObjectId(it)
+      }
+    }
+    writeWholeFile(file, text)
+  }
+
+  companion object {
+    private const val STARRED_SUFFIX = ".starred.txt"
+
+    private const val COMMENT = "#"
+
+    /** What the lines are, for whoever opens this file without the app that wrote it. */
+    private const val HEADER =
+      "# Objects starred in Shark Dive, in the order they were starred.\n" +
+        "# One address per line."
+  }
+}

--- a/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/DeepLinkTest.kt
+++ b/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/DeepLinkTest.kt
@@ -147,6 +147,24 @@ class DeepLinkTest {
     assertThat(DeepLink.parse("shark://leak.hprof/agent-log?session=1a2b3c4d").place).isEqualTo(place)
   }
 
+  /** Where a `?` in the window goes, and therefore what a link to one somebody was reading has to open. */
+  @Test
+  fun `one page of the reference is named by the page`() {
+    val place = Place.Reference(Topic.LEAK_FINGERPRINT)
+
+    assertThat(DeepLink("leak.hprof", place).toUri())
+      .isEqualTo("shark://leak.hprof/reference?topic=leak-fingerprint")
+    assertThat(DeepLink.parse("shark://leak.hprof/reference?topic=leak-fingerprint").place)
+      .isEqualTo(place)
+  }
+
+  @Test
+  fun `a reference link naming no page of it says which pages there are`() {
+    assertThatThrownBy { DeepLink.parse("shark://leak.hprof/reference?topic=how-to-fix-it") }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("leak-fingerprint")
+  }
+
   @Test
   fun `an agent log link with no session says what is missing`() {
     assertThatThrownBy { DeepLink.parse("shark://leak.hprof/agent-log") }
@@ -169,6 +187,8 @@ class DeepLinkTest {
       Place.Leaks(),
       Place.Leaks(expandedGroups = setOf("APPLICATION 12ab")),
       Place.Starred,
+      Place.Reference(Topic.values().first()),
+      Place.Reference(Topic.values().last()),
       Place.AgentLogs,
       Place.AgentLog("1a2b3c4d")
     )
@@ -298,6 +318,8 @@ class DeepLinkTest {
       Place.Leaks(),
       Place.Leaks(expandedGroups = setOf("APPLICATION 12ab", "LIBRARY 34cd")),
       Place.Starred,
+      Place.Reference(Topic.values().first()),
+      Place.Reference(Topic.values().last()),
       Place.AgentLogs,
       Place.AgentLog("1a2b3c4d")
     )

--- a/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/HeapReachabilityTest.kt
+++ b/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/HeapReachabilityTest.kt
@@ -11,7 +11,6 @@ import shark.GcRoot.StickyClass
 import shark.HprofWriterHelper
 import shark.ValueHolder.ReferenceHolder
 import shark.dump
-import shark.dive.HeapDominatorTreemap.Companion.UNREACHABLE_LABEL
 import shark.dive.HeapDominatorTreemap.Companion.UNREACHABLE_NODE_ID
 import shark.dive.ReachabilityStrength.FINALIZER
 import shark.dive.ReachabilityStrength.PHANTOM
@@ -240,7 +239,7 @@ class HeapReachabilityTest {
 
       // One rectangle beside the objects a GC root holds, rather than a level of its own beside a level of
       // theirs: the root of the map is the whole heap dump wherever the reader is.
-      assertThat(topLevel.map { tree.label(it) }).contains("Holder", UNREACHABLE_LABEL)
+      assertThat(topLevel.map { tree.label(it) }).contains("Holder", ReachabilityStrength.UNREACHABLE.label)
       val unreachable = tree.groupOrNull(UNREACHABLE_NODE_ID)!!
       assertThat(unreachable.strength).isEqualTo(ReachabilityStrength.UNREACHABLE)
       assertThat(unreachable.objectCount).isEqualTo(2)

--- a/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/NoteTest.kt
+++ b/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/NoteTest.kt
@@ -277,8 +277,44 @@ class NoteTest {
     assertThat(resolved.resolvedWith(references)).isEqualTo(resolved)
   }
 
+  /**
+   * The other reading, for text that was wrapped to fit a column rather than typed into a box. Verbatim from
+   * `AndroidReferenceMatchers.ACCOUNT_MANAGER`, because the shape being read here is a real one: Shark's
+   * library leak patterns carry their description as a `"""` block, and the leaks screen draws it.
+   */
+  @Test fun `wrapped prose is one paragraph rather than a block per line`() {
+    val note = Note.ofDocument(WRAPPED_DESCRIPTION)
+
+    assertThat(textOf(note)).isEqualTo(
+      "AccountManager.AmsTask.Response is a stub, and as all stubs it's held in memory by a native ref " +
+        "until the calling side gets GCed, which can happen long after the stub is no longer of use. " +
+        "https://issuetracker.google.com/issues/318303120"
+    )
+  }
+
+  /** Which is what made rendering these as note markdown worth doing: half of them end in one. */
+  @Test fun `a URL in wrapped prose leads to it`() {
+    val links = Note.ofDocument(WRAPPED_DESCRIPTION).blocks.single().spans.mapNotNull { it.link }
+
+    assertThat(links).containsExactly(NoteLink.Web("https://issuetracker.google.com/issues/318303120"))
+  }
+
+  /** And read as a note it would be four blocks, three of them ending mid-sentence. */
+  @Test fun `the same prose read as a note is a block per line`() {
+    assertThat(Note.of(WRAPPED_DESCRIPTION).blocks).hasSize(4)
+  }
+
   private fun spansOf(text: String): List<NoteSpan> = Note.of(text).blocks.single().spans
 
   private fun textOf(note: Note): String =
     note.blocks.joinToString("\n") { block -> block.spans.joinToString("") { it.text } }
+
+  private companion object {
+    val WRAPPED_DESCRIPTION = """
+      AccountManager.AmsTask.Response is a stub, and as all stubs it's held in memory by a
+      native ref until the calling side gets GCed, which can happen long after the stub is no
+      longer of use.
+      https://issuetracker.google.com/issues/318303120
+    """.trimIndent()
+  }
 }

--- a/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/ReferenceTest.kt
+++ b/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/ReferenceTest.kt
@@ -1,0 +1,71 @@
+package shark.dive
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+/**
+ * What holds the reference to being a reference: a page per topic, each opening with the one sentence its `?`
+ * shows, and every page of it published.
+ *
+ * These are copy rules rather than behaviour, and they are here because copy is what goes wrong quietly. A
+ * hint that has grown into a paragraph still draws; a page nobody included still opens in the app. Both are
+ * only ever noticed by whoever reads the screen next, which is why they fail the build instead.
+ */
+class ReferenceTest {
+
+  @Test
+  fun `every topic has a page`() {
+    // Reading them at all is the assertion: a topic with no file throws saying which, from ReferencePage.
+    assertThat(ReferencePage.all.map { it.topic }).isEqualTo(Topic.values().toList())
+    ReferencePage.all.forEach { page ->
+      assertThat(page.title).describedAs(page.topic.name).isNotBlank()
+      assertThat(page.blocks).describedAs(page.topic.name).isNotEmpty()
+    }
+  }
+
+  /**
+   * Because it is a tooltip: it is read while deciding whether to look further, over the top of the thing it
+   * is about. The page under it is where the rest goes, and it has no length limit at all.
+   */
+  @Test
+  fun `every hint is one short sentence`() {
+    ReferencePage.all.forEach { page ->
+      val words = page.hint.trim().split(WHITESPACE)
+      assertThat(words.size)
+        .describedAs("${page.topic.name} hint, \"${page.hint}\"")
+        .isLessThanOrEqualTo(MOST_HINT_WORDS)
+      assertThat(page.hint.trim())
+        .describedAs("${page.topic.name} hint")
+        .endsWith(".")
+      assertThat(page.hint.trim().dropLast(1))
+        .describedAs("${page.topic.name} hint, which is one sentence")
+        .doesNotContain(".")
+    }
+  }
+
+  /**
+   * The half of "one copy of every sentence" that only the repository can answer: the app reads these files
+   * off its classpath, and this is what says the website reads the same ones.
+   *
+   * A page the site doesn't include is a page that is in the app and nowhere else, which is the drift shipping
+   * the reference inside the build was meant to rule out. See `copyReference`, and `mkdocs.yml`.
+   */
+  @Test
+  fun `the website publishes every page`() {
+    val published = File(System.getProperty(REFERENCE_PAGE_PROPERTY)).readText()
+
+    Topic.values().forEach { topic ->
+      assertThat(published)
+        .describedAs("docs/shark-dive-reference.md includes ${topic.page}")
+        .contains("\"docs/shark-dive-reference/${topic.page}.md\"")
+    }
+  }
+
+  /** As many as fit a tooltip a reader glances at, which is one line of prose and not three. */
+  private companion object {
+    const val MOST_HINT_WORDS = 25
+    const val REFERENCE_PAGE_PROPERTY = "shark.dive.referencePage"
+    val WHITESPACE = Regex("""\s+""")
+  }
+}

--- a/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/StarredFileTest.kt
+++ b/shark/shark-dive/shark-dive-core/src/test/java/shark/dive/StarredFileTest.kt
@@ -1,0 +1,117 @@
+package shark.dive
+
+import java.io.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class StarredFileTest {
+
+  @get:Rule
+  var testFolder = TemporaryFolder()
+
+  @Test fun `a heap dump nobody has starred anything in has nothing starred`() {
+    assertThat(starredFile("heap.hprof").read()).isEmpty()
+  }
+
+  @Test fun `what was starred is read back`() {
+    val file = starredFile("heap.hprof")
+
+    file.write(listOf(HOLDER_ID, PAYLOAD_ID))
+
+    assertThat(file.read()).containsExactly(HOLDER_ID, PAYLOAD_ID)
+  }
+
+  @Test fun `the same heap dump is the same objects in another run`() {
+    starredFile("heap.hprof").write(listOf(HOLDER_ID))
+
+    assertThat(starredFile("heap.hprof").read()).containsExactly(HOLDER_ID)
+  }
+
+  /** Two runs of one app produce two dumps of one name, and they are two investigations. */
+  @Test fun `two heap dumps of one name in two directories are two working sets`() {
+    starredFile("dumps/monday/heap.hprof").write(listOf(HOLDER_ID))
+
+    assertThat(starredFile("dumps/tuesday/heap.hprof").read()).isEmpty()
+  }
+
+  /**
+   * Starring is how a handful of objects are held side by side while being compared, so the list somebody
+   * built is the list they expect to come back to — not the same list sorted by something.
+   */
+  @Test fun `they come back in the order they were starred`() {
+    val file = starredFile("heap.hprof")
+
+    file.write(listOf(PAYLOAD_ID, HIGH_ID, HOLDER_ID))
+
+    assertThat(file.read()).containsExactly(PAYLOAD_ID, HIGH_ID, HOLDER_ID)
+  }
+
+  /**
+   * An object address is unsigned, and half the addresses of a 64 bit heap dump don't fit in a signed long
+   * the right way round. One written as a negative number and read back as another object would be a star
+   * quietly moved onto something else.
+   */
+  @Test fun `an object above the middle of the address space is the object it was starred on`() {
+    val file = starredFile("heap.hprof")
+
+    file.write(listOf(HIGH_ID))
+
+    assertThat(file.read()).containsExactly(HIGH_ID)
+  }
+
+  @Test fun `the last star taken off is the file deleted`() {
+    val file = starredFile("heap.hprof")
+    file.write(listOf(HOLDER_ID))
+
+    file.write(emptyList())
+
+    assertThat(file.file.exists()).isFalse()
+    assertThat(file.read()).isEmpty()
+  }
+
+  /** This file is hand editable on purpose, so one typo in it must not be a working set that went. */
+  @Test fun `a line that cannot be read is skipped and the rest are kept`() {
+    val file = starredFile("heap.hprof")
+    file.write(listOf(HOLDER_ID, PAYLOAD_ID))
+    file.file.writeText(
+      file.file.readText() +
+        "not an address\n" +
+        "0xnope\n" +
+        "\n" +
+        "# A comment somebody left\n"
+    )
+
+    assertThat(file.read()).containsExactly(HOLDER_ID, PAYLOAD_ID)
+  }
+
+  /** Because two rows for one object is two rows that scroll, select and open as one. */
+  @Test fun `an address listed twice is one starred object`() {
+    val file = starredFile("heap.hprof")
+    file.write(listOf(HOLDER_ID))
+    file.file.appendText("${exactHexObjectId(HOLDER_ID)}\n")
+
+    assertThat(file.read()).containsExactly(HOLDER_ID)
+  }
+
+  /** So that a working set can be read, mailed and pasted from without going through this app. */
+  @Test fun `the starred objects are one file named after the heap dump`() {
+    assertThat(starredFile("large-dump.hprof").file.name)
+      .startsWith("large-dump.hprof")
+      .endsWith(".starred.txt")
+  }
+
+  private fun starredFile(heapDumpPath: String) =
+    StarredFile(starredRoot, File(testFolder.root, heapDumpPath))
+
+  private val starredRoot by lazy { testFolder.newFolder("starred") }
+
+  companion object {
+    private const val HOLDER_ID = 0x82182c00L
+    private const val PAYLOAD_ID = 0x1234L
+
+    /** Which is what a `long` holds an address of `0xffff…` as. */
+    private const val HIGH_ID = -0x1234L
+  }
+}


### PR DESCRIPTION
The window had verbose plain-language explanations in it — unusual for an expert tool, and a lot of content to go through before you get to the heap dump. A fair diagnosis of where they came from: the chatty UI is the model leaking into the product; half those labels are for the agent that wrote them, not the human reading them.

Seven commits, each one a single move.

**1. Delete the paragraphs saying what the picture already said.** A rectangle drawn inside another already says it is dominated by it.

**2. Put a `?` beside the labels that take a paragraph to explain.** Hovering it gives one sentence; clicking it opens the reference as a tab of the window. The pages ship with the app rather than linking out, so a release explains itself with the text it was built with, and the same markdown files are the website's via `pymdownx.snippets`. Each page's opening sentence *is* the tooltip, so the short answer can't drift from the long one. Nothing fades and nothing decays: no first-run tour, no hint that stops appearing.

**3. Say what to do about a library leak.** The screen used to say there was "usually nothing to do about them but wait for a fix upstream", which is wrong twice — a leak in a library is an issue to file and often a small fix to send, and a leak in the framework has a workaround to look for. The `?` there leads to the page saying which to do, including `AndroidLeakFixes`. And the description Shark carries for the leak is now drawn in full with its links live: 51 of the 85 end in the AOSP change that introduced the leak, which is where the way round it usually is, and three ellipsized lines of plain text was throwing exactly that away.

**4. Give each reachability strength one name.** The panel spelled out a sentence per strength where the legend said `Strong` and the leaks screen said `Softly reachable` for the same nine things. One `label` each, and one reference page for what they mean.

**5. Say how many, once, for a rectangle that isn't one object.** Three nouns — `300 smaller objects`, `400 objects of one class`, `Unreachable` — where the line under each already said which was which.

**6. Make starred a list of objects, kept on disk, and name a size once.** Starred was a screen of its own, holding a copy of each object's sizes taken when it was starred — which went stale the moment a verdict changed what something retains. It is now the same row the object list draws, read out of the heap dump, with the addresses kept in `~/.shark-dive/starred`: one file per dump, one address per line, in the order they were starred, hand editable like the leak statuses beside it. That left one vocabulary to settle — the same two numbers were `Retained`/`Shallow` in the panel, `Retains 1.2 MB in 57 objects`/`88 B of its own` on the card, and `Retaining …` on a chain. Now `Retained` and `Shallow` everywhere. `Dominates` means one thing, on the chain.

**7. Write down what the window is allowed to say.** Nothing in the repo said why any of the above, so the next change was free to put it all back — and likely to, since every guide and KDoc here is written at length on purpose, which reads as a house style that applies to labels too. Two sections in `shark/shark-dive/AGENTS.md`, plus the line in the root guide separating repo prose from screen prose.

`./gradlew :shark:shark-dive:*:check` green across all five modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)