### PR TITLE
Log the full agent traffic, and which way in each message came

### DIFF
--- a/.claude/skills/shark-dive/SKILL.md
+++ b/.claude/skills/shark-dive/SKILL.md
@@ -54,6 +54,9 @@ was built debuggable or the whole device build is; `list_devices` says which.
 ```
 
 An investigation somebody already ran is either the answer or the half of the dump not worth doing again.
+Adding `session=<id>` reads one of them call by call, each with the exact text it sent and read back — which
+is how you tell a step that read an answer from one that misread it, and a long answer for that reason, so
+reach for it when a run went wrong rather than as a matter of course.
 
 ## The command line
 

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -85,9 +85,13 @@ uses, without the one for a newly recognized library leak:
   what an agent *said* it was doing, and a step taken on an answer that said nothing reads exactly like one
   taken on an answer that said everything until you open both. The `▸ {}` under a row is what opens it, and
   what was sent names the tool the agent called as well as what it sent to it — `describe_object` beside the
-  window's own word for it, which is the pair worth having when a step doesn't follow. `agent_log` hands an
-  agent the same text, so one agent can work out where another went wrong. Kept in `~/.shark-dive/agents/sessions`,
-  one file per session and the newest hundred kept, so a session outlives the window it was worked in.
+  window's own word for it, which is the pair worth having when a step doesn't follow. **The full traffic, not
+  only the calls that worked**: the handshake, a call naming a tool that doesn't exist and a line that wasn't
+  JSON are rows too, a refusal and an error are under `answered:` as the agent was handed them, and each row
+  says whether it came in over MCP or from `--agent` at a shell — because what this screen gets opened for is
+  often why *nothing* happened. `agent_log` hands an agent the same text, so one agent can work out where
+  another went wrong. Kept in `~/.shark-dive/agents/sessions`, one file per session and the newest hundred
+  kept, so a session outlives the window it was worked in.
   See [Hand it to an agent](shark-dive.md#hand-it-to-an-agent).
 * ✨ **The chain marks the faulty reference**: the one step going from an `Expected` object straight to a
   `Stuck` one reads `Holder.activity · faulty reference`, which is the leak itself rather than one of the

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -80,7 +80,11 @@ uses, without the one for a newly recognized library leak:
   one is everything that agent did — what each call did, which object it did it to, and the sentence it gave
   for making it, with the refusals in red. A row leads where the call went, so reading what an agent did and
   going to look at it are one move — including a row about a heap dump this window hasn't got, which opens
-  that dump, and whose link is there to copy like every other. Kept in `~/.shark-dive/agents/sessions`,
+  that dump, and whose link is there to copy like every other. **And every row unfolds onto the call itself**,
+  what was sent and what came back, as the text each of them was and never a first line of it: a reason is
+  what an agent *said* it was doing, and a step taken on an answer that said nothing reads exactly like one
+  taken on an answer that said everything until you open both. `agent_log` hands an agent the same text, so
+  one agent can work out where another went wrong. Kept in `~/.shark-dive/agents/sessions`,
   one file per session and the newest hundred kept, so a session outlives the window it was worked in.
   See [Hand it to an agent](shark-dive.md#hand-it-to-an-agent).
 * ✨ **The chain marks the faulty reference**: the one step going from an `Expected` object straight to a

--- a/docs/shark-dive-changelog.md
+++ b/docs/shark-dive-changelog.md
@@ -83,8 +83,10 @@ uses, without the one for a newly recognized library leak:
   that dump, and whose link is there to copy like every other. **And every row unfolds onto the call itself**,
   what was sent and what came back, as the text each of them was and never a first line of it: a reason is
   what an agent *said* it was doing, and a step taken on an answer that said nothing reads exactly like one
-  taken on an answer that said everything until you open both. `agent_log` hands an agent the same text, so
-  one agent can work out where another went wrong. Kept in `~/.shark-dive/agents/sessions`,
+  taken on an answer that said everything until you open both. The `▸ {}` under a row is what opens it, and
+  what was sent names the tool the agent called as well as what it sent to it — `describe_object` beside the
+  window's own word for it, which is the pair worth having when a step doesn't follow. `agent_log` hands an
+  agent the same text, so one agent can work out where another went wrong. Kept in `~/.shark-dive/agents/sessions`,
   one file per session and the newest hundred kept, so a session outlives the window it was worked in.
   See [Hand it to an agent](shark-dive.md#hand-it-to-an-agent).
 * ✨ **The chain marks the faulty reference**: the one step going from an `Expected` object straight to a

--- a/docs/shark-dive.md
+++ b/docs/shark-dive.md
@@ -371,7 +371,7 @@ press, because a surface with less than that is one whose answer is "ask your hu
 | --- | --- |
 | `open_heap_dumps` | Every heap dump open, by the file name the other tools take, with the method to follow. |
 | `list_leaks` | The **Leaks** screen: what this heap dump says shouldn't be there. |
-| `agent_log` | The **Agent logs** screen: what has already been tried on this dump, and what it came to. |
+| `agent_log` | The **Agent logs** screen: what has already been tried on this dump, and what it came to — and, for one session, every call it made with the text it sent and read back. |
 | `chain_from_gc_root` | One chain, every step with its labels and its verdict. |
 | `describe_object` | What an object is: its class, fields, labels, size. |
 | `ways_held` | Every way an object is held, rather than the one chain — the *X ways from here* list. |
@@ -425,14 +425,14 @@ the sentence it gave for doing it:
 ```
 08:23:04 ▸ Asked which heap dumps are open
           because: Seeing what there is to read before asking anything about it.
-08:23:11  Listed the leaks
+08:23:11 ▸ Listed the leaks
           because: Starting from what the heap dump already says shouldn't be here.
-08:23:18  Read the chain to 0x12d368b8
+08:23:18 ▸ Read the chain to 0x12d368b8
           because: This is the one App leak: a MainActivity the app watched and whose mDestroyed is
           true. Reading the chain from a GC root.
-08:23:27  Looked at 0x12d00c30
+08:23:27 ▸ Looked at 0x12d00c30
           because: The FutureTask in the middle of the chain: checking whether it is really running.
-08:23:34  Looked for every way of holding 0x12d368b8
+08:23:34 ▸ Looked for every way of holding 0x12d368b8
           because: Checking whether anything else holds the activity, or only this one chain.
 ```
 
@@ -454,10 +454,48 @@ rather than on to an answer:
           reference: the rules can only name one once something below it is known not to belong. […]
 ```
 
+**And every row unfolds onto the call itself** — the ▸ opens what the agent sent and what it read back, as
+the text each of them was, so a step you don't follow is one question rather than a dead end:
+
+```
+11:37:31 ▾ Looked at 0x12d368b8
+          because: The one App leak: a MainActivity the app watched. Reading what it is before the chain.
+          sent:
+            {
+                "object": "0x12d368b8",
+                "reason": "The one App leak: a MainActivity the app watched. Reading what it is
+                           before the chain."
+            }
+          answered:
+            {
+                "object": "0x12d368b8",
+                "label": "MainActivity",
+                "className": "com.example.leakcanary.MainActivity",
+                "kind": "INSTANCE",
+                "strength": "STRONG",
+                "shallowBytes": 214,
+                "retainedBytes": 210978,
+                "verdict": "STUCK",
+                "verdictReason": "ObjectWatcher was watching this and Activity#mDestroyed is true",
+                […]
+            }
+```
+
+Whole, never a first line of it: what you open a call for is the part the sentence left out, so an answer cut
+to fit would be one where the field that misled the agent is the part that got cut. A refused call shows what
+it sent and no answer, its answer having been the refusal already on the row. And a session recorded by an
+older Shark Dive says so rather than opening onto a gap.
+
+**Reading it is what makes the reasons worth anything**, since a reason is what an agent *said* it was doing:
+a step that reads as sound and was taken on an answer that said nothing looks exactly like a step taken on
+one that said everything, until you open both. Select and copy either half — into an issue, into a message to
+whoever handed you the dump, into a diff of two runs.
+
 A session is kept in `~/.shark-dive/agents/sessions`, one file per agent that connected and the newest
-hundred kept, a line of JSON per call — so it outlives the window and can be read by something other than
-this app. **And the reads each call cost are in the run's log**, in `~/.shark-dive/logs`, where the reason
-it gave is followed by the work it caused:
+hundred kept, a line of JSON per call, each carrying that call's `input` and `output` — so it outlives the
+window and can be read by something other than this app. `agent_log` hands an agent the same text, which is
+how one agent works out where another went wrong. **And the reads each call cost are in the run's log**, in
+`~/.shark-dive/logs`, where the reason it gave is followed by the work it caused:
 
 ```
 18:19:48.035 [shark-dive-agents] An agent called chain_from_gc_root(object=0x12d368b8, window=zvphq4r3)

--- a/docs/shark-dive.md
+++ b/docs/shark-dive.md
@@ -423,16 +423,16 @@ and there is every call that agent made, in order and in words — what it did, 
 the sentence it gave for doing it:
 
 ```
-08:23:04 ▸ Asked which heap dumps are open
+08:23:04  Asked which heap dumps are open
           because: Seeing what there is to read before asking anything about it.
-08:23:11 ▸ Listed the leaks
+08:23:11  Listed the leaks
           because: Starting from what the heap dump already says shouldn't be here.
-08:23:18 ▸ Read the chain to 0x12d368b8
+08:23:18  Read the chain to 0x12d368b8
           because: This is the one App leak: a MainActivity the app watched and whose mDestroyed is
           true. Reading the chain from a GC root.
-08:23:27 ▸ Looked at 0x12d00c30
+08:23:27  Looked at 0x12d00c30
           because: The FutureTask in the middle of the chain: checking whether it is really running.
-08:23:34 ▸ Looked for every way of holding 0x12d368b8
+08:23:34  Looked for every way of holding 0x12d368b8
           because: Checking whether anything else holds the activity, or only this one chain.
 ```
 
@@ -440,8 +440,8 @@ the sentence it gave for doing it:
 *0x12d368b8* on *Read the chain to 0x12d368b8* and the window opens that object, so reading what an agent did
 and going to look at it are one move. A call that named nothing went somewhere all the same — *leaks* on
 *Listed the leaks* is the leaks screen, and *dominator tree* on *Read the dominator tree* is the tree from its
-root. The one row that leads to several places unfolds instead: *Asked which heap dumps are open* opens into
-the dumps that were open, each of them a window away.
+root. The one row that leads to several places keeps them behind its fold instead: *Asked which heap dumps are
+open* opens into the dumps that were open, each of them a window away.
 
 **A refused call is a row too**, in red, under the reason the agent gave for making it — and those are the
 half of a session worth reading, since a refusal is where the method sent an agent back to the heap dump
@@ -454,37 +454,45 @@ rather than on to an answer:
           reference: the rules can only name one once something below it is known not to belong. […]
 ```
 
-**And every row unfolds onto the call itself** — the ▸ opens what the agent sent and what it read back, as
-the text each of them was, so a step you don't follow is one question rather than a dead end:
+**And every row unfolds onto the call itself** — the `▸ {}` under a row opens what the agent sent and what it
+read back, as the text each of them was, so a step you don't follow is one question rather than a dead end:
 
 ```
-11:37:31 ▾ Looked at 0x12d368b8
+11:37:31  Looked at 0x12d368b8
           because: The one App leak: a MainActivity the app watched. Reading what it is before the chain.
-          sent:
-            {
-                "object": "0x12d368b8",
-                "reason": "The one App leak: a MainActivity the app watched. Reading what it is
-                           before the chain."
-            }
-          answered:
-            {
-                "object": "0x12d368b8",
-                "label": "MainActivity",
-                "className": "com.example.leakcanary.MainActivity",
-                "kind": "INSTANCE",
-                "strength": "STRONG",
-                "shallowBytes": 214,
-                "retainedBytes": 210978,
-                "verdict": "STUCK",
-                "verdictReason": "ObjectWatcher was watching this and Activity#mDestroyed is true",
-                […]
-            }
+          ▾ {}
+            sent:
+              describe_object {
+                  "object": "0x12d368b8",
+                  "reason": "The one App leak: a MainActivity the app watched. Reading what it is
+                             before the chain."
+              }
+            answered:
+              {
+                  "object": "0x12d368b8",
+                  "label": "MainActivity",
+                  "className": "com.example.leakcanary.MainActivity",
+                  "kind": "INSTANCE",
+                  "strength": "STRONG",
+                  "shallowBytes": 214,
+                  "retainedBytes": 210978,
+                  "verdict": "STUCK",
+                  "verdictReason": "ObjectWatcher was watching this and Activity#mDestroyed is true",
+                  […]
+              }
 ```
+
+What it sent is the tool's own name and then the arguments under it, which is the call as the model wrote it:
+*Looked at* is this window's word for `describe_object`, and the pair is worth having side by side exactly
+when a step doesn't follow from the one before it.
 
 Whole, never a first line of it: what you open a call for is the part the sentence left out, so an answer cut
 to fit would be one where the field that misled the agent is the part that got cut. A refused call shows what
 it sent and no answer, its answer having been the refusal already on the row. And a session recorded by an
 older Shark Dive says so rather than opening onto a gap.
+
+The mark is under the row rather than on the verb because a row is a sentence with one link in it, and a fold
+over its first words made hovering light up the half that isn't the link.
 
 **Reading it is what makes the reasons worth anything**, since a reason is what an agent *said* it was doing:
 a step that reads as sound and was taken on an answer that said nothing looks exactly like a step taken on

--- a/docs/shark-dive.md
+++ b/docs/shark-dive.md
@@ -419,10 +419,13 @@ unexplained steps cannot report a root cause, however sure it is, and what it ge
 objects to go and read.
 
 **What it did is on the *Agent logs* screen**, one row per agent that has connected to the app. Open a row
-and there is every call that agent made, in order and in words — what it did, which object it did it to, and
-the sentence it gave for doing it:
+and there is everything that agent sent, in order and in words — what each call did, which object it did it
+to, and the sentence it gave for doing it:
 
 ```
+08:23:01  Connected
+08:23:01  Sent the notification notifications/initialized
+08:23:02  Asked what the tools are
 08:23:04  Asked which heap dumps are open
           because: Seeing what there is to read before asking anything about it.
 08:23:11  Listed the leaks
@@ -454,6 +457,24 @@ rather than on to an answer:
           reference: the rules can only name one once something below it is known not to belong. […]
 ```
 
+**And so is every other line that arrived** — the three at the top of that session are the handshake. A call
+naming a tool that doesn't exist, a line that wasn't JSON at all, a read that failed: each is a row, and the
+ones nothing could answer say *Failed* rather than *Refused*, which is the opposite claim. A refusal is the
+method working; this is Shark Dive not working.
+
+```
+08:24:02  Called solve_the_leak 0x12d368b8
+          because: Trying my luck.
+          Failed: There is no tool called "solve_the_leak". This server has open_heap_dumps, […]
+08:24:09  Sent something this app could not read
+          Failed: That is not JSON: Unexpected JSON token at offset 0
+```
+
+Which is the point of keeping them: what this screen gets opened for is often why *nothing* happened, and a
+screen holding only the calls that worked is the one screen that can't answer that. It shows in the shape of a
+session — one sent from a shell is a *Connected* per call, `--agent` being a process per call — and the
+`n call(s)` above the rows counts the calls rather than the lines.
+
 **And every row unfolds onto the call itself** — the `▸ {}` under a row opens what the agent sent and what it
 read back, as the text each of them was, so a step you don't follow is one question rather than a dead end:
 
@@ -461,7 +482,7 @@ read back, as the text each of them was, so a step you don't follow is one quest
 11:37:31  Looked at 0x12d368b8
           because: The one App leak: a MainActivity the app watched. Reading what it is before the chain.
           ▾ {}
-            sent:
+            sent over MCP:
               describe_object {
                   "object": "0x12d368b8",
                   "reason": "The one App leak: a MainActivity the app watched. Reading what it is
@@ -484,12 +505,19 @@ read back, as the text each of them was, so a step you don't follow is one quest
 
 What it sent is the tool's own name and then the arguments under it, which is the call as the model wrote it:
 *Looked at* is this window's word for `describe_object`, and the pair is worth having side by side exactly
-when a step doesn't follow from the one before it.
+when a step doesn't follow from the one before it. And *over MCP* is which way in it came — a client holding a
+connection open, or `--agent` typed at this window — which is the one thing about a call that nothing else on
+the screen can tell you, since by the time anything answers one the two are the same protocol on the same
+socket.
 
 Whole, never a first line of it: what you open a call for is the part the sentence left out, so an answer cut
-to fit would be one where the field that misled the agent is the part that got cut. A refused call shows what
-it sent and no answer, its answer having been the refusal already on the row. And a session recorded by an
-older Shark Dive says so rather than opening onto a gap.
+to fit would be one where the field that misled the agent is the part that got cut. And a session recorded by
+an older Shark Dive says so rather than opening onto a gap.
+
+**Including the calls that came to nothing**, which is what this is most worth opening for. A refusal is
+under `answered:` as the agent was handed it, as well as in red on the row; so is an error, if a read failed
+or this app has a bug; so is the answer to a call naming a tool that doesn't exist. The only row with nothing
+under `answered:` is a notification, which is the one kind of message the protocol forbids answering.
 
 The mark is under the row rather than on the verb because a row is a sentence with one link in it, and a fold
 over its first words made hovering light up the half that isn't the link.
@@ -500,9 +528,9 @@ one that said everything, until you open both. Select and copy either half — i
 whoever handed you the dump, into a diff of two runs.
 
 A session is kept in `~/.shark-dive/agents/sessions`, one file per agent that connected and the newest
-hundred kept, a line of JSON per call, each carrying that call's `input` and `output` — so it outlives the
-window and can be read by something other than this app. `agent_log` hands an agent the same text, which is
-how one agent works out where another went wrong. **And the reads each call cost are in the run's log**, in
+hundred kept, a line of JSON per message, each carrying that message's `input` and `output` — so it outlives
+the window and can be read by something other than this app. `agent_log` hands an agent the same text, which
+is how one agent works out where another went wrong. **And the reads each call cost are in the run's log**, in
 `~/.shark-dive/logs`, where the reason it gave is followed by the work it caused:
 
 ```

--- a/shark/shark-dive/notes/agent-surface.md
+++ b/shark/shark-dive/notes/agent-surface.md
@@ -36,7 +36,8 @@ next" — and the numbers are worth knowing before reaching for it. Measured on 
 | | Measured |
 | --- | --- |
 | The five answers as recorded | 7,783 + 7,783 + 11,935 + 5,364 characters, and none for the refusal |
-| The whole `agent_log session=…` answer | 39,400 characters, ≈9,850 tokens |
+| The five calls as sent | 95 + 81 + 150 + 121 + 163 characters — a rounding error beside the answers |
+| The whole `agent_log session=…` answer | 39,615 characters, ≈9,900 tokens |
 
 So **a session is roughly two thousand tokens a call**, and a thirty-call investigation read in full is most
 of a small context window. That is the tool being used for what it is for rather than a leak — it is the one

--- a/shark/shark-dive/notes/agent-surface.md
+++ b/shark/shark-dive/notes/agent-surface.md
@@ -25,6 +25,29 @@ mitigations that shipped in 2026 (Anthropic's tool search, code execution over M
 **This surface is not where a context window goes to die**, and a per-tool cost of ~300 tokens is what buys
 descriptions that say when to reach for a tool. Re-measure it if the count doubles again.
 
+## And what reading somebody else's session costs
+
+`agent_log` without a session id is a line per session and cheap. With one, it is now every call of that
+session *with what each one sent and read back*, which is the only form that answers "why did it do that
+next" — and the numbers are worth knowing before reaching for it. Measured on a five-call session against
+`leak_asynctask_o.hprof`, one `list_leaks` twice, a `describe_object`, a `chain_from_gc_root` and a refused
+`conclude`:
+
+| | Measured |
+| --- | --- |
+| The five answers as recorded | 7,783 + 7,783 + 11,935 + 5,364 characters, and none for the refusal |
+| The whole `agent_log session=…` answer | 39,400 characters, ≈9,850 tokens |
+
+So **a session is roughly two thousand tokens a call**, and a thirty-call investigation read in full is most
+of a small context window. That is the tool being used for what it is for rather than a leak — it is the one
+call on this surface whose subject is somebody else's whole investigation — but it means the list form is
+what "worth reading before starting" points at, and the session form is what somebody reaches for when an
+investigation went wrong and the reasons on their own didn't say where.
+
+Nothing truncates it, deliberately: a session cut to fit is one where the answer that misled an agent is the
+part that got cut. If this needs to be cheaper the answer is a way to ask for *one call's* exchange, not a
+shorter version of every call's.
+
 ## What the command line costs, now that there is one
 
 `--agent <tool> name=value …` is a process per call, and the thing to know is what that *doesn't* cost.

--- a/shark/shark-dive/notes/agent-surface.md
+++ b/shark/shark-dive/notes/agent-surface.md
@@ -27,27 +27,33 @@ descriptions that say when to reach for a tool. Re-measure it if the count doubl
 
 ## And what reading somebody else's session costs
 
-`agent_log` without a session id is a line per session and cheap. With one, it is now every call of that
-session *with what each one sent and read back*, which is the only form that answers "why did it do that
-next" — and the numbers are worth knowing before reaching for it. Measured on a five-call session against
-`leak_asynctask_o.hprof`, one `list_leaks` twice, a `describe_object`, a `chain_from_gc_root` and a refused
-`conclude`:
+`agent_log` without a session id is a line per session and cheap. With one, it is now every *message* of that
+session with what each one sent and read back, which is the only form that answers "why did it do that
+next" — and the numbers are worth knowing before reaching for it. Measured against a packaged run on
+`leak_asynctask_o.hprof`: four calls typed at `--agent` (two `list_leaks`, a refused `conclude`, a
+`solve_the_leak` that is no tool) and four messages pushed at the socket by hand (a line that is not JSON, a
+`resources/list`, a `tools/call` with no name, a notification):
 
 | | Measured |
 | --- | --- |
-| The five answers as recorded | 7,783 + 7,783 + 11,935 + 5,364 characters, and none for the refusal |
-| The five calls as sent | 95 + 81 + 150 + 121 + 163 characters — a rounding error beside the answers |
-| The whole `agent_log session=…` answer | 39,615 characters, ≈9,900 tokens |
+| The four tool-call rows | 8,783 + 8,775 + 1,750 + 987 characters — the answer is nearly all of each |
+| The four protocol rows | 37,313 characters, of which **32,976 is four `initialize` answers** |
+| The whole `agent_log session=…` answer | 57,693 characters, ≈14,400 tokens |
 
-So **a session is roughly two thousand tokens a call**, and a thirty-call investigation read in full is most
-of a small context window. That is the tool being used for what it is for rather than a leak — it is the one
-call on this surface whose subject is somebody else's whole investigation — but it means the list form is
-what "worth reading before starting" points at, and the session form is what somebody reaches for when an
-investigation went wrong and the reasons on their own didn't say where.
+So **a tool call is one to two thousand tokens** and a thirty-call investigation read in full is most of a
+small context window. That is the tool being used for what it is for rather than a leak — it is the one call
+on this surface whose subject is somebody else's whole investigation.
+
+**The handshakes are the surprise, and they are a command line's.** `initialize` answers with
+`AgentMethod.INSTRUCTIONS`, and `--agent` is a process per call, so a session of typed calls carries the
+method once per call: 57% of the answer above, handed to a reader that already has the same text in its own
+context. An MCP session pays it once. Nothing about that is a reason to record less — a session that keeps
+only what reached a tool cannot say why nothing did, which is the whole point of keeping the traffic — but if
+`agent_log` needs to be cheaper, **the handshake answers are where to look first**, and the shape to reach
+for is a way to ask for one message's exchange rather than a shorter version of every message's.
 
 Nothing truncates it, deliberately: a session cut to fit is one where the answer that misled an agent is the
-part that got cut. If this needs to be cheaper the answer is a way to ask for *one call's* exchange, not a
-shorter version of every call's.
+part that got cut.
 
 ## What the command line costs, now that there is one
 

--- a/shark/shark-dive/shark-dive-agent/AGENTS.md
+++ b/shark/shark-dive/shark-dive-agent/AGENTS.md
@@ -91,8 +91,24 @@ same string `toolResult` puts in `content[0].text`, formatted once and then both
 down, so that a session can be compared against a client's own transcript character for character. Everything
 else on a call is derived, and a derived field is the one thing that is no use when the question is why an
 investigation went wrong: a step made on an answer that said nothing reads exactly like a step made on one
-that said everything. **A refused call has no `output`**, its answer having been the refusal that is already
-in `refused` — writing it twice would put the same paragraph on disk and on the screen twice over.
+that said everything.
+
+**`output` is what went back, whatever that was.** A refusal is in it as well as in `refused`, and an error as
+well as in `error`, and the two are not the same field said twice: `refused` and `error` are this app's
+reading — the method said no, this app could not answer — and `output` is the text the agent was handed. The
+first version left `output` null for a refusal on the grounds that the refusal was already written down, and
+what that looked like from outside was a call that got no answer at all. **Null on `output` means nothing went
+back**, which is a notification and nothing else.
+
+**And a line goes down for every message, not only the ones that reached a tool.** The handshake, a
+`tools/list`, a ping, a notification, a method this build has never heard of, a `tools/call` with no name or a
+name nothing answers to, and a line that was not JSON: all of them. `tool` is null for the ones that reached
+no tool and `method` says what arrived instead, `AgentSession.toolCalls` is the subset that got as far as a
+tool, and **that distinction is not cosmetic** — the eval counts calls, and a run scored on lines sent would
+have a number that moved with the transport. `AgentSessionCall.over` is which way in a line came, told to
+`McpSession` at construction because a command line and an MCP client are indistinguishable from the moment
+the handshake is past, which is the point of them. The word travels as the last field of `AgentServer`'s
+handshake line, and a connection that says nothing is MCP.
 
 The name is in `input` even though `tool` has it, and that is not an oversight: this field is read as one
 thing, and a set of arguments lifted away from what they are arguments *to* is the one form of a call nobody
@@ -114,8 +130,10 @@ answer printed twice.
 
 **The verbs are here rather than in the app.** `verbOfTool` is beside the tool names, so that a screen never
 spells them itself and drift is one list rather than two. `AgentSessionFileTest` asserts every tool in the
-registry has one; a tool added without a verb reads as its own name, which is the protocol showing through on
-the screen that exists to not show it.
+registry has one — **which is what makes the fallback mean something**: a name `verbOfTool` has no verb for is
+a name this build has no tool for, so a row reading `Called solve_the_leak` is a typo or a tool from a newer
+build, and the name is left exactly as it arrived because that string is what somebody is looking for. A
+message that reached no tool at all reads through `verbOfMethod` instead.
 
 **A verb stops where the thing it was about starts**, which is why several of them end mid-sentence: a row of
 that screen is prose with one link in it, and the link is the thing. So `list_leaks` is "Listed the" and
@@ -152,10 +170,10 @@ to one adapter and not the other is the mistake this shape exists to make imposs
 `notes/agent-surface.md`, which also has what a call costs.
 
 **A process per call would otherwise be a session per call**, and a session is what somebody reads afterwards.
-So the handshake is `token[ sessionName]` on one line, `AgentSessionFile.continuing` appends to the newest file
-whose name carries that id, and a command line defaults to `cli<the shell's pid>` — an agent's calls come out
-of one shell the way its MCP calls come out of one connection. A client that says nothing gets a session of
-its own, which is what every MCP client does.
+So the handshake is `token[ sessionName[ over]]` on one line, `AgentSessionFile.continuing` appends to the
+newest file whose name carries that id, and a command line defaults to `cli<the shell's pid>` — an agent's
+calls come out of one shell the way its MCP calls come out of one connection. A client that says nothing gets
+a session of its own, which is what every MCP client does, and its lines are recorded as MCP.
 
 **The name is checked at both ends**, because it becomes part of a file name: the command line refuses one
 that isn't letters and digits before calling anything, and `AgentServer` serves the connection anyway with a

--- a/shark/shark-dive/shark-dive-agent/AGENTS.md
+++ b/shark/shark-dive/shark-dive-agent/AGENTS.md
@@ -85,6 +85,21 @@ heap dump read on every call to answer a question the reader already has the dum
 can open a second dump, and a call about one this window hasn't got is a row it leaves as the address, saying
 which file, and opens that dump when clicked.
 
+**A call keeps the exchange as well as this app's reading of it.** `input` is the arguments as they arrived,
+formatted, and `output` is the answer as the text that reached the model — the same string `toolResult` puts
+in `content[0].text`, formatted once and then both answered with and written down, so that a session can be
+compared against a client's own transcript character for character. Everything else on a call is derived, and
+a derived field is the one thing that is no use when the question is why an investigation went wrong: a step
+made on an answer that said nothing reads exactly like a step made on one that said everything. **A refused
+call has no `output`**, its answer having been the refusal that is already in `refused` — writing it twice
+would put the same paragraph on disk and on the screen twice over.
+
+Two things follow. The window's *Agent logs* screen unfolds **every** row onto this, not only the one that
+answers with a list, so the verb is a fold on all of them and the thing beside it is still the only link.
+And `agent_log` with a session id hands the same text over, which makes it the one expensive call on this
+surface — `notes/agent-surface.md` has the measurement. Neither of them truncates: a session cut to fit is
+one where the answer that misled an agent is the part that got cut.
+
 **Two fields come off the answer instead.** What an agent asked is what it typed, and what it concluded is
 what the heap dump *agreed to* — so `outcomeOfTool` reads the reference out of `conclude`'s answer. Both
 readers need that one and neither can work it out: the screen's last row is what a session came to, and the

--- a/shark/shark-dive/shark-dive-agent/AGENTS.md
+++ b/shark/shark-dive/shark-dive-agent/AGENTS.md
@@ -85,20 +85,24 @@ heap dump read on every call to answer a question the reader already has the dum
 can open a second dump, and a call about one this window hasn't got is a row it leaves as the address, saying
 which file, and opens that dump when clicked.
 
-**A call keeps the exchange as well as this app's reading of it.** `input` is the arguments as they arrived,
-formatted, and `output` is the answer as the text that reached the model — the same string `toolResult` puts
-in `content[0].text`, formatted once and then both answered with and written down, so that a session can be
-compared against a client's own transcript character for character. Everything else on a call is derived, and
-a derived field is the one thing that is no use when the question is why an investigation went wrong: a step
-made on an answer that said nothing reads exactly like a step made on one that said everything. **A refused
-call has no `output`**, its answer having been the refusal that is already in `refused` — writing it twice
-would put the same paragraph on disk and on the screen twice over.
+**A call keeps the exchange as well as this app's reading of it.** `input` is the tool's own name and then
+the arguments as they arrived, formatted, and `output` is the answer as the text that reached the model — the
+same string `toolResult` puts in `content[0].text`, formatted once and then both answered with and written
+down, so that a session can be compared against a client's own transcript character for character. Everything
+else on a call is derived, and a derived field is the one thing that is no use when the question is why an
+investigation went wrong: a step made on an answer that said nothing reads exactly like a step made on one
+that said everything. **A refused call has no `output`**, its answer having been the refusal that is already
+in `refused` — writing it twice would put the same paragraph on disk and on the screen twice over.
+
+The name is in `input` even though `tool` has it, and that is not an oversight: this field is read as one
+thing, and a set of arguments lifted away from what they are arguments *to* is the one form of a call nobody
+can read on its own.
 
 Two things follow. The window's *Agent logs* screen unfolds **every** row onto this, not only the one that
-answers with a list, so the verb is a fold on all of them and the thing beside it is still the only link.
-And `agent_log` with a session id hands the same text over, which makes it the one expensive call on this
-surface — `notes/agent-surface.md` has the measurement. Neither of them truncates: a session cut to fit is
-one where the answer that misled an agent is the part that got cut.
+answers with a list, and does it from a mark under the row rather than from the verb, so a row stays a
+sentence with one link in it. And `agent_log` with a session id hands the same text over, which makes it the
+one expensive call on this surface — `notes/agent-surface.md` has the measurement. Neither of them truncates:
+a session cut to fit is one where the answer that misled an agent is the part that got cut.
 
 **Two fields come off the answer instead.** What an agent asked is what it typed, and what it concluded is
 what the heap dump *agreed to* — so `outcomeOfTool` reads the reference out of `conclude`'s answer. Both

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentCommandLine.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentCommandLine.kt
@@ -164,9 +164,11 @@ object AgentCommandLine {
   ): Int {
     val toApp = PrintWriter(OutputStreamWriter(socket.getOutputStream(), Charsets.UTF_8), true)
     val fromApp = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.UTF_8))
-    // The token, and then which session this call is one of: one line, because the alternative is a
-    // handshake that has to be answered before the protocol can start. See [AgentServer].
-    toApp.println("${run.token} $sessionName")
+    // The token, then which session this call is one of, then that it was typed rather than sent by a
+    // client: one line, because the alternative is a handshake that has to be answered before the protocol
+    // can start. Saying so here is the only chance there is — from the next line on this is indistinguishable
+    // from an MCP client, which is the point of it. See [AgentServer] and [AgentTransport].
+    toApp.println("${run.token} $sessionName ${AgentTransport.CLI.recorded}")
     if (fromApp.readLine() != AgentServer.ACCEPTED) {
       say("Shark Dive run ${run.pid} refused the token in ${run.file}, so it is not the run that wrote it")
       return NOTHING_ANSWERED

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentJson.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentJson.kt
@@ -91,8 +91,16 @@ internal object AgentJson {
     put("session", session.sessionId)
     put("client", session.client)
     put("startedAt", session.startedAt?.toString())
-    put("calls", session.calls.size)
+    // Which way in it was talked to, and usually one: a session with both in it is somebody typing calls at
+    // the window a client is working in, which is worth knowing before reading it.
+    putJsonArray("over") { session.transports.forEach { add(it.recorded) } }
+    // The calls that reached a tool, and not every message of it: the protocol around them is in the session
+    // form below, and counting it here would make a command line's investigation — a handshake per call —
+    // read as twice the work it was. See [AgentSession.toolCalls].
+    put("calls", session.toolCalls.size)
     put("refused", session.refusedCount)
+    // And how many got no answer at all, which is this app failing rather than the surface saying no.
+    put("errors", session.errorCount)
     // What it concluded, which is the one thing a reader is looking for — and null for a session that
     // concluded nothing, which is most of them.
     put("concluded", session.calls.mapNotNull { it.outcome }.lastOrNull())
@@ -124,6 +132,11 @@ internal object AgentJson {
       session.calls.forEach { call ->
         addJsonObject {
           put("at", call.at.toString())
+          // Which way in it came, and what arrived: null on `tool` is a message that reached none, and the
+          // method is then the whole of what it was. Not only the calls, because a session that shows the
+          // ones that worked cannot answer why the others didn't. See [AgentSession.calls].
+          put("over", call.over?.recorded)
+          put("method", call.method)
           put("tool", call.tool)
           put("reason", call.reason)
           // What the call was about, as the agent wrote it: an address is that dump's address, and this is
@@ -131,10 +144,12 @@ internal object AgentJson {
           put("about", call.subject)
           put("heapDumpPath", call.heapDumpPath)
           put("refused", call.refusal)
+          // And why nothing could be answered at all, which is a different thing from being told no.
+          put("error", call.error)
           put("outcome", call.outcome)
           // Last, and in that order, because they are the two long ones and they read as the call: this is
           // what went out, and this is what came back. Null on both for a session recorded by a build older
-          // than they are; null on `output` alone for a call whose answer was the refusal above it.
+          // than they are; null on `output` alone for a notification nothing was sent back for.
           put("input", call.input)
           put("output", call.output)
         }

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentJson.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentJson.kt
@@ -100,11 +100,22 @@ internal object AgentJson {
   }
 
   /**
-   * Every call of one session, in the order it made them, with the reason the agent gave for each.
+   * Every call of one session, in the order it made them, with the reason the agent gave for each — and the
+   * exchange itself.
    *
    * The reasons are the point. A session read as a list of tool names is the protocol showing through; read
    * as what was asked and why, it either follows from itself or doesn't — which is the same judgement the
    * person at the window makes on that screen.
+   *
+   * **And `input` and `output` are what the reasons are checked against**, which is why this answer is a long
+   * one: a reason is what the agent said it was doing, and the two of them are what it actually sent and
+   * actually read. An agent asked to work out where another one went wrong cannot do it from a summary,
+   * however well worded — the step that misread an answer reads exactly like the step that read it right.
+   * The same text the window's *Agent logs* screen unfolds a row onto.
+   *
+   * So a session with a hundred calls in it is a large answer, and that is the tool being used as intended
+   * rather than a leak: this is the only call on this surface whose subject is somebody else's whole
+   * investigation. The list without `session` is the short form, and how a reader picks which one to read.
    */
   fun agentSessionCalls(session: AgentSession): JsonObject = buildJsonObject {
     put("session", session.sessionId)
@@ -121,6 +132,11 @@ internal object AgentJson {
           put("heapDumpPath", call.heapDumpPath)
           put("refused", call.refusal)
           put("outcome", call.outcome)
+          // Last, and in that order, because they are the two long ones and they read as the call: this is
+          // what went out, and this is what came back. Null on both for a session recorded by a build older
+          // than they are; null on `output` alone for a call whose answer was the refusal above it.
+          put("input", call.input)
+          put("output", call.output)
         }
       }
     }

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentServer.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentServer.kt
@@ -158,8 +158,8 @@ object AgentServer {
   }
 
   /**
-   * One connection: the token and optionally a session to join, then a JSON-RPC message per line until the
-   * agent goes away.
+   * One connection: the token, optionally a session to join and which way in it is, then a JSON-RPC message
+   * per line until the agent goes away.
    *
    * **No read timeout**, unlike the link socket. An agent thinking, or waiting for the person at the
    * machine, is a connection with nothing on it for minutes at a time, and a session dropped for being
@@ -194,7 +194,10 @@ object AgentServer {
         // heap dump sees what another one working on it right now has done so far.
         AgentTools(heapDumps) { AgentSessionFile.sessionsIn(sessions) },
         serverVersion,
-        sessionFile
+        sessionFile,
+        // A connection that did not say is a client holding a session open, which is what an MCP one does
+        // and the only thing anything did before the command line existed. See [transport].
+        over = transport(handshake.getOrNull(2))
       )
       while (true) {
         val line = reader.readLine() ?: break
@@ -237,6 +240,24 @@ object AgentServer {
     return AgentSessionFile.continuing(sessions, serverVersion, name)
   }
 
+  /**
+   * Which way in this connection said it is, and MCP for one that said nothing.
+   *
+   * The last word of the handshake, because it is the last chance: from the next line on a command line and an
+   * MCP client are the same protocol on the same socket, which is what makes them one surface rather than two.
+   * A default and not a refusal for the word missing — the bridge sends none, and neither did anything before
+   * the command line existed — and a default for a word this build has no way in for, since a connection
+   * mislabelled is a session to read rather than one to lose. See [AgentTransport].
+   */
+  private fun transport(said: String?): AgentTransport {
+    if (said == null) {
+      return AgentTransport.MCP
+    }
+    return AgentTransport.ofRecordedOrNull(said) ?: AgentTransport.MCP.also {
+      SharkLog.d { "An agent said it was connecting over \"$said\", which is no way in: recording it as MCP" }
+    }
+  }
+
   private fun newToken(): String {
     val bytes = ByteArray(TOKEN_BYTES)
     SecureRandom().nextBytes(bytes)
@@ -264,7 +285,7 @@ object AgentServer {
   internal const val ACCEPTED = "OK"
   internal const val DECLINED = "NO"
 
-  /** Between the token and the session a connection is joining, which is why a name has no spaces in it. */
+  /** Between the token, the session a connection is joining and how, which is why a name has no spaces. */
   private const val HANDSHAKE_SEPARATOR = ' '
   private const val PORT_PROPERTY = "port"
   private const val TOKEN_PROPERTY = "token"

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentSessionFile.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentSessionFile.kt
@@ -38,6 +38,14 @@ import shark.dive.Place
  * and [AgentSessionCall.output] are what the agent sent and what it read back, verbatim, which is what makes
  * a session something to debug and follow along with rather than only a summary to skim.
  *
+ * **Every message, not only the ones that reached a tool.** A line goes down for the handshake, for
+ * `tools/list`, for a ping, for a notification nothing was sent back for, for a method this app has never
+ * heard of, and for a line that was not JSON at all. Which is the whole point of keeping traffic: the
+ * messages worth reading are exactly the ones that went wrong, and a log that keeps what worked and drops
+ * what didn't answers every question except the one it was opened for. [AgentSessionCall.tool] is null for
+ * all of those and [AgentSessionCall.method] says what arrived instead; [AgentSession.toolCalls] is the
+ * subset that reached a tool, for the readers that are counting an investigation rather than reading it.
+ *
  * JSON, one object per line, flushed per line, because the session worth reading is often the one that ended
  * by the agent giving up or the app being killed. A header line naming the session, then a line per call.
  * Beside the notes and the verdicts under `~/.shark-dive`, since it is the same kind of thing: what
@@ -211,9 +219,11 @@ class AgentSessionFile private constructor(
         val read = line.asJsonOrNull(file, index + 1)
         when {
           read == null -> Unit
-          read[TOOL_KEY] != null -> read.asCallOrNull(file, index + 1)?.let { calls += it }
+          // The header first, since it is the one line that is about the session rather than one message of
+          // it — and every message line is stamped with when it arrived, whether or not it named a tool.
           read[SESSION_KEY] != null -> header = header ?: read
-          else -> SharkLog.d { "Skipping line ${index + 1} of $file: it is neither a session nor a call" }
+          read[AT_KEY] != null -> read.asCallOrNull(file, index + 1)?.let { calls += it }
+          else -> SharkLog.d { "Skipping line ${index + 1} of $file: it is neither a session nor a message" }
         }
       }
       return AgentSession(
@@ -255,7 +265,9 @@ class AgentSessionFile private constructor(
 
     private fun AgentSessionCall.asJson(): JsonObject = buildJsonObject {
       put(AT_KEY, at.toString())
-      put(TOOL_KEY, tool)
+      over?.let { put(OVER_KEY, it.recorded) }
+      method?.let { put(METHOD_KEY, it) }
+      tool?.let { put(TOOL_KEY, it) }
       reason?.let { put(REASON_KEY, it) }
       windowId?.let { put(WINDOW_KEY, it) }
       heapDumpPath?.let { put(HEAP_DUMP_KEY, it) }
@@ -263,6 +275,7 @@ class AgentSessionFile private constructor(
       // clickable: the place to go to, and a line the agent's human can paste anywhere. See [DeepLink].
       link()?.let { put(LINK_KEY, it) }
       refusal?.let { put(REFUSAL_KEY, it) }
+      error?.let { put(ERROR_KEY, it) }
       outcome?.let { put(OUTCOME_KEY, it) }
       if (openHeapDumps.isNotEmpty()) {
         putJsonArray(OPEN_HEAP_DUMPS_KEY) { openHeapDumps.forEach { add(it) } }
@@ -283,16 +296,20 @@ class AgentSessionFile private constructor(
       file: File,
       lineNumber: Int
     ): AgentSessionCall? {
-      val tool = text(TOOL_KEY)
       val at = instant(AT_KEY)
-      if (tool == null || at == null) {
-        SharkLog.d { "Skipping line $lineNumber of $file: it says no tool, or no time it was called" }
+      if (at == null) {
+        SharkLog.d { "Skipping line $lineNumber of $file: it says no time it arrived" }
         return null
       }
+      val tool = text(TOOL_KEY)
       val link = text(LINK_KEY)
       val arguments = this[ARGUMENTS_KEY]?.asStringMap().orEmpty()
       return AgentSessionCall(
         at = at,
+        over = text(OVER_KEY)?.let { AgentTransport.ofRecorded(it, file, lineNumber) },
+        // From the tool for a session written before the method was kept: every line there was a tool call,
+        // which is the one method a tool name can have arrived under.
+        method = text(METHOD_KEY) ?: tool?.let { TOOLS_CALL_METHOD },
         tool = tool,
         reason = text(REASON_KEY),
         windowId = text(WINDOW_KEY),
@@ -300,11 +317,12 @@ class AgentSessionFile private constructor(
         // From the tool for a line with no link, which is a session written by a build that recorded no
         // place for a call that named nothing — and it went to the same screen then as it would now.
         place = link?.let { placeOfLinkOrNull(it, file, lineNumber) }
-          ?: screenOfTool(tool, arguments)?.place,
+          ?: tool?.let { screenOfTool(it, arguments)?.place },
         arguments = arguments,
         input = text(INPUT_KEY),
         output = text(OUTPUT_KEY),
         refusal = text(REFUSAL_KEY),
+        error = text(ERROR_KEY),
         outcome = text(OUTCOME_KEY),
         openHeapDumps = this[OPEN_HEAP_DUMPS_KEY].asStrings(),
         millis = text(MILLIS_KEY)?.toLongOrNull() ?: 0L
@@ -401,12 +419,30 @@ class AgentSessionFile private constructor(
     private const val SERVER_KEY = "sharkDive"
 
     private const val AT_KEY = "at"
+
+    /** How the message arrived, and what it asked for. See [AgentSessionCall.over]. */
+    private const val OVER_KEY = "over"
+    private const val METHOD_KEY = "method"
+
+    /**
+     * What a tool call arrives as, which is the method every line of an older session was one of.
+     *
+     * Spelled here rather than beside the protocol it belongs to because [McpSession]'s companion is private
+     * and this one is read from both sides: one string, so that a session read back cannot disagree with the
+     * one written.
+     */
+    internal const val TOOLS_CALL_METHOD = "tools/call"
+
     private const val TOOL_KEY = "tool"
     private const val REASON_KEY = "reason"
     private const val WINDOW_KEY = "window"
     private const val HEAP_DUMP_KEY = "heapDump"
     private const val LINK_KEY = "link"
     private const val REFUSAL_KEY = "refused"
+
+    /** And why this app could not answer at all, which is a different thing. See [AgentSessionCall.error]. */
+    private const val ERROR_KEY = "error"
+
     private const val OUTCOME_KEY = "outcome"
     private const val OPEN_HEAP_DUMPS_KEY = "openHeapDumps"
     private const val MILLIS_KEY = "millis"
@@ -415,6 +451,57 @@ class AgentSessionFile private constructor(
     /** The call as it was sent and the answer as it was read, verbatim. See [AgentSessionCall.input]. */
     private const val INPUT_KEY = "input"
     private const val OUTPUT_KEY = "output"
+  }
+}
+
+/**
+ * Which of the two ways into this app a message came in by. See [AgentSessionCall.over].
+ *
+ * Both end up in the same [McpSession] speaking the same protocol, which is the point of them — a refusal
+ * met on a command line is the refusal an MCP client would have met. So the difference is invisible from
+ * anywhere except the door, and it is worth recording at the door: "the agent sent that" and "I typed that
+ * into a shell" are different claims about the same line, and reading a session is often working out which.
+ */
+enum class AgentTransport(
+  /** How it is written in a session file, and answered to an agent asking what another one did. */
+  val recorded: String,
+  /** And what a person reading the screen is shown, which is what they would call it. */
+  val words: String
+) {
+
+  /** A client holding a connection open, over the pipe or over this process's own stdin. */
+  MCP("mcp", "MCP"),
+
+  /** `--agent <tool> name=value …`, which is a process per call. See [AgentCommandLine]. */
+  CLI("cli", "CLI");
+
+  companion object {
+
+    /**
+     * The transport [recorded] names, or null having said in the run log which line named nothing.
+     *
+     * Null rather than a guess, for the reason a status this app can't read is skipped rather than defaulted:
+     * a session that says it came in a way this build has never heard of is one to look at, and a line
+     * quietly relabelled "MCP" is one nobody looks at.
+     */
+    internal fun ofRecorded(
+      recorded: String,
+      file: File,
+      lineNumber: Int
+    ): AgentTransport? = ofRecordedOrNull(recorded).also {
+      if (it == null) {
+        SharkLog.d { "Line $lineNumber of $file came in over \"$recorded\", which is no way into this build" }
+      }
+    }
+
+    /**
+     * The same lookup for the handshake, where there is no line of a file to name.
+     *
+     * The word crossing the socket is [recorded] rather than a spelling of its own, so that what a connection
+     * says it is and what its lines are written as cannot come apart. See [AgentServer].
+     */
+    internal fun ofRecordedOrNull(recorded: String): AgentTransport? =
+      entries.firstOrNull { it.recorded == recorded }
   }
 }
 
@@ -428,11 +515,27 @@ class AgentSession(
   /** Which build of the app answered it. */
   val serverVersion: String?,
   val file: File,
+  /** Every message of it, in the order it arrived — the protocol around the tools included. */
   val calls: List<AgentSessionCall>
 ) {
 
+  /**
+   * The ones that reached a tool, which is what an investigation is made of.
+   *
+   * For the readers that are counting rather than reading: how many calls a leak took is a number about the
+   * tools, and it would move because a client says hello differently if it counted every message. The screen
+   * draws [calls], because what somebody following an investigation needs is what happened.
+   */
+  val toolCalls: List<AgentSessionCall> get() = calls.filter { it.tool != null }
+
   /** How many of the calls were refused, which is the one number a list of sessions is worth showing. */
   val refusedCount: Int get() = calls.count { it.refusal != null }
+
+  /** And how many this app could not answer at all, which is a different thing. See [AgentSessionCall.error]. */
+  val errorCount: Int get() = calls.count { it.error != null }
+
+  /** Which ways in were used, in the order they first were: one of them for almost every session. */
+  val transports: List<AgentTransport> get() = calls.mapNotNull { it.over }.distinct()
 
   /**
    * Which heap dumps it read, in the order it first read each of them.
@@ -445,7 +548,11 @@ class AgentSession(
 }
 
 /**
- * One call an agent made, and what it did.
+ * One message an agent sent, and what went back.
+ *
+ * Usually a call to a tool, and **not only** a call to a tool: the handshake, `tools/list`, a ping, a
+ * notification, a method this build has never heard of and a line that was not JSON at all are each one of
+ * these too. [tool] is what separates them, and [method] is what a message that reached no tool arrived as.
  *
  * The place is what makes a row of the *Agent logs* screen clickable: it is where the window goes when the
  * row is clicked, so that reading what an agent did and going to look at it are the same move. Null for a
@@ -454,7 +561,26 @@ class AgentSession(
  */
 class AgentSessionCall(
   val at: Instant,
-  val tool: String,
+  /**
+   * Which way it came in: an MCP client's connection, or the `--agent` command line.
+   *
+   * Per message rather than per session, because a session file is a name and either adapter can call
+   * itself by that name — a shell joining what an MCP client started is a thing somebody will do, and then
+   * the header's client is the truth about the first message and about nothing else.
+   *
+   * Null for a session recorded before this was kept.
+   */
+  val over: AgentTransport?,
+  /**
+   * The JSON-RPC method it arrived as, and null for a line this app could not read one out of.
+   *
+   * `tools/call` for every call to a tool, which is what [tool] is the name from. The rest are the protocol
+   * around the tools — `initialize`, `tools/list`, `ping`, the notifications — and they are here because a
+   * session that keeps only what reached a tool cannot answer why nothing did.
+   */
+  val method: String?,
+  /** The tool it called, and null for every message that reached no tool. See [method]. */
+  val tool: String?,
   /** Why the agent said it was making the call, and null for one refused for not saying. */
   val reason: String?,
   val windowId: String?,
@@ -463,8 +589,13 @@ class AgentSessionCall(
   /** The rest of the arguments, by name, with `reason` and `window` left out: they have fields of their own. */
   val arguments: Map<String, String>,
   /**
-   * What the agent sent, as the text it sent: the tool it named and the arguments it named it with,
-   * formatted, nothing left out and nothing added.
+   * What the agent sent, as the text it sent: for a call, the tool it named and the arguments it named it
+   * with, formatted, nothing left out and nothing added — and for every other message, the line as it
+   * arrived.
+   *
+   * The line for those because there is nothing else to have: a message that named no method, or no tool, or
+   * was not JSON at all is one this app could make nothing of, and the bytes are the whole of what there is
+   * to look at.
    *
    * Every other field of a call is *about* the call — the verb, the subject, the place, the arguments the
    * screen puts beside a verb — and every one of them is this app's reading of what happened. This is the
@@ -491,12 +622,29 @@ class AgentSessionCall(
    * investigation afterwards: a step that reads as sound and was made on an answer that said nothing is a
    * step nobody can see the trouble with until they read what the agent read.
    *
-   * Null for a refused call, whose answer text *is* the refusal: it would be the same string twice, on disk
-   * and on the screen, since a row already prints [refusal] in full.
+   * **A refusal and a failure are in here too**, and that is not the same string twice beside [refusal] and
+   * [error]: those two are this app's reading of what happened — one of them says the method sent the agent
+   * back and the other says this app could not answer — and this is the text the agent was actually handed.
+   * A session that keeps the reading and drops the text is one that cannot answer whether what was sent was
+   * what somebody thinks was sent, which is the question a log is opened for.
+   *
+   * For a call it is the text of the tool's answer, which is what the model reads, and for every other
+   * message it is the whole response, which is all there is of one. **Null only where nothing went back**:
+   * a notification, which JSON-RPC forbids answering. And null for a session recorded before this was kept.
    */
   val output: String?,
   /** Why the call was refused, and null for one that was answered. See [AgentRefusal]. */
   val refusal: String?,
+  /**
+   * Why this app could not answer at all, and null for a message it answered.
+   *
+   * Apart from [refusal] because they are opposites in the one way that matters to whoever is reading: a
+   * refusal is the surface working — the method sending an agent back to the heap dump — and this is the
+   * surface failing. A malformed line, a method that doesn't exist, a `tools/call` naming a tool that
+   * doesn't, a handler that threw. Counting the first as the second would say a run was refused into giving
+   * up when what happened is that this app fell over. See `EvalScore`.
+   */
+  val error: String?,
   /**
    * What the call came to, for the calls whose answer is worth a word. See [outcomeOfTool].
    *
@@ -537,15 +685,39 @@ class AgentSessionCall(
  * What the call did, as a couple of words, and never the thing it did it to.
  *
  * Here rather than in the window that draws it because this is where the tool names are: a screen spelling
- * them itself would be a second list of them to keep in step. Every tool has one, which `AgentSessionFileTest`
- * is what keeps true — a tool added without a verb reads as its own name, which is the raw protocol showing
- * through on a screen that exists to not show it.
+ * them itself would be a second list of them to keep in step. Every tool of this build has one, which
+ * `AgentSessionFileTest` is what keeps true — **so a name with no verb is a name this build has no tool for**,
+ * a typo or a tool from a newer one, and it reads as itself unchanged, since the exact string is the whole of
+ * what somebody is looking for when a call went nowhere.
  *
  * **Prose, so it can be drawn as prose.** What a row leads to is [subject] or [screen], and a verb that
  * swallowed the thing it was about — "Listed the leaks" — leaves a row with no part of it to be the link
  * except the whole sentence. So a verb ends where the thing begins, even when that makes it "Listed the".
  */
-val AgentSessionCall.verb: String get() = verbOfTool(tool, arguments) ?: tool.replace('_', ' ')
+val AgentSessionCall.verb: String
+  get() = tool?.let { verbOfTool(it, arguments) ?: "Called $it" } ?: verbOfMethod(method)
+
+/**
+ * And what to call a message that reached no tool, which is the protocol around them.
+ *
+ * In words like every other row, because the screen is one screen: a reader following an investigation should
+ * not have to change how they are reading half way down it to find out that a client said hello. The ones
+ * with no word of their own read as what arrived, which for a method this build has never heard of is the
+ * whole of what is known about it.
+ */
+internal fun verbOfMethod(method: String?): String = when {
+  method == null -> "Sent something this app could not read"
+  method == "initialize" -> "Connected"
+  method == "tools/list" -> "Asked what the tools are"
+  // Which a client sends to find out whether this end is still there, and this end is a window somebody may
+  // have closed.
+  method == "ping" -> "Checked this window is still open"
+  // A call that named no tool, which is the one tools/call that reaches none: an unknown *name* keeps its
+  // name and reads as itself, since a typo is the thing worth seeing.
+  method == "tools/call" -> "Called a tool it did not name"
+  method.startsWith("notifications/") -> "Sent the notification $method"
+  else -> "Sent $method"
+}
 
 /**
  * What the call was about, in the words the window uses for it: an address, a class name, a place.
@@ -569,7 +741,7 @@ val AgentSessionCall.subject: String?
  * titles reads as "Listed the Leaks". Null for a call that named an object — [subject] is that — and for the
  * calls about the app rather than about a heap dump, which have no place of one to go to.
  */
-val AgentSessionCall.screen: String? get() = screenOfTool(tool, arguments)?.words
+val AgentSessionCall.screen: String? get() = tool?.let { screenOfTool(it, arguments)?.words }
 
 /**
  * What the answer to a call came to, as a couple of words, and null when the answer is data rather than a

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentSessionFile.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentSessionFile.kt
@@ -32,6 +32,12 @@ import shark.dive.Place
  * Which is why it is machine readable and appended to rather than the run log reworded: the run log is prose
  * about everything the app did, and this is the one agent's calls with nothing else in the file.
  *
+ * **And a call carries the exchange itself, not only this app's reading of it.** Every derived field here —
+ * the verb, the subject, the place a row leads to — is what Shark Dive made of a call, and a reading is the
+ * one thing that is no use when the question is why an investigation went wrong. So [AgentSessionCall.input]
+ * and [AgentSessionCall.output] are what the agent sent and what it read back, verbatim, which is what makes
+ * a session something to debug and follow along with rather than only a summary to skim.
+ *
  * JSON, one object per line, flushed per line, because the session worth reading is often the one that ended
  * by the agent giving up or the app being killed. A header line naming the session, then a line per call.
  * Beside the notes and the verdicts under `~/.shark-dive`, since it is the same kind of thing: what
@@ -267,6 +273,10 @@ class AgentSessionFile private constructor(
           arguments.forEach { (name, value) -> put(name, value) }
         }
       }
+      // Last, because they are the long ones: a line stays readable to whoever is looking at it with `head
+      // -c` or a text editor's first screenful, and what is up there is what says which call this is.
+      input?.let { put(INPUT_KEY, it) }
+      output?.let { put(OUTPUT_KEY, it) }
     }
 
     private fun JsonObject.asCallOrNull(
@@ -292,6 +302,8 @@ class AgentSessionFile private constructor(
         place = link?.let { placeOfLinkOrNull(it, file, lineNumber) }
           ?: screenOfTool(tool, arguments)?.place,
         arguments = arguments,
+        input = text(INPUT_KEY),
+        output = text(OUTPUT_KEY),
         refusal = text(REFUSAL_KEY),
         outcome = text(OUTCOME_KEY),
         openHeapDumps = this[OPEN_HEAP_DUMPS_KEY].asStrings(),
@@ -356,8 +368,12 @@ class AgentSessionFile private constructor(
     private val JSON = Json { ignoreUnknownKeys = true }
 
     /**
-     * How many sessions are kept. More than the run logs beside them, because these are a few kilobytes
-     * each and because "what did that agent do" is asked about an investigation rather than about a run.
+     * How many sessions are kept. More than the run logs beside them, because "what did that agent do" is
+     * asked about an investigation rather than about a run.
+     *
+     * A session is as big as the answers it read — tens of kilobytes for a short one, more where a chain or a
+     * tree came back — since [AgentSessionCall.output] keeps them. Which is the trade: a hundred sessions of
+     * summaries would fit in a fraction of that and would be a hundred sessions nobody can check.
      */
     const val KEEP_SESSION_COUNT = 100
 
@@ -395,6 +411,10 @@ class AgentSessionFile private constructor(
     private const val OPEN_HEAP_DUMPS_KEY = "openHeapDumps"
     private const val MILLIS_KEY = "millis"
     private const val ARGUMENTS_KEY = "arguments"
+
+    /** The call as it was sent and the answer as it was read, verbatim. See [AgentSessionCall.input]. */
+    private const val INPUT_KEY = "input"
+    private const val OUTPUT_KEY = "output"
   }
 }
 
@@ -442,6 +462,32 @@ class AgentSessionCall(
   val place: Place?,
   /** The rest of the arguments, by name, with `reason` and `window` left out: they have fields of their own. */
   val arguments: Map<String, String>,
+  /**
+   * What the agent sent, as the text it sent: its arguments, formatted, nothing left out and nothing added.
+   *
+   * Every other field of a call is *about* the call — the verb, the subject, the place, the arguments the
+   * screen puts beside a verb — and every one of them is this app's reading of what happened. This is the
+   * thing itself, which is what somebody debugging a session needs: an argument that looks right on the row
+   * and was spelled wrong on the wire is invisible in a paraphrase and obvious here.
+   *
+   * The arguments and not the JSON-RPC envelope around them, because the envelope is the client's and the
+   * arguments are the model's. The tool name is [tool] and the id is a number the client counted to.
+   *
+   * Null for a session written before this was recorded, which is how the *Agent logs* screen knows to say
+   * so rather than unfolding onto nothing.
+   */
+  val input: String?,
+  /**
+   * And exactly what it got back: the answer, formatted, as the text that reached the model.
+   *
+   * Not a summary of it — [outcome] is that, and only `conclude` has one. What this is for is following an
+   * investigation afterwards: a step that reads as sound and was made on an answer that said nothing is a
+   * step nobody can see the trouble with until they read what the agent read.
+   *
+   * Null for a refused call, whose answer text *is* the refusal: it would be the same string twice, on disk
+   * and on the screen, since a row already prints [refusal] in full.
+   */
+  val output: String?,
   /** Why the call was refused, and null for one that was answered. See [AgentRefusal]. */
   val refusal: String?,
   /**

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentSessionFile.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentSessionFile.kt
@@ -463,15 +463,22 @@ class AgentSessionCall(
   /** The rest of the arguments, by name, with `reason` and `window` left out: they have fields of their own. */
   val arguments: Map<String, String>,
   /**
-   * What the agent sent, as the text it sent: its arguments, formatted, nothing left out and nothing added.
+   * What the agent sent, as the text it sent: the tool it named and the arguments it named it with,
+   * formatted, nothing left out and nothing added.
    *
    * Every other field of a call is *about* the call — the verb, the subject, the place, the arguments the
    * screen puts beside a verb — and every one of them is this app's reading of what happened. This is the
    * thing itself, which is what somebody debugging a session needs: an argument that looks right on the row
    * and was spelled wrong on the wire is invisible in a paraphrase and obvious here.
    *
-   * The arguments and not the JSON-RPC envelope around them, because the envelope is the client's and the
-   * arguments are the model's. The tool name is [tool] and the id is a number the client counted to.
+   * **The name as the tool spells it**, `describe_object` rather than "Looked at", and not because [tool]
+   * doesn't have it: what this field is for is being read as one thing, and a call whose name has been
+   * lifted out of it is a set of values with nothing saying what they are values of. The verb beside it on
+   * the screen is this app's word for the same call, which is exactly the pair worth seeing together when a
+   * step doesn't follow.
+   *
+   * The name and the arguments and not the JSON-RPC envelope around them, because the envelope is the
+   * client's and both of these are the model's: the id is a number the client counted to.
    *
    * Null for a session written before this was recorded, which is how the *Agent logs* screen knows to say
    * so rather than unfolding onto nothing.

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentStdioServer.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentStdioServer.kt
@@ -43,7 +43,10 @@ object AgentStdioServer {
     val session = McpSession(
       AgentTools(heapDumps) { AgentSessionFile.sessionsIn(sessions) },
       serverVersion,
-      sessionFile
+      sessionFile,
+      // A client holding this process's own pipe open, which is MCP however little of the shape around it
+      // there is: there is no socket here and no command line either. See [AgentTransport].
+      over = AgentTransport.MCP
     )
     val reader = BufferedReader(InputStreamReader(System.`in`, Charsets.UTF_8))
     val writer = PrintWriter(OutputStreamWriter(System.out, Charsets.UTF_8), true)

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentTools.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/AgentTools.kt
@@ -130,13 +130,18 @@ internal class AgentTools(
     name = AGENT_LOG,
     description = "What has already been done to this heap dump, by you and by anybody else: one entry per " +
       "session, newest first, with what it concluded and how many of its calls were refused — and with " +
-      "`$SESSION`, every call of one session in order, with the reason the agent gave for each. The " +
+      "`$SESSION`, every call of one session in order, each with the reason the agent gave and the exact " +
+      "text it sent and read back. The " +
       "window's *Agent logs* screen, which is where a person reads the same thing. Worth reading before " +
       "starting: an investigation somebody already ran is either the answer or the half of the dump not " +
       "worth doing again. Sessions of earlier runs of the app are in it, and so is this one.",
     schema = schema(
       HEAP_DUMP to heapDumpArgument(),
-      SESSION to string("Optional: one session's id, from the list, to read every call it made.").optional()
+      SESSION to string(
+        "Optional: one session's id, from the list, to read every call it made, with what each call sent " +
+          "and what it got back. A long answer, and the only way to tell a step that read an answer from " +
+          "one that misread it."
+      ).optional()
     )
   ) { arguments ->
     val dump = arguments.heapDump()

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/McpSession.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/McpSession.kt
@@ -41,7 +41,15 @@ internal class McpSession(
    * eval scores. One per connection, so that two agents at one heap dump are two files. See
    * [AgentSessionFile].
    */
-  private val sessionFile: AgentSessionFile
+  private val sessionFile: AgentSessionFile,
+  /**
+   * Which way in this session is being spoken through, stamped on every line it writes.
+   *
+   * Told rather than worked out: both adapters arrive here over the same socket speaking the same protocol,
+   * which is what makes them one surface, so the only place that knows is the one that opened the door. See
+   * [AgentTransport].
+   */
+  private val over: AgentTransport
 ) {
 
   /**
@@ -49,41 +57,83 @@ internal class McpSession(
    *
    * Notifications are the null case and it is not optional: JSON-RPC forbids answering a message with no
    * id, and a client that gets one back for `notifications/initialized` treats the session as broken.
+   *
+   * **Every message that arrives here is written down**, answered or refused or unreadable, before this
+   * returns. A log that keeps the calls that worked is a log that cannot answer the question it gets opened
+   * for, which is why nothing came back — so a line that is not JSON, a method this build has never heard
+   * of and a call to a tool that does not exist are each a row of a session like any other. See
+   * [AgentSessionFile].
    */
   suspend fun answer(line: String): String? {
+    val at = Instant.now()
+    val startedAt = System.nanoTime()
     val message = try {
       JSON.parseToJsonElement(line).jsonObject
     } catch (notJson: Exception) {
       SharkLog.d(notJson) { "An agent sent something that is no JSON-RPC message" }
-      return JSON.encodeToString(
-        JsonElement.serializer(),
-        errorResponse(id = null, code = PARSE_ERROR, message = "That is not JSON: $notJson")
-      )
+      val error = "That is not JSON: $notJson"
+      return answered(errorResponse(id = null, code = PARSE_ERROR, message = error), line, null, error, at, startedAt)
     }
     val id = message["id"]
     val method = (message["method"] as? JsonPrimitive)?.content
     if (method == null) {
-      return JSON.encodeToString(
-        JsonElement.serializer(),
-        errorResponse(id, INVALID_REQUEST, "A request needs a \"method\".")
-      )
+      val error = "A request needs a \"method\"."
+      return answered(errorResponse(id, INVALID_REQUEST, error), line, null, error, at, startedAt)
     }
-    // No id is a notification: nothing is waiting for an answer and sending one is a protocol error.
+    val params = message["params"]?.jsonObject ?: EMPTY_PARAMS
+    // No id is a notification: nothing is waiting for an answer and sending one is a protocol error. The
+    // line still goes down, with nothing as what came back, since that is what happened.
     if (id == null) {
       SharkLog.d { "An agent sent the notification $method" }
+      recordMessage(line, method, output = null, error = null, at = at, startedAt = startedAt)
       return null
     }
-    val response = try {
-      successResponse(id, dispatch(method, message["params"]?.jsonObject ?: EMPTY_PARAMS))
+    // Written down by the one place that has a tool's own reading of a call, rather than here.
+    if (method == TOOLS_CALL) {
+      return JSON.encodeToString(
+        JsonElement.serializer(),
+        successResponse(id, callTool(line, params, at, startedAt))
+      )
+    }
+    return try {
+      answered(successResponse(id, dispatch(method, params)), line, method, null, at, startedAt)
     } catch (unknown: UnknownMethod) {
-      errorResponse(id, METHOD_NOT_FOUND, unknown.message)
+      answered(
+        errorResponse(id, METHOD_NOT_FOUND, unknown.message), line, method, unknown.message, at, startedAt
+      )
     } catch (throwable: Throwable) {
       // A read that failed or a bug of ours, either way told to the agent rather than dropped: a client
       // waiting for a response it never gets has no way to tell that from the app having gone away.
       SharkLog.d(throwable) { "An agent's $method failed" }
-      errorResponse(id, INTERNAL_ERROR, throwable.toString())
+      answered(
+        errorResponse(id, INTERNAL_ERROR, throwable.toString()),
+        line,
+        method,
+        throwable.toString(),
+        at,
+        startedAt
+      )
     }
-    return JSON.encodeToString(JsonElement.serializer(), response)
+  }
+
+  /**
+   * The response as the line it goes back as, written down on the way out.
+   *
+   * The whole response for these rather than the text inside it, which is what a call records: there is no
+   * inside to one of these — a `tools/list` answer and a JSON-RPC error are each the whole of what the client
+   * read. See [AgentSessionCall.output].
+   */
+  private fun answered(
+    response: JsonObject,
+    input: String,
+    method: String?,
+    error: String?,
+    at: Instant,
+    startedAt: Long
+  ): String {
+    val text = JSON.encodeToString(JsonElement.serializer(), response)
+    recordMessage(input, method, output = text, error = error, at = at, startedAt = startedAt)
+    return text
   }
 
   private suspend fun dispatch(
@@ -102,7 +152,6 @@ internal class McpSession(
         }
       }
     }
-    "tools/call" -> callTool(params)
     // Answered because clients use it to find out whether this end is still there, and this end is a
     // window someone may have closed.
     "ping" -> buildJsonObject { }
@@ -141,23 +190,36 @@ internal class McpSession(
     }
   }
 
-  private suspend fun callTool(params: JsonObject): JsonObject {
+  /**
+   * One call to a tool, written down whatever became of it.
+   *
+   * Which is four endings and not two: answered, refused, a name no tool of this build has, and no name at
+   * all. The last two are a message that reached no tool, so they are recorded as one — with the name kept
+   * where there was one, since a typo is the whole of what somebody is looking for when a call went nowhere.
+   */
+  private suspend fun callTool(
+    line: String,
+    params: JsonObject,
+    at: Instant,
+    startedAt: Long
+  ): JsonObject {
     val name = (params["name"] as? JsonPrimitive)?.content
-      ?: return toolError("A tools/call needs the \"name\" of a tool.")
-    val tool = tools.byName(name)
-      ?: return toolError(
-        "There is no tool called \"$name\". This server has " +
-          tools.all.joinToString(", ") { it.name } + "."
-      )
+    if (name == null) {
+      val error = "A tools/call needs the \"name\" of a tool."
+      recordMessage(line, TOOLS_CALL, output = error, error = error, at = at, startedAt = startedAt)
+      return toolError(error)
+    }
     val arguments = params["arguments"]?.jsonObject ?: EMPTY_PARAMS
+    val tool = tools.byName(name)
+    if (tool == null) {
+      val error = "There is no tool called \"$name\". This server has " +
+        tools.all.joinToString(", ") { it.name } + "."
+      recordCall(name, arguments, refusal = null, error = error, output = error, at = at, startedAt = startedAt)
+      return toolError(error)
+    }
     // One line per call, before the reads it causes, so that a session log reads as what the agent was
     // trying to learn and then what that cost. See [AgentTools].
     SharkLog.d { "An agent called $name${arguments.logLine()}" }
-    // What the call is about, read before it is made rather than after: a refused call is recorded pointing
-    // at whatever it was asking about, which is most of what makes a refusal worth reading afterwards.
-    val target = tools.target(name, arguments)
-    val at = Instant.now()
-    val startedAt = System.nanoTime()
     return try {
       val answer = tool.call(arguments)
       // Formatted once and then both answered with and written down, so that the text in the session is the
@@ -165,11 +227,11 @@ internal class McpSession(
       val answered = PRETTY_JSON.encodeToString(JsonElement.serializer(), answer)
       // The answer as well as the arguments, because two of them are things the arguments don't say: what
       // was concluded, and which heap dumps were open. See [outcomeOfTool] and [openHeapDumpsOfTool].
-      record(
+      recordCall(
         name,
         arguments,
-        target,
         refusal = null,
+        error = null,
         output = answered,
         outcome = outcomeOfTool(name, answer),
         openHeapDumps = openHeapDumpsOfTool(name, answer),
@@ -181,44 +243,57 @@ internal class McpSession(
       // A refusal is an answer to the agent and not a failure of the server, so it comes back as a tool
       // result the model reads rather than as a JSON-RPC error the client may swallow.
       SharkLog.d { "Refused $name: ${refused.message}" }
-      record(
+      recordCall(
         name,
         arguments,
-        target,
         refusal = refused.message,
-        // Which is the whole of what came back, so there is nothing else to keep: a refusal is text, and
-        // this is it. See [AgentSessionCall.output].
-        output = null,
-        outcome = null,
+        error = null,
+        // The refusal again, and not a duplicate of the field above it: that one is this app's reading —
+        // the method said no — and this is the text the agent was handed. See [AgentSessionCall.output].
+        output = refused.message,
         at = at,
         startedAt = startedAt
       )
       toolError(refused.message)
+    } catch (throwable: Throwable) {
+      // A read that failed or a bug of ours. Caught here rather than left to [answer] so that the call is
+      // written down as a call — pointing at the object it was about, with the reason the agent gave — and
+      // not as a line saying only that something went wrong somewhere.
+      SharkLog.d(throwable) { "An agent's $name failed" }
+      val error = throwable.toString()
+      recordCall(name, arguments, refusal = null, error = error, output = error, at = at, startedAt = startedAt)
+      toolError(error)
     }
   }
 
   /**
-   * Writes the call down, answered or refused.
+   * Writes a call down: answered, refused, failed, or made to a tool this build has never heard of.
    *
    * Here rather than in [AgentTool] because this is the one place that has both halves of a call: what was
    * asked, and what came back. Every call, in the order they were made, is what turns a session into
    * something a person can follow — and the reason for each is the agent's own sentence rather than a
    * paraphrase of it.
    */
-  private fun record(
+  private fun recordCall(
     name: String,
     arguments: JsonObject,
-    target: AgentTarget,
     refusal: String?,
+    error: String?,
     output: String?,
-    outcome: String?,
+    outcome: String? = null,
     openHeapDumps: List<String> = emptyList(),
     at: Instant,
     startedAt: Long
   ) {
+    // What the call is about, read off the arguments rather than out of the answer: a call that was refused,
+    // or that named a tool nothing answers to, is still recorded pointing at whatever it was asking about,
+    // which is most of what makes one worth reading afterwards.
+    val target = tools.target(name, arguments)
     sessionFile.called(
       AgentSessionCall(
         at = at,
+        over = over,
+        method = TOOLS_CALL,
         tool = name,
         reason = (arguments[REASON_ARGUMENT] as? JsonPrimitive)?.content,
         windowId = target.windowId,
@@ -230,8 +305,45 @@ internal class McpSession(
         input = "$name ${PRETTY_JSON.encodeToString(JsonElement.serializer(), arguments)}",
         output = output,
         refusal = refusal,
+        error = error,
         outcome = outcome,
         openHeapDumps = openHeapDumps,
+        millis = (System.nanoTime() - startedAt) / NANOS_PER_MILLI
+      )
+    )
+  }
+
+  /**
+   * And writes down a message that reached no tool, which is the protocol around them.
+   *
+   * The line as it arrived is the whole of what there is to keep for one of these: there is no tool to name
+   * it after, no arguments to read a subject out of, and nowhere in a heap dump for it to lead. Which is why
+   * they are worth keeping — a session that holds only what reached a tool cannot say why nothing did.
+   */
+  private fun recordMessage(
+    input: String,
+    method: String?,
+    output: String?,
+    error: String?,
+    at: Instant,
+    startedAt: Long
+  ) {
+    sessionFile.called(
+      AgentSessionCall(
+        at = at,
+        over = over,
+        method = method,
+        tool = null,
+        reason = null,
+        windowId = null,
+        heapDumpPath = null,
+        place = null,
+        arguments = emptyMap(),
+        input = input,
+        output = output,
+        refusal = null,
+        error = error,
+        outcome = null,
         millis = (System.nanoTime() - startedAt) / NANOS_PER_MILLI
       )
     )
@@ -315,6 +427,9 @@ internal class McpSession(
      * of an initialize. The revision this was written against, so that such a client gets a real answer.
      */
     const val FALLBACK_PROTOCOL_VERSION = "2025-06-18"
+
+    /** The one method that reaches a tool, which is what this whole surface is. */
+    const val TOOLS_CALL = AgentSessionFile.TOOLS_CALL_METHOD
 
     const val PARSE_ERROR = -32700
     const val INVALID_REQUEST = -32600

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/McpSession.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/McpSession.kt
@@ -160,6 +160,9 @@ internal class McpSession(
     val startedAt = System.nanoTime()
     return try {
       val answer = tool.call(arguments)
+      // Formatted once and then both answered with and written down, so that the text in the session is the
+      // text the model read rather than the same object printed a second way. See [AgentSessionCall.output].
+      val answered = PRETTY_JSON.encodeToString(JsonElement.serializer(), answer)
       // The answer as well as the arguments, because two of them are things the arguments don't say: what
       // was concluded, and which heap dumps were open. See [outcomeOfTool] and [openHeapDumpsOfTool].
       record(
@@ -167,12 +170,13 @@ internal class McpSession(
         arguments,
         target,
         refusal = null,
+        output = answered,
         outcome = outcomeOfTool(name, answer),
         openHeapDumps = openHeapDumpsOfTool(name, answer),
         at = at,
         startedAt = startedAt
       )
-      toolResult(answer)
+      toolResult(answer, answered)
     } catch (refused: AgentRefusal) {
       // A refusal is an answer to the agent and not a failure of the server, so it comes back as a tool
       // result the model reads rather than as a JSON-RPC error the client may swallow.
@@ -182,6 +186,9 @@ internal class McpSession(
         arguments,
         target,
         refusal = refused.message,
+        // Which is the whole of what came back, so there is nothing else to keep: a refusal is text, and
+        // this is it. See [AgentSessionCall.output].
+        output = null,
         outcome = null,
         at = at,
         startedAt = startedAt
@@ -203,6 +210,7 @@ internal class McpSession(
     arguments: JsonObject,
     target: AgentTarget,
     refusal: String?,
+    output: String?,
     outcome: String?,
     openHeapDumps: List<String> = emptyList(),
     at: Instant,
@@ -217,6 +225,10 @@ internal class McpSession(
         heapDumpPath = target.heapDumpPath,
         place = target.place,
         arguments = arguments.recorded(),
+        // Everything the client sent under this tool's name, formatted the way the answer is: the fields
+        // above are what this app made of it, and this is what it was. See [AgentSessionCall.input].
+        input = PRETTY_JSON.encodeToString(JsonElement.serializer(), arguments),
+        output = output,
         refusal = refusal,
         outcome = outcome,
         openHeapDumps = openHeapDumps,
@@ -225,13 +237,20 @@ internal class McpSession(
     )
   }
 
-  private fun toolResult(result: JsonObject): JsonObject = buildJsonObject {
+  private fun toolResult(
+    result: JsonObject,
+    /**
+     * [result] as text, which the caller already has because the session file keeps the same string.
+     *
+     * Indented, because the reader is a model reading a chain of twenty steps and every one of them matters.
+     * The newlines are escaped by being inside a JSON string, so the wire stays one line.
+     */
+    text: String
+  ): JsonObject = buildJsonObject {
     putJsonArray("content") {
       addJsonObject {
         put("type", "text")
-        // Indented, because the reader is a model reading a chain of twenty steps and every one of them
-        // matters. The newlines are escaped by being inside a JSON string, so the wire stays one line.
-        put("text", PRETTY_JSON.encodeToString(JsonElement.serializer(), result))
+        put("text", text)
       }
     }
     // For the clients that read it, alongside the text for the ones that don't.

--- a/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/McpSession.kt
+++ b/shark/shark-dive/shark-dive-agent/src/main/java/shark/dive/agent/McpSession.kt
@@ -225,9 +225,9 @@ internal class McpSession(
         heapDumpPath = target.heapDumpPath,
         place = target.place,
         arguments = arguments.recorded(),
-        // Everything the client sent under this tool's name, formatted the way the answer is: the fields
-        // above are what this app made of it, and this is what it was. See [AgentSessionCall.input].
-        input = PRETTY_JSON.encodeToString(JsonElement.serializer(), arguments),
+        // The whole call, formatted the way the answer is: the fields above are what this app made of it,
+        // and this is what it was. See [AgentSessionCall.input].
+        input = "$name ${PRETTY_JSON.encodeToString(JsonElement.serializer(), arguments)}",
         output = output,
         refusal = refusal,
         outcome = outcome,

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentCommandLineTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentCommandLineTest.kt
@@ -92,9 +92,19 @@ class AgentCommandLineTest {
     // an investigation is what somebody reads afterwards, and a process per call would have cut it up.
     val session = sessions().single()
     assertThat(session.sessionId).isEqualTo(SESSION_NAME)
-    assertThat(session.calls.map { it.tool }).containsExactly("open_heap_dumps", "list_leaks")
+    assertThat(session.toolCalls.map { it.tool }).containsExactly("open_heap_dumps", "list_leaks")
     // Said once, by the call that started the session, since a file with two headers is two sessions.
     assertThat(session.client).isEqualTo("shark-dive-cli")
+    // And every line of it says it was typed rather than sent by a client — which nothing after the handshake
+    // could tell, this being the same protocol on the same socket an MCP client speaks. Two handshakes in
+    // there, one per process: a session of typed calls reads as Connected, called, Connected, called.
+    assertThat(session.transports).containsExactly(AgentTransport.CLI)
+    assertThat(session.calls.map { it.method }).containsExactly(
+      "initialize",
+      "tools/call",
+      "initialize",
+      "tools/call"
+    )
   }
 
   @Test

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentServerTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentServerTest.kt
@@ -106,7 +106,40 @@ class AgentServerTest {
     // that holds a connection open says nothing and gets a session of its own. See [AgentCommandLineTest].
     val session = sessions().single()
     assertThat(session.sessionId).isEqualTo("cli7")
-    assertThat(session.calls.map { it.tool }).containsExactly("open_heap_dumps")
+    assertThat(session.toolCalls.map { it.tool }).containsExactly("open_heap_dumps")
+    // The ping is in there too, since the full traffic is what a session holds: it reached no tool and it is
+    // still what happened on that connection. See [AgentSessionCall.method].
+    assertThat(session.calls.map { it.method }).containsExactly("ping", "tools/call")
+  }
+
+  @Test
+  fun `a connection that says which way in it is has every line of it recorded that way`() {
+    listen()
+    val run = AgentServer.publishedRuns(directory).single()
+
+    connect(run, sessionName = "cli7", over = AgentTransport.CLI).use { it.ask(CALL_OPEN_HEAP_DUMPS) }
+    // And one that says nothing is a client holding a session open, which is what every MCP client does and
+    // what everything did before the command line existed. See [AgentServer].
+    connect(run).use { it.ask(CALL_OPEN_HEAP_DUMPS) }
+
+    assertThat(sessions().map { it.transports })
+      .containsExactlyInAnyOrder(listOf(AgentTransport.CLI), listOf(AgentTransport.MCP))
+  }
+
+  @Test
+  fun `a connection that names a way in this build has none of is served and recorded as MCP`() {
+    listen()
+    val run = AgentServer.publishedRuns(directory).single()
+
+    connect(run, sessionName = "odd", handshakeSuffix = " carrier-pigeon").use {
+      assertThat(it.accepted).isTrue()
+      it.ask(CALL_OPEN_HEAP_DUMPS)
+    }
+
+    // Served, for the reason a name this cannot use is: the calls are none the worse for it, and refusing the
+    // connection would lose the investigation to protect a label. The log says which word it was.
+    assertThat(sessions().single().transports).containsExactly(AgentTransport.MCP)
+    assertThat(log).anyMatch { it.contains("carrier-pigeon") }
   }
 
   @Test
@@ -155,8 +188,11 @@ class AgentServerTest {
   private fun connect(
     run: AgentServer.PublishedRun,
     token: String = run.token,
-    sessionName: String? = null
-  ): TestClient = TestClient(run.port, token, sessionName)
+    sessionName: String? = null,
+    over: AgentTransport? = null,
+    /** Whatever else a client puts on the handshake, for the words this build has no way in for. */
+    handshakeSuffix: String = ""
+  ): TestClient = TestClient(run.port, token, sessionName, over, handshakeSuffix)
 
   private fun sessions(): List<AgentSession> =
     AgentSessionFile.sessionsIn(AgentServer.sessionsDirectory(directory))
@@ -166,7 +202,10 @@ class AgentServerTest {
     port: Int,
     token: String,
     /** The session this connection joins, which a command line names and a client holding one open doesn't. */
-    sessionName: String?
+    sessionName: String?,
+    /** And which way in it is, which only a command line says. See [AgentTransport]. */
+    over: AgentTransport?,
+    handshakeSuffix: String
   ) : Closeable {
 
     private val socket = Socket(InetAddress.getLoopbackAddress(), port)
@@ -176,7 +215,7 @@ class AgentServerTest {
     val accepted: Boolean
 
     init {
-      toApp.println(listOfNotNull(token, sessionName).joinToString(" "))
+      toApp.println(listOfNotNull(token, sessionName, over?.recorded).joinToString(" ") + handshakeSuffix)
       accepted = fromApp.readLine() == AgentServer.ACCEPTED
     }
 

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentSessionFileTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentSessionFileTest.kt
@@ -87,6 +87,62 @@ class AgentSessionFileTest {
   }
 
   @Test
+  fun `a message that reached no tool is a line like any other`() {
+    val file = AgentSessionFile.starting(directory, SERVER_VERSION)
+    file.called(message(method = "tools/list", input = """{"method":"tools/list"}""", output = """{"tools":[]}"""))
+    file.called(message(method = null, input = "this is not JSON", output = "no", error = "That is not JSON"))
+    file.called(call(tool = "list_leaks"))
+
+    // All three, since the full traffic is what a session is: the calls are the subset that got as far as a
+    // tool, and everything else is how it got there or why it didn't. See [AgentSession.toolCalls].
+    val session = AgentSessionFile.sessionsIn(directory).single()
+    assertThat(session.calls).hasSize(3)
+    assertThat(session.toolCalls.map { it.tool }).containsExactly("list_leaks")
+    assertThat(session.errorCount).isEqualTo(1)
+    val unreadable = session.calls[1]
+    assertThat(unreadable.method).isNull()
+    assertThat(unreadable.input).isEqualTo("this is not JSON")
+    assertThat(unreadable.error).isEqualTo("That is not JSON")
+    // Which is what the row of it says, since there is no tool to name it after and no place to lead to.
+    assertThat(unreadable.verb).isEqualTo("Sent something this app could not read")
+    assertThat(unreadable.place).isNull()
+  }
+
+  @Test
+  fun `which way in a message came is read back, and a session says which ways it was talked to`() {
+    val file = AgentSessionFile.starting(directory, SERVER_VERSION)
+    file.called(call(tool = "list_leaks", over = AgentTransport.MCP))
+    file.called(call(tool = "describe_object", over = AgentTransport.CLI))
+
+    // An MCP client's call and a call somebody typed at the window are the same protocol on the same socket
+    // by the time anything answers them, so the door is the only place that knows and this is where it says.
+    val session = AgentSessionFile.sessionsIn(directory).single()
+    assertThat(session.calls.map { it.over })
+      .containsExactly(AgentTransport.MCP, AgentTransport.CLI)
+    assertThat(session.transports).containsExactly(AgentTransport.MCP, AgentTransport.CLI)
+  }
+
+  @Test
+  fun `a session recorded before the way in was kept says nothing rather than guessing one`() {
+    directory.mkdirs()
+    File(directory, "agent-2026-08-25_18-19-48_035-older.jsonl").writeText(
+      """{"agentSession":"older","startedAt":"$STARTED_AT","sharkDive":"1.0.0"}""" + "\n" +
+        """{"at":"$STARTED_AT","tool":"list_leaks","reason":"What the dump says.","millis":3}""" + "\n" +
+        """{"at":"$STARTED_AT","over":"carrier pigeon","tool":"list_leaks","millis":3}""" + "\n"
+    )
+
+    // Null, not MCP: a command line's calls are exactly the ones a guess would label wrongly. And a way in
+    // this build has never heard of reads the same, with a line in the log saying which.
+    val session = AgentSessionFile.sessionsIn(directory).single()
+    assertThat(session.calls.map { it.over }).containsExactly(null, null)
+    assertThat(session.transports).isEmpty()
+    assertThat(log).anyMatch { it.contains("carrier pigeon") }
+    // And a tool call from a build that recorded no method still reads as the one method it can have been.
+    assertThat(session.calls.map { it.method }).containsOnly("tools/call")
+    assertThat(session.toolCalls).hasSize(2)
+  }
+
+  @Test
   fun `a call that was refused says so, and still says what it was about`() {
     val file = AgentSessionFile.starting(directory, SERVER_VERSION)
     file.called(call(tool = "conclude", place = Place.Object(OBJECT_ID), refusal = "Not concluded. 3 steps"))
@@ -252,10 +308,14 @@ class AgentSessionFileTest {
     input: String? = null,
     output: String? = null,
     refusal: String? = null,
+    error: String? = null,
     outcome: String? = null,
+    over: AgentTransport = AgentTransport.MCP,
     openHeapDumps: List<String> = emptyList()
   ) = AgentSessionCall(
     at = STARTED_AT,
+    over = over,
+    method = "tools/call",
     tool = tool,
     reason = reason,
     windowId = WINDOW_ID,
@@ -265,9 +325,35 @@ class AgentSessionFileTest {
     input = input,
     output = output,
     refusal = refusal,
+    error = error,
     outcome = outcome,
     openHeapDumps = openHeapDumps,
     millis = 12L
+  )
+
+  /** A message that reached no tool, which is the rest of what a session holds. See [AgentSessionCall]. */
+  private fun message(
+    method: String?,
+    input: String,
+    output: String? = null,
+    error: String? = null,
+    over: AgentTransport = AgentTransport.MCP
+  ) = AgentSessionCall(
+    at = STARTED_AT,
+    over = over,
+    method = method,
+    tool = null,
+    reason = null,
+    windowId = null,
+    heapDumpPath = null,
+    place = null,
+    arguments = emptyMap(),
+    input = input,
+    output = output,
+    refusal = null,
+    error = error,
+    outcome = null,
+    millis = 3L
   )
 
   private companion object {

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentSessionFileTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentSessionFileTest.kt
@@ -275,8 +275,12 @@ class AgentSessionFileTest {
     const val WINDOW_ID = "zvphq4r3"
     const val OBJECT_ID = 0x12d368b8L
 
-    /** An exchange as it crosses the wire: formatted over several lines, which one line of JSON escapes. */
-    const val SENT = "{\n  \"object\": \"0x12d368b8\",\n  \"reason\": \"Reading the holder's fields.\"\n}"
+    /**
+     * An exchange as it crosses the wire: the tool's own name and then several lines of formatted JSON,
+     * which one line of the session file escapes.
+     */
+    const val SENT =
+      "describe_object {\n  \"object\": \"0x12d368b8\",\n  \"reason\": \"Reading the holder's fields.\"\n}"
     const val ANSWERED = "{\n  \"object\": \"0x12d368b8\",\n  \"className\": \"com.example.Holder\"\n}"
 
     val STARTED_AT: Instant = Instant.parse("2026-08-25T18:19:48.035Z")

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentSessionFileTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentSessionFileTest.kt
@@ -58,6 +58,35 @@ class AgentSessionFileTest {
   }
 
   @Test
+  fun `what a call sent and what it read back are kept as they were`() {
+    val file = AgentSessionFile.starting(directory, SERVER_VERSION)
+    file.called(call(tool = "describe_object", input = SENT, output = ANSWERED))
+
+    // Character for character, newlines and all, because the point of keeping these is that they are not a
+    // reading of what happened: an argument spelled wrong reads right in every derived field there is.
+    val call = AgentSessionFile.sessionsIn(directory).single().calls.single()
+    assertThat(call.input).isEqualTo(SENT)
+    assertThat(call.output).isEqualTo(ANSWERED)
+  }
+
+  @Test
+  fun `a session recorded before the exchange was kept reads back without one`() {
+    directory.mkdirs()
+    File(directory, "agent-2026-08-25_18-19-48_035-older.jsonl").writeText(
+      """{"agentSession":"older","startedAt":"$STARTED_AT","sharkDive":"1.0.0"}""" + "\n" +
+        """{"at":"$STARTED_AT","tool":"list_leaks","reason":"What the dump says.",""" +
+        """"window":"$WINDOW_ID","heapDump":"/dumps/leak.hprof","millis":3}""" + "\n"
+    )
+
+    // Null rather than empty, which is what the *Agent logs* screen says out loud: a fold that opens onto
+    // nothing reads as an app that lost the answer rather than one that was never given it.
+    val call = AgentSessionFile.sessionsIn(directory).single().calls.single()
+    assertThat(call.input).isNull()
+    assertThat(call.output).isNull()
+    assertThat(call.reason).isEqualTo("What the dump says.")
+  }
+
+  @Test
   fun `a call that was refused says so, and still says what it was about`() {
     val file = AgentSessionFile.starting(directory, SERVER_VERSION)
     file.called(call(tool = "conclude", place = Place.Object(OBJECT_ID), refusal = "Not concluded. 3 steps"))
@@ -220,6 +249,8 @@ class AgentSessionFileTest {
     reason: String? = "Because.",
     place: Place? = null,
     arguments: Map<String, String> = emptyMap(),
+    input: String? = null,
+    output: String? = null,
     refusal: String? = null,
     outcome: String? = null,
     openHeapDumps: List<String> = emptyList()
@@ -231,6 +262,8 @@ class AgentSessionFileTest {
     heapDumpPath = "/dumps/leak.hprof",
     place = place,
     arguments = arguments,
+    input = input,
+    output = output,
     refusal = refusal,
     outcome = outcome,
     openHeapDumps = openHeapDumps,
@@ -241,6 +274,10 @@ class AgentSessionFileTest {
     const val SERVER_VERSION = "1.2.3"
     const val WINDOW_ID = "zvphq4r3"
     const val OBJECT_ID = 0x12d368b8L
+
+    /** An exchange as it crosses the wire: formatted over several lines, which one line of JSON escapes. */
+    const val SENT = "{\n  \"object\": \"0x12d368b8\",\n  \"reason\": \"Reading the holder's fields.\"\n}"
+    const val ANSWERED = "{\n  \"object\": \"0x12d368b8\",\n  \"className\": \"com.example.Holder\"\n}"
 
     val STARTED_AT: Instant = Instant.parse("2026-08-25T18:19:48.035Z")
   }

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentToolsTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentToolsTest.kt
@@ -900,13 +900,15 @@ class AgentToolsTest {
     const val PLACE_LEAKS = "leaks"
 
     /**
-     * What the calls of a recorded session sent and read back, as the text they were.
+     * What the calls of a recorded session sent and read back, as the text they were: the tool's own name
+     * and then what was sent to it.
      *
      * The refused one has no output, its answer having been the refusal — which is the shape a reader of one
      * of these has to be able to tell from a call whose answer went missing.
      */
-    const val REFUSED_CALL_SENT = "{\n  \"heapDump\": \"leak.hprof\"\n}"
-    const val CONCLUDE_SENT = "{\n  \"object\": \"0x12d368b8\",\n  \"rootCause\": \"Nothing clears it.\"\n}"
+    const val REFUSED_CALL_SENT = "list_leaks {\n  \"heapDump\": \"leak.hprof\"\n}"
+    const val CONCLUDE_SENT =
+      "conclude {\n  \"object\": \"0x12d368b8\",\n  \"rootCause\": \"Nothing clears it.\"\n}"
     const val CONCLUDE_ANSWERED = "{\n  \"concluded\": true\n}"
 
     /**

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentToolsTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentToolsTest.kt
@@ -139,6 +139,24 @@ class AgentToolsTest {
   }
 
   @Test
+  fun `one session of the log is what each call sent and what it read back`() {
+    tools = agentTools(
+      FakeAgentHeapDumps(listOf(window)),
+      sessions = listOf(recordedSession("cli7", concluded = "Holder.activity"))
+    )
+
+    val calls = call(AGENT_LOG, "session" to "cli7").array("calls").map { it.jsonObject }
+
+    // Exactly, because an agent asked why an investigation went wrong is looking for the step whose reason
+    // reads fine and whose answer didn't say what the reason assumed. A paraphrase hides that by definition.
+    assertThat(calls.last().text("input")).isEqualTo(CONCLUDE_SENT)
+    assertThat(calls.last().text("output")).isEqualTo(CONCLUDE_ANSWERED)
+    // And a refused call kept what it sent, its answer being the refusal already above it.
+    assertThat(calls.first().text("input")).isEqualTo(REFUSED_CALL_SENT)
+    assertThat(calls.first()["output"]).isEqualTo(JsonNull)
+  }
+
+  @Test
   fun `a session that read another heap dump is refused by name here`() {
     tools = agentTools(
       FakeAgentHeapDumps(listOf(window)),
@@ -792,12 +810,15 @@ class AgentToolsTest {
         tool = "list_leaks",
         heapDumpPath = heapDumpPath,
         reason = "Reading what the dump says about itself.",
+        input = REFUSED_CALL_SENT,
         refusal = "list_leaks needs `reason`, and it was not given."
       ),
       recordedCall(
         tool = "conclude",
         heapDumpPath = heapDumpPath,
         reason = "Naming the reference the chain agrees on.",
+        input = CONCLUDE_SENT,
+        output = CONCLUDE_ANSWERED,
         outcome = concluded
       )
     )
@@ -807,6 +828,8 @@ class AgentToolsTest {
     tool: String,
     heapDumpPath: String,
     reason: String,
+    input: String? = null,
+    output: String? = null,
     refusal: String? = null,
     outcome: String? = null
   ) = AgentSessionCall(
@@ -817,6 +840,8 @@ class AgentToolsTest {
     heapDumpPath = heapDumpPath,
     place = null,
     arguments = emptyMap(),
+    input = input,
+    output = output,
     refusal = refusal,
     outcome = outcome,
     millis = 3L
@@ -873,6 +898,16 @@ class AgentToolsTest {
     const val HEAP_DUMP = "heapDump"
     const val OBJECT = "object"
     const val PLACE_LEAKS = "leaks"
+
+    /**
+     * What the calls of a recorded session sent and read back, as the text they were.
+     *
+     * The refused one has no output, its answer having been the refusal — which is the shape a reader of one
+     * of these has to be able to tell from a call whose answer went missing.
+     */
+    const val REFUSED_CALL_SENT = "{\n  \"heapDump\": \"leak.hprof\"\n}"
+    const val CONCLUDE_SENT = "{\n  \"object\": \"0x12d368b8\",\n  \"rootCause\": \"Nothing clears it.\"\n}"
+    const val CONCLUDE_ANSWERED = "{\n  \"concluded\": true\n}"
 
     /**
      * One value of a field of the answer, whatever it is, as text.

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentToolsTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/AgentToolsTest.kt
@@ -834,6 +834,8 @@ class AgentToolsTest {
     outcome: String? = null
   ) = AgentSessionCall(
     at = Instant.parse("2026-08-26T09:15:01Z"),
+    over = AgentTransport.MCP,
+    method = "tools/call",
     tool = tool,
     reason = reason,
     windowId = window.windowId,
@@ -843,6 +845,7 @@ class AgentToolsTest {
     input = input,
     output = output,
     refusal = refusal,
+    error = null,
     outcome = outcome,
     millis = 3L
   )

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/McpSessionTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/McpSessionTest.kt
@@ -236,9 +236,12 @@ class McpSessionTest {
     // against the client's own transcript of it.
     val call = sessions().single().calls.single()
     assertThat(call.output).isEqualTo(result.array("content").single().jsonObject.text("text"))
-    // And everything the client sent under the tool's name, `reason` included: the derived fields leave it
-    // out because they have one of their own, and this is the call rather than a reading of it.
+    // And the call as the model wrote it: the tool it named, then everything it sent, `reason` included —
+    // the derived fields leave that out because they have one of their own, and this is the call rather than
+    // a reading of it. The name because a set of arguments with nothing saying what they are arguments to is
+    // the one form of this that can't be read on its own.
     assertThat(call.input)
+      .startsWith("describe_object {")
       .contains(""""object": "${hex(heapDump.holderObjectId)}"""")
       .contains(""""reason": "Reading the holder's fields."""")
   }
@@ -255,7 +258,9 @@ class McpSessionTest {
     val call = sessions().single().calls.single()
     assertThat(call.output).isNull()
     assertThat(call.refusal).isEqualTo(result.array("content").single().jsonObject.text("text"))
-    assertThat(call.input).contains(""""rootCause": "The holder never lets go."""")
+    assertThat(call.input)
+      .startsWith("conclude {")
+      .contains(""""rootCause": "The holder never lets go."""")
   }
 
   @Test

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/McpSessionTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/McpSessionTest.kt
@@ -225,6 +225,40 @@ class McpSessionTest {
   }
 
   @Test
+  fun `a call is written down as the text that was sent and the text that came back`() {
+    val result = callTool(
+      """{"name":"describe_object","arguments":{"object":"${hex(heapDump.holderObjectId)}",""" +
+        """"reason":"Reading the holder's fields."}}"""
+    )
+
+    // The same string the model read, not the same JSON printed a second way: what a session is kept for is
+    // following what an agent did, and an answer reformatted on its way to disk is one nobody can compare
+    // against the client's own transcript of it.
+    val call = sessions().single().calls.single()
+    assertThat(call.output).isEqualTo(result.array("content").single().jsonObject.text("text"))
+    // And everything the client sent under the tool's name, `reason` included: the derived fields leave it
+    // out because they have one of their own, and this is the call rather than a reading of it.
+    assertThat(call.input)
+      .contains(""""object": "${hex(heapDump.holderObjectId)}"""")
+      .contains(""""reason": "Reading the holder's fields."""")
+  }
+
+  @Test
+  fun `a refused call keeps what it sent, its answer being the refusal`() {
+    val result = callTool(
+      """{"name":"conclude","arguments":{"object":"${hex(heapDump.activityObjectId)}",""" +
+        """"rootCause":"The holder never lets go.","reason":"I know what this is."}}"""
+    )
+
+    // Written once rather than twice: the text a refused call was answered with *is* its refusal, which the
+    // row of the *Agent logs* screen already prints in full. See [AgentSessionCall.output].
+    val call = sessions().single().calls.single()
+    assertThat(call.output).isNull()
+    assertThat(call.refusal).isEqualTo(result.array("content").single().jsonObject.text("text"))
+    assertThat(call.input).contains(""""rootCause": "The holder never lets go."""")
+  }
+
+  @Test
   fun `a refused call is written down with the refusal and what it was asking about`() {
     callTool(
       """{"name":"conclude","arguments":{"object":"${hex(heapDump.activityObjectId)}",""" +

--- a/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/McpSessionTest.kt
+++ b/shark/shark-dive/shark-dive-agent/src/test/java/shark/dive/agent/McpSessionTest.kt
@@ -46,7 +46,8 @@ class McpSessionTest {
     session = McpSession(
       tools = agentTools(FakeAgentHeapDumps(listOf(window))),
       serverVersion = SERVER_VERSION,
-      sessionFile = AgentSessionFile.starting(sessionsDirectory, SERVER_VERSION)
+      sessionFile = AgentSessionFile.starting(sessionsDirectory, SERVER_VERSION),
+      over = AgentTransport.MCP
     )
   }
 
@@ -207,7 +208,8 @@ class McpSessionTest {
     val session = sessions().single()
     assertThat(session.client).isEqualTo("claude-code 9.9.9")
     assertThat(session.serverVersion).isEqualTo(SERVER_VERSION)
-    val call = session.calls.single()
+    // The handshake is a line of the session too, so the calls are the subset that reached a tool.
+    val call = session.toolCalls.single()
     assertThat(call.verb).isEqualTo("Looked at")
     assertThat(call.subject).isEqualTo(hex(heapDump.holderObjectId))
     assertThat(call.reason).isEqualTo("Checking whether the holder is the singleton it looks like.")
@@ -253,11 +255,13 @@ class McpSessionTest {
         """"rootCause":"The holder never lets go.","reason":"I know what this is."}}"""
     )
 
-    // Written once rather than twice: the text a refused call was answered with *is* its refusal, which the
-    // row of the *Agent logs* screen already prints in full. See [AgentSessionCall.output].
+    // Both, and not one of them: `refused` is this app's reading — the method said no — and `output` is the
+    // text the agent was handed. Writing only the reading was tried and is what "an answer that isn't logged"
+    // looked like from the outside. See [AgentSessionCall.output].
     val call = sessions().single().calls.single()
-    assertThat(call.output).isNull()
-    assertThat(call.refusal).isEqualTo(result.array("content").single().jsonObject.text("text"))
+    val answered = result.array("content").single().jsonObject.text("text")
+    assertThat(call.output).isEqualTo(answered)
+    assertThat(call.refusal).isEqualTo(answered)
     assertThat(call.input)
       .startsWith("conclude {")
       .contains(""""rootCause": "The holder never lets go."""")
@@ -334,6 +338,90 @@ class McpSessionTest {
     // asked is what it typed, and what it concluded is what the heap dump agreed to. That is the line the
     // *Agent logs* screen ends a session with, and the one the eval marks against an answer key.
     assertThat(sessions().single().calls.last().outcome).isEqualTo(FAULTY_REFERENCE)
+  }
+
+  @Test
+  fun `the protocol around the tools is written down too, and says which way in it came`() {
+    answer(
+      """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18",""" +
+        """"clientInfo":{"name":"claude-code","version":"9.9.9"},"capabilities":{}}}"""
+    )
+    answerOrNull("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+    answer("""{"jsonrpc":"2.0","id":2,"method":"tools/list"}""")
+    callTool("""{"name":"list_leaks","arguments":{"reason":"Starting with what the dump says."}}""")
+
+    // Every line, in the order it arrived, because the question this gets read for is often why nothing
+    // happened: a session that keeps only the calls that reached a tool cannot answer it.
+    val session = sessions().single()
+    assertThat(session.calls.map { it.verb }).containsExactly(
+      "Connected",
+      "Sent the notification notifications/initialized",
+      "Asked what the tools are",
+      "Listed the"
+    )
+    // And nothing of the protocol pretends to be a call: no tool, nowhere to go, and the calls are the four
+    // lines minus the three. See [AgentSession.toolCalls].
+    assertThat(session.calls.map { it.tool })
+      .containsExactly(null, null, null, "list_leaks")
+    assertThat(session.toolCalls).hasSize(1)
+    assertThat(session.calls.map { it.over }).containsOnly(AgentTransport.MCP)
+  }
+
+  @Test
+  fun `a message with nothing behind it keeps the line and the answer that went back`() {
+    val notJson = answer("this is not JSON")
+    val noMethod = answer("""{"jsonrpc":"2.0","id":4}""")
+
+    // The line as it arrived, since there is nothing else to keep — and the answer, which is the half that
+    // was missing: an agent told "that is not JSON" and a session that recorded nothing is a session saying
+    // this app went quiet.
+    val calls = sessions().single().calls
+    assertThat(calls.map { it.input }).containsExactly("this is not JSON", """{"jsonrpc":"2.0","id":4}""")
+    assertThat(calls.map { it.output }).containsExactly(notJson.toString(), noMethod.toString())
+    assertThat(calls.map { it.method }).containsExactly(null, null)
+    assertThat(calls[0].error).contains("not JSON")
+    assertThat(calls[1].error).contains("method")
+  }
+
+  @Test
+  fun `a method this server does not have is written down as what arrived`() {
+    val answered = answer("""{"jsonrpc":"2.0","id":3,"method":"resources/list"}""")
+
+    val call = sessions().single().calls.single()
+    assertThat(call.method).isEqualTo("resources/list")
+    assertThat(call.verb).isEqualTo("Sent resources/list")
+    assertThat(call.output).isEqualTo(answered.toString())
+    assertThat(call.error).contains("resources/list")
+  }
+
+  @Test
+  fun `a call to a tool this server does not have is written down under the name it used`() {
+    val result = callTool("""{"name":"solve_the_leak","arguments":{"reason":"Trying my luck."}}""")
+
+    // Under the name, because a name nothing answers to is exactly what somebody is looking for when a call
+    // went nowhere — a typo, or a tool from a build newer than this one.
+    val call = sessions().single().calls.single()
+    assertThat(call.tool).isEqualTo("solve_the_leak")
+    // As it arrived, and not tidied into words: every tool of this build has a verb, so a name with none is a
+    // name this build has no tool for, and the exact string is the whole of what a reader is after.
+    assertThat(call.verb).isEqualTo("Called solve_the_leak")
+    assertThat(call.reason).isEqualTo("Trying my luck.")
+    assertThat(call.input).startsWith("solve_the_leak {")
+    assertThat(call.output).isEqualTo(result.array("content").single().jsonObject.text("text"))
+    assertThat(call.error).contains("solve_the_leak").contains("describe_object")
+    // Not a refusal: the surface said no to nothing, this build simply has no such tool.
+    assertThat(call.refusal).isNull()
+  }
+
+  @Test
+  fun `a tools_call that named no tool is written down as the call it was`() {
+    val result = callTool("""{"arguments":{"reason":"Forgot the name."}}""")
+
+    val call = sessions().single().calls.single()
+    assertThat(call.tool).isNull()
+    assertThat(call.method).isEqualTo("tools/call")
+    assertThat(call.verb).isEqualTo("Called a tool it did not name")
+    assertThat(call.output).isEqualTo(result.array("content").single().jsonObject.text("text"))
   }
 
   private fun sessions(): List<AgentSession> = AgentSessionFile.sessionsIn(sessionsDirectory)

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import java.io.File
 import java.time.Instant
@@ -281,6 +282,12 @@ internal fun AgentLogScreen(
  * this window; a call that named nothing went to a screen of the dump all the same, and the words for that
  * come with the verb. A row with no link is a call about the app rather than about a heap dump — which dumps
  * are open, which devices are connected — or one about a heap dump that has since been deleted.
+ *
+ * **And every row unfolds onto what actually crossed the wire**, which is the other half of following an
+ * investigation. The sentence on the row is this window's reading of a call, and a reading is no use for the
+ * question a reader ends up with — why did it do *that* next — because a step made on an answer that said
+ * nothing reads exactly like a step made on one that said everything. So the arrow is on every row and what
+ * is behind it is [AgentSessionCall.input] and [AgentSessionCall.output], as sent and as read.
  */
 @Composable
 private fun AgentCallRow(
@@ -324,23 +331,18 @@ private fun AgentCallRow(
       // Wrapped rather than truncated, since a class name is as long as it is and the reason under it is a
       // sentence: this row is read, not scanned past.
       FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        UnfoldableVerb(call.verb, isUnfolded) { isUnfolded = !isUnfolded }
         when {
-          openHeapDumps.isNotEmpty() -> UnfoldableVerb(call.verb, isUnfolded) { isUnfolded = !isUnfolded }
-          target == null -> Text(call.verb, style = MaterialTheme.typography.bodyMedium)
+          target == null -> Unit
+          leadsTo == null -> Text(target, style = MaterialTheme.typography.bodyMedium)
+          // Another dump: one place to go, and a link that names that dump for somebody to go there
+          // without this window.
+          opens != null -> CopyLinkTarget({ onCopyHeapDumpLink(opens, leadsTo) }) {
+            LinkText(target, Modifier.openable { onOpenHeapDump(opens, leadsTo) })
+          }
           else -> {
-            Text(call.verb, style = MaterialTheme.typography.bodyMedium)
-            when {
-              leadsTo == null -> Text(target, style = MaterialTheme.typography.bodyMedium)
-              // Another dump: one place to go, and a link that names that dump for somebody to go there
-              // without this window.
-              opens != null -> CopyLinkTarget({ onCopyHeapDumpLink(opens, leadsTo) }) {
-                LinkText(target, Modifier.openable { onOpenHeapDump(opens, leadsTo) })
-              }
-              else -> {
-                val open: (OpenIn) -> Unit = { openIn -> onOpen(leadsTo, openIn) }
-                OpenTarget(open, { onCopyLink(leadsTo) }) { LinkText(target, Modifier.openable(open)) }
-              }
-            }
+            val open: (OpenIn) -> Unit = { openIn -> onOpen(leadsTo, openIn) }
+            OpenTarget(open, { onCopyLink(leadsTo) }) { LinkText(target, Modifier.openable(open)) }
           }
         }
         // What the answer came to, and — for a row that opens another dump when clicked — which dump that
@@ -366,17 +368,74 @@ private fun AgentCallRow(
         openHeapDumps.forEach { path ->
           OpenHeapDumpRow(path, heapDumpFile, onOpenHeapDump, onCopyHeapDumpLink)
         }
+        CallExchange(call)
       }
     }
   }
 }
 
 /**
- * A verb with what is behind it, for the call whose answer is a list rather than a thing.
+ * What the agent sent and what it read back, under the row that says what this window made of it.
  *
- * The verb itself is what opens it, since there is no thing on that row to be a link — and the arrow is the
- * same one the leaks screen folds its sections with, because it is the same gesture on a screen somebody
- * reads straight after that one.
+ * **Whole, and never a first line of it.** What somebody unfolds a call for is the part the row left out, so
+ * an answer cut to fit is the one shape this must not take: the field that was null, the address that was a
+ * digit out, the list that came back empty are all in the tail. It is behind a fold and monospaced for the
+ * same reason — this is data being read closely, not prose being skimmed, and JSON that doesn't line up is
+ * JSON nobody reads twice.
+ *
+ * A refused call has no output here because its answer *was* the refusal, which the row prints in full above.
+ * A call with neither says so: a session recorded before this app kept them unfolds onto a sentence rather
+ * than onto nothing.
+ */
+@Composable
+private fun CallExchange(call: AgentSessionCall) {
+  val input = call.input
+  val output = call.output
+  if (input == null && output == null) {
+    Text(
+      NOTHING_KEPT,
+      Modifier.padding(start = UNFOLDED_INSET),
+      style = MaterialTheme.typography.bodySmall,
+      color = MUTED_TEXT
+    )
+    return
+  }
+  input?.let { ExchangeText(SENT, it) }
+  output?.let { ExchangeText(ANSWERED, it) }
+}
+
+/** One side of an exchange: what it is, and then it, as it was. */
+@Composable
+private fun ExchangeText(
+  label: String,
+  text: String
+) {
+  Column(
+    Modifier.padding(start = UNFOLDED_INSET),
+    verticalArrangement = Arrangement.spacedBy(2.dp)
+  ) {
+    Text(label, style = MaterialTheme.typography.bodySmall, color = MUTED_TEXT)
+    // Selectable, because what somebody does with an exact answer is take it somewhere else: into an issue,
+    // into a diff of two runs, into a message to whoever handed them the dump.
+    SelectionContainer {
+      Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
+        Text(
+          text,
+          Modifier.padding(8.dp),
+          style = MaterialTheme.typography.bodySmall,
+          fontFamily = FontFamily.Monospace
+        )
+      }
+    }
+  }
+}
+
+/**
+ * A verb with what is behind it, which is on every row.
+ *
+ * The verb itself is what opens it, since the thing on a row is a link to where the call went — and the arrow
+ * is the same one the leaks screen folds its sections with, because it is the same gesture on a screen
+ * somebody reads straight after that one.
  */
 @Composable
 private fun UnfoldableVerb(
@@ -495,6 +554,20 @@ private const val LEADS_TO = "→"
 private const val IN = "in"
 
 private const val REFUSED = "Refused:"
+
+/** Over the two halves of an unfolded call, which are the call itself rather than a word about it. */
+private const val SENT = "sent:"
+private const val ANSWERED = "answered:"
+
+/**
+ * And where a session from an older build has neither.
+ *
+ * Rather than a fold that opens onto an empty gap, which reads as an app that lost the answer instead of one
+ * that was never given it.
+ */
+private const val NOTHING_KEPT =
+  "This session was recorded before Shark Dive kept what was sent and answered, so only the line above it " +
+    "is left."
 
 private const val A_CLIENT_THAT_DID_NOT_SAY = "An agent"
 

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
@@ -29,6 +29,7 @@ import shark.SharkLog
 import shark.dive.Place
 import shark.dive.agent.AgentSession
 import shark.dive.agent.AgentSessionCall
+import shark.dive.agent.AgentTransport
 import shark.dive.agent.screen
 import shark.dive.agent.subject
 import shark.dive.agent.verb
@@ -214,6 +215,12 @@ private fun List<AgentSession>.byHeapDump(heapDumpFile: File): List<HeapDumpSess
  * look at. A call that went on to another heap dump leads to that dump instead, named on the row: a session is
  * one agent's connection and can read as many dumps as were open, and a row leading nowhere would be the app
  * showing somebody what an agent looked at and then declining to show them the thing.
+ *
+ * **Every message, not only the ones that reached a tool.** The handshake, a `tools/list`, a ping, a call to a
+ * tool this build has never heard of and a line that was not JSON at all are each a row here, because the
+ * question this screen gets opened for is often why *nothing* happened — and a screen that draws the calls
+ * that worked is the one screen that cannot answer it. The cost is visible and worth it: a command line sends
+ * a handshake per call, so a session of typed calls reads as Connected, called, Connected, called.
  */
 @Composable
 internal fun AgentLogScreen(
@@ -365,6 +372,16 @@ private fun AgentCallRow(
           color = MaterialTheme.colorScheme.error
         )
       }
+      // And what could not be answered at all, which is this app failing rather than the surface saying no.
+      // The same red, because both are a call that came to nothing, and a different word because what to do
+      // about them is not the same thing: a refusal is the method working. See [AgentSessionCall.error].
+      call.error?.let { error ->
+        Text(
+          "$FAILED $error",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.error
+        )
+      }
       // Under everything this window made of the call, because it is the call: last is where a reader
       // arrives having read the sentence and wanted more of it, and it opens where it is.
       ExchangeToggle(isUnfolded) { isUnfolded = !isUnfolded }
@@ -387,9 +404,11 @@ private fun AgentCallRow(
  * same reason — this is data being read closely, not prose being skimmed, and JSON that doesn't line up is
  * JSON nobody reads twice.
  *
- * A refused call has no output here because its answer *was* the refusal, which the row prints in full above.
- * A call with neither says so: a session recorded before this app kept them unfolds onto a sentence rather
- * than onto nothing.
+ * **Including for a call that came to nothing**, which is the case this is most worth unfolding for: the
+ * refusal, the error and the line that was not a message at all are all answers that went back to the agent,
+ * so they are all here as they were sent. A call with nothing at all under `answered:` is a notification —
+ * the one kind of message JSON-RPC forbids answering. A call with neither half says so, since a session
+ * recorded before this app kept them unfolds onto a sentence rather than onto nothing.
  */
 @Composable
 private fun CallExchange(call: AgentSessionCall) {
@@ -404,7 +423,7 @@ private fun CallExchange(call: AgentSessionCall) {
     )
     return
   }
-  input?.let { ExchangeText(SENT, it) }
+  input?.let { ExchangeText(sentLabel(call.over), it) }
   output?.let { ExchangeText(ANSWERED, it) }
 }
 
@@ -527,17 +546,26 @@ private fun AgentSession.title(): String = listOfNotNull(
 ).joinToString(" ")
 
 /**
- * What it did, in numbers: how many calls, how many of those were refused, and which heap dumps it read.
+ * What it did, in numbers: how many calls, how they went, which way in it came, and which dumps it read.
  *
  * The refusals are here rather than only in the session because they are the number worth seeing before
  * opening one: a session that was refused half its calls is a session where the method was being enforced,
- * which is either an agent that was made to go back and look, or a refusal message that isn't landing.
+ * which is either an agent that was made to go back and look, or a refusal message that isn't landing. The
+ * failures are the number that says the opposite — that this app is what went wrong — and they are worth
+ * seeing at the same glance for exactly that reason.
+ *
+ * **The calls, not every message.** A session holds the protocol around them too, and a command line's
+ * investigation is a handshake per call, so counting the lines would make the same work read as twice as much
+ * of it depending on how it was sent. Which is why the way in is a word of its own here. See
+ * [AgentSession.toolCalls].
  */
 private fun AgentSession.summary(): String {
   val dumps = heapDumpPaths.map { File(it).name }
   return listOfNotNull(
-    "${calls.size} call(s)",
+    "${toolCalls.size} call(s)",
     "$refusedCount refused".takeIf { refusedCount > 0 },
+    "$errorCount failed".takeIf { errorCount > 0 },
+    transports.joinToString(", ") { it.words }.takeIf { it.isNotEmpty() },
     dumps.joinToString(", ").takeIf { it.isNotEmpty() },
     sessionId
   ).joinToString(" · ")
@@ -562,6 +590,9 @@ private const val IN = "in"
 
 private const val REFUSED = "Refused:"
 
+/** And where nothing could be answered, which is not the same thing as being told no. */
+private const val FAILED = "Failed:"
+
 /**
  * What opens a call, folded and open: the arrow this app folds everything with, and JSON's braces.
  *
@@ -574,6 +605,20 @@ private const val EXPANDED_EXCHANGE = "$EXPANDED_ARROW {}"
 /** Over the two halves of an unfolded call, which are the call itself rather than a word about it. */
 private const val SENT = "sent:"
 private const val ANSWERED = "answered:"
+
+/**
+ * And which way in it came, on the half that came in.
+ *
+ * Here rather than on the row because it is a property of the line and not of what the line did: an MCP
+ * client's call and a call somebody typed at this window are the same protocol on the same socket by the time
+ * anything answers them, so this is the only thing that says which — and it belongs beside the text it is a
+ * fact about. A session recorded before this app kept it says nothing rather than guessing MCP, since a
+ * command line's calls are exactly the ones that would be labelled wrongly.
+ */
+private fun sentLabel(over: AgentTransport?): String =
+  if (over == null) SENT else "$SENT_OVER ${over.words}:"
+
+private const val SENT_OVER = "sent over"
 
 /**
  * And where a session from an older build has neither.
@@ -610,7 +655,8 @@ private const val NO_HEAP_DUMP_READ = "No heap dump"
  */
 private const val NO_SESSIONS = "No agent has worked on this heap dump."
 
-private const val NOTHING_ASKED = "Connected and asked nothing."
+/** A handshake is a row of this screen now, so an empty session is a client that never spoke at all. */
+private const val NOTHING_ASKED = "Connected and sent nothing."
 
 /** And after a link to a session the newer ones have pushed out, which is the likeliest way to be here. */
 private const val NO_SUCH_SESSION = "No session by that name. The newest hundred are kept."

--- a/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
+++ b/shark/shark-dive/shark-dive-app/src/main/java/shark/dive/app/AgentLogsScreen.kt
@@ -286,8 +286,9 @@ internal fun AgentLogScreen(
  * **And every row unfolds onto what actually crossed the wire**, which is the other half of following an
  * investigation. The sentence on the row is this window's reading of a call, and a reading is no use for the
  * question a reader ends up with — why did it do *that* next — because a step made on an answer that said
- * nothing reads exactly like a step made on one that said everything. So the arrow is on every row and what
- * is behind it is [AgentSessionCall.input] and [AgentSessionCall.output], as sent and as read.
+ * nothing reads exactly like a step made on one that said everything. So there is a mark under every row and
+ * what is behind it is [AgentSessionCall.input] and [AgentSessionCall.output], as sent and as read. Under it
+ * rather than on the sentence: see [ExchangeToggle].
  */
 @Composable
 private fun AgentCallRow(
@@ -331,7 +332,7 @@ private fun AgentCallRow(
       // Wrapped rather than truncated, since a class name is as long as it is and the reason under it is a
       // sentence: this row is read, not scanned past.
       FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        UnfoldableVerb(call.verb, isUnfolded) { isUnfolded = !isUnfolded }
+        Text(call.verb, style = MaterialTheme.typography.bodyMedium)
         when {
           target == null -> Unit
           leadsTo == null -> Text(target, style = MaterialTheme.typography.bodyMedium)
@@ -364,6 +365,9 @@ private fun AgentCallRow(
           color = MaterialTheme.colorScheme.error
         )
       }
+      // Under everything this window made of the call, because it is the call: last is where a reader
+      // arrives having read the sentence and wanted more of it, and it opens where it is.
+      ExchangeToggle(isUnfolded) { isUnfolded = !isUnfolded }
       if (isUnfolded) {
         openHeapDumps.forEach { path ->
           OpenHeapDumpRow(path, heapDumpFile, onOpenHeapDump, onCopyHeapDumpLink)
@@ -431,29 +435,32 @@ private fun ExchangeText(
 }
 
 /**
- * A verb with what is behind it, which is on every row.
+ * The mark at the foot of a row, which opens the call under it. On every row.
  *
- * The verb itself is what opens it, since the thing on a row is a link to where the call went — and the arrow
- * is the same one the leaks screen folds its sections with, because it is the same gesture on a screen
- * somebody reads straight after that one.
+ * **A mark of its own rather than the verb**, which is where this began and was wrong for a reason worth
+ * keeping: a row is a sentence, one part of it is a link to where the call went, and folding it from the
+ * first words made hovering the sentence light up the half of it that *isn't* the link. Two pressable pieces
+ * of one sentence, doing different things, and the highlight drawing a box round the wrong one. So the
+ * sentence stays a sentence and what opens the call sits under it, where what it opens appears.
+ *
+ * Braces, because what is behind it is the JSON, with the arrow the leaks screen folds its sections with in
+ * front — the same gesture on a screen somebody reads straight after that one. Small and grey and wordless
+ * because it is on every row of a screen read for the sentences: a word here is a word to read past forty
+ * times before reaching the row worth opening.
  */
 @Composable
-private fun UnfoldableVerb(
-  verb: String,
+private fun ExchangeToggle(
   isUnfolded: Boolean,
   onToggle: () -> Unit
 ) {
-  Row(
-    Modifier.clickableRow(onClick = onToggle),
-    horizontalArrangement = Arrangement.spacedBy(4.dp)
-  ) {
-    Text(
-      if (isUnfolded) EXPANDED_ARROW else FOLDED_ARROW,
-      style = MaterialTheme.typography.bodyMedium,
-      color = MUTED_TEXT
-    )
-    Text(verb, style = MaterialTheme.typography.bodyMedium)
-  }
+  Text(
+    if (isUnfolded) EXPANDED_EXCHANGE else FOLDED_EXCHANGE,
+    // Padded inside the click, so that a mark this small is still something a pointer can land on.
+    Modifier.clickableRow(onClick = onToggle).padding(end = 6.dp, top = 2.dp, bottom = 2.dp),
+    style = MaterialTheme.typography.bodySmall,
+    fontFamily = FontFamily.Monospace,
+    color = MUTED_TEXT
+  )
 }
 
 /**
@@ -555,6 +562,15 @@ private const val IN = "in"
 
 private const val REFUSED = "Refused:"
 
+/**
+ * What opens a call, folded and open: the arrow this app folds everything with, and JSON's braces.
+ *
+ * Which is the whole of what it says, and enough — braces are what the thing behind it looks like. See
+ * [ExchangeToggle].
+ */
+private const val FOLDED_EXCHANGE = "$FOLDED_ARROW {}"
+private const val EXPANDED_EXCHANGE = "$EXPANDED_ARROW {}"
+
 /** Over the two halves of an unfolded call, which are the call itself rather than a word about it. */
 private const val SENT = "sent:"
 private const val ANSWERED = "answered:"
@@ -580,7 +596,7 @@ private const val THIS_HEAP_DUMP = "this heap dump"
  */
 private const val MISSING_HEAP_DUMP = "missing"
 
-/** How far the rows behind a verb sit in from it, which is the arrow's width and the gap after it. */
+/** How far what a row opens sits in from the mark that opened it, which is that mark's own width. */
 private val UNFOLDED_INSET = 20.dp
 
 /** And over the sessions of a client that connected and read nothing, which no window can be about. */

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/AgentLogsScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/AgentLogsScreenTest.kt
@@ -82,11 +82,10 @@ class AgentLogsScreenTest {
       waitUntilAtLeastOneExists(hasText(activityName()), OPEN_TIMEOUT_MILLIS)
 
       // What a reader wants to go and look at is the object, so that is the whole of what moves the window:
-      // a row where clicking the word "Looked at" navigates is a row with a hand cursor over prose. What the
-      // verb does instead is unfold the call in place, which leaves the tab where it was.
+      // a row where clicking the word "Looked at" navigates is a row with a hand cursor over prose. And the
+      // verb is nothing to press either — what opens the call is the mark under the row.
       onNodeWithText(activityName()).assertHasClickAction()
-      onNodeWithText(LOOKED_AT).performClick()
-      selectedTab().assertTextContains(Place.AgentLog(SESSION_ID).title)
+      onNodeWithText(LOOKED_AT).assertHasNoClickAction()
     }
   }
 
@@ -98,9 +97,8 @@ class AgentLogsScreenTest {
 
       // "Listed the leaks" is a sentence about the leaks screen, so *leaks* is the link and what comes
       // before it is prose. Linking the whole of it was underlining a verb; naming the place from the tool
-      // instead read as "Listed the leaks Leaks". The verb unfolds the call and goes nowhere.
-      onNodeWithText(LISTED_THE).performClick()
-      selectedTab().assertTextContains(Place.AgentLog(SESSION_ID).title)
+      // instead read as "Listed the leaks Leaks".
+      onNodeWithText(LISTED_THE).assertHasNoClickAction()
       onNodeWithText(LEAKS).assertHasClickAction()
       onNodeWithText(LEAKS).performClick()
 
@@ -116,11 +114,11 @@ class AgentLogsScreenTest {
       waitUntilAtLeastOneExists(hasText(DOMINATOR_TREE), OPEN_TIMEOUT_MILLIS)
 
       // Reading the tree from its root is what this window opens on, so a row saying an agent did it leads
-      // there. Anything an agent can do that a person can do here is a row that goes where they went.
-      // The tab is on the agent's log until the row moves it — which the verb does not do, it being the fold
-      // over the call — and then on the tree from its root, which is where a window opens and what the row
-      // said the agent read.
-      onNodeWithText(READ_THE).performClick()
+      // there. Anything an agent can do that a person can do here is a row that goes where they went — and
+      // "Read the" is the prose in front of it rather than a second thing to press.
+      onNodeWithText(READ_THE).assertHasNoClickAction()
+      // The tab is on the agent's log until the row moves it, and then on the tree from its root, which is
+      // where a window opens and what the row said the agent read.
       selectedTab().assertTextContains(Place.AgentLog(SESSION_ID).title)
       onNodeWithText(DOMINATOR_TREE).performClick()
 
@@ -152,10 +150,10 @@ class AgentLogsScreenTest {
       onNodeWithText(CLIENT, substring = true).performClick()
       waitUntilAtLeastOneExists(hasText(LOOKED_AT), OPEN_TIMEOUT_MILLIS)
 
-      // Behind the verb until asked for, because a session read straight through is sentences: the exchange
-      // is what somebody opens one call for when the sentences stopped explaining the next step.
+      // Behind the mark under the row until asked for, because a session read straight through is sentences:
+      // the exchange is what somebody opens one call for when the sentences stopped explaining the next step.
       onNodeWithText(SENT, substring = true).assertDoesNotExist()
-      onNodeWithText(LOOKED_AT).performClick()
+      exchangeToggle().performClick()
 
       // Both halves, whole, and as they were: this is the one thing on the screen that is not this window's
       // reading of what happened.
@@ -171,7 +169,7 @@ class AgentLogsScreenTest {
       )
       onNodeWithText(CLIENT, substring = true).performClick()
       waitUntilAtLeastOneExists(hasText(CONCLUDED_ABOUT), OPEN_TIMEOUT_MILLIS)
-      onNodeWithText(CONCLUDED_ABOUT).performClick()
+      exchangeToggle().performClick()
 
       // The refusal is already on the row in full, so unfolding adds what was sent and does not print the
       // same sentence a second time in a box.
@@ -185,7 +183,7 @@ class AgentLogsScreenTest {
       openAgentLogs(listOf(session(calls = listOf(call(input = null, output = null)))))
       onNodeWithText(CLIENT, substring = true).performClick()
       waitUntilAtLeastOneExists(hasText(LOOKED_AT), OPEN_TIMEOUT_MILLIS)
-      onNodeWithText(LOOKED_AT).performClick()
+      exchangeToggle().performClick()
 
       // A gap where the exchange should be reads as an app that lost it; this is the app saying it was never
       // given one, which is a thing about that session rather than about this window.
@@ -313,10 +311,10 @@ class AgentLogsScreenTest {
       thisWindowsSession().performClick()
       waitUntilAtLeastOneExists(hasText(ASKED_WHICH_ARE_OPEN), OPEN_TIMEOUT_MILLIS)
 
-      // Behind the verb until somebody asks, because what this one came back with is a list where every
-      // other row of a session is a sentence.
+      // Behind the mark under the row until somebody asks, because what this one came back with is a list
+      // where every other row of a session is a sentence.
       onNodeWithText(otherHeapDump.name).assertDoesNotExist()
-      onNodeWithText(ASKED_WHICH_ARE_OPEN).performClick()
+      exchangeToggle().performClick()
 
       // The dump this window has open says so and leads nowhere — it is already here — and the other one is
       // a window away, which is what makes a list of what *was* open worth keeping.
@@ -423,6 +421,14 @@ class AgentLogsScreenTest {
   )
 
   /**
+   * What opens a call, which is under the row rather than on the sentence it is under.
+   *
+   * The first of them, for the sessions here that have more than one call: a mark per row, and the row a
+   * test is about is the one it built first.
+   */
+  private fun ComposeUiTest.exchangeToggle() = onAllNodesWithText(FOLDED_EXCHANGE)[0]
+
+  /**
    * The session as this window's group of them lists it, which is the first: a session that read two dumps is
    * listed under both, and only this window's group is read here.
    */
@@ -519,11 +525,15 @@ class AgentLogsScreenTest {
     const val REFUSED = "Refused:"
 
     /**
-     * What a call sent and what came back, as the text they were: several lines of formatted JSON, which is
-     * what reaches the model and so what a session keeps. See [shark.dive.agent.AgentSessionCall.input].
+     * What a call sent and what came back, as the text they were: the tool's own name and then several lines
+     * of formatted JSON, which is what reaches the model and so what a session keeps. See
+     * [shark.dive.agent.AgentSessionCall.input] — and `McpSessionTest` for these being what is recorded.
      */
-    const val SENT = "{\n  \"object\": \"0x12d368b8\",\n  \"reason\": \"$REASON\"\n}"
+    const val SENT = "describe_object {\n  \"object\": \"0x12d368b8\",\n  \"reason\": \"$REASON\"\n}"
     const val ANSWERED = "{\n  \"object\": \"0x12d368b8\",\n  \"verdict\": \"UNKNOWN\"\n}"
+
+    /** The mark under a row that opens the call, which is on every row. See `AgentLogsScreen`. */
+    const val FOLDED_EXCHANGE = "▸ {}"
 
     /** And what a row of a session recorded before either of them was kept unfolds onto. */
     const val NOTHING_KEPT = "recorded before Shark Dive kept what was sent and answered"

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/AgentLogsScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/AgentLogsScreenTest.kt
@@ -81,10 +81,12 @@ class AgentLogsScreenTest {
       onNodeWithText(CLIENT, substring = true).performClick()
       waitUntilAtLeastOneExists(hasText(activityName()), OPEN_TIMEOUT_MILLIS)
 
-      // What a reader wants to go and look at is the object, so that is the whole of what leads anywhere:
-      // a row where clicking the word "Looked at" navigates is a row with a hand cursor over prose.
+      // What a reader wants to go and look at is the object, so that is the whole of what moves the window:
+      // a row where clicking the word "Looked at" navigates is a row with a hand cursor over prose. What the
+      // verb does instead is unfold the call in place, which leaves the tab where it was.
       onNodeWithText(activityName()).assertHasClickAction()
-      onNodeWithText(LOOKED_AT).assertHasNoClickAction()
+      onNodeWithText(LOOKED_AT).performClick()
+      selectedTab().assertTextContains(Place.AgentLog(SESSION_ID).title)
     }
   }
 
@@ -96,8 +98,9 @@ class AgentLogsScreenTest {
 
       // "Listed the leaks" is a sentence about the leaks screen, so *leaks* is the link and what comes
       // before it is prose. Linking the whole of it was underlining a verb; naming the place from the tool
-      // instead read as "Listed the leaks Leaks".
-      onNodeWithText(LISTED_THE).assertHasNoClickAction()
+      // instead read as "Listed the leaks Leaks". The verb unfolds the call and goes nowhere.
+      onNodeWithText(LISTED_THE).performClick()
+      selectedTab().assertTextContains(Place.AgentLog(SESSION_ID).title)
       onNodeWithText(LEAKS).assertHasClickAction()
       onNodeWithText(LEAKS).performClick()
 
@@ -114,9 +117,10 @@ class AgentLogsScreenTest {
 
       // Reading the tree from its root is what this window opens on, so a row saying an agent did it leads
       // there. Anything an agent can do that a person can do here is a row that goes where they went.
-      onNodeWithText(READ_THE).assertHasNoClickAction()
-      // The tab is on the agent's log until the row moves it, and then on the tree from its root, which is
-      // where a window opens and what the row said the agent read.
+      // The tab is on the agent's log until the row moves it — which the verb does not do, it being the fold
+      // over the call — and then on the tree from its root, which is where a window opens and what the row
+      // said the agent read.
+      onNodeWithText(READ_THE).performClick()
       selectedTab().assertTextContains(Place.AgentLog(SESSION_ID).title)
       onNodeWithText(DOMINATOR_TREE).performClick()
 
@@ -139,6 +143,53 @@ class AgentLogsScreenTest {
       onNodeWithText(BIGGEST_OBJECTS).performClick()
 
       waitUntilAtLeastOneExists(hasText(Place.OBJECTS_LABEL) and isTab(), OPEN_TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `a row unfolds onto what the call sent and what it read back`() {
+    diveUiTest {
+      openAgentLogs(listOf(session(calls = listOf(call()))))
+      onNodeWithText(CLIENT, substring = true).performClick()
+      waitUntilAtLeastOneExists(hasText(LOOKED_AT), OPEN_TIMEOUT_MILLIS)
+
+      // Behind the verb until asked for, because a session read straight through is sentences: the exchange
+      // is what somebody opens one call for when the sentences stopped explaining the next step.
+      onNodeWithText(SENT, substring = true).assertDoesNotExist()
+      onNodeWithText(LOOKED_AT).performClick()
+
+      // Both halves, whole, and as they were: this is the one thing on the screen that is not this window's
+      // reading of what happened.
+      waitUntilAtLeastOneExists(hasText(SENT), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText(ANSWERED).assertIsDisplayed()
+    }
+  }
+
+  @Test fun `a refused call unfolds onto what it sent, its answer being the refusal on the row`() {
+    diveUiTest {
+      openAgentLogs(
+        listOf(session(calls = listOf(call(tool = "conclude", output = null, refusal = REFUSAL))))
+      )
+      onNodeWithText(CLIENT, substring = true).performClick()
+      waitUntilAtLeastOneExists(hasText(CONCLUDED_ABOUT), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText(CONCLUDED_ABOUT).performClick()
+
+      // The refusal is already on the row in full, so unfolding adds what was sent and does not print the
+      // same sentence a second time in a box.
+      waitUntilAtLeastOneExists(hasText(SENT), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText("$REFUSED $REFUSAL").assertIsDisplayed()
+    }
+  }
+
+  @Test fun `a session recorded before the exchange was kept says so rather than unfolding onto nothing`() {
+    diveUiTest {
+      openAgentLogs(listOf(session(calls = listOf(call(input = null, output = null)))))
+      onNodeWithText(CLIENT, substring = true).performClick()
+      waitUntilAtLeastOneExists(hasText(LOOKED_AT), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText(LOOKED_AT).performClick()
+
+      // A gap where the exchange should be reads as an app that lost it; this is the app saying it was never
+      // given one, which is a thing about that session rather than about this window.
+      waitUntilAtLeastOneExists(hasText(NOTHING_KEPT, substring = true), OPEN_TIMEOUT_MILLIS)
     }
   }
 
@@ -352,6 +403,8 @@ class AgentLogsScreenTest {
   private fun call(
     tool: String = "describe_object",
     heapDumpPath: String = heapDump.file.absolutePath,
+    input: String? = SENT,
+    output: String? = ANSWERED,
     refusal: String? = null,
     outcome: String? = null
   ) = AgentSessionCall(
@@ -362,6 +415,8 @@ class AgentLogsScreenTest {
     heapDumpPath = heapDumpPath,
     place = Place.Object(activityObjectId()),
     arguments = mapOf("object" to hex(activityObjectId())),
+    input = input,
+    output = output,
     refusal = refusal,
     outcome = outcome,
     millis = 12L
@@ -382,6 +437,8 @@ class AgentLogsScreenTest {
     heapDumpPath = heapDump.file.absolutePath,
     place = Place.Leaks(),
     arguments = emptyMap(),
+    input = SENT,
+    output = ANSWERED,
     refusal = null,
     outcome = null,
     millis = 12L
@@ -399,6 +456,8 @@ class AgentLogsScreenTest {
     heapDumpPath = heapDump.file.absolutePath,
     place = if (tool == "find_objects") Place.Objects() else Place.wholeHeapDump(),
     arguments = emptyMap(),
+    input = SENT,
+    output = ANSWERED,
     refusal = null,
     outcome = null,
     millis = 12L
@@ -414,6 +473,8 @@ class AgentLogsScreenTest {
     // Nowhere to go: this one asks the app rather than a heap dump. What it came back with is where it goes.
     place = null,
     arguments = emptyMap(),
+    input = SENT,
+    output = ANSWERED,
     refusal = null,
     outcome = null,
     openHeapDumps = listOf(heapDump.file.absolutePath, otherHeapDump.absolutePath),
@@ -453,6 +514,19 @@ class AgentLogsScreenTest {
     const val CLIENT = "claude-code 9.9.9"
     const val REASON = "Checking whether this activity is really destroyed."
     const val REFUSAL = "3 step(s) have no verdict"
+
+    /** In front of a refusal on a row, which is where the answer to a refused call already is. */
+    const val REFUSED = "Refused:"
+
+    /**
+     * What a call sent and what came back, as the text they were: several lines of formatted JSON, which is
+     * what reaches the model and so what a session keeps. See [shark.dive.agent.AgentSessionCall.input].
+     */
+    const val SENT = "{\n  \"object\": \"0x12d368b8\",\n  \"reason\": \"$REASON\"\n}"
+    const val ANSWERED = "{\n  \"object\": \"0x12d368b8\",\n  \"verdict\": \"UNKNOWN\"\n}"
+
+    /** And what a row of a session recorded before either of them was kept unfolds onto. */
+    const val NOTHING_KEPT = "recorded before Shark Dive kept what was sent and answered"
     const val FAULTY_REFERENCE = "Holder.activity"
     const val NO_AGENT_YET = "No agent has worked on this heap dump"
 

--- a/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/AgentLogsScreenTest.kt
+++ b/shark/shark-dive/shark-dive-app/src/test/java/shark/dive/app/AgentLogsScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -33,6 +34,7 @@ import shark.dive.HeapDominatorTreemap
 import shark.dive.Place
 import shark.dive.agent.AgentSession
 import shark.dive.agent.AgentSessionCall
+import shark.dive.agent.AgentTransport
 import shark.dive.exactHexObjectId
 import shark.dive.hexObjectId
 
@@ -162,19 +164,85 @@ class AgentLogsScreenTest {
     }
   }
 
-  @Test fun `a refused call unfolds onto what it sent, its answer being the refusal on the row`() {
+  @Test fun `a refused call unfolds onto the refusal as the agent was handed it`() {
     diveUiTest {
       openAgentLogs(
-        listOf(session(calls = listOf(call(tool = "conclude", output = null, refusal = REFUSAL))))
+        listOf(session(calls = listOf(call(tool = "conclude", output = REFUSAL, refusal = REFUSAL))))
       )
       onNodeWithText(CLIENT, substring = true).performClick()
       waitUntilAtLeastOneExists(hasText(CONCLUDED_ABOUT), OPEN_TIMEOUT_MILLIS)
       exchangeToggle().performClick()
 
-      // The refusal is already on the row in full, so unfolding adds what was sent and does not print the
-      // same sentence a second time in a box.
+      // Both, and the same sentence twice on purpose: the row is this window's reading — the method said no —
+      // and the box is the text that went back to the agent. Recording only the reading is what "a refused
+      // call returns no answer" looked like from outside.
       waitUntilAtLeastOneExists(hasText(SENT), OPEN_TIMEOUT_MILLIS)
       onNodeWithText("$REFUSED $REFUSAL").assertIsDisplayed()
+      onAllNodesWithText(REFUSAL, substring = true).assertCountEquals(2)
+    }
+  }
+
+  @Test fun `an unfolded call says which way in it came`() {
+    diveUiTest {
+      openAgentLogs(
+        listOf(
+          session(
+            calls = listOf(
+              call(over = AgentTransport.CLI),
+              call(tool = "list_leaks", over = AgentTransport.MCP)
+            )
+          )
+        )
+      )
+      onNodeWithText(CLIENT, substring = true).performClick()
+      waitUntilAtLeastOneExists(hasText(LOOKED_AT), OPEN_TIMEOUT_MILLIS)
+
+      // The one thing about a call that nothing else on the screen can say: by the time anything answers one,
+      // a command line and an MCP client are the same protocol on the same socket.
+      onAllNodesWithText(FOLDED_EXCHANGE)[0].performClick()
+      waitUntilAtLeastOneExists(hasText(SENT_OVER_CLI), OPEN_TIMEOUT_MILLIS)
+      onAllNodesWithText(FOLDED_EXCHANGE)[0].performClick()
+      waitUntilAtLeastOneExists(hasText(SENT_OVER_MCP), OPEN_TIMEOUT_MILLIS)
+      // And the summary above says both, in the order they first appear, since a session with two in it is
+      // somebody typing calls at a window a client is already working in.
+      onNodeWithText("CLI, MCP", substring = true).assertIsDisplayed()
+    }
+  }
+
+  @Test fun `a message that reached no tool is a row of the session like any other`() {
+    diveUiTest {
+      openAgentLogs(
+        listOf(
+          session(
+            calls = listOf(
+              message(method = "initialize", input = HANDSHAKE, output = HANDSHAKE_ANSWER),
+              call()
+            )
+          )
+        )
+      )
+      onNodeWithText(CLIENT, substring = true).performClick()
+
+      // The handshake, in words, because the question this screen gets opened for is often why *nothing*
+      // happened — and it says one call rather than two, the protocol not being what an agent did.
+      waitUntilAtLeastOneExists(hasText(CONNECTED), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText(CONNECTED).assertHasNoClickAction()
+      onNodeWithText("1 call(s)", substring = true).assertIsDisplayed()
+      onAllNodesWithText(FOLDED_EXCHANGE)[0].performClick()
+      waitUntilAtLeastOneExists(hasText(HANDSHAKE), OPEN_TIMEOUT_MILLIS)
+    }
+  }
+
+  @Test fun `a call this app could not answer says so, and is not read as a refusal`() {
+    diveUiTest {
+      openAgentLogs(listOf(session(calls = listOf(call(output = FAILURE, error = FAILURE)))))
+      onNodeWithText(CLIENT, substring = true).performClick()
+
+      // Which is the opposite claim from a refusal: one is the method working and this is this app failing,
+      // so a screen with one word for both would be a screen nobody can tell them apart on.
+      waitUntilAtLeastOneExists(hasText("$FAILED $FAILURE"), OPEN_TIMEOUT_MILLIS)
+      onNodeWithText(REFUSED, substring = true).assertDoesNotExist()
+      onNodeWithText("1 failed", substring = true).assertIsDisplayed()
     }
   }
 
@@ -404,9 +472,13 @@ class AgentLogsScreenTest {
     input: String? = SENT,
     output: String? = ANSWERED,
     refusal: String? = null,
-    outcome: String? = null
+    error: String? = null,
+    outcome: String? = null,
+    over: AgentTransport? = AgentTransport.MCP
   ) = AgentSessionCall(
     at = STARTED_AT,
+    over = over,
+    method = "tools/call",
     tool = tool,
     reason = REASON,
     windowId = "zvphq4r3",
@@ -416,8 +488,33 @@ class AgentLogsScreenTest {
     input = input,
     output = output,
     refusal = refusal,
+    error = error,
     outcome = outcome,
     millis = 12L
+  )
+
+  /** A message that reached no tool, which is the protocol around them. See [AgentSessionCall]. */
+  private fun message(
+    method: String?,
+    input: String,
+    output: String? = null,
+    error: String? = null
+  ) = AgentSessionCall(
+    at = STARTED_AT,
+    over = AgentTransport.MCP,
+    method = method,
+    tool = null,
+    reason = null,
+    windowId = null,
+    heapDumpPath = null,
+    place = null,
+    arguments = emptyMap(),
+    input = input,
+    output = output,
+    refusal = null,
+    error = error,
+    outcome = null,
+    millis = 3L
   )
 
   /**
@@ -437,6 +534,8 @@ class AgentLogsScreenTest {
   /** The one call that names nothing: the leaks screen is the whole of what it was about. */
   private fun leaksCall() = AgentSessionCall(
     at = STARTED_AT,
+    over = AgentTransport.MCP,
+    method = "tools/call",
     tool = "list_leaks",
     reason = REASON,
     windowId = "zvphq4r3",
@@ -446,6 +545,7 @@ class AgentLogsScreenTest {
     input = SENT,
     output = ANSWERED,
     refusal = null,
+    error = null,
     outcome = null,
     millis = 12L
   )
@@ -456,6 +556,8 @@ class AgentLogsScreenTest {
    */
   private fun wholeDumpCall(tool: String) = AgentSessionCall(
     at = STARTED_AT,
+    over = AgentTransport.MCP,
+    method = "tools/call",
     tool = tool,
     reason = REASON,
     windowId = "zvphq4r3",
@@ -465,6 +567,7 @@ class AgentLogsScreenTest {
     input = SENT,
     output = ANSWERED,
     refusal = null,
+    error = null,
     outcome = null,
     millis = 12L
   )
@@ -472,6 +575,8 @@ class AgentLogsScreenTest {
   /** The first call of most sessions: which dumps are open, answered with the ones that were. */
   private fun openHeapDumpsCall(otherHeapDump: File) = AgentSessionCall(
     at = STARTED_AT,
+    over = AgentTransport.MCP,
+    method = "tools/call",
     tool = "open_heap_dumps",
     reason = REASON,
     windowId = "zvphq4r3",
@@ -482,6 +587,7 @@ class AgentLogsScreenTest {
     input = SENT,
     output = ANSWERED,
     refusal = null,
+    error = null,
     outcome = null,
     openHeapDumps = listOf(heapDump.file.absolutePath, otherHeapDump.absolutePath),
     millis = 12L
@@ -521,8 +627,12 @@ class AgentLogsScreenTest {
     const val REASON = "Checking whether this activity is really destroyed."
     const val REFUSAL = "3 step(s) have no verdict"
 
-    /** In front of a refusal on a row, which is where the answer to a refused call already is. */
+    /** In front of a refusal on a row, and in front of what could not be answered at all. */
     const val REFUSED = "Refused:"
+    const val FAILED = "Failed:"
+
+    /** What a call that nothing could answer was answered with, which is the exception it hit. */
+    const val FAILURE = "java.io.IOException: The heap dump went away mid-read"
 
     /**
      * What a call sent and what came back, as the text they were: the tool's own name and then several lines
@@ -534,6 +644,17 @@ class AgentLogsScreenTest {
 
     /** The mark under a row that opens the call, which is on every row. See `AgentLogsScreen`. */
     const val FOLDED_EXCHANGE = "▸ {}"
+
+    /** Over the half of an unfolded call that came in, which is where the way in is said. */
+    const val SENT_OVER_MCP = "sent over MCP:"
+    const val SENT_OVER_CLI = "sent over CLI:"
+
+    /** A message that reached no tool: the handshake, as it crossed the wire and as it was answered. */
+    const val HANDSHAKE = """{"jsonrpc":"2.0","id":1,"method":"initialize"}"""
+    const val HANDSHAKE_ANSWER = """{"jsonrpc":"2.0","id":1,"result":{}}"""
+
+    /** And what its row says, which is prose about the protocol rather than about a heap dump. */
+    const val CONNECTED = "Connected"
 
     /** And what a row of a session recorded before either of them was kept unfolds onto. */
     const val NOTHING_KEPT = "recorded before Shark Dive kept what was sent and answered"

--- a/shark/shark-dive/shark-dive-eval/src/main/java/shark/dive/eval/EvalScore.kt
+++ b/shark/shark-dive/shark-dive-eval/src/main/java/shark/dive/eval/EvalScore.kt
@@ -53,7 +53,11 @@ class EvalResult(
       session: AgentSession,
       heapDumpPath: String
     ): EvalResult {
-      val concludes = session.calls.filter { it.tool == CONCLUDE }
+      // The calls, not every message: a session holds the protocol around them too, and a run scored on how
+      // many handshakes it sent is a number that changes with the transport rather than with the agent. See
+      // [AgentSession.toolCalls].
+      val toolCalls = session.toolCalls
+      val concludes = toolCalls.filter { it.tool == CONCLUDE }
       val concluded = concludes.firstNotNullOfOrNull { it.outcome }
       return EvalResult(
         scenario = scenario.name,
@@ -62,10 +66,10 @@ class EvalResult(
         concluded = concluded,
         key = scenario.key,
         wanderedTo = concludes.mapNotNull { it.heapDumpPath }.firstOrNull { it != heapDumpPath },
-        callCount = session.calls.size,
+        callCount = toolCalls.size,
         refusalCount = session.refusedCount,
         concludeCount = concludes.size,
-        readMillis = session.calls.sumOf { it.millis },
+        readMillis = toolCalls.sumOf { it.millis },
         sessionId = session.sessionId
       )
     }

--- a/shark/shark-dive/shark-dive-eval/src/test/java/shark/dive/eval/EvalScoreTest.kt
+++ b/shark/shark-dive/shark-dive-eval/src/test/java/shark/dive/eval/EvalScoreTest.kt
@@ -138,6 +138,10 @@ class EvalScoreTest {
     heapDumpPath = heapDumpPath,
     place = null,
     arguments = emptyMap(),
+    // What a run scores on is what it concluded and how many calls it took, so the exchange every call also
+    // carries is nothing this reads. See [AgentSessionCall.input].
+    input = null,
+    output = null,
     refusal = refusal,
     outcome = outcome,
     millis = 12L

--- a/shark/shark-dive/shark-dive-eval/src/test/java/shark/dive/eval/EvalScoreTest.kt
+++ b/shark/shark-dive/shark-dive-eval/src/test/java/shark/dive/eval/EvalScoreTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import shark.dive.agent.AgentSession
 import shark.dive.agent.AgentSessionCall
+import shark.dive.agent.AgentTransport
 
 /**
  * What a session is scored as, which is a handful of counts and one string comparison.
@@ -94,6 +95,26 @@ class EvalScoreTest {
   }
 
   @Test
+  fun `the protocol a session also records is no part of what a run is scored on`() {
+    val result = score(
+      calls = listOf(
+        message("initialize"),
+        message("notifications/initialized"),
+        message("tools/list"),
+        call("list_leaks"),
+        concluded(KEY)
+      )
+    )
+
+    // Two calls, not five. A session holds the full traffic on purpose, and a run measured on the lines it
+    // sent is a run whose number moves when the same investigation is typed at a command line instead — which
+    // sends a handshake per call. The time is the calls' too, a handshake being no read of a heap dump.
+    assertThat(result.outcome).isEqualTo(EvalOutcome.RIGHT)
+    assertThat(result.callCount).isEqualTo(2)
+    assertThat(result.readMillis).isEqualTo(24L)
+  }
+
+  @Test
   fun `a run leads back to the session it was read from`() {
     val result = score(calls = listOf(concluded(KEY)))
 
@@ -132,6 +153,8 @@ class EvalScoreTest {
     heapDumpPath: String = HEAP_DUMP_PATH
   ) = AgentSessionCall(
     at = AT,
+    over = AgentTransport.MCP,
+    method = "tools/call",
     tool = tool,
     reason = "Because.",
     windowId = null,
@@ -143,8 +166,34 @@ class EvalScoreTest {
     input = null,
     output = null,
     refusal = refusal,
+    error = null,
     outcome = outcome,
     millis = 12L
+  )
+
+  /**
+   * A message that reached no tool, which a session holds as many of as the transport asked for.
+   *
+   * Nothing here scores one, and that is what the tests using this are about: a run measured on the lines it
+   * sent rather than on the calls it made is a run whose number changes when somebody types the same
+   * investigation at a command line instead. See [AgentSession.toolCalls].
+   */
+  private fun message(method: String) = AgentSessionCall(
+    at = AT,
+    over = AgentTransport.MCP,
+    method = method,
+    tool = null,
+    reason = null,
+    windowId = null,
+    heapDumpPath = null,
+    place = null,
+    arguments = emptyMap(),
+    input = "{\"method\":\"$method\"}",
+    output = "{}",
+    refusal = null,
+    error = null,
+    outcome = null,
+    millis = 40L
   )
 
   private fun EvalResult.asRunLine() = listOf(this).asRunLines()


### PR DESCRIPTION
The **Agent logs** screen was every call as this app's *reading* of it — a verb, the object, the sentence the agent gave — and a reading is the one thing that is no use when the question is why an investigation went wrong. A step taken on an answer that said nothing reads exactly like a step taken on one that said everything, and nothing on the screen could tell them apart.

So a session now records the traffic itself, all of it, and every row opens onto it.

## What a message keeps

- **`input`** — the tool the model named and the arguments it named it with, formatted. The name even though `tool` has it: this field is read as one thing, and a set of arguments lifted away from what they are arguments *to* is the one form of a call nobody can read on its own. For a message that reached no tool, the line as it arrived.
- **`output`** — the answer as the text that reached the model. The same string `toolResult` puts in `content[0].text`, formatted once and then both answered with and written down, so a session can be compared against a client's own transcript character for character. **Whatever that answer was**: a refusal is in it as well as in `refused`, and an error as well as in `error`. Null means nothing went back, which is a notification and nothing else.
- **`error`**, separate from `refused`, because they are opposite claims about the same shape of row: a refusal is the method working and an error is Shark Dive failing. The eval scores refusals as the surface doing its job, so folding the two together would corrupt that.
- **`over`** — MCP, or `--agent` typed at a shell.

## Every message, not only the ones that reached a tool

The handshake, a `tools/list`, a ping, a notification, a method this build has never heard of, a `tools/call` with no name or a name nothing answers to, and a line that was not JSON at all: each is a row. `tool` is null for those and `method` says what arrived instead; `AgentSession.toolCalls` is the subset that got as far as a tool, which is what the eval counts and what the screen's `n call(s)` says — so a command line's handshake per call doesn't read as twice the work it was.

A name `verbOfTool` has no verb for is a name this build has no tool for, since a test asserts every registered tool has one. So it reads as itself, unchanged: `Called solve_the_leak` is a typo or a tool from a newer build, and the exact string is what somebody is looking for.

```
16:17:31  Connected
16:17:31  Listed the leaks
          because: Starting with what the dump says about itself.
16:17:31  Connected
16:17:31  Concluded about MainActivity 0x12d368b8
          because: I think I already know.
          Refused: Not concluded. 4 step(s) between the last EXPECTED object and the first STUCK one
          have no verdict.
          ▾ {}
            sent over CLI:
              conclude {
                  "object": "0x12d368b8",
                  "rootCause": "Nothing clears it."
              }
            answered:
              Not concluded. 4 step(s) between the last EXPECTED object and the first STUCK one have no
              verdict.
16:17:31  Called solve_the_leak
          because: Trying my luck.
          Failed: There is no tool called "solve_the_leak". This server has open_heap_dumps, …
16:17:31  Sent something this app could not read
          Failed: That is not JSON: Unexpected JSON token at offset 0
16:17:31  Sent the notification notifications/cancelled
```

## Which way in, and why it is told rather than worked out

Past the handshake a command line and an MCP client are the same protocol on the same socket — which is the point of them, since a refusal met on a command line has to be the refusal an MCP client would have met. So the door is the only place that can know, and `McpSession` is told at construction. The word travels as the last field of `AgentServer`'s handshake line, `token[ sessionName[ over]]`, and a connection that says nothing is MCP, which is what every MCP client is and what everything was before `--agent` existed.

On the screen it is the label over the half that came in — `sent over CLI:` — because it is a fact about that line rather than about what the line did, and the session summary says which ways it was talked to at all.

## What this reverses

The previous commit left `output` null for a refused call on the grounds that the refusal was already in `refused`, and writing it twice would put the same paragraph on disk twice. From outside, that looked like a call the app answered and then declined to log. Two fields, deliberately: one is this app's reading and one is the text the agent was handed.

## Tried for real

Packaged build, one window on `leak_asynctask_o.hprof`. Four calls typed at `--agent` (two `list_leaks`, a refused `conclude`, a `solve_the_leak` that is no tool) and four messages pushed at the loopback socket by hand (a line that is not JSON, a `resources/list`, a `tools/call` with no name, a notification). All twelve lines are in the session file with the right `over`, `method`, `output` and `error`, and `agent_log session=traffic` hands all twelve back. The screen above is a headless capture of the same shape.

**And a measurement worth knowing**, in `notes/agent-surface.md`: that twelve-message session is 57,693 characters through `agent_log`, of which **32,976 is four `initialize` answers** — `initialize` answers with the whole method, and `--agent` is a process per call. An MCP session pays it once. Not a reason to record less, but if `agent_log` needs to be cheaper, the handshake answers are where to look first.

`shark-dive-agent`, `shark-dive-app`, `shark-dive-eval` and `shark-dive-core` `check` are green, detekt included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
